### PR TITLE
Bug 680013 - Users received a 404 error when clicking on a crash report t

### DIFF
--- a/webapp-php/application/controllers/report.php
+++ b/webapp-php/application/controllers/report.php
@@ -374,8 +374,12 @@ class Report_Controller extends Controller {
 
 	$report = $this->report_model->getByUUID($uuid, $crash_uri);
 
+    $uuid_timestamp = $this->report_model->uuidTimestamp($id);
+
         if ( is_bool($report) && $report == true) {
 	    return url::redirect('report/pending/'.$uuid);
+        } else if ( date('n/j/Y', $uuid_timestamp) == date('n/j/Y')) {
+            return url::redirect('report/pending/'.$uuid);
         } else if ( (is_bool($report) && $report == false) || is_null($report) ) {
             $this->setView('report/notfound');
             $this->setViewData(


### PR DESCRIPTION
Bug 680013 - Users received a 404 error when clicking on a crash report that had just been submitted or was being submitted. This fixes that bug.
