### PR TITLE
Bug692833 - added searchRoot to orphansubmitter

### DIFF
--- a/scripts/config/orphansubmitterconf.py.dist
+++ b/scripts/config/orphansubmitterconf.py.dist
@@ -2,17 +2,6 @@ import stat
 import socorro.lib.ConfigurationManager as cm
 
 #-------------------------------------------------------------------------------
-# general
-
-numberOfThreads = cm.Option()
-numberOfThreads.doc = 'the number of threads to use'
-numberOfThreads.default = 4
-
-dryrun = cm.Option()
-dryrun.doc = "if True, don't actually move things into destination"
-dryrun.default = False
-
-#-------------------------------------------------------------------------------
 # source storage
 
 sourceStorageClass = cm.Option()
@@ -45,6 +34,21 @@ destinationStorageClass.fromStringConverter = cm.classConverter
 from config.commonconfig import hbaseHost
 from config.commonconfig import hbasePort
 from config.commonconfig import hbaseTimeout
+
+#-------------------------------------------------------------------------------
+# general
+
+searchRoot = cm.Option()
+searchRoot.doc = 'the file system root at which to start the orphan search'
+searchRoot.default = localFS.default
+
+numberOfThreads = cm.Option()
+numberOfThreads.doc = 'the number of threads to use'
+numberOfThreads.default = 4
+
+dryrun = cm.Option()
+dryrun.doc = "if True, don't actually move things into destination"
+dryrun.default = False
 
 #-------------------------------------------------------------------------------
 # logging

--- a/socorro/storage/orphans.py
+++ b/socorro/storage/orphans.py
@@ -25,7 +25,7 @@ def move (conf,
     yielding the ooids of every new entry in the filelsystem.  If there
     are no new entries, it yields None"""
     destinationCrashStore = crashStoragePoolForDest.crashStorage()
-    for dir,dirs,files in os.walk(conf.localFS):
+    for dir,dirs,files in os.walk(conf.searchRoot):
       print dir, files
       for aFile in files:
         if aFile.endswith('json'):


### PR DESCRIPTION
The orphan submitter currently searches the entire local data file system for orphans.  This means that it can interfere with the crashmover in an active system.  By adding a feature where the orphan submitter can target a specific directory, the interference can be ameliorated.
