### PR TITLE
fixes bug 764990:  missing date constraint on sql

### DIFF
--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -651,7 +651,13 @@ class Processor(object):
       threadLocalCursor.execute("update jobs set completeddatetime = %s, success = False, message = %s where id = %s", (self.nowFunc(), message, jobId))
       threadLocalDatabaseConnection.commit()
       try:
-        threadLocalCursor.execute("update reports set started_datetime = timestamp with time zone %s, completed_datetime = timestamp with time zone %s, success = False, processor_notes = %s where id = %s and date_processed = timestamp with time zone %s", (startedDateTime, self.nowFunc(), message, reportId, date_processed))
+        threadLocalCursor.execute(
+          "update reports set started_datetime = timestamp with time zone %%s,"
+          " completed_datetime = timestamp with time zone %%s, "
+          "success = False, processor_notes = %%s where id = %%s and "
+          "date_processed = timestamp with time zone '%s'" % date_processed,
+          (startedDateTime, self.nowFunc(), message, reportId)
+        )
         threadLocalDatabaseConnection.commit()
         self.saveProcessedDumpJson(newReportRecordAsDict, threadLocalCrashStorage)
       except Exception, x:
@@ -788,7 +794,7 @@ class Processor(object):
       self.extensionsTable.insert(threadLocalCursor, (reportId, date_processed, i, addon_id[:100], addon_version), self.databaseConnectionPool.connectionCursorPair, date_processed=date_processed)
       listOfAddonsForOutput.append((addon_id, addon_version))
     return listOfAddonsForOutput
-  
+
   #-----------------------------------------------------------------------------------------------------------------
   def insertCrashProcess (self, threadLocalCursor, reportId, jsonDocument,
                           date_processed, processorErrorMessages):

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -785,12 +785,12 @@ def testProcessJob06():
     c.fakeConnection.expect('commit', (), {}, None)
     c.fakeCursor.expect('execute',
                         ("update reports set started_datetime = timestamp "
-                         "with time zone %s, completed_datetime = "
-                         "timestamp with time zone %s, success = False, "
-                         "processor_notes = %s where id = %s and "
-                         "date_processed = timestamp with time zone %s",
-                         (startedDatetime, failedDatetime, message, reportId,
-                          date_processed)),
+                         "with time zone %%s, completed_datetime = "
+                         "timestamp with time zone %%s, success = False, "
+                         "processor_notes = %%s where id = %%s and "
+                         "date_processed = timestamp with time zone '%s'" %
+                         str(date_processed),
+                         (startedDatetime, failedDatetime, message, reportId)),
                         {})
     c.fakeConnection.expect('commit', (), {}, None)
     fakeSaveProcessedDumpJson = exp.DummyObjectWithExpectations()


### PR DESCRIPTION
the infamous processor lock problem was tracked down to a missing partition constraint on an SQL update statement. This patch resolves the problem.
