### PR TITLE
bug 684112 - disable releases for old scraper

### DIFF
--- a/scripts/startBuilds.py
+++ b/scripts/startBuilds.py
@@ -37,6 +37,7 @@ config.logger = logger
 
 try:
   builds.recordNightlyBuilds(config)
-  builds.recordReleaseBuilds(config)
+  # replaced by ftpscraper.py
+  #builds.recordReleaseBuilds(config)
 finally:
   logger.info("Done.")


### PR DESCRIPTION
Unfortunately not ready to drop this scraper completely until we get the "Nightly Builds" report moved over to releases_raw, but this will prevent both scrapers from writing to releases_raw in the meantime.
