### PR TITLE
fixes Bug 701202 - empty sig, uncaught exception

### DIFF
--- a/socorro/processor/externalProcessor.py
+++ b/socorro/processor/externalProcessor.py
@@ -171,7 +171,7 @@ class ProcessorWithExternalBreakpad (processor.Processor):
         reportUpdateSqlParts.extend(['reason = %(reason)s','address = %(address)s'])
         try:
           crashedThread = int(values[3])
-        except (ValueError, IndexError):
+        except Exception:
           crashedThread = None
       elif values[0] == 'Module':
         # grab only the flash version, which is not quite as easy as it looks


### PR DESCRIPTION
there was a line in the interpretation of MDSW output that explicitly caught two exceptions IndexError and ValueError.  Well, it turns out that if the index item were None, it raises a TypeError.  Since the enclosing try block includes just the one line, I changed it to catch all exceptions.  

This fix was tested with a crash that was known to trigger the error.
