### PR TITLE
fixes bug 773010 - HBase mods fixing retry behavior

### DIFF
--- a/socorro/external/hbase/hbase_client.py
+++ b/socorro/external/hbase/hbase_client.py
@@ -11,6 +11,7 @@ import heapq
 import time
 import tarfile
 import random
+import sys
 import contextlib
 
 import socket
@@ -300,7 +301,8 @@ class HBaseConnection(object):
                                       self.thriftModule.TException,
                                       #HBaseClientException,
                                       socket.timeout,
-                                      socket.error
+                                      socket.error,
+                                      FatalException
                                       )
         self.operational_exceptions = self.hbaseThriftExceptions
         self.conditional_exceptions = ()


### PR DESCRIPTION
For retry behavior in the new crash storage system, the list of HBase
exceptions ought to include FatalException
