### PR TITLE
Bug 772860 - Update forced versions for correlations for Firefox cycle starting 2012-07-17

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -25,7 +25,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="14.0 15.0a2 16.0a1"
+MANUAL_VERSION_OVERRIDE="15.0 16.0a2 17.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 772860 - this should go to production ASAP after 2012-07-17, so should hopefully make it into 17.
