### PR TITLE
bug 678796 - disable failing unit test

### DIFF
--- a/socorro/unittest/cron/testTopCrashesBySignature.py
+++ b/socorro/unittest/cron/testTopCrashesBySignature.py
@@ -283,7 +283,9 @@ class TestTopCrashesBySignature(unittest.TestCase):
     tc = topcrasher.TopCrashesBySignature(me.config)
     expectedStart = now.replace(hour=0,minute=0,second=0,microsecond=0) - tc.configContext.get('initialDeltaDate',dt.timedelta(days=4))
     expectedEnd = now.replace(hour=0,minute=0,second=0,microsecond=0)
-    assert expectedStart == tc.startDate
+    # this doesn't work around midnight ~2am Pacific
+    # see bug 678796
+    #assert expectedStart == tc.startDate
     assert tc.endDate <= now, 'But NOT %s <= %s'%(tc.endDate,now)
     assert dt.timedelta(days=4) <= tc.deltaDate, 'But got %s'%(tc.deltaDate)
     # Check for defaults. If the defaults are hard-code changed, this block needs equivalent changes


### PR DESCRIPTION
Disabled this per meeting - old TCBS is going to be gone for everything except Camino as of 2.3.1
