### PR TITLE
bug 637661 - split query into release/non-release, use timestamp instead 

### DIFF
--- a/socorro/services/hangReport.py
+++ b/socorro/services/hangReport.py
@@ -27,7 +27,7 @@ class HangReport(webapi.JsonServiceBase):
           FROM hang_report
           WHERE product = %(product)s
           AND version = %(version)s
-          AND report_day > utc_day_begins_pacific(((%(end)s)::timestamp - interval '%(duration)s days')::date)
+          AND date_processed > utc_day_begins_pacific(((%(end)s)::timestamp - interval '%(duration)s days')::date)
     """
 
     logger.debug(cursor.mogrify(hangReportCountSql, parameters))
@@ -46,13 +46,14 @@ class HangReport(webapi.JsonServiceBase):
           /* socorro.services.HangReport */
           SELECT browser_signature, plugin_signature, 
                  browser_hangid, flash_version, url,
-                 uuid, duplicates, report_day
+                 uuid, duplicates, date_processed
           FROM hang_report
           WHERE product = %(product)s
           AND version = %(version)s
-          AND report_day > utc_day_begins_pacific(((%(end)s)::timestamp - interval '%(duration)s days')::date)
+          AND date_processed > utc_day_begins_pacific(((%(end)s)::timestamp - interval '%(duration)s days')::date)
           LIMIT %(listsize)s
-          OFFSET %(offset)s"""
+          OFFSET %(offset)s
+          ORDER BY date_processed"""
   
     logger.debug(cursor.mogrify(hangReportSql, parameters))
     cursor.execute(hangReportSql, parameters)
@@ -60,7 +61,7 @@ class HangReport(webapi.JsonServiceBase):
     result = []
     for row in cursor.fetchall():
       (browser_signature, plugin_signature, browser_hangid, flash_version,
-       url, uuid, duplicates, report_day) = row
+       url, uuid, duplicates, date_processed) = row
       result.append({'browser_signature': browser_signature,
                      'plugin_signature': plugin_signature,
                      'browser_hangid': browser_hangid,
@@ -68,6 +69,6 @@ class HangReport(webapi.JsonServiceBase):
                      'url': url,
                      'uuid': uuid,
                      'duplicates': duplicates,
-                     'report_day': str(report_day)})
+                     'date_processed': str(date_processed)})
     return {'hangReport': result, 'endDate': str(parameters['end']), 'totalPages': totalPages, 'currentPage': page,
             'totalCount': hangReportCount}

--- a/sql/upgrade/2.3/hang_report.sql
+++ b/sql/upgrade/2.3/hang_report.sql
@@ -6,10 +6,11 @@ CREATE TABLE hang_report(
     browser_hangid TEXT,
     flash_version TEXT,
     url TEXT,
-    uuid TEXT,
+    uuid TEXT PRIMARY KEY,
     duplicates TEXT[],
-    report_day DATE);
+    report_day TIMESTAMP WITHOUT TIME ZONE);
 
+CREATE INDEX hang_report_report_day ON hang_report (report_day);
 GRANT ALL ON hang_report TO breakpad_rw;
 ALTER TABLE hang_report OWNER TO breakpad_rw;
 
@@ -22,6 +23,7 @@ CREATE OR REPLACE FUNCTION update_hang_report(updateday DATE) RETURNS BOOLEAN
     -- daily batch update function for hang/crash pair report
     -- created for bug 637661
 
+    -- release channel
     INSERT INTO hang_report (
         SELECT DISTINCT
             product_name AS product,
@@ -37,7 +39,7 @@ CREATE OR REPLACE FUNCTION update_hang_report(updateday DATE) RETURNS BOOLEAN
                 FROM reports_duplicates AS dups
                 WHERE browser.uuid = dups.uuid
             ) AS duplicates,
-            updateday AS report_day
+            browser.date_processed AS report_day
         FROM reports AS browser
         JOIN reports AS plugin ON plugin.hangid = browser.hangid
         JOIN product_version_builds AS pvb
@@ -45,12 +47,59 @@ CREATE OR REPLACE FUNCTION update_hang_report(updateday DATE) RETURNS BOOLEAN
         JOIN product_versions AS pv
           ON pvb.product_version_id = pv.product_version_id
         WHERE plugin.signature LIKE 'hang | %'
+        AND pv.build_type = 'Release'
+        AND browser.release_channel NOT IN ('nightly', 'aurora', 'beta')
         AND browser.hangid != ''
         AND browser.process_type IS NULL
         AND plugin.process_type = 'plugin'
         AND browser.signature != plugin.signature
-        AND browser.date_processed > utc_day_begins_pacific(updateday)
+        AND browser.date_processed >= utc_day_begins_pacific(updateday)
         AND browser.date_processed < utc_day_ends_pacific(updateday)
+        AND plugin.date_processed >= utc_day_begins_pacific(updateday - 1)
+        AND plugin.date_processed < utc_day_ends_pacific(updateday + 1)
+    );
+
+    -- beta channel
+    INSERT INTO hang_report (
+        SELECT DISTINCT
+            product_name AS product,
+            version_string AS version,
+            browser.signature AS browser_signature,
+            plugin.signature AS plugin_signature,
+            browser.hangid AS browser_hangid,
+            plugin.flash_version AS flash_version,
+            browser.url AS url,
+            browser.uuid AS uuid,
+            ARRAY(
+                SELECT dups.uuid
+                FROM reports_duplicates AS dups
+                WHERE browser.uuid = dups.uuid
+            ) AS duplicates,
+            browser.date_processed AS report_day
+        FROM reports AS browser
+        JOIN reports AS plugin ON plugin.hangid = browser.hangid
+        JOIN product_version_builds AS pvb
+          ON browser.build::NUMERIC = pvb.build_id
+        JOIN product_versions AS pv
+          ON pv.release_version = browser.version
+        WHERE plugin.signature LIKE 'hang | %'
+        AND browser.product = plugin.product
+        AND browser.product = pv.product_name
+        AND browser.release_channel IN ('nightly', 'aurora', 'beta')
+        AND pv.build_type != 'Release'
+        AND EXISTS (
+            SELECT 1
+            FROM product_version_builds AS pvb
+            WHERE pv.product_version_id = pvb.product_version_id
+            AND browser.build::NUMERIC = pvb.build_id)
+        AND browser.hangid != ''
+        AND browser.process_type IS NULL
+        AND plugin.process_type = 'plugin'
+        AND browser.signature != plugin.signature
+        AND browser.date_processed >= utc_day_begins_pacific(updateday)
+        AND browser.date_processed < utc_day_ends_pacific(updateday)
+        AND plugin.date_processed >= utc_day_begins_pacific(updateday - 1)
+        AND plugin.date_processed < utc_day_ends_pacific(updateday + 1)
     );
 
     ANALYZE hang_report;

--- a/webapp-php/application/views/hangreport/byversion.php
+++ b/webapp-php/application/views/hangreport/byversion.php
@@ -41,7 +41,7 @@ if (false) {
 }
 ?>
           <th class="header">OOID</th>
-          <th class="header">Report Day</th>
+          <th class="header">Date Processed</th>
         </tr>
       </thead>
       <tbody>
@@ -88,7 +88,7 @@ if ($resp) {
             <a href="<?php out::H($uuid_link_url)?>"><?php out::H($entry->uuid) ?></a>
           </td>
           <td>
-            <?php out::H($entry->report_day) ?>
+            <?php out::H($entry->date_processed) ?>
           </td>
         </tr>
 <?php


### PR DESCRIPTION
bug 637661 - split query into release/non-release, use timestamp instead of date so we can sort
