### PR TITLE
bug 684112 - reinstate old release scraper until new DB changes are ready

### DIFF
--- a/scripts/startBuilds.py
+++ b/scripts/startBuilds.py
@@ -37,7 +37,6 @@ config.logger = logger
 
 try:
   builds.recordNightlyBuilds(config)
-  # replaced by ftpscraper.py
-  #builds.recordReleaseBuilds(config)
+  builds.recordReleaseBuilds(config)
 finally:
   logger.info("Done.")


### PR DESCRIPTION
This is needed for today's 2.3.1 release so please merge to 2.3.1 branch too
