### PR TITLE
fixes Bug 726078 - bad error message/signature on corrupt crashing thread stack

### DIFF
--- a/socorro/processor/externalProcessor.py
+++ b/socorro/processor/externalProcessor.py
@@ -336,7 +336,8 @@ class ProcessorWithExternalBreakpad (processor.Processor):
       # generate a C signature
       signature, \
         signature_notes = self.c_signature_tool.generate(signature_list,
-                                                         hang_type=hang_type)
+                                                         hang_type,
+                                                         crashed_thread)
     if signature_notes:
       processor_notes_list.extend(signature_notes)
 


### PR DESCRIPTION
The CSignatureTool created a bad signature and error message when the stack frame was bad.  This happended because the crashed thread number wasn't being passed to the signature generation tool.  The crashed thread number is only used in this context to choose between error messages and create a default signature.  Other non-degenerate stack frames didn't suffer the problem of not having the crashing thread number because they didn't have to create an error message.
