### PR TITLE
Bug 689688 - crashmover, retry and orphans

### DIFF
--- a/socorro/storage/crashstorage.py
+++ b/socorro/storage/crashstorage.py
@@ -288,8 +288,6 @@ class CrashStorageSystemForHBase(CrashStorageSystem):
                 config[hbasePort],
                 config[hbaseTimeout],
                 logger=self.logger)
-    #print hbaseClient
-    #print hbaseClient.hbaseThriftExceptions
     retry_exceptions_list = list(hbaseClient.hbaseThriftExceptions)
     retry_exceptions_list.append(hbaseClient.NoConnectionException)
     self.exceptionsEligibleForRetry = tuple(retry_exceptions_list)

--- a/socorro/unittest/storage/testCrashstorage.py
+++ b/socorro/unittest/storage/testCrashstorage.py
@@ -179,7 +179,6 @@ def testCrashStorageSystemForHBase___init__():
   j.dirPermissions = d.hbaseFallbackDirPermissions = 770
   j.logger = d.logger = util.SilentFakeLogger()
   fakeHbaseConnection = exp.DummyObjectWithExpectations('fakeHbaseConnection')
-  #fakeHbaseConnection.expect('hbaseThriftExceptions', (), {}, [], None)
   fakeHbaseModule = exp.DummyObjectWithExpectations('fakeHbaseModule')
   fakeHbaseModule.expect('HBaseConnectionForCrashReports', (d.hbaseHost, d.hbasePort, d.hbaseTimeout), {"logger":d.logger}, fakeHbaseConnection, None)
   fakeHbaseModule.expect('hbaseThriftExceptions', None, None, (), None)
@@ -215,7 +214,6 @@ def testCrashStorageSystemForHBase_save_1():
   d.logger = util.SilentFakeLogger()
 
   fakeHbaseConnection = exp.DummyObjectWithExpectations('fakeHbaseConnection')
-  #fakeHbaseConnection.expect('hbaseThriftExceptions', (), {}, [], None)
   fakeHbaseConnection.expect('put_json_dump', ('uuid', jdict, expectedDumpResult), {"number_of_retries":2}, None, None)
 
   fakeHbaseModule = exp.DummyObjectWithExpectations('fakeHbaseModule')
@@ -256,8 +254,6 @@ def testCrashStorageSystemForHBase_save_2():
   j.logger = d.logger = util.SilentFakeLogger()
 
   fakeHbaseConnection = exp.DummyObjectWithExpectations('fakeHbaseConnection')
-  #fakeHbaseConnection.expect('hbaseThriftExceptions', (), {}, [], None)
-  #fakeHbaseConnection.expect('create_ooid', ('uuid', jdict, expectedDumpResult), {}, None, Exception())
   fakeHbaseConnection.expect('put_json_dump', ('uuid', jdict, expectedDumpResult), {"number_of_retries":2}, None, Exception())
 
   fakeHbaseModule = exp.DummyObjectWithExpectations('fakeHbaseModule')
@@ -308,7 +304,6 @@ def testCrashStorageSystemForHBase_save_3():
   d.logger = util.SilentFakeLogger()
 
   fakeHbaseConnection = exp.DummyObjectWithExpectations('fakeHbaseConnection')
-  #fakeHbaseConnection.expect('hbaseThriftExceptions', (), {}, [], None)
   fakeHbaseConnection.expect('put_json_dump', ('uuid', jdict, expectedDumpResult), {"number_of_retries":2}, None, Exception())
 
   fakeHbaseModule = exp.DummyObjectWithExpectations('fakeHbaseModule')
@@ -349,7 +344,6 @@ def testCrashStorageSystemForHBase_save_4():
   d.logger = util.SilentFakeLogger()
 
   fakeHbaseConnection = exp.DummyObjectWithExpectations('fakeHbaseConnection')
-  #fakeHbaseConnection.expect('hbaseThriftExceptions', (), {}, [], None)
   fakeHbaseConnection.expect('put_json_dump', ('uuid', jdict, expectedDumpResult), {"number_of_retries":2}, None, hbc.NoConnectionException(Exception()))
 
   fakeHbaseModule = exp.DummyObjectWithExpectations('fakeHbaseModule')
@@ -410,8 +404,6 @@ def testCrashStorageForDualHbaseCrashStorageSystem01():
   j.logger = d.logger = util.SilentFakeLogger()
   fakeHbaseConnection1 = exp.DummyObjectWithExpectations('fakeHbaseConnection1')
   fakeHbaseConnection2 = exp.DummyObjectWithExpectations('fakeHbaseConnection2')
-  #fakeHbaseConnection1.expect('hbaseThriftExceptions', (), {}, [], None)
-  #fakeHbaseConnection2.expect('hbaseThriftExceptions', (), {}, [], None)
   fakeHbaseConnection1.expect('get_json', ('fakeOoid1',), {'number_of_retries':2}, 'fake_json1')
   import socorro.storage.hbaseClient as hbc
   fakeHbaseConnection1.expect('get_json', ('fakeOoid2',), {'number_of_retries':2}, None, hbc.OoidNotFoundException())
@@ -423,7 +415,6 @@ def testCrashStorageForDualHbaseCrashStorageSystem01():
   fakeHbaseModule.expect('HBaseConnectionForCrashReports', (d.secondaryHbaseHost, d.secondaryHbasePort, d.secondaryHbaseTimeout), {"logger":d.logger}, fakeHbaseConnection2, None)
   fakeHbaseModule.expect('hbaseThriftExceptions', None, None, (), None)
   fakeHbaseModule.expect('NoConnectionException', None, None, hbc.NoConnectionException, None)
-  #fakeHbaseModule.expect('OoidNotFoundException', (), {}, hbc.OoidNotFoundException)
   fakeJsonDumpStore = exp.DummyObjectWithExpectations('fakeJsonDumpStore')
   fakeJsonDumpModule = exp.DummyObjectWithExpectations('fakeJsonDumpModule')
   fakeJsonDumpModule.expect('JsonDumpStorage', (), j, fakeJsonDumpStore, None)


### PR DESCRIPTION
Changed the crash storage component for HBase to properly return RETRY for NoConnectionExceptions.
Added unittest to test this behavior
