### PR TITLE
fixes bug 772961 - relocated logging to its own namespace

### DIFF
--- a/config/crontabber.ini
+++ b/config/crontabber.ini
@@ -27,42 +27,46 @@ jobs='''socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronA
         socorro.cron.jobs.matviews.NightlyBuildsCronApp|1d
 '''
 
-# name: stderr_error_logging_level
-# doc: logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
-# converter: int
-stderr_error_logging_level=10
-
-# name: stderr_line_format_string
-# doc: python logging system format for logging to stderr
-# converter: str
-stderr_line_format_string={asctime} {levelname} - {threadName} - {message}
-
-# name: syslog_error_logging_level
-# doc: logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
-# converter: int
-syslog_error_logging_level=40
-
-# name: syslog_facility_string
-# doc: syslog facility string ("user", "local0", etc)
-# converter: str
-syslog_facility_string=user
-
-# name: syslog_host
-# doc: syslog hostname
-# converter: str
-syslog_host=localhost
-
-# name: syslog_line_format_string
-# doc: python logging system format for syslog entries
-# converter: str
-syslog_line_format_string=crontabber (pid {process}): {asctime} {levelname} - {threadName} - {message}
-
-# name: syslog_port
-# doc: syslog port
-# converter: int
-syslog_port=514
-
 # name: transaction_executor_class
 # doc: a class that will execute transactions
 # converter: configman.converters.class_converter
 transaction_executor_class=socorro.database.transaction_executor.TransactionExecutor
+
+[logging]
+
+    # name: stderr_error_logging_level
+    # doc: logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # converter: int
+    stderr_error_logging_level='10'
+
+    # name: stderr_line_format_string
+    # doc: python logging system format for logging to stderr
+    # converter: str
+    stderr_line_format_string='{asctime} {levelname} - {threadName} - {message}'
+
+    # name: syslog_error_logging_level
+    # doc: logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # converter: int
+    syslog_error_logging_level='10'
+
+    # name: syslog_facility_string
+    # doc: syslog facility string ("user", "local0", etc)
+    # converter: str
+    syslog_facility_string='user'
+
+    # name: syslog_host
+    # doc: syslog hostname
+    # converter: str
+    syslog_host='localhost'
+
+    # name: syslog_line_format_string
+    # doc: python logging system format for syslog entries
+    # converter: str
+    syslog_line_format_string='processor_app (pid {process}): {asctime} {levelname} - {threadName} - {message}'
+
+    # name: syslog_port
+    # doc: syslog port
+    # converter: int
+    syslog_port='514'
+
+


### PR DESCRIPTION
earlier updates to generic_app have broken crontabber's ini file.  the correction is to move crontabber's logging options into a 'logging' namespace.
