### PR TITLE
Fixes bug 724670 - Decode double encoded slashes in terms and signature ...

### DIFF
--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -27,12 +27,9 @@ class Crashes(PostgreSQLBase):
         filtering.
         """
         params = search_common.get_parameters(kwargs)
-        params["signature"] = kwargs.get("signature")
 
         if params["signature"] is None:
             return None
-        elif isinstance(params["signature"], list):
-            params["signature"] = " ".join(params["signature"])
 
         params["terms"] = params["signature"]
         params["search_mode"] = "is_exactly"

--- a/socorro/external/postgresql/report.py
+++ b/socorro/external/postgresql/report.py
@@ -29,12 +29,9 @@ class Report(PostgreSQLBase):
         cur = self.connection.cursor()
 
         params = search_common.get_parameters(kwargs)
-        params["signature"] = kwargs.get("signature")
 
         if params["signature"] is None:
             return None
-        elif isinstance(params["signature"], list):
-            params["signature"] = " ".join(params["signature"])
 
         params["terms"] = params["signature"]
         params["search_mode"] = "is_exactly"

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -81,6 +81,7 @@ def get_parameters(kwargs):
     filters = [
         ("data_type", "signatures", "str"),
         ("terms", None, ["list", "str"]),
+        ("signature", None, "str"),
         ("fields", "signature", ["list", "str"]),
         ("search_mode", "default", "str"),
         ("from_date", lastweek, "datetime"),
@@ -103,6 +104,12 @@ def get_parameters(kwargs):
     ]
 
     params = extern.parse_arguments(filters, kwargs)
+
+    # Decode double-encoded slashes in terms and signture
+    if params["signature"] is not None:
+        params["signature"] = params["signature"].replace("%2F", "/")
+    if params["terms"] is not None:
+        params["terms"] = [x.replace("%2F", "/") for x in params["terms"]]
 
     # To be moved into a config file?
     authorized_modes = [

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -61,6 +61,17 @@ class TestSearchCommon(unittest.TestCase):
                 self.assertTrue(not params[i] or typei is int or typei is str
                                 or typei is list)
 
+        # Test with encoded slashes in terms and signature
+        params = co.get_parameters({
+            "terms": ["some", "terms%2Fsig"],
+            "signature": "my%2Flittle%2Fsignature"
+        })
+
+        self.assertTrue("signature" in params)
+        self.assertTrue("terms" in params)
+        self.assertEqual(params["terms"], ["some", "terms/sig"])
+        self.assertEqual(params["signature"], "my/little/signature")
+
     #--------------------------------------------------------------------------
     def test_restrict_fields(self):
         """


### PR DESCRIPTION
...parameters.

Also handle the 'signature' parameter in a better way now. 
