### PR TITLE
Fixes bug 745170 - Call the right function in feeds. 

### DIFF
--- a/socorro/middleware/report_list_service.py
+++ b/socorro/middleware/report_list_service.py
@@ -31,9 +31,6 @@ class ReportList(DataAPIService):
         """
         # Parse parameters
         params = self.parse_query_string(args[0])
-        if not "signature" in params:
-            raise web.webapi.BadRequest()
-
         params = self._bind_params(params)
 
         module = self.get_module(params)

--- a/webapp-php/application/controllers/feed.php
+++ b/webapp-php/application/controllers/feed.php
@@ -1,66 +1,73 @@
 <?php
+
 require_once(Kohana::find_file('libraries', 'MY_SearchReportHelper', TRUE, 'php'));
 require_once(Kohana::find_file('libraries', 'moz_feed', TRUE, 'php'));
+
 /**
  * Feeds for Socorro UI
  */
-class Feed_Controller extends Controller {
-
-  /**
-   *
-   * Bug#492017 - provide RSS feed of latest crashes
-   */
+class Feed_Controller extends Controller
+{
+    /**
+     *
+     * Bug#492017 - provide RSS feed of latest crashes
+     */
     public function crashes_by_product($product, $version, $platform='ALL')
     {
 
-        $db = new Common_Model;
+        $model = new Report_Model;
         $searchHelper = new SearchReportHelper;
         $params = $searchHelper->defaultParams();
-	$params['product'] = array($product);
-	$params['version'] = array($product . ':' . $version);
-	if ($platform != 'ALL') {
-	    $params['platform'] = array($platform);
-	}
-	$params['range_value'] = '2';
+        $params['product'] = array($product);
+        $params['version'] = array($product . ':' . $version);
+        if ($platform != 'ALL') {
+            $params['platform'] = array($platform);
+        }
+        $params['range_value'] = '2';
 
-	$reports = $db->queryReports($params);
+        $page = 0;
+        $items_per_page = Kohana::config('search.number_report_list');
+        $reports = $model->crashesList($params, $items_per_page, $page);
 
-	$this->auto_render = FALSE;
+        $this->auto_render = FALSE;
 
-	$feed = moz_feed(url::base(),
-			 url::current(TRUE),
-			 "Mozilla $product $version $platform Recent Crashes",
-			 $reports);
-	header( 'Content-Type: ' . $feed['contentType'] . '; charset=utf-8' );
-	echo $feed['xml'];
+        $feed = moz_feed(url::base(),
+                         url::current(TRUE),
+                         "Mozilla $product $version $platform Recent Crashes",
+                         $reports);
+        header( 'Content-Type: ' . $feed['contentType'] . '; charset=utf-8' );
+        echo $feed['xml'];
     }
 
-  /**
-   *
-   * Bug#492017 - provide RSS feed of latest crashes
-   */
+    /**
+     *
+     * Bug#492017 - provide RSS feed of latest crashes
+     */
     public function crashes_by_platform($platform='ALL')
     {
-        $db = new Common_Model;
+        $model = new Report_Model;
         $searchHelper = new SearchReportHelper;
         $params = $searchHelper->defaultParams();
-	$params['product'] = array();
+        $params['product'] = array();
 
-	$params['range_value'] = '2';
-       	if ($platform != 'ALL') {
-	    $params['platform'] = array($platform);
-	}
+        $params['range_value'] = '2';
+            if ($platform != 'ALL') {
+            $params['platform'] = array($platform);
+        }
 
-	$reports = $db->queryReports($params);
+        $page = 0;
+        $items_per_page = Kohana::config('search.number_report_list');
+        $reports = $model->crashesList($params, $items_per_page, $page);
 
-	$this->auto_render = FALSE;
+        $this->auto_render = FALSE;
 
-	$feed = moz_feed(url::site(),
-			 url::current(TRUE),
-			 "Mozilla $platform Recent Crashes",
-			 $reports);
-	header( 'Content-Type: ' . $feed['contentType'] . '; charset=utf-8' );
-	echo $feed['xml'];
+        $feed = moz_feed(url::site(),
+                         url::current(TRUE),
+                         "Mozilla $platform Recent Crashes",
+                         $reports);
+        header( 'Content-Type: ' . $feed['contentType'] . '; charset=utf-8' );
+        echo $feed['xml'];
     }
 }
+
 ?>

--- a/webapp-php/application/models/report.php
+++ b/webapp-php/application/models/report.php
@@ -260,9 +260,12 @@ class Report_Model extends Model {
         $apiData = array(
             Kohana::config('webserviceclient.socorro_hostname'),
             $apiEntry,
-            'signature',
-            rawurlencode(str_replace('/', '%2F', $params['signature']))
         );
+        if (!empty($params['signature']))
+        {
+            $apiData[] = 'signature';
+            $apiData[] = rawurlencode(str_replace('/', '%2F', $params['signature']));
+        }
 
         //echo '<pre>',var_dump($params),'</pre>';
 


### PR DESCRIPTION
Allow no signature passed in middleware service.

The feed.php file was massively re-indented, but the only things that changed in it are the name of the variable containing the model, the model that is instantiated, and the function that is called.  

Schalk, r?
