### PR TITLE
Removed a log message from tcbs to make debug logs a bit cleaner.

### DIFF
--- a/socorro/external/postgresql/tcbs_impl/modern.py
+++ b/socorro/external/postgresql/tcbs_impl/modern.py
@@ -152,7 +152,7 @@ def listOfListsWithChangeInRank(listOfQueryResultsIterable):
     aRowAsDict = prevRowAsDict = None
     for rank, aRow in enumerate(aListOfTopCrashers):
       prevRowAsDict = aRowAsDict
-      logger.debug(aRowAsDict)
+      #logger.debug(aRowAsDict)
       aRowAsDict = dict(zip(['signature', 'count', 'win_count', 'linux_count',
                              'mac_count', 'hang_count', 'plugin_count',
                              'content_count', 'first_report_exact', 'versions', 'percentOfTotal'], aRow))


### PR DESCRIPTION
That log message shows every single result we get for TCBS. Is that really needed? It makes debug logs heavy and hard to read, and gives no good information. 
