### PR TITLE
use DotDict as raw_crash and processed_crash

### DIFF
--- a/socorro/external/filesystem/crashstorage.py
+++ b/socorro/external/filesystem/crashstorage.py
@@ -20,6 +20,7 @@ from socorro.external.filesystem.processed_dump_storage import \
                                                 ProcessedDumpStorage
 from socorro.external.crashstorage_base import (CrashStorageBase,
                                                 OOIDNotFoundException)
+from socorro.lib.util import DotDict
 from socorro.collector.throttler import LegacyThrottler
 
 
@@ -90,7 +91,7 @@ class FileSystemRawCrashStorage(CrashStorageBase):
     #--------------------------------------------------------------------------
     def _load_raw_crash_from_file(self, pathname):
         with open(pathname) as json_file:
-            raw_crash = json.load(json_file)
+            raw_crash = json.load(json_file, object_hook=DotDict)
         return raw_crash
 
     #--------------------------------------------------------------------------

--- a/socorro/external/filesystem/processed_dump_storage.py
+++ b/socorro/external/filesystem/processed_dump_storage.py
@@ -95,7 +95,7 @@ class ProcessedDumpStorage(socorro_dumpStorage.DumpStorage):
     df = None
     try:
       df = gzip.open(self.getDumpPath(ooid))
-      return json.load(df)
+      return json.load(df, object_hook=socorro_util.DotDict)
     finally:
       if df:
         df.close()

--- a/socorro/external/hbase/hbase_client.py
+++ b/socorro/external/hbase/hbase_client.py
@@ -388,7 +388,7 @@ class HBaseConnectionForCrashReports(HBaseConnection):
     """Return the json metadata for a given ooid as an json data object"""
     jsonColumnOfRow = self.get_json_meta_as_string(ooid,old_format, number_of_retries=number_of_retries)
     #self.logger.debug('jsonColumnOfRow: %s', jsonColumnOfRow)
-    json_data = json.loads(jsonColumnOfRow)
+    json_data = json.loads(jsonColumnOfRow, object_hook=DotDict)
     return json_data
 
   @optional_retry_wrapper
@@ -444,7 +444,7 @@ class HBaseConnectionForCrashReports(HBaseConnection):
     If the ooid doesn't exist, return an empty string.
     """
     jsonColumnOfRow = self.get_processed_json_as_string(ooid, number_of_retries=number_of_retries)
-    json_data = json.loads(jsonColumnOfRow)
+    json_data = json.loads(jsonColumnOfRow, object_hook=DotDict)
     return json_data
 
   @optional_retry_wrapper

--- a/socorro/unittest/external/filesystem/test-crashstorage.py
+++ b/socorro/unittest/external/filesystem/test-crashstorage.py
@@ -11,6 +11,7 @@ from socorro.external.filesystem.crashstorage import (
   FileSystemRawCrashStorage,
   FileSystemThrottledCrashStorage,
   FileSystemCrashStorage)
+from socorro.lib.util import DotDict
 from configman import ConfigurationManager
 from mock import Mock
 
@@ -94,12 +95,12 @@ class TestFileSystemRawCrashStorage(unittest.TestCase):
 
         meta = crashstorage.get_raw_crash(
           '114559a5-d8e6-428c-8b88-1c1f22120314')
-        assert isinstance(meta, dict)
+        self.assertTrue(isinstance(meta, DotDict))
         self.assertEqual(meta['name'], 'Peter')
 
         dump = crashstorage.get_raw_dump(
           '114559a5-d8e6-428c-8b88-1c1f22120314')
-        assert isinstance(dump, basestring)
+        self.assertTrue(isinstance(dump, basestring))
         self.assertTrue("fake dump" in dump)
 
         crashstorage.remove('114559a5-d8e6-428c-8b88-1c1f22120314')
@@ -151,12 +152,12 @@ class TestFileSystemRawCrashStorage(unittest.TestCase):
 
         meta = crashstorage.get_raw_crash(
           '114559a5-d8e6-428c-8b88-1c1f22120314')
-        assert isinstance(meta, dict)
+        self.assertTrue(isinstance(meta, DotDict))
         self.assertEqual(meta['name'], 'Peter')
 
         dump = crashstorage.get_raw_dump(
           '114559a5-d8e6-428c-8b88-1c1f22120314')
-        assert isinstance(dump, basestring)
+        self.assertTrue(isinstance(dump, basestring))
         self.assertTrue("fake dump" in dump)
 
         crashstorage.remove('114559a5-d8e6-428c-8b88-1c1f22120314')
@@ -206,8 +207,10 @@ class TestFileSystemRawCrashStorage(unittest.TestCase):
                                }
             ooid = processed_crash['ooid']
             crashstorage.save_processed(processed_crash)
-            returned_procesessed_crash = crashstorage.get_processed(ooid)
-            self.assertEqual(processed_crash, returned_procesessed_crash)
+            returned_processed_crash = crashstorage.get_processed(ooid)
+            self.assertEqual(processed_crash, returned_processed_crash)
+            self.assertTrue(isinstance(returned_processed_crash,
+                                       DotDict))
 
             crashstorage.remove(ooid)
             self.assertRaises(OOIDNotFoundException,

--- a/socorro/unittest/external/hbase/test_crashstorage.py
+++ b/socorro/unittest/external/hbase/test_crashstorage.py
@@ -10,6 +10,7 @@ from socorro.external.hbase import hbase_client
 
 from socorro.external.crashstorage_base import OOIDNotFoundException
 from socorro.external.hbase.crashstorage import HBaseCrashStorage
+from socorro.lib.util import DotDict
 from socorro.unittest.config import commonconfig
 from socorro.database.transaction_executor import (
   TransactionExecutorWithLimitedBackoff
@@ -365,6 +366,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
                 m = mock.Mock(return_value=raw_crash)
                 klass.get_json = m
                 r = crashstorage.get_raw_crash("abc123")
+                self.assertTrue(isinstance(r, DotDict))
                 a = klass.get_json.call_args
                 self.assertEqual(len(a[0]), 2)
                 self.assertEqual(a[0][1], "abc123")
@@ -385,6 +387,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
                 m = mock.Mock(return_value=expected_processed_crash)
                 klass.get_processed_json = m
                 r = crashstorage.get_processed_crash("abc123")
+                self.assertTrue(isinstance(r, DotDict))
                 a = klass.get_processed_json.call_args
                 self.assertEqual(len(a[0]), 2)
                 self.assertEqual(a[0][1], "abc123")


### PR DESCRIPTION
changed all crash storage classes that allow retrieval of raw_crash and processed_crash to return them as DotDict instances rather than plain dicts.  This makes processor code much more readable.
