### PR TITLE
work around ipv6 getaddr bug in statsd client

### DIFF
--- a/scripts/config/commonconfig.py.dist
+++ b/scripts/config/commonconfig.py.dist
@@ -30,7 +30,7 @@ databasePassword.default = 'aPassword'
 
 statsdHost = cm.Option()
 statsdHost.doc = ''
-statsdHost.default = 'localhost'
+statsdHost.default = '127.0.0.1'
 
 statsdPort = cm.Option()
 statsdPort.doc = '8125'

--- a/socorro/unittest/config/commonconfig.py.dist
+++ b/socorro/unittest/config/commonconfig.py.dist
@@ -48,7 +48,7 @@ hbaseTimeout.default = 5000
 
 statsdHost = cm.Option()
 statsdHost.doc = ''
-statsdHost.default = ''
+statsdHost.default = '127.0.0.1'
 
 statsdPort = cm.Option()
 statsdPort.doc = ''


### PR DESCRIPTION
StatsClient constructor does this:

```
    # Use getaddrinfo to support IPv4/6.
    self._addr = socket.getaddrinfo(host, port)[0][4]
```

This works for both IPv4/6, but the problem is that IPv4 addresses return a two-tuple while IPv6 returns a four-tuple.

See:
http://docs.python.org/library/socket.html#socket.getaddrinfo

Specifically:
"""whose format depends on the returned family (a (address, port) 2-tuple for AF_INET, a (address, port, flow info, scope id) 4-tuple for AF_INET6"""

I'll see if I can get a patch upstream too.
