### PR TITLE
Skiplist 2.3.3

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -207,6 +207,7 @@ prefixSignatureRegEx = '|'.join([
   '__swrite',
   'dvmAbort',
   'JNI_CreateJavaVM',
+  'dvmStringLen',
   ])
 
 signaturesWithLineNumbersRegEx = cm.Option()


### PR DESCRIPTION
Fixes bug 700463, add dvmStringLen to the prefix skiplist
Fixes bug 701503, add 'libicudata.so@.*' to the skiplist as irrelevantSignatureRegEx
