### PR TITLE
Fixes Bug 710904 - refactors to not use setdefault

### DIFF
--- a/socorro/database/database.py
+++ b/socorro/database/database.py
@@ -180,37 +180,14 @@ class DatabaseConnectionPool(dict):
     self.logger = self.database.logger
 
   #-----------------------------------------------------------------------------------------------------------------
-  #def connectionWithoutTest(self, name=None):
   def connection(self, name=None):
     """Try to re-use this named connection, else create one and use that"""
     if not name:
       name = threading.currentThread().getName()
-    return self.setdefault(name, self.database.connection())
-
-  #-----------------------------------------------------------------------------------------------------------------
-  #def connection(self, name=None):
-    #"""Like connecionCursorPairNoTest, but test that the specified connection actually works"""
-    #connection = self.connectionWithoutTest(name)
-    #try:
-      #cursor = connection.cursor()
-      #cursor.execute("select 1")
-      #cursor.fetchall()
-      #return connection
-    #except psycopg2.Error:
-      ## did the connection time out?
-      #self.logger.info("%s - trying to re-establish a database connection", threading.currentThread().getName())
-      #try:
-        #del self[name]
-      #except KeyError:
-        #pass
-      #try:
-        #connection = self.connectionWithoutTest(name)
-        #cursor.execute("select 1")
-        #cursor.fetchall()
-        #return connection
-      #except Exception, x:
-        #self.logger.critical("%s - something's gone horribly wrong with the database connection", threading.currentThread().getName())
-        #raise CannotConnectToDatabase(x)
+    if name in self:
+      return self[name]
+    self[name] = self.database.connection()
+    return self[name]
 
   #-----------------------------------------------------------------------------------------------------------------
   def connectionCursorPair(self, name=None):


### PR DESCRIPTION
It seems that all Socorro code that uses internal database pooling (processor, monitor, middleware, etc) may be suffering a bug with that cause spurious unused database connections.  This bug has likely existed since 2008.

In socorro/database/database.py there is a connection pool that uses a dict as the cache for connections. It uses the setdefault dict method to see if there is named connection entry already existing. If not, the default value is a new connection.  However, Python doesn't short circuit the second parameter of the setdefault call if a connection is found.  That means that a new connection is made and then ignored each time a connection is fetched from the pool.

This fix eliminates the use of setdefault.  Included are new tests to make sure that the number of connection attempts is precisely what is expected.
