### PR TITLE
bug 731381 - Update forced versions for correlations for Firefox cycle starting 2012-02-13

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -21,7 +21,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="11.0 12.0a2 13.0a1"
+MANUAL_VERSION_OVERRIDE="12.0 13.0a2 14.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 731381 - this should only go to production after 2012-02-13, but preferably within the week following that date, so I think that's Socorro 2.5.1 material.

This commit is re-based on a current master, so that it doesn't run into problems with the git history messup last week.
