### PR TITLE
bug 761186 - Update forced versions for correlations for Firefox cycle starting 2012-06-04

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -21,7 +21,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="13.0 14.0a2 15.0a1"
+MANUAL_VERSION_OVERRIDE="14.0 15.0a2 16.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 761186 - this should only go to production ASAP (Firefox source versions changes landed today), so should hopefully make it into 12.
