### PR TITLE
Wrap not exception-safe method call into try-except

### DIFF
--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -479,7 +479,13 @@ class Processor(object):
       threadLocalCursor.execute("update jobs set starteddatetime = %s where id = %s", (startedDateTime, jobId))
       threadLocalDatabaseConnection.commit()
 
-      jsonDocument = threadLocalCrashStorage.get_meta(jobUuid)
+      try:
+        jsonDocument = threadLocalCrashStorage.get_meta(jobUuid)
+      except:
+        # if HBase database is corrupted, it's OK to report missing job as done
+        # but report on this accident as on error
+        logger.error("can not load document %s from HBase", jobUuid)
+        return Processor.ok
 
       # some products report under the same name but have a different product ID.
       # rename the product if there is an override in the productIdMap


### PR DESCRIPTION
Losing some data in the HBase causes to unhandled exception in the
threadLocalCrashStorage.get_meta() method. Futher code relies that
jsonDocument object is existing in the scope.

For example this is a sample from my log:

```
File "/data/socorro/application/socorro/processor/processor.py", line 618, in processJob
    threadLocalCursor.execute("update reports                                        \
                               set started_datetime = timestamp with time zone %s,   \
                                   completed_datetime = timestamp with time zone %s, \
                                   success = False,                                  \
                                   processor_notes = %s                              \
                               where id = %s and                                     \
                                     date_processed = timestamp with time zone %s",
                              (startedDateTime, self.nowFunc(), message, reportId, date_processed))
UnboundLocalError: local variable 'reportId' referenced before assignment
```

because reportId depends on jsonDocument and it is defined a few lines after.
