### PR TITLE
Fixed problem with stored function name in daily report

### DIFF
--- a/socorro/cron/dailyMatviews.py
+++ b/socorro/cron/dailyMatviews.py
@@ -23,7 +23,7 @@ def update(config, targetDate):
       ('update_daily_crashes', [targetDate],
        ['update_product_versions' 'update_signatures']),
       ('update_hang_report', [targetDate], []),
-      ('rank_compare', [targetDate], []),
+      ('update_rank_compare', [targetDate], []),
     )
 
     failed = set()


### PR DESCRIPTION
I've found some errors in PL/SQL function call in the log file. Here is the sample:

```
Traceback (most recent call last):
  File "/data/socorro/application/scripts/startDailyMatviews.py", line 35, in <module>
    exitCode = dailyMatviews.update(config, targetDate)
  File "/data/socorro/application/socorro/cron/dailyMatviews.py", line 52, in update
    cursor.callproc(funcname, parameters)
psycopg2.ProgrammingError: function rank_compare(unknown) does not exist
LINE 1: SELECT * FROM rank_compare('2012-02-05')
                      ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

Then I looked into breakpad_schema.sql

```
$ egrep -i "create function.*rank_compare" sql/schema/*/breakpad_schema.sql
sql/schema/2.4/breakpad_schema.sql:CREATE FUNCTION backfill_rank_compare(updateday date DEFAULT NULL::date) RETURNS boolean
sql/schema/2.4/breakpad_schema.sql:CREATE FUNCTION update_rank_compare(updateday date DEFAULT NULL::date, checkdata boolean DEFAULT true) RETURNS boolean
```

So, this patch is seems to be a solution.
