### PR TITLE
Bug 694345 - Implement signature generation for single-process hangs

### DIFF
--- a/socorro/processor/signatureUtilities.py
+++ b/socorro/processor/signatureUtilities.py
@@ -1,5 +1,9 @@
 import re
 
+hang_prefixes = { -1: "hang",
+                   1: "chromehang"
+                }
+
 #===============================================================================
 class SignatureUtilities (object):
     _config_requirements = ("irrelevantSignatureRegEx",
@@ -54,7 +58,7 @@ class SignatureUtilities (object):
     #---------------------------------------------------------------------------
     def generate_signature_from_list(self,
                                      signatureList,
-                                     isHang=False,
+                                     hangType=0,
                                      escapeSingleQuote=True,
                                      maxLen=255,
                                      signatureDelimeter=' | '):
@@ -91,9 +95,9 @@ class SignatureUtilities (object):
             newSignatureList.append(aSignature)
             if not self.prefixSignatureRegEx.match(aSignature):
                 break
+        if hangType:
+            newSignatureList.insert(0, hang_prefixes[hangType])
         signature = signatureDelimeter.join(newSignatureList)
-        if isHang:
-            signature = "hang | %s" % signature
         if len(signature) > maxLen:
             signature = "%s..." % signature[:maxLen - 3]
         if escapeSingleQuote:

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -829,7 +829,7 @@ def testProcessJob07():
                                              (reportId,
                                               ooid1,
                                               dump_pathname,
-                                              True,
+                                              -1,
                                               c.fakeCursor,
                                               date_processed,
                                               proc_err_msg_list),

--- a/socorro/unittest/processor/testSignatureUtilities.py
+++ b/socorro/unittest/processor/testSignatureUtilities.py
@@ -90,12 +90,22 @@ def testGenerate2():
     s, c = setupSigUtil('a|b|c', 'd|e|f')
     a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
     e = 'hang | d | e | f | g'
-    r = s.generate_signature_from_list(a, isHang=True)
+    r = s.generate_signature_from_list(a, hangType=-1)
     assert_expected(e,r)
 
     a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
     e = 'hang | d | e | f | g'
-    r = s.generate_signature_from_list(a, isHang=True)
+    r = s.generate_signature_from_list(a, hangType=-1)
+    assert_expected(e,r)
+
+    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+    e = 'd | e | f | g'
+    r = s.generate_signature_from_list(a, hangType=0)
+    assert_expected(e,r)
+
+    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+    e = 'chromehang | d | e | f | g'
+    r = s.generate_signature_from_list(a, hangType=1)
     assert_expected(e,r)
 
 
@@ -118,7 +128,7 @@ def testGenerate2():
         "ddddddddd | eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" \
         "eeeeeeeeeeeeee | fffffffffffffffffffffffffffffffffffffffffffffffffff" \
         "fffffffffffffffffff | gggggggggggggggggggggggggg..."
-    r = s.generate_signature_from_list(a, isHang=True)
+    r = s.generate_signature_from_list(a, hangType=-1)
     assert_expected(e,r)
 
 def testGenerate3():


### PR DESCRIPTION
added the new "chromehang" for all crashes that have Hang=1 in the meta data json.

fixed misbehaving unit tests
fixed incorrect comment
made sure that Hang is interpretted as an int.
