### PR TITLE
Bug 742735 - detect new Windows Flash versions correctly

### DIFF
--- a/socorro/processor/externalProcessor.py
+++ b/socorro/processor/externalProcessor.py
@@ -42,6 +42,7 @@ class ProcessorWithExternalBreakpad (processor.Processor):
     tmp = toPythonRE.sub(r'%(\1)s',tmp)
     self.commandLine = tmp % config
 
+
 #-----------------------------------------------------------------------------------------------------------------
   def invokeBreakpadStackdump(self, dumpfilePathname):
     """ This function invokes breakpad_stackdump as an external process capturing and returning
@@ -212,22 +213,24 @@ class ProcessorWithExternalBreakpad (processor.Processor):
   flashRE = re.compile(r'NPSWF32_?(.*)\.dll|libflashplayer(.*)\.(.*)|Flash ?Player-?(.*)')
   def getVersionIfFlashModule(self,moduleData):
     """If (we recognize this module as Flash and figure out a version): Returns version; else (None or '')"""
-    #logger.debug(" flash?  %s", moduleData)
+    #logger.debug(" flash? %s", moduleData)
     try:
       module,filename,version,debugFilename,debugId = moduleData[:5]
     except ValueError:
-      logger.debug("bad module line  %s", moduleData)
+      logger.debug("bad module line %s", moduleData)
       return None
     m = ProcessorWithExternalBreakpad.flashRE.match(filename)
     if m:
       if not version:
-        version = m.groups()[0].replace('_', '.')
-      if not version:
-        version = m.groups()[1]
-      if not version:
-        version = m.groups()[3]
-      if not version and 'knownFlashDebugIdentifiers' in self.config:
-        version = self.config.knownFlashDebugIdentifiers.get(debugId) # probably a miss
+        groups = m.groups()
+        if groups[0]:
+          version = groups[0].replace('_', '.')
+        elif groups[1]:
+          version = groups[1]
+        elif groups[3]:
+          version = groups[3]
+        elif 'knownFlashDebugIdentifiers' in self.config:
+          version = self.config.knownFlashDebugIdentifiers.get(debugId) # probably a miss
     else:
       version = None
     return version

--- a/socorro/unittest/processor/testExternalProcessor.py
+++ b/socorro/unittest/processor/testExternalProcessor.py
@@ -1,0 +1,70 @@
+import unittest
+from socorro.processor.externalProcessor import ProcessorWithExternalBreakpad
+from socorro.lib.util import DotDict
+
+
+class Abused_ProcessorWithExternalBreakpad(ProcessorWithExternalBreakpad):
+
+    def __init__(self, config):
+        self.config = config
+
+
+class TestProcessorWithExternalBreakpad(unittest.TestCase):
+
+    def test_getVersionIfFlashModule(self):
+        config = DotDict()
+        config.knownFlashDebugIdentifiers = {'yyy': '9.0'}
+        proc = Abused_ProcessorWithExternalBreakpad(config)
+
+        # junk moduleData
+        moduleData = []
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertTrue(not version)
+
+        moduleData = ['xxx', 'doesntmatter', '0.0', 'xxx', 'xxx']
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, None)
+
+        moduleData[1] = 'gobblygook'
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, None)
+
+        moduleData[1] = 'Flash Player-10.4'
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '0.0')
+
+        moduleData[1] = 'Flash Player-10.4'
+        moduleData[2] = ''
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '10.4')
+
+        moduleData[1] = 'libflashplayer2.1_3.so'
+        moduleData[2] = '0.0'
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '0.0')  # matched but use the defaul
+
+        moduleData[1] = 'libflashplayer2.1_3.so'
+        moduleData[2] = ''
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '2.1_3')
+
+        moduleData[1] = 'NPSWF32_11_2_202_228.dll'
+        moduleData[2] = '11.2.444'
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '11.2.444')
+
+        moduleData[1] = 'NPSWF32_11_2_202_228.dll'
+        moduleData[2] = ''
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '11.2.202.228')
+
+        # it's case sensitive
+        moduleData[1] = 'NPSWF32_11_2_202_228.DLL'
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, None)
+
+        moduleData[1] = 'NPSWF32.dll'  # filename
+        moduleData[2] = ''  # version
+        moduleData[4] = 'yyy'  # debugId (see above)
+        version = proc.getVersionIfFlashModule(moduleData)
+        self.assertEqual(version, '9.0')


### PR DESCRIPTION
If I read the code correctly, this should fix the issue that new Flash versions that have the version in their file name are not detected correctly. Some testing should be done on this, though, but I don't think I have the means for that myself.
