### PR TITLE
Make vagrant faster

### DIFF
--- a/puppet/manifests/classes/socorro-base.pp
+++ b/puppet/manifests/classes/socorro-base.pp
@@ -91,8 +91,9 @@ class socorro-base {
     }
 
     exec {
-        '/usr/bin/apt-get update':
-            alias => 'apt-get-update';
+        '/usr/bin/apt-get update && touch /tmp/apt-get-update':
+            alias => 'apt-get-update',
+            creates => '/tmp/apt-get-update';
     }
 
     exec {

--- a/puppet/manifests/classes/socorro-db.pp
+++ b/puppet/manifests/classes/socorro-db.pp
@@ -38,8 +38,9 @@ class socorro-db inherits socorro-base {
 
     exec {
        'update-postgres-ppa':
-            command => '/usr/bin/apt-get update',
-            require => Exec['add-postgres-ppa'];
+            command => '/usr/bin/apt-get update && touch /tmp/update-postgres-ppa',
+            require => Exec['add-postgres-ppa'],
+            creates => '/tmp/update-postgres-ppa';
     }
 
     exec {

--- a/puppet/manifests/classes/socorro-hbase.pp
+++ b/puppet/manifests/classes/socorro-hbase.pp
@@ -11,14 +11,17 @@ class socorro-hbase {
     exec { '/usr/bin/apt-get install -y hadoop-hbase hadoop-hbase-master hadoop-hbase-thrift liblzo2-dev':
             alias => 'install-hbase',
             logoutput => on_failure,
+            refreshonly => true,
+            subscribe => Exec['apt-get-update-cloudera'],
             require => [Exec['apt-get-update'],Exec['apt-get-update-cloudera']];
     }
 
     exec { 
         'apt-get-update-cloudera':
-            command => '/usr/bin/apt-get update',
+            command => '/usr/bin/apt-get update && touch /tmp/apt-get-update-cloudera',
             require => [Exec['install-oracle-jdk'],
-                        File['/etc/apt/sources.list.d/cloudera.list']];
+                        File['/etc/apt/sources.list.d/cloudera.list']],
+            creates => '/tmp/apt-get-update-cloudera';
     }
 
     exec {


### PR DESCRIPTION
This makes vagrant consistently faster, I get 20s reload and 13s provision with these changes (avoiding hbase connection and only checking for system updates once per reboot)

The long pole in there seems to be supervisord, which is just needed for the backend services like processor, monitor, and crashmover (so it's probably really the time it takes for those to shut down).

Note that if you're just working on PHP and/or mware, the fastest build time is probably by using something like this inside the VM:

make reinstall && sudo /etc/init.d/apache2 restart & sudo /etc/init.d/memcached restart & wait

That takes ~2s in my VM. We may want to just have a "reinstall" script in the repo or something that triggers this directly, instead of going via puppet. Puppet has the nice side-effect of making sure everything is installed and running though.
