### PR TITLE
Skiplist changes for bug 691912:

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -198,6 +198,8 @@ prefixSignatureRegEx = '|'.join([
   'mozilla::ipc::RPCChannel::Call',
   'RtlDeleteCriticalSection',
   'PR_DestroyLock',
+  '.*abort',
+  '_ZdaPvRKSt9nothrow_t\"', 
   ])
 
 signaturesWithLineNumbersRegEx = cm.Option()


### PR DESCRIPTION
Add .*abort
Add _ZdaPvRKSt9nothrow_t\" (which is a mangled version of
    operator delete[](void*, std::nothrow_t const&)
