### PR TITLE
bug 695928 cleanup daily.js to fix graph colours

### DIFF
--- a/webapp-php/js/socorro/daily.js
+++ b/webapp-php/js/socorro/daily.js
@@ -1,118 +1,101 @@
-var chartOpts;
-$(document).ready(function() {
-  chartOpts = {
-    xaxis: {
-      mode: 'time',
-      timeformat: "%b %d",
-      minTickSize: [1, "day"],
-      },
-    yaxis: {},
-    series: {
-      lines: { show: true },
-      points: { show: false },
-      shadowSize: 0,
-      },
-    // colors: [ '#058DC7', '#ED561B', '#50B432', '#990099'],
-    grid: {
-      color: '#606060',
-      backgroundColor: '#ffffff',
-      borderColor: '#c0c0c0',
-      borderWidth: 0
-      },
-    legend: {}
-  };
+$(function() {
+    var colours = ['#058DC7', '#ED561B', '#50B432', '#990099'], 
+        chartOpts = {
+            xaxis: {
+              mode: 'time',
+              timeformat: "%b %d",
+              minTickSize: [1, "day"],
+            },
+            yaxis: {},
+            series: {
+                lines: { show: true },
+                points: { show: false },
+                shadowSize: 0,
+            },
+            colors: colours,
+            grid: {
+                color: '#606060',
+                backgroundColor: '#ffffff',
+                borderColor: '#c0c0c0',
+                borderWidth: 0
+            },
+            legend: {}
+        };
 
-  if (window.socGraphByReportType === true) {
-      //$.plot($("#adu-chart"), data, chartOpts);
-
-    $('#adu-chart-controls button').click(function() {
-      var currentData = [];
-      for (var i=0; i < data.length; i++) {
-        if ($('input[name=graph_data_' + i + ']').attr('checked')) {
-          currentData.push(data[i]);
-        }
-      }
-      $.plot($("#adu-chart"), currentData, chartOpts);
-      return false;
-    }).trigger('click');
-  } else {
-    chartOpts['colors'] = [ '#058DC7', '#ED561B', '#50B432', '#990099'];
-    chartOpts['legend'] = {};
-    try {
-      var chartData = [
-        { data: data.ratio1 },
-        { data: data.ratio2 },
-        { data: data.ratio3 },
-      { data: data.ratio4 }
-      ];
-
-      $(document).ready(function() {
+    if (window.socGraphByReportType === true) {
+        $('#adu-chart-controls button').click(function() {
+            var currentData = [];
+            for (var i=0; i < data.length; i++) {
+                if ($('input[name=graph_data_' + i + ']').attr('checked')) {
+                    currentData.push(data[i]);
+                }
+            }
+            $.plot($("#adu-chart"), currentData, chartOpts);
+            return false;
+        }).trigger('click');
+    } else {
+        var chartData = [
+            { data: data.ratio1 },
+            { data: data.ratio2 },
+            { data: data.ratio3 },
+            { data: data.ratio4 }
+        ];
         $.plot($("#adu-chart"), chartData, chartOpts);
-      });
-     } catch(err) {
-         if (window.console) { console.error(err); }
-     }
+    }
 
-  }
-
-  $("#click_by_version").bind("click", function(){
-    showHideDaily("daily_search_version_form");
-  });
-
-  $("#click_by_os").bind("click", function(){
-    showHideDaily("daily_search_os_form");
-  });
-
-  $("#click_by_report_type").bind("click", function(){
-    showHideDaily("daily_search_report_type_form");
-  });
-
-  $("#daily_search_version_form_products").change(function(){
-    var url_form = $("#daily_search_version_form").attr('action');
-    var product = $(this).find(":selected").val();
-    var url = url_form + '?p=' + product;
-    window.location = url;
-  });
-
-  $("#daily_search_os_form_products").change(function(){
-    var url_form = $("#daily_search_os_form").attr('action');
-    var product = $(this).find(":selected").val();
-    var url = url_form + '?p=' + product;
-    window.location = url;
-  });
-
-  for (i=0; i<=8; i++){
-    $("#version"+i).change(function(){
-      var key = $(this).find(":selected").attr('key');
-      var throttle_default = $(this).find(":selected").attr('throttle');
-      $("#throttle"+key).val(throttle_default);
+    $("#click_by_version").bind("click", function() {
+        showHideDaily("daily_search_version_form");
     });
-  }
-  
-	var datepickerDaily = $(".datepicker-daily").length;
-  
-	if(datepickerDaily > 0) {
-		$(".datepicker-daily input").datepicker({
-			dateFormat: "yy-mm-dd"
-		});
-	}
 
-});
+    $("#click_by_os").bind("click", function() {
+        showHideDaily("daily_search_os_form");
+    });
 
-$("#adu-chart").ready(function(){
-  var colors = chartOpts['colors'] || [ '#058DC7', '#ED561B', '#50B432', '#990099'];
-  $('h4').each(function(){
-    $(this).css('color',colors.shift())
-  })
-  $('th.version').each(function(){
-    $(this).css('color',colors.shift())
-  })
+    $("#click_by_report_type").bind("click", function() {
+        showHideDaily("daily_search_report_type_form");
+    });
+
+    $("#daily_search_version_form_products").change(function() {
+        var url_form = $("#daily_search_version_form").attr('action'),
+            product = $(this).find(":selected").val(),
+            url = url_form + '?p=' + product;
+        window.location = url;
+    });
+
+    $("#daily_search_os_form_products").change(function() {
+        var url_form = $("#daily_search_os_form").attr('action'),
+            product = $(this).find(":selected").val(),
+            url = url_form + '?p=' + product;
+        window.location = url;
+    });
+
+    for (i=0; i<=8; i++) {
+        $("#version"+i).change(function() {
+            var key = $(this).find(":selected").attr('key'),
+                throttle_default = $(this).find(":selected").attr('throttle');
+            $("#throttle"+key).val(throttle_default);
+        });
+    }
+
+    $('h4').each(function() {
+        $(this).css('color', colours.shift());
+    });
+
+    $('th.version').each(function() {
+        $(this).css('color', colours.shift());
+    });
+
+    if ($(".datepicker-daily").length) {
+        $(".datepicker-daily input").datepicker({
+            dateFormat: "yy-mm-dd"
+        });
+    }
 });
 
 function showHideDaily(id) {
-  $("#daily_search_version_form").hide();
-  $("#daily_search_os_form").hide();
-  $("#daily_search_report_type_form").hide();
-  $("#"+id).show("fast");
+    $("#daily_search_version_form").hide();
+    $("#daily_search_os_form").hide();
+    $("#daily_search_report_type_form").hide();
+    $("#"+id).show("fast");
 }
 


### PR DESCRIPTION
The actual bug fix got rolled up with the formatting when I diffed it to get it out, so here's the highlights:

Bring all the color-related code into the document ready function. Create a single array of color values, use that to provide colors for the headers and the colors in the graphs.

You can see this in the first few lines, where the chart opts are brought into the ready function and the color values are defined independently of the opts. The rest of the bug fix is at the end, where the table header coloring code has been moved into the primary ready event. Instead of waiting for a ready event to be fired from the graph, it will just execute sequentially after the plot function is called.
