### PR TITLE
bug 746676 - Update forced versions for correlations for Firefox cycle starting 2012-04-24

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -21,7 +21,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="12.0 13.0a2 14.0a1"
+MANUAL_VERSION_OVERRIDE="13.0 14.0a2 15.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 746676 - this should only go to production ASAP after 2012-04-24, so should hopefully make it into 7.
