### PR TITLE
adding collector_app and crashstorage refactoring

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -81,7 +81,7 @@ class FetchTransformSaveApp(App):
         """this iterator yields individual ooids from the source crashstorage
         class's 'new_ooids' method."""
         while(True):  # loop forever and never raise StopIteration
-            for x in self.source.new_ooids():
+            for x in self.source.new_crashes():
                 if x is None:
                     yield None
                 else:

--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+"""the collector recieves crashes from the field"""
+
+# This app can be invoked like this:
+#     .../socorro/collector/collector_app.py --help
+# set your path to make that simpler
+# set both socorro and configman in your PYTHONPATH
+
+import datetime
+
+from socorro.app.generic_app import App, main
+from socorro.collector.wsgi_collector import Collector
+
+
+from configman import Namespace
+from configman.converters import class_converter
+
+# an app running under modwsgi needs to have a name at the module level called
+# application.  The value is set in the App's 'main' function below.  Only the
+# modwsgi Apache version actually makes use of this variable.
+application = None
+
+
+#==============================================================================
+class CollectorApp(App):
+    app_name = 'collector'
+    app_version = '4.0'
+    app_description = __doc__
+
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    # collector namespace
+    #     the namespace is for config parameters about how to interpret
+    #     crash submissions
+    #--------------------------------------------------------------------------
+    required_config.namespace('collector')
+    required_config.collector.add_option(
+        'dump_field',
+        doc='the name of the form field containing the raw dump',
+        default='upload_file_minidump'
+    )
+    required_config.collector.add_option(
+        'dump_id_prefix',
+        doc='the prefix to return to the client in front of the OOID',
+        default='bp-'
+    )
+
+    #--------------------------------------------------------------------------
+    # throttler namespace
+    #     the namespace is for config parameters for the throttler system
+    #--------------------------------------------------------------------------
+    required_config.namespace('throttler')
+    required_config.throttler.add_option(
+        'throttler_class',
+        default='socorro.collector.throttler.LegacyThrottler',
+        doc='the class that implements the throttling action',
+        from_string_converter=class_converter
+    )
+    #--------------------------------------------------------------------------
+    # storage namespace
+    #     the namespace is for config parameters crash storage
+    #--------------------------------------------------------------------------
+    required_config.namespace('storage')
+    required_config.storage.add_option(
+        'crashstorage_class',
+        doc='the source storage class',
+        default='socorro.external.filesystem.crashstorage.'
+        'FileSystemRawCrashStorage',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    # web_server namespace
+    #     the namespace is for config parameters the web server
+    #--------------------------------------------------------------------------
+    required_config.namespace('web_server')
+    required_config.web_server.add_option(
+        'wsgi_server_class',
+        doc='a class implementing a wsgi web server',
+        default='socorro.webapi.servers.CherryPy',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def main(self):
+        # Apache modwsgi requireds a module level name 'applicaiton'
+        global application
+
+        services_list = (
+            Collector,
+        )
+        self.config.crash_storage = self.config.storage.crashstorage_class(
+            self.config.storage
+        )
+        self.config.throttler = self.config.throttler.throttler_class(
+            self.config.throttler
+        )
+        self.web_server = self.config.web_server.wsgi_server_class(
+            self.config,  # needs the whole config not the local namespace
+            services_list
+        )
+
+        # for modwsgi the 'run' method returns the wsgi function that Apache
+        # will use.  For other webservers, the 'run' method actually starts
+        # the standalone web server.
+        application = self.web_server.run()
+
+
+if __name__ == '__main__':
+    main(CollectorApp)

--- a/socorro/collector/wsgi_collector.py
+++ b/socorro/collector/wsgi_collector.py
@@ -1,0 +1,60 @@
+import web
+import time
+
+import socorro.lib.ooid as sooid
+from socorro.lib.ooid import createNewOoid
+import socorro.storage.crashstorage as cstore
+
+from socorro.lib.util import DotDict
+from socorro.collector.throttler import DISCARD
+from socorro.lib.datetimeutil import utc_now
+
+#==============================================================================
+class Collector(object):
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.logger = self.config.logger
+        self.throttler = config.throttler
+        self.dump_id_prefix = config.collector.dump_id_prefix
+        self.crash_storage = config.crash_storage
+        self.dump_field = config.collector.dump_field
+
+    #--------------------------------------------------------------------------
+    uri = '/submit'
+    #--------------------------------------------------------------------------
+
+    #--------------------------------------------------------------------------
+    def make_raw_crash (self, form):
+        names = (name for name in form.keys() if name != self.dump_field)
+        raw_crash = DotDict()
+        for name in names:
+            if isinstance(form[name], basestring):
+                raw_crash[name] = form[name]
+            else:
+                raw_crash[name] = form[name].value
+        raw_crash.timestamp = time.time()
+        return raw_crash
+
+    #--------------------------------------------------------------------------
+    def POST(self, *args):
+        the_form = web.input()
+        raw_crash = self.make_raw_crash(the_form)
+        dump = the_form[self.dump_field]
+
+        current_timestamp = utc_now()
+        raw_crash.submitted_timestamp = current_timestamp.isoformat()
+
+        ooid = createNewOoid(current_timestamp)
+        self.logger.info('%s received', ooid)
+
+        raw_crash.legacy_processing = self.throttler.throttle(raw_crash)
+        if raw_crash.legacy_processing == DISCARD:
+            return "Discarded=1\n"
+
+        result = self.config.crash_storage.save_raw_crash(
+          raw_crash,
+          dump,
+          ooid
+        )
+        return "CrashID=%s%s\n" % (self.dump_id_prefix, ooid)

--- a/socorro/monitor/crashstore_new_crash_source.py
+++ b/socorro/monitor/crashstore_new_crash_source.py
@@ -2,7 +2,7 @@ from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
 #==============================================================================
-class CrashStorageOoidSource(RequiredConfig):
+class CrashStorageNewCrashSource(RequiredConfig):
     """this class provides an iterator that will pull from any crash
     storage class new_ooids generator"""
     required_config = Namespace()
@@ -20,7 +20,7 @@ class CrashStorageOoidSource(RequiredConfig):
         self.crash_store = config.crashstorage_class(config)
 
     def __call__(self):
-        return self.crash_store.new_ooids()
+        return self.crash_store.new_crashes()
 
     def close(self):
         self.crash_store.close()

--- a/socorro/monitor/monitor_app.py
+++ b/socorro/monitor/monitor_app.py
@@ -37,7 +37,7 @@ class MonitorApp(App):
     table in Posgres.  This class is multithread hot, creating three thread in
     addition to the MainThread:
 
-        standard_job_thread - this thread polls the 'ooid_source' for new
+        standard_job_thread - this thread polls the 'new_crash_source' for new
                               crashes.  New crashes are entered into the It
                               allocates new crashes to registered
                               processors in a balanced manner making sure that
@@ -57,7 +57,7 @@ class MonitorApp(App):
     app_description = __doc__
 
     required_config = Namespace()
-    # configuration is broken into three namespaces: registrar, ooid_source,
+    # configuration is broken into three namespaces: registrar, new_crash_source,
     # and job_manager
 
     #--------------------------------------------------------------------------
@@ -104,16 +104,16 @@ class MonitorApp(App):
     )
 
     #--------------------------------------------------------------------------
-    # ooid_source namespace
+    # new_crash_source namespace
     #     this namespace is for config parameter having to do with the source
     #     of new ooids.  This generally for a crashstorage class that
     #     implements the 'new_ooids' iterator
     #--------------------------------------------------------------------------
-    required_config.namespace('ooid_source')
-    required_config.ooid_source.add_option(
-      'ooid_source_class',
+    required_config.namespace('new_crash_source')
+    required_config.new_crash_source.add_option(
+      'new_crash_source_class',
       doc='an iterable that will stream ooids needing processing',
-      default='socorro.monitor.crashstore_ooid_source.CrashStorageOoidSource',
+      default='socorro.monitor.crashstore_new_crash_source.CrashStorageNewCrashSource',
       from_string_converter=class_converter
     )
 
@@ -179,8 +179,8 @@ class MonitorApp(App):
             quit_check_callback=self._quit_check
           )
 
-        self.ooid_source = config.ooid_source.ooid_source_class(
-          config.ooid_source,
+        self.new_crash_source = config.new_crash_source.new_crash_source_class(
+          config.new_crash_source,
           ''
         )
 
@@ -635,8 +635,8 @@ class MonitorApp(App):
     #--------------------------------------------------------------------------
     def _standard_job_thread(self):
         """This is the main method for the 'standard_job_thread'.  It is
-        responsible for iterating through the 'ooid_source' for new crashes,
-        and assigning them to processors.
+        responsible for iterating through the 'new_crash_source' for new
+        crashes, and assigning them to processors.
         """
         try:
             self.config.logger.info("starting _standard_job_thread")
@@ -647,7 +647,7 @@ class MonitorApp(App):
                 self.config.logger.debug("getting _balanced_processor_iter")
                 processor_iter = self._balanced_processor_iter()
                 self.config.logger.debug("scanning for new crashes")
-                for uuid in self.ooid_source():
+                for uuid in self.new_crash_source():
                     try:
                         self.config.logger.debug("new job: %s", uuid)
                         while True:

--- a/socorro/processor/legacy_new_crash_source.py
+++ b/socorro/processor/legacy_new_crash_source.py
@@ -11,7 +11,7 @@ from socorro.database.transaction_executor import TransactionExecutor
 
 
 #==============================================================================
-class LegacyOoidSource(RequiredConfig):
+class LegacyNewCrashSource(RequiredConfig):
     """this class is a refactoring of the iteratior portion of the legacy
     Socorro processor.  It isolates just the part of fetching the ooids of
     jobs to be processed"""

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -9,7 +9,7 @@ from socorro.app.fetch_transform_save_app import FetchTransformSaveApp, main
 from socorro.external.postgresql.crashstorage import PostgreSQLCrashStorage
 from socorro.external.crashstorage_base import (
   PolyCrashStorage,
-  OOIDNotFoundException,
+  CrashIDNotFound,
 )
 
 
@@ -30,8 +30,8 @@ class ProcessorApp(FetchTransformSaveApp):
     )
 
     required_config = Namespace()
-    # configuration is broken into three namespaces: processor, ooid_source,
-    # and registrar
+    # configuration is broken into three namespaces: processor,
+    # new_crash_source, and registrar
     #--------------------------------------------------------------------------
     # processor namespace
     #     this namespace is for config parameter having to do with the
@@ -47,15 +47,15 @@ class ProcessorApp(FetchTransformSaveApp):
       from_string_converter=class_converter
     )
     #--------------------------------------------------------------------------
-    # ooid_source namespace
+    # new_crash_source namespace
     #     this namespace is for config parameter having to do with the source
     #     of new ooids.
     #--------------------------------------------------------------------------
-    required_config.namespace('ooid_source')
-    required_config.ooid_source.add_option(
-      'ooid_source_class',
+    required_config.namespace('new_crash_source')
+    required_config.new_crash_source.add_option(
+      'new_crash_source_class',
       doc='an iterable that will stream ooids needing processing',
-      default='socorro.processor.legacy_ooid_source.LegacyOoidSource',
+      default='socorro.processor.legacy_new_crash_source.LegacyNewCrashSource',
       from_string_converter=class_converter
     )
     #--------------------------------------------------------------------------
@@ -76,8 +76,8 @@ class ProcessorApp(FetchTransformSaveApp):
     def source_iterator(self):
         """this iterator yields individual ooids from the source crashstorage
         class's 'new_ooids' method."""
-        self.iterator = self.config.ooid_source.ooid_source_class(
-          self.config.ooid_source,
+        self.iterator = self.config.new_crash_source.new_crash_source_class(
+          self.config.new_crash_source,
           self.registrar.processor_name,
           self.quit_check
         )
@@ -106,14 +106,20 @@ class ProcessorApp(FetchTransformSaveApp):
         processed crash is saved to the 'destination'."""
         try:
             raw_crash = self.source.get_raw_crash(ooid)
-        except OOIDNotFoundException:
+            dump = self.source.get_raw_dump(ooid)
+        except CrashIDNotFound:
             self.processor.reject_raw_crash(
               ooid,
               'this crash cannot be found in raw crash storage'
             )
             return
+        except Exception, x:
+            self.processor.reject_raw_crash(
+              ooid,
+              'error in loading: %s' % x
+            )
+            return
 
-        dump = self.source.get_raw_dump(ooid)
         if 'uuid' not in raw_crash:
             raw_crash.uuid = ooid
         processed_crash = \
@@ -125,8 +131,8 @@ class ProcessorApp(FetchTransformSaveApp):
 
     #--------------------------------------------------------------------------
     def _setup_source_and_destination(self):
-        """this method simply instatiates the source, destination, ooid_source,
-        and the processor algorithm implementation."""
+        """this method simply instatiates the source, destination,
+        new_crash_source, and the processor algorithm implementation."""
         super(ProcessorApp, self)._setup_source_and_destination()
         self.registrar = self.config.registrar.registrar_class(
           self.config.registrar,

--- a/socorro/unittest/app/test_generic_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_generic_fetch_transform_save_app.py
@@ -54,7 +54,7 @@ class TestFetchTransformSaveApp(unittest.TestCase):
     def test_bogus_source_and_destination(self):
         class NonInfiniteFTSAppClass(FetchTransformSaveApp):
             def source_iterator(self):
-                for x in self.source.new_ooids():
+                for x in self.source.new_crashes():
                     yield ((x,), {})
 
         class FakeStorageSource(object):

--- a/socorro/unittest/collector/test_throttler.py
+++ b/socorro/unittest/collector/test_throttler.py
@@ -2,18 +2,18 @@ import re
 import mock
 
 from socorro.lib.util import DotDict
-from socorro.collector.throttler import LegacyThrottler
+from socorro.collector.throttler import LegacyThrottler, ACCEPT, DEFER, DISCARD
 
 def testLegacyThrottler():
   config = DotDict()
-  config.throttleConditions = [ ('alpha', re.compile('ALPHA'), 100),
+  config.throttle_conditions = [ ('alpha', re.compile('ALPHA'), 100),
                                 ('beta',  'BETA', 100),
                                 ('gamma', lambda x: x == 'GAMMA', 100),
                                 ('delta', True, 100),
                                 (None, True, 0)
                               ]
-  config.minimalVersionForUnderstandingRefusal = { 'product1': '3.5', 'product2': '4.0' }
-  config.neverDiscard = False
+  config.minimal_version_for_understanding_refusal = { 'product1': '3.5', 'product2': '4.0' }
+  config.never_discard = False
   config.logger = mock.Mock()
   thr = LegacyThrottler(config)
   expected = 5
@@ -36,7 +36,7 @@ def testLegacyThrottler():
   actual = thr.understands_refusal(raw_crash)
   assert expected == actual, "understand refusal expected %d, but got %d instead" % (expected, actual)
 
-  expected = LegacyThrottler.ACCEPT
+  expected = ACCEPT
   actual = thr.throttle(raw_crash)
   assert expected == actual, "regexp throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -44,7 +44,7 @@ def testLegacyThrottler():
                          'Version':'3.4',
                          'alpha':'not correct',
                        })
-  expected = LegacyThrottler.DEFER
+  expected = DEFER
   actual = thr.throttle(raw_crash)
   assert expected == actual, "regexp throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -52,7 +52,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'alpha':'not correct',
                        })
-  expected = LegacyThrottler.DISCARD
+  expected = DISCARD
   actual = thr.throttle(raw_crash)
   assert expected == actual, "regexp throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -60,7 +60,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'beta':'BETA',
                        })
-  expected = LegacyThrottler.ACCEPT
+  expected = ACCEPT
   actual = thr.throttle(raw_crash)
   assert expected == actual, "string equality throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -68,7 +68,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'beta':'not BETA',
                        })
-  expected = LegacyThrottler.DISCARD
+  expected = DISCARD
   actual = thr.throttle(raw_crash)
   assert expected == actual, "string equality throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -76,7 +76,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'gamma':'GAMMA',
                        })
-  expected = LegacyThrottler.ACCEPT
+  expected = ACCEPT
   actual = thr.throttle(raw_crash)
   assert expected == actual, "string equality throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -84,7 +84,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'gamma':'not GAMMA',
                        })
-  expected = LegacyThrottler.DISCARD
+  expected = DISCARD
   actual = thr.throttle(raw_crash)
   assert expected == actual, "string equality throttle expected %d, but got %d instead" % (expected, actual)
 
@@ -92,7 +92,7 @@ def testLegacyThrottler():
                          'Version':'3.6',
                          'delta':"value doesn't matter",
                        })
-  expected = LegacyThrottler.ACCEPT
+  expected = ACCEPT
   actual = thr.throttle(raw_crash)
   assert expected == actual, "string equality throttle expected %d, but got %d instead" % (expected, actual)
 

--- a/socorro/unittest/external/postgresql/test_crashstorage.py
+++ b/socorro/unittest/external/postgresql/test_crashstorage.py
@@ -14,7 +14,7 @@ from socorro.database.transaction_executor import (
   TransactionExecutorWithLimitedBackoff
 )
 from socorro.external.crashstorage_base import (
-  CrashStorageBase, OOIDNotFoundException)
+  CrashStorageBase, CrashIDNotFound)
 from socorro.external.postgresql.crashstorage import PostgreSQLCrashStorage
 from socorro.unittest.config import commonconfig
 from socorro.unittest.config.commonconfig import (
@@ -88,7 +88,7 @@ class DontTestIntegrationPostgresSQLCrashStorage(object):
                'user=%(database_user)s password=%(database_password)s' % DSN)
         self.conn = psycopg2.connect(dsn)
         cursor = self.conn.cursor()
-        date_suffix = PostgreSQLCrashStorage._table_suffix_for_ooid(a_processed_crash['uuid'])
+        date_suffix = PostgreSQLCrashStorage._table_suffix_for_crash_id(a_processed_crash['uuid'])
         self.reports_table_name = 'reports%s' % date_suffix
         cursor.execute("""
         DROP TABLE IF EXISTS %(table_name)s;

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -60,7 +60,7 @@ class TestBase(unittest.TestCase):
               config,
               quit_check_callback=fake_quit_check
             )
-            crashstorage.save_raw_crash({}, 'payload')
+            crashstorage.save_raw_crash({}, 'payload', 'ooid')
             crashstorage.save_processed({})
             self.assertRaises(NotImplementedError,
                               crashstorage.get_raw_crash, 'ooid')
@@ -70,7 +70,7 @@ class TestBase(unittest.TestCase):
                               crashstorage.get_processed, 'ooid')
             self.assertRaises(NotImplementedError,
                               crashstorage.remove, 'ooid')
-            self.assertRaises(StopIteration, crashstorage.new_ooids)
+            self.assertRaises(StopIteration, crashstorage.new_crashes)
             crashstorage.close()
 
 
@@ -147,17 +147,22 @@ class TestBase(unittest.TestCase):
                 v.save_processed = Mock()
                 v.close = Mock()
 
-            poly_store.save_raw_crash(raw_crash, dump)
+            poly_store.save_raw_crash(raw_crash, dump, '')
             for v in poly_store.stores.itervalues():
-                v.save_raw_crash.assert_called_once_with(raw_crash, dump)
+                v.save_raw_crash.assert_called_once_with(raw_crash, dump, '')
 
             poly_store.save_processed(processed_crash)
             for v in poly_store.stores.itervalues():
                 v.save_processed.assert_called_once_with(processed_crash)
 
-            poly_store.save_raw_and_processed(raw_crash, dump, processed_crash)
+            poly_store.save_raw_and_processed(
+              raw_crash,
+              dump,
+              processed_crash,
+              'n'
+            )
             for v in poly_store.stores.itervalues():
-                v.save_raw_crash.assert_called_with(raw_crash, dump)
+                v.save_raw_crash.assert_called_with(raw_crash, dump, 'n')
                 v.save_processed.assert_called_with(processed_crash)
 
             raw_crash = {'ooid': 'oaeu'}
@@ -174,9 +179,10 @@ class TestBase(unittest.TestCase):
             self.assertRaises(PolyStorageError,
                               poly_store.save_raw_crash,
                               raw_crash,
-                              dump)
+                              dump,
+                              '')
             for v in poly_store.stores.itervalues():
-                v.save_raw_crash.assert_called_with(raw_crash, dump)
+                v.save_raw_crash.assert_called_with(raw_crash, dump, '')
 
             self.assertRaises(PolyStorageError,
                               poly_store.save_processed,

--- a/socorro/unittest/processor/test_legacy_new_crash_source.py
+++ b/socorro/unittest/processor/test_legacy_new_crash_source.py
@@ -3,8 +3,8 @@ import mock
 
 from configman.dotdict import DotDict
 
-from socorro.processor.legacy_ooid_source import (
-  LegacyOoidSource,
+from socorro.processor.legacy_new_crash_source import (
+  LegacyNewCrashSource,
 )
 from socorro.external.postgresql.dbapi2_util import (
     execute_no_results,
@@ -24,11 +24,11 @@ def sequencer(*args):
         return value
     return foo
 
-class TestLegacyOoidSource(unittest.TestCase):
+class TestLegacyNewCrashSource(unittest.TestCase):
     """
     """
 
-    def test_legacy_ooid_source_basics(self):
+    def test_legacy_new_crash_source_basics(self):
         m_transaction_executor_class = mock.Mock()
 
         config = DotDict()
@@ -37,7 +37,7 @@ class TestLegacyOoidSource(unittest.TestCase):
         config.transaction_executor_class = m_transaction_executor_class
         config.batchJobLimit = 10
 
-        ooid_source = LegacyOoidSource(config,
+        new_crash_source = LegacyNewCrashSource(config,
                                        processor_name='dwight-1234')
 
         self.assertEqual(m_transaction_executor_class.call_count, 1)
@@ -53,7 +53,7 @@ class TestLegacyOoidSource(unittest.TestCase):
         config.batchJobLimit = 10
         config.logger = mock.Mock()
 
-        class StubbedIterators(LegacyOoidSource):
+        class StubbedIterators(LegacyNewCrashSource):
             def _priority_jobs_iter(self):
                 while True:
                     yield None
@@ -69,7 +69,7 @@ class TestLegacyOoidSource(unittest.TestCase):
                 for x in values:
                     yield x
 
-        ooid_source = StubbedIterators(config,
+        new_crash_source = StubbedIterators(config,
                                        processor_name='sherman1234')
         expected = ('1234',
                     '2345',
@@ -77,10 +77,10 @@ class TestLegacyOoidSource(unittest.TestCase):
                     '4567',
                     '5678',
                    )
-        for x, y in zip(ooid_source, expected):
+        for x, y in zip(new_crash_source, expected):
             self.assertEqual(x, y)
 
-        self.assertEqual(len([x for x in ooid_source]), 5)
+        self.assertEqual(len([x for x in new_crash_source]), 5)
 
 
     def test_incoming_job_stream_priority(self):
@@ -90,7 +90,7 @@ class TestLegacyOoidSource(unittest.TestCase):
         config.batchJobLimit = 10
         config.logger = mock.Mock()
 
-        class StubbedIterators(LegacyOoidSource):
+        class StubbedIterators(LegacyNewCrashSource):
             def _normal_jobs_iter(self):
                 while True:
                     yield None
@@ -106,7 +106,7 @@ class TestLegacyOoidSource(unittest.TestCase):
                 for x in values:
                     yield x
 
-        ooid_source = StubbedIterators(config,
+        new_crash_source = StubbedIterators(config,
                                        processor_name='victor1234')
         expected = ('1234',
                     '2345',
@@ -114,10 +114,10 @@ class TestLegacyOoidSource(unittest.TestCase):
                     '4567',
                     '5678',
                    )
-        for x, y in zip(ooid_source, expected):
+        for x, y in zip(new_crash_source, expected):
             self.assertEqual(x, y)
 
-        self.assertEqual(len([x for x in ooid_source]), 5)
+        self.assertEqual(len([x for x in new_crash_source]), 5)
 
     def test_incoming_job_stream_interleaved(self):
         config = DotDict()
@@ -126,7 +126,7 @@ class TestLegacyOoidSource(unittest.TestCase):
         config.batchJobLimit = 10
         config.logger = mock.Mock()
 
-        class StubbedIterators(LegacyOoidSource):
+        class StubbedIterators(LegacyNewCrashSource):
             def _normal_jobs_iter(self):
                 values = [
                     (1, '1234', 1),
@@ -156,7 +156,7 @@ class TestLegacyOoidSource(unittest.TestCase):
                 for x in values:
                     yield x
 
-        ooid_source = StubbedIterators(config,
+        new_crash_source = StubbedIterators(config,
                                        processor_name='sherman1234')
         expected = ('1234',
                     'p1234',
@@ -169,10 +169,10 @@ class TestLegacyOoidSource(unittest.TestCase):
                     'p5678',
                     '5678',
                    )
-        for x, y in zip(ooid_source, expected):
+        for x, y in zip(new_crash_source, expected):
             self.assertEqual(x, y)
 
-        self.assertEqual(len([x for x in ooid_source]), 10)
+        self.assertEqual(len([x for x in new_crash_source]), 10)
 
 
     def test_priority_jobs_iter_simple(self):
@@ -217,10 +217,10 @@ class TestLegacyOoidSource(unittest.TestCase):
             (5, '5678', 1),
         )
 
-        ooid_source = LegacyOoidSource(config,
+        new_crash_source = LegacyNewCrashSource(config,
                                        processor_name='dwight')
 
-        for x, y in zip(ooid_source._priority_jobs_iter(), expected_sequence):
+        for x, y in zip(new_crash_source._priority_jobs_iter(), expected_sequence):
             self.assertEqual(x, y)
 
         expected_get_priority_jobs_sql = (
@@ -236,7 +236,7 @@ class TestLegacyOoidSource(unittest.TestCase):
           "delete from priority_jobs_17 where uuid = %s"
         )
         expected_transactions = (
-            ((ooid_source._create_priority_jobs,),),
+            ((new_crash_source._create_priority_jobs,),),
             ((execute_query_fetchall, expected_get_priority_jobs_sql,),),
             ((execute_no_results, expected_delete_one_priority_job_sql,
                 ('1234',)),),
@@ -293,10 +293,10 @@ class TestLegacyOoidSource(unittest.TestCase):
             (5, '5678', 1),
         )
 
-        ooid_source = LegacyOoidSource(config,
+        new_crash_source = LegacyNewCrashSource(config,
                                        processor_name='dwight')
-        ooid_source.processor_id = 17
-        for x, y in zip(ooid_source._normal_jobs_iter(), exepected_sequence):
+        new_crash_source.processor_id = 17
+        for x, y in zip(new_crash_source._normal_jobs_iter(), exepected_sequence):
             self.assertEqual(x, y)
 
         expected_get_normal_sql = (
@@ -313,7 +313,7 @@ class TestLegacyOoidSource(unittest.TestCase):
           "  limit 10"
         )
         expected_transactions = (
-            ((ooid_source._create_priority_jobs,),),
+            ((new_crash_source._create_priority_jobs,),),
             ((execute_query_fetchall, expected_get_normal_sql,),),
             ((execute_query_fetchall, expected_get_normal_sql,),),
             ((execute_query_fetchall, expected_get_normal_sql,),),

--- a/socorro/webapi/servers.py
+++ b/socorro/webapi/servers.py
@@ -1,0 +1,85 @@
+import web
+
+from socorro.webapi.classPartial import classWithPartialInit
+
+from configman import Namespace, RequiredConfig
+
+#==============================================================================
+class WebServerBase(RequiredConfig):
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, services_list):
+        self.config = config
+        self.urls = tuple(y for a_tuple in
+                         ((x.uri, classWithPartialInit(x, config))
+                            for x in services_list) for y in a_tuple)
+        #self.config.logger.info(str(self.urls))
+        web.webapi.internalerror = web.debugerror
+        web.config.debug = False
+        self._identify()
+        self._wsgi_func = web.application(self.urls, globals()).wsgifunc()
+
+    #--------------------------------------------------------------------------
+    def run(self):
+        raise NotImplemented
+
+    #--------------------------------------------------------------------------
+    def _identify(self):
+        pass
+
+
+
+#==============================================================================
+class ApacheModWSGI(WebServerBase):
+    """When running Apache, modwsgi requires a reference to a "wsgifunc" In
+    this varient of the WebServer class, the run function returns the result of
+    the webpy framework's wsgifunc.  Applications that use this class must
+    provide a module level variable 'application' in the module given to Apache
+    modwsgi configuration.  The value of the variable must be the _wsgi_func.
+    """
+
+    #--------------------------------------------------------------------------
+    def run(self):
+        return self._wsgi_func
+
+    #--------------------------------------------------------------------------
+    def _identify(self):
+        self.config.logger.info('this is ApacheModWSGI')
+
+
+#==============================================================================
+class StandAloneServer(WebServerBase):
+    required_config = Namespace()
+    required_config.add_option(
+      'port',
+      doc='the port to listen to for submissions',
+      default=8882
+    )
+
+
+#==============================================================================
+class CherryPy(StandAloneServer):
+    required_config = Namespace()
+    required_config.add_option(
+      'ip_address',
+      doc='the IP address from which to accept submissions',
+      default='127.0.0.1'
+    )
+
+    #--------------------------------------------------------------------------
+    def run(self):
+        web.runsimple(
+          self._wsgi_func,
+          (self.config.web_server.ip_address, self.config.web_server.port)
+        )
+
+    #--------------------------------------------------------------------------
+    def _identify(self):
+        self.config.logger.info(
+          'this is CherryPy from web.py running standalone at %s:%d',
+          self.config.web_server.ip_address,
+          self.config.web_server.port
+        )
+
+

--- a/socorro/webapi/tornado_server.py
+++ b/socorro/webapi/tornado_server.py
@@ -1,0 +1,23 @@
+from tornado.wsgi import WSGIContainer
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+
+from socorro.webapi.servers import StandAloneServer
+from configman import Namespace
+
+#==============================================================================
+class Tornado(StandAloneServer):
+    #--------------------------------------------------------------------------
+    def run(self):
+        container = WSGIContainer(self._wsgi_func)
+        http_server = HTTPServer(container)
+        http_server.listen(self.config.web_server.port)
+        IOLoop.instance().start()
+
+    #--------------------------------------------------------------------------
+    def _identify(self):
+        self.config.logger.info(
+          'this is the Tornado Web Server on port: %d',
+          self.config.web_server.port
+        )
+


### PR DESCRIPTION
in this epic pull request, we have the introduction of the new configman enabled collector_app.  With the introduction of collector_app, I had to refactor the crashstorage system.  When we first created the crashstorage system, it was assumed that the ooid/uuid/crash_id was in the raw_crash.  That was an erroneous assumption.  Therefore, I had to add a parameter to any crashstorage method that saves raw crashes...
