### PR TITLE
fixes Bug 722908 - Unbound local on failed database connection

### DIFF
--- a/socorro/monitor/monitor.py
+++ b/socorro/monitor/monitor.py
@@ -312,6 +312,7 @@ class Monitor (object):
       raise
     try:
       try:
+        databaseConnection = None
         while (True):
           databaseConnection, databaseCursor = self.getDatabaseConnectionPair()
           self.cleanUpDeadProcessors(databaseCursor)
@@ -344,15 +345,18 @@ class Monitor (object):
       except hbc.FatalException, x:
         logger.debug("somethings gone horribly wrong with HBase")
         socorro.lib.util.reportExceptionAndContinue(logger, loggingLevel=logging.CRITICAL)
-        databaseConnection.rollback()
+        if databaseConnection is not None:
+          databaseConnection.rollback()
         self.quit = True
       except (KeyboardInterrupt, SystemExit):
         logger.debug("outer detects quit")
-        databaseConnection.rollback()
+        if databaseConnection is not None:
+          databaseConnection.rollback()
         self.quit = True
         raise
     finally:
-      databaseConnection.close()
+      if databaseConnection is not None:
+        databaseConnection.close()
       logger.debug("standardLoop done.")
 
   #-----------------------------------------------------------------------------------------------------------------
@@ -423,6 +427,7 @@ class Monitor (object):
     #deferredSymLinkIndexPath = os.path.join(self.config.deferredStorageRoot, "index")
     try:
       try:
+        databaseConnection = None
         while (True):
           databaseConnection, databaseCursor = self.getDatabaseConnectionPair()
           try:
@@ -439,7 +444,8 @@ class Monitor (object):
           except hbc.FatalException:
             raise
           except:
-            databaseConnection.rollback()
+            if databaseConnection is not None:
+              databaseConnection.rollback()
             socorro.lib.util.reportExceptionAndContinue(logger)
           self.quitCheck()
           logger.debug("sleeping")
@@ -447,11 +453,13 @@ class Monitor (object):
       except hbc.FatalException, x:
         logger.debug("somethings gone horribly wrong with HBase")
         socorro.lib.util.reportExceptionAndContinue(logger, loggingLevel=logging.CRITICAL)
-        databaseConnection.rollback()
+        if databaseConnection is not None:
+          databaseConnection.rollback()
         self.quit = True
       except (KeyboardInterrupt, SystemExit):
         logger.debug("outer detects quit")
-        databaseConnection.rollback()
+        if databaseConnection is not None:
+          databaseConnection.rollback()
         self.quit = True
     finally:
       logger.info("priorityLoop done.")


### PR DESCRIPTION
Hi!

I've found out, that if connection to the HBase is unavailable, some trace-back information is written in the monitor-stdout.log

Ex.:

```
Exception in thread priorityLoopingThread:
Traceback (most recent call last):
  File "/usr/lib/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.6/threading.py", line 484, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/data/socorro/application/socorro/monitor/monitor.py", line 454, in priorityJobAllocationLoop
    databaseConnection.rollback()
UnboundLocalError: local variable 'databaseConnection' referenced before assignment
```

```
Traceback (most recent call last):
  File "/data/socorro/application/scripts/startMonitor.py", line 32, in <module>
    m.start()
  File "/data/socorro/application/socorro/monitor/monitor.py", line 486, in start
    self.standardJobAllocationLoop()
  File "/data/socorro/application/socorro/monitor/monitor.py", line 355, in standardJobAllocationLoop
    databaseConnection.close()
UnboundLocalError: local variable 'databaseConnection' referenced before assignment
```

So, I've written a patch to fix this behavior. After applying this patch the missing connection is displayed in the log-file as follows:

```
2012-01-31 14:24:08,077 ERROR - MainThread - Traceback (most recent call last):
2012-01-31 14:24:08,078 ERROR - MainThread - File "/data/socorro/application/socorro/storage/hbaseClient.py", line 252, in __init__
    self.make_connection(timeout=self.timeout)
2012-01-31 14:24:08,078 ERROR - MainThread - File "/data/socorro/application/socorro/storage/hbaseClient.py", line 276, in make_connection
    self.transport.open()
2012-01-31 14:24:08,078 ERROR - MainThread - File "/data/socorro/thirdparty/thrift/transport/TTransport.py", line 145, in open
    return self.__trans.open()
2012-01-31 14:24:08,078 ERROR - MainThread - File "/data/socorro/thirdparty/thrift/transport/TSocket.py", line 89, in open
    raise TTransportException(type=TTransportException.NOT_OPEN, message=message)
2012-01-31 14:24:08,079 ERROR - MainThread - NoConnectionException: the connection is not viable.  retries fail: No connection was made to HBase (2 tries): <class 'thrift.transport.TTransport.TTransportException'>-Could not connect to crash-stats:9090
2012-01-31 14:24:08,100 CRITICAL - priorityLoopingThread - priorityLoopingThread - cannot connect to the database
```
