### PR TITLE
Fixes bug 725379 - Always make list of channels a tuple before inserting...

### DIFF
--- a/socorro/external/postgresql/base.py
+++ b/socorro/external/postgresql/base.py
@@ -278,6 +278,6 @@ class PostgreSQLBase(object):
             else:
                 # it's a release
                 version_where.append(("r.release_channel NOT IN %s" %
-                                      config.channels))
+                                      (tuple(config.channels),)))
 
         return version_where


### PR DESCRIPTION
... it into a SQL query.

`IN` was unhappy with brackets, now it has parentheses. 
