### PR TITLE
copied to match the layout page

### DIFF
--- a/webapp-php/application/views/kohana_error_page.php
+++ b/webapp-php/application/views/kohana_error_page.php
@@ -89,8 +89,8 @@
     		</div>
     		<ul>
                 <li><a href="<?php echo url::base() ?>status">Server Status</a></li>
-                <li><a href="http://code.google.com/p/socorro/">Project Info</a></li>
-                <li><a href="http://code.google.com/p/socorro/source">Source Code</a></li>
+                <li><a href="http://socorro.readthedocs.org/">Project Info</a></li>
+                <li><a href="https://github.com/mozilla/socorro">Source Code</a></li>
                 <li><a href="http://wiki.mozilla.org/Breakpad">Breakpad Wiki</a></li>
                 <li><a href="http://www.mozilla.org/about/policies/privacy-policy.html">Privacy Policy</a></li>
     		</ul>


### PR DESCRIPTION
The error page has duplicate code due to the design of the framework. This mirrors the recent changes to layout.php to remove references to our old svn system.
