### PR TITLE
HTTP POST API for adding builds for existing products

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -648,22 +648,25 @@ total, indicating the number of products returned::
 Products Builds
 ---------------
 
-Return information about nightly builds of one or several products.
+Query and update information about builds for products.
 
 API specifications
 ^^^^^^^^^^^^^^^^^^
 
 +----------------+--------------------------------------------------------------------------------+
-| HTTP method    | GET                                                                            |
+| HTTP method    | GET, POST                                                                      |
 +----------------+--------------------------------------------------------------------------------+
 | URL schema     | /products/builds/(optional_parameters)                                         |
 +----------------+--------------------------------------------------------------------------------+
 | Full URL       | /products/builds/product/(product)/version/(version)/date_from/(date_from)/    |
 +----------------+--------------------------------------------------------------------------------+
-| Example        | http://socorro-api/bpapi/products/builds/product/Firefox/version/9.0a1/        |
+| GET Example    | http://socorro-api/bpapi/products/builds/product/Firefox/version/9.0a1/        |
+| POST Example   | http://socorro-api/bpapi/products/builds/product/Firefox/,                     |
+|                |     data: version=10.0&platform=macosx&build_id=20120416012345&                |
+|                |         build_type=Beta&beta_number=2&repository=mozilla-central               |
 +----------------+--------------------------------------------------------------------------------+
 
-Mandatory parameters
+Mandatory GET parameters
 ^^^^^^^^^^^^^^^^^^^^
 
 +---------+---------------+---------------+-----------------------------------+
@@ -673,7 +676,7 @@ Mandatory parameters
 |         |               |               | builds.                           |
 +---------+---------------+---------------+-----------------------------------+
 
-Optional parameters
+Optional GET parameters
 ^^^^^^^^^^^^^^^^^^^
 
 +------------+---------------+------------------+-----------------------------+
@@ -686,7 +689,7 @@ Optional parameters
 |            |               |                  | nightly builds.             |
 +------------+---------------+------------------+-----------------------------+
 
-Return value
+GET return value
 ^^^^^^^^^^^^
 
 Return an array of objects::
@@ -704,6 +707,43 @@ Return an array of objects::
         },
         ...
     ]
+
+Mandatory POST parameters
+^^^^^^^^^^^^^^^^^^^^
+
++-------------+---------------+---------------+-------------------------------------------------------+
+| Name        | Type of value | Default value | Description                                           |
++=============+===============+===============+=======================================================+
+| product     | String        | None          | Product for which to add a build.                     |
++-------------+---------------+---------------+-------------------------------------------------------+
+| version     | String        | None          | Version for new build, e.g. "10.0".                   |
++-------------+---------------+---------------+-------------------------------------------------------+
+| platform    | String        | None          | Platform for new build, e.g. "macosx".                |
++-------------+---------------+---------------+-------------------------------------------------------+
+| build_id    | String        | None          | Build ID for new build (YYYYMMDD######).              |
++-------------+---------------+---------------+-------------------------------------------------------+
+| build_type  | String        | None          | Type of build, e.g. "Release", "Beta", "Aurora", etc. |
++-------------+---------------+---------------+-------------------------------------------------------+
+
+Optional POST parameters
+^^^^^^^^^^^^^^^^^^^
+
++-------------+---------------+---------------+-------------------------------------------------------+
+| Name        | Type of value | Default value | Description                                           |
++=============+===============+===============+=======================================================+
+| beta_number | String        | None          | Beta number if build_type is "Beta".  Mandatory if    |
+|             |               |               | build_type is "Beta", ignored otherwise.              |
++-------------+---------------+---------------+-------------------------------------------------------+
+| repository  | String        | ""            | The repository from which this release came.          |
++-------------+---------------+---------------+-------------------------------------------------------+
+
+POST return value
+^^^^^^^^^^^^
+
+
+On success, returns a 303 See Other redirect to the newly-added build's API page at::
+
+    /products/builds/product/(product)/version/(version)/
 
 .. ############################################################################
    Search API

--- a/socorro/cron/ftpscraper.py
+++ b/socorro/cron/ftpscraper.py
@@ -3,12 +3,12 @@
 ftpscraper.py pulls build information from ftp.mozilla.org for
 nightly and release builds.
 """
-import sys
 import logging
 import urllib2
 import lxml.html
 import datetime
 
+import socorro.lib.buildutil as buildutil
 import socorro.lib.psycopghelper as psy
 import socorro.lib.util as util
 
@@ -86,7 +86,6 @@ def getNightly(dirname, url, urllib=urllib2, backfill_date=None):
         else:
             return
 
-        product = pv.split('-')[:-1]
         version = pv.split('-')[-1]
         repository = []
 
@@ -126,55 +125,6 @@ def recordBuilds(config, backfill_date):
         databaseConnectionPool.cleanup()
 
 
-def buildExists(cursor, product_name, version, platform, build_id, build_type,
-                beta_number, repository):
-    """ Determine whether or not a particular release build exists already """
-    sql = """
-        SELECT *
-        FROM releases_raw
-        WHERE product_name = %s
-        AND version = %s
-        AND platform = %s
-        AND build_id = %s
-        AND build_type = %s
-    """
-
-    if beta_number is not None:
-        sql += """ AND beta_number = %s """
-    else:
-        sql += """ AND beta_number IS %s """
-
-    sql += """ AND repository = %s """
-
-    params = (product_name, version, platform, build_id, build_type,
-              beta_number, repository)
-    cursor.execute(sql, params)
-    exists = cursor.fetchone()
-
-    return exists is not None
-
-
-def insertBuild(cursor, product_name, version, platform, build_id, build_type,
-                beta_number, repository):
-    """ Insert a particular build into the database """
-    if not buildExists(cursor, product_name, version, platform, build_id,
-                       build_type, beta_number, repository):
-        sql = """ INSERT INTO releases_raw
-                  (product_name, version, platform, build_id, build_type,
-                   beta_number, repository)
-                  VALUES (%s, %s, %s, %s, %s, %s, %s)"""
-
-        try:
-            params = (product_name, version, platform, build_id, build_type,
-                      beta_number, repository)
-            cursor.execute(sql, params)
-            cursor.connection.commit()
-            logger.info("Inserted: %s %s %s %s %s %s %s" % params)
-        except Exception:
-            cursor.connection.rollback()
-            util.reportExceptionAndAbort(logger)
-
-
 def scrapeReleases(config, cursor, product_name, urllib=urllib2):
     prod_url = '%s/%s/' % (config.base_url, product_name)
 
@@ -201,9 +151,9 @@ def scrapeReleases(config, cursor, product_name, urllib=urllib2):
                         version, beta_number = version.split('b')
                         repository = 'mozilla-beta'
                     build_id = kvpairs['buildID']
-                    insertBuild(cursor, product_name, version, platform,
-                                build_id, build_type, beta_number,
-                                repository)
+                    buildutil.insert_build(cursor, product_name, version,
+                                           platform, build_id, build_type,
+                                           beta_number, repository)
         except urllib.URLError:
             util.reportExceptionAndContinue(logger)
 
@@ -226,8 +176,8 @@ def scrapeNightlies(config, cursor, product_name, urllib=urllib2, date=None):
                 build_type = 'Nightly'
                 if version.endswith('a2'):
                     build_type = 'Aurora'
-                insertBuild(cursor, product_name, version, platform,
-                            build_id, build_type, None, repository)
+                buildutil.insert_build(cursor, product_name, version, platform,
+                                       build_id, build_type, None, repository)
 
     except urllib.URLError:
         util.reportExceptionAndContinue(logger)

--- a/socorro/external/postgresql/products_builds.py
+++ b/socorro/external/postgresql/products_builds.py
@@ -1,4 +1,5 @@
 import logging
+import psycopg2
 import web
 
 from datetime import timedelta
@@ -6,13 +7,14 @@ from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.lib.datetimeutil import utc_now
 
 import socorro.database.database as db
+import socorro.lib.buildutil as buildutil
 import socorro.lib.external_common as external_common
 import socorro.lib.util as util
 
 logger = logging.getLogger("webapi")
 
 
-class MissingOrBadArgumentException(Exception):
+class MissingOrBadArgumentError(Exception):
     pass
 
 
@@ -35,11 +37,24 @@ class ProductsBuilds(PostgreSQLBase):
         """
         try:
             return self.builds(**kwargs)
-        except MissingOrBadArgumentException:
-            raise web.webapi.BadRequest()
+        except MissingOrBadArgumentError as e:
+            raise web.webapi.BadRequest(e)
         except Exception:
             util.reportExceptionAndContinue(logger)
             raise web.webapi.InternalError()
+
+    def _require_parameters(self, params, *required):
+        """
+        Checks that all required parameters are present in and non-empty in
+        params, where required is a list of strings.
+
+        Raises MissingOrBadArgumentError if a required parameter is
+        missing or empty.
+        """
+        for p in required:
+            if not params.get(p, None):
+                raise MissingOrBadArgumentError(
+                    "Mandatory parameter '%s' is missing or empty" % p)
 
     def builds(self, **kwargs):
         """
@@ -79,9 +94,7 @@ class ProductsBuilds(PostgreSQLBase):
         ]
         params = external_common.parse_arguments(filters, kwargs)
 
-        if "product" not in params or not params["product"]:
-            raise MissingOrBadArgumentException(
-                        "Mandatory parameter 'product' is missing or empty")
+        self._require_parameters(params, "product")
 
         # FIXME this will be moved to the DB in 7, see bug 740829
         if params["product"].startswith("Fennec"):
@@ -139,3 +152,64 @@ class ProductsBuilds(PostgreSQLBase):
             results[i]["date"] = line["date"].strftime("%Y-%m-%d")
 
         return results
+
+    def create(self, **kwargs):
+        """
+        Create a new build for a product.
+
+        See http://socorro.readthedocs.org/en/latest/middleware.html#builds
+
+        Required keyword arguments:
+        product - Concerned product, e.g. firefox
+        version - Concerned version, e.g. 9.0a1
+        platform - Platform for this build, e.g. win32
+        build_id - Build ID for this build (yyyymmdd######)
+        build_type - Type of build, e.g. Nightly, Beta, Aurora, Release
+
+        Required if build_type is Beta:
+        beta_number - The beta number, e.g. 9.0b#
+
+        Optional keyword arguments:
+        repository - Repository this build came from
+
+        Return: (product_name, version)
+        """
+
+        # Parse arguments
+        filters = [
+            ("product", None, "str"),
+            ("version", None, "str"),
+            ("platform", None, "str"),
+            ("build_id", None, "str"),
+            ("build_type", None, "str"),
+            ("beta_number", None, "str"),
+            ("repository", "", "str")
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+
+        self._require_parameters(params, "product", "version", "platform",
+                                     "build_id", "build_type")
+
+        if params["build_type"].lower() == "beta":
+            self._require_parameters(params, "beta_number")
+
+        try:
+            connection = self.database.connection()
+            cursor = connection.cursor()
+
+            buildutil.insert_build(cursor, params["product"],
+                                   params["version"], params["platform"],
+                                   params["build_id"], params["build_type"],
+                                   params["beta_number"],
+                                   params["repository"])
+        except psycopg2.Error:
+            logger.error("Failed inserting build data into PostgresSQL",
+                         exc_info=True)
+            connection.rollback()
+            raise
+        else:
+            connection.commit()
+        finally:
+            connection.close()
+
+        return (params["product"], params["version"])

--- a/socorro/lib/buildutil.py
+++ b/socorro/lib/buildutil.py
@@ -1,0 +1,58 @@
+"""
+buildutil.py provides utility functions for querying, editing, and adding
+builds to Socorro.
+"""
+import logging
+
+import util
+
+logger = logging.getLogger("webapi")
+
+
+def build_exists(cursor, product_name, version, platform, build_id, build_type,
+                beta_number, repository):
+    """ Determine whether or not a particular release build exists already """
+    sql = """
+        SELECT *
+        FROM releases_raw
+        WHERE product_name = %s
+        AND version = %s
+        AND platform = %s
+        AND build_id = %s
+        AND build_type = %s
+    """
+
+    if beta_number is not None:
+        sql += """ AND beta_number = %s """
+    else:
+        sql += """ AND beta_number IS %s """
+
+    sql += """ AND repository = %s """
+
+    params = (product_name, version, platform, build_id, build_type,
+              beta_number, repository)
+    cursor.execute(sql, params)
+    exists = cursor.fetchone()
+
+    return exists is not None
+
+
+def insert_build(cursor, product_name, version, platform, build_id, build_type,
+                beta_number, repository):
+    """ Insert a particular build into the database """
+    if not build_exists(cursor, product_name, version, platform, build_id,
+                       build_type, beta_number, repository):
+        sql = """ INSERT INTO releases_raw
+                  (product_name, version, platform, build_id, build_type,
+                   beta_number, repository)
+                  VALUES (%s, %s, %s, %s, %s, %s, %s)"""
+
+        try:
+            params = (product_name, version, platform, build_id, build_type,
+                      beta_number, repository)
+            cursor.execute(sql, params)
+            cursor.connection.commit()
+            logger.info("Inserted: %s %s %s %s %s %s %s" % params)
+        except Exception:
+            cursor.connection.rollback()
+            util.reportExceptionAndAbort(logger)

--- a/socorro/middleware/products_builds_service.py
+++ b/socorro/middleware/products_builds_service.py
@@ -1,4 +1,5 @@
 import logging
+import web
 
 from socorro.middleware.service import DataAPIService
 
@@ -31,3 +32,18 @@ class ProductsBuilds(DataAPIService):
         impl = module.ProductsBuilds(config=self.context)
 
         return impl.get(**params)
+
+    def post(self, *args):
+        """
+        Insert a new build given the URL-encoded data provided in the request.
+        On success, raises a 303 See Other redirect to the newly-added build.
+        """
+        params = self.parse_query_string(args[0])
+        params.update(web.input())
+
+        module = self.get_module(params)
+        impl = module.ProductsBuilds(config=self.context)
+
+        product, version = impl.create(**params)
+        raise web.seeother("/products/builds/product/%s/version/%s" %
+                           (product, version))

--- a/socorro/unittest/cron/testFtpScraper.py
+++ b/socorro/unittest/cron/testFtpScraper.py
@@ -2,11 +2,11 @@
 import errno
 import logging
 import os
-import urllib2
 
 import psycopg2
 
 import unittest
+import socorro.lib.buildutil as buildutil
 import socorro.lib.ConfigurationManager as cfgManager
 import socorro.lib.util
 import socorro.lib.psycopghelper as psy
@@ -139,23 +139,23 @@ class TestFtpScraper(unittest.TestCase):
     def tearDown(self):
         self.logger.clear()
 
-    def do_buildExists(self, d, correct):
+    def do_build_exists(self, d, correct):
         me.cur = me.conn.cursor(cursor_factory=psy.LoggingCursor)
         me.cur.setLogger(me.fileLogger)
 
-        actual = ftpscraper.buildExists(
+        actual = buildutil.build_exists(
               me.cur, d[0], d[1], d[2], d[3], d[4], d[5], d[6])
         assert actual == correct, "expected %s, got %s " % (correct, actual)
 
-    def test_buildExists(self):
+    def test_build_exists(self):
         d = ("failfailfail", "VERSIONAME1", "PLATFORMNAME1", "1",
              "BUILDTYPE1", "1", "REPO1")
-        self.do_buildExists(d, False)
+        self.do_build_exists(d, False)
         r = ("PRODUCTNAME1", "VERSIONAME1", "PLATFORMNAME1", "1",
              "BUILDTYPE1", "1", "REPO1")
-        self.do_buildExists(r, True)
+        self.do_build_exists(r, True)
 
-    def test_insertBuild(self):
+    def test_insert_build(self):
         me.cur = me.conn.cursor(cursor_factory=psy.LoggingCursor)
         me.cur.setLogger(me.fileLogger)
 
@@ -165,14 +165,14 @@ class TestFtpScraper(unittest.TestCase):
         me.cur.connection.commit()
 
         try:
-            ftpscraper.insertBuild(me.cur, 'PRODUCTNAME5', 'VERSIONAME5',
+            buildutil.insert_build(me.cur, 'PRODUCTNAME5', 'VERSIONAME5',
                   'PLATFORMNAME5', '5', 'BUILDTYPE5', '5', 'REPO5')
-            actual = ftpscraper.buildExists(me.cur, 'PRODUCTNAME5',
+            actual = buildutil.build_exists(me.cur, 'PRODUCTNAME5',
                   'VERSIONAME5', 'PLATFORMNAME5', '5', 'BUILDTYPE5',
                   '5', 'REPO5')
             assert actual == 1, "expected 1, got %s" % (actual)
         except Exception, x:
-            print "Exception in do_insertBuild() ... Error: ", type(x), x
+            print "Exception in do_insert_build() ... Error: ", type(x), x
             socorro.lib.util.reportExceptionAndAbort(me.fileLogger)
         finally:
             me.cur.connection.rollback()

--- a/socorro/unittest/external/postgresql/test_products_builds.py
+++ b/socorro/unittest/external/postgresql/test_products_builds.py
@@ -1,0 +1,139 @@
+import psycopg2
+import psycopg2.extras
+
+from socorro.external.postgresql import products_builds
+import socorro.database.database as db
+import socorro.unittest.testlib.util as testutil
+
+from unittestbase import PostgreSQLTestCase
+
+import logging
+logger = logging.getLogger("webapi")
+
+
+#------------------------------------------------------------------------------
+def setup_module():
+    testutil.nosePrintModule(__file__)
+
+
+#==============================================================================
+class IntegrationTestProductsBuilds(PostgreSQLTestCase):
+    """Test socorro.external.postgresql.products_builds.ProductsBuilds class.
+    """
+
+    #--------------------------------------------------------------------------
+    def setUp(self):
+        """Set up this test class by populating the reports table with fake
+        data. """
+        super(IntegrationTestProductsBuilds, self).setUp()
+
+        cursor = self.connection.cursor()
+
+        # Create tables
+        cursor.execute("""
+            CREATE TABLE releases_raw
+            (
+                product_name citext NOT NULL,
+                version text NOT NULL,
+                platform text NOT NULL,
+                build_id numeric NOT NULL,
+                build_type citext NOT NULL,
+                beta_number integer,
+                repository citext DEFAULT 'mozilla-release'::citext NOT NULL
+            );
+        """)
+
+        self.connection.commit()
+
+    #--------------------------------------------------------------------------
+    def tearDown(self):
+        """Clean up the database, delete tables and functions. """
+        cursor = self.connection.cursor()
+        cursor.execute("""
+            DROP TABLE releases_raw;
+            DROP FUNCTION build_date(numeric);
+        """)
+        self.connection.commit()
+        super(IntegrationTestProductsBuilds, self).tearDown()
+
+    #--------------------------------------------------------------------------
+    def _get_builds_for_product(self, product):
+        cursor = self.connection.cursor(
+            cursor_factory=psycopg2.extras.RealDictCursor)
+        result = db.execute(cursor, """
+            SELECT product_name as product,
+                   version,
+                   build_id,
+                   build_type,
+                   platform,
+                   repository
+            FROM releases_raw
+            WHERE product_name = %(product)s
+        """, {"product": product})
+        return list(result)
+
+    #--------------------------------------------------------------------------
+    def test_create(self):
+        builds = products_builds.ProductsBuilds(config=self.config)
+
+        #......................................................................
+        # Test 1: a new build
+        params = {
+            "product": "firefox",
+            "version": "20.0",
+            "build_id": 20120417012345,
+            "build_type": "Release",
+            "platform": "macosx",
+            "repository": "mozilla-central"
+        }
+        product, version = builds.create(**params)
+        self.assertEqual(params["product"], product)
+        self.assertEqual(params["version"], version)
+
+        # Verify that build has been created in the DB
+        res = self._get_builds_for_product(params["product"])
+
+        self.assertEqual(1, len(res))
+        self.assertEqual(params, res[0])
+
+        #......................................................................
+        # Test 2: required parameters
+        params = {}
+        self.assertRaises(products_builds.MissingOrBadArgumentError,
+                          builds.create,
+                          **params)
+
+        #......................................................................
+        # Test 3: optional parameters
+        params = {
+            "product": "thunderbird",
+            "version": "17.0",
+            "build_id": 20120416012345,
+            "build_type": "Aurora",
+            "platform": "win32"
+        }
+        product, version = builds.create(**params)
+        self.assertEqual(params["product"], product)
+        self.assertEqual(params["version"], version)
+
+        # Verify that build has been created in the DB
+        res = self._get_builds_for_product(params["product"])
+
+        # create() supplies an empty repository as the default
+        params["repository"] = ""
+
+        self.assertEqual(1, len(res))
+        self.assertEqual(params, res[0])
+
+        #......................................................................
+        # Test 4: beta_number required if build_type is beta
+        params = {
+            "product": "waterwolf",
+            "version": "1.0",
+            "build_id": 20110316000005,
+            "build_type": "Beta",
+            "platform": "linux"
+        }
+        self.assertRaises(products_builds.MissingOrBadArgumentError,
+                          builds.create,
+                          **params)


### PR DESCRIPTION
Changed the Products Builds middleware API to support POST. This allows clients of the Socorro API to programmatically add new builds/releases for an existing product. This is useful for a push-based approach to adding builds (instead of a pull-based approach like in ftpscraper.py). Additionally, it is a first step towards an admin UI for managing releases.
