### PR TITLE
Bug 710570 - server page refresh

### DIFF
--- a/webapp-php/application/controllers/status.php
+++ b/webapp-php/application/controllers/status.php
@@ -56,7 +56,7 @@ class Status_Controller extends Controller {
      */
     public function index() {
         $server_status_model = new Server_Status_Model();
-        $serverStats = $server_status_model->loadStats();
+        $serverStats = $server_status_model->getStats();
         cachecontrol::set(array(
             'last-modified' => time(),
             'expires' => time() + (120) // 120 seconds
@@ -65,9 +65,8 @@ class Status_Controller extends Controller {
         $product = $this->chosen_version['product'];
 
         $this->setViewData(array(
-            'server_stats'            => $serverStats->data,
-            'plotData'                => $serverStats->getPlotData(),
-            'status'                  => $serverStats->status(),
+            'server_stats'            => $serverStats['data'],
+            'plotData'                => $serverStats['plotData'],
             'url_base'                => url::site('products/'.$product),
             'url_nav'                 => url::site('products/'.$product)
         ));

--- a/webapp-php/application/models/server_status.php
+++ b/webapp-php/application/models/server_status.php
@@ -5,40 +5,16 @@
  */
 class Server_Status_Model extends Model {
 
-  public function loadStats(){
-    return new Server_Stats( $this->fetchRows("/* soc.web servstat.loadStat */ SELECT * FROM server_status ORDER BY date_created DESC LIMIT 12") );
-  }
-
-}
-
-/**
- * Represents a snapshot across time of the Socorro servers health.
- */
-class Server_Stats {
-  const HAPPY   = 'happy';
-  const GRUMPY  = 'grumpy';
-  const DEATHLY = 'deathly';
-
-  public $data;
-
-  /**
-   * data - An array where each element is an associative arrays
-   * which has server statistics including:
-   * avg_process_sec, avg_wait_sec, waiting_job_count, etc
-   */
-  public function __construct($data){
-    $this->data = $data;
-  }
-
-  public function getPlotData(){
+  public function getStats() {
+    $data = $this->fetchRows("/* soc.web servstat.loadStat */ SELECT * FROM server_status ORDER BY date_created DESC LIMIT 12");
     $plotData = array();
     foreach( array('avg_process_sec', 'avg_wait_sec', 'waiting_job_count', 'processors_count',
                        'xaxis_ticks') as $field){
       $plotData[$field] = array();
     }
-    $k = count($this->data) - 1;
-    for($i = 0; $i < count($this->data); $i += 1){
-      $stat = $this->data[$i];
+    $k = count($data) - 1;
+    for($i = 0; $i < count($data); $i += 1){
+      $stat = $data[$i];
       $plotData['avg_process_sec'][] = array($k, $stat->avg_process_sec);
       $plotData['avg_wait_sec'][] = array($k, $stat->avg_wait_sec);
       $plotData['waiting_job_count'][] = array($k, $stat->waiting_job_count);
@@ -46,18 +22,8 @@ class Server_Stats {
       $plotData['xaxis_ticks'][] = array($k, date('G:i', strtotime($stat->date_created)));
       $k -= 1;
     }
-    return $plotData;
+    return array( 'data' => $data, 'plotData' => $plotData );
   }
-  public function status(){
-    $stat = $this->data[0];
 
-    if( $stat->avg_wait_sec < 300 ){
-      return Server_Stats::HAPPY;
-    }elseif( $stat->avg_wait_sec < 600 ){
-      return Server_Stats::GRUMPY;
-    }else{
-      return Server_Stats::DEATHLY;
-    }
-  }
 }
 ?>

--- a/webapp-php/css/screen.css
+++ b/webapp-php/css/screen.css
@@ -1332,15 +1332,6 @@ th.bugzilla_numbers {
     max-width: 100%;
 }
 
-
-/**
- * Server Status Page
-*/
-
-#toc {
-    margin-left: 10px;
-}
-
 #buildid-graph{
     width: 600px; 
 	height: 200px;
@@ -1365,22 +1356,21 @@ th.bugzilla_numbers {
 	font-weight: bold;
 }
 
-#server-status-graph-comb,
-#server-status-graph-jobs-wait,
-#server-status-graph-proc-count,
-#server-status-graph-avg-proc,
-#server-status-graph-avg-wait {
-    width: 800px;
-    height: 300px;
+/**
+ * Server Status Page
+ */
+.server-status-graph + .server-status-graph {
+    margin: 16px 4px 4px 4px;
 }
 
-#server-status-graph-comb,
-#server-status-graph-jobs-wait,
-#server-status-graph-proc-count,
-#server-status-graph-avg-proc,
-#server-status-graph-avg-wait {
-    width: 800px;
-    height: 300px;
+.server-status-graph > div {
+    width: 100%;
+    height: 100px;
+}
+
+.server-status-graph > h2 {
+    font-size: 16px;
+    font-weight: bold;
 }
 
 table.server_status td {

--- a/webapp-php/js/socorro/server_status.js
+++ b/webapp-php/js/socorro/server_status.js
@@ -1,0 +1,52 @@
+$(function() {
+  var graphOpts = {
+    series: {
+      lines: {show: true},
+      points: {
+        radius: 1,
+        show: true,
+      }
+    },
+    legend: {},
+    xaxis: {
+      ticks: x_ticks,
+    },
+    yaxis: {
+      tickDecimals: 0,
+    },
+    grid: {
+      color: '#606060',
+      borderColor: '#c0c0c0',
+      borderWidth: 0,
+      minBorderMargin: 9,
+    },
+    colors: ["#058DC7"],
+    shadowSize: 0
+  };
+
+  $.plot(
+    $("#server-status-graph-jobs-wait"),
+    [{ data: waiting_job_count }],
+    graphOpts
+  );
+
+  $.plot(
+    $("#server-status-graph-proc-count"),
+    [{ data: processors_count }],
+    graphOpts
+  );
+
+  $.plot(
+    $("#server-status-graph-avg-proc"),
+    [{ data: avg_process_sec }],
+    graphOpts
+  );
+
+  $.plot(
+    $("#server-status-graph-avg-wait"),
+    [{ data: avg_wait_sec }],
+    graphOpts
+  );
+  $('#server-stats-table').tablesorter();
+  $('abbr.timeago').timeago();
+});

--- a/webapp-php/js/timeago/jquery.timeago.js
+++ b/webapp-php/js/timeago/jquery.timeago.js
@@ -1,0 +1,16 @@
+/*
+ * timeago: a jQuery plugin, version: 0.9.3 (2011-01-21)
+ * @requires jQuery v1.2.3 or later
+ *
+ * Timeago is a jQuery plugin that makes it easy to support automatically
+ * updating fuzzy timestamps (e.g. "4 minutes ago" or "about 1 day ago").
+ *
+ * For usage and examples, visit:
+ * http://timeago.yarp.com/
+ *
+ * Licensed under the MIT:
+ * http://www.opensource.org/licenses/mit-license.php
+ *
+ * Copyright (c) 2008-2011, Ryan McGeary (ryanonjavascript -[at]- mcgeary [*dot*] org)
+ */
+(function(d){d.timeago=function(g){if(g instanceof Date){return a(g)}else{if(typeof g==="string"){return a(d.timeago.parse(g))}else{return a(d.timeago.datetime(g))}}};var f=d.timeago;d.extend(d.timeago,{settings:{refreshMillis:60000,allowFuture:false,strings:{prefixAgo:null,prefixFromNow:null,suffixAgo:"ago",suffixFromNow:"from now",seconds:"less than a minute",minute:"about a minute",minutes:"%d minutes",hour:"about an hour",hours:"about %d hours",day:"a day",days:"%d days",month:"about a month",months:"%d months",year:"about a year",years:"%d years",numbers:[]}},inWords:function(l){var m=this.settings.strings;var i=m.prefixAgo;var q=m.suffixAgo;if(this.settings.allowFuture){if(l<0){i=m.prefixFromNow;q=m.suffixFromNow}l=Math.abs(l)}var o=l/1000;var g=o/60;var n=g/60;var p=n/24;var j=p/365;function h(r,t){var s=d.isFunction(r)?r(t,l):r;var u=(m.numbers&&m.numbers[t])||t;return s.replace(/%d/i,u)}var k=o<45&&h(m.seconds,Math.round(o))||o<90&&h(m.minute,1)||g<45&&h(m.minutes,Math.round(g))||g<90&&h(m.hour,1)||n<24&&h(m.hours,Math.round(n))||n<48&&h(m.day,1)||p<30&&h(m.days,Math.floor(p))||p<60&&h(m.month,1)||p<365&&h(m.months,Math.floor(p/30))||j<2&&h(m.year,1)||h(m.years,Math.floor(j));return d.trim([i,k,q].join(" "))},parse:function(h){var g=d.trim(h);g=g.replace(/\.\d\d\d+/,"");g=g.replace(/-/,"/").replace(/-/,"/");g=g.replace(/T/," ").replace(/Z/," UTC");g=g.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2");return new Date(g)},datetime:function(h){var i=d(h).get(0).tagName.toLowerCase()==="time";var g=i?d(h).attr("datetime"):d(h).attr("title");return f.parse(g)}});d.fn.timeago=function(){var h=this;h.each(c);var g=f.settings;if(g.refreshMillis>0){setInterval(function(){h.each(c)},g.refreshMillis)}return h};function c(){var g=b(this);if(!isNaN(g.datetime)){d(this).text(a(g.datetime))}return this}function b(g){g=d(g);if(!g.data("timeago")){g.data("timeago",{datetime:f.datetime(g)});var h=d.trim(g.text());if(h.length>0){g.attr("title",h)}}return g.data("timeago")}function a(g){return f.inWords(e(g))}function e(g){return(new Date().getTime()-g.getTime())}document.createElement("abbr");document.createElement("time")}(jQuery));


### PR DESCRIPTION
splits the default graph into four smaller graphs, removes unhelpful fields, and makes some of the timestamps easier to process as you read. Also ~ 100 line less code than the current solution.
