### PR TITLE
Skiplist 2.3.2

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -107,7 +107,8 @@ signatureSentinels.doc = 'a list of frame signatures that should always be consi
 signatureSentinels.default = ['_purecall',
                               ('mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)',
                                   lambda x: 'CrashReporter::CreatePairedMinidumps(void*, unsigned long, nsAString_internal*, nsILocalFile**, nsILocalFile**)' in x),
-                              'Java_org_mozilla_gecko_GeckoAppShell_reportJavaCrash']
+                              'Java_org_mozilla_gecko_GeckoAppShell_reportJavaCrash',
+                              'google_breakpad::ExceptionHandler::HandleInvalidParameter(wchar_t const*,wchar_t const*,wchar_t const*,unsigned int,unsigned int)']
 
 irrelevantSignatureRegEx = cm.Option()
 irrelevantSignatureRegEx.doc = 'a regular expression matching frame signatures that should be ignored when generating an overall signature'


### PR DESCRIPTION
Fixes bug 695791, fixes bug 695096, fixes bug 695082.

Add __swrite, dvmAbort, and JNI_CreateJavaVM to the prefix list
Add a new sentinel to the list, to wit 
google_breakpad::ExceptionHandler::HandleInvalidParameter(wchar_t const_,wchar_t const_,wchar_t const*,unsigned int,unsigned int)
