### PR TITLE
Added a check in setupdb_app.py for database existence. Returns immediately if it already exists

### DIFF
--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -145,9 +145,7 @@ class SocorroDB(App):
         dsn = dsn_template % 'template1'
 
         with PostgreSQLManager(dsn, self.config.logger) as db:
-            if db.breakpad_db_exists():
-                print 'The DB already exists. Safe return'
-                return 0
+            
 
         with PostgreSQLManager(dsn, self.config.logger) as db:
             db_version = db.version()
@@ -166,6 +164,9 @@ class SocorroDB(App):
                 db.execute('DROP DATABASE %s' % self.database_name,
                     ['database "%s" does not exist' % self.database_name])
                 db.execute('DROP SCHEMA pgx_diag', ['schema "pgx_diag" does not exist'])
+            else if db.breakpad_db_exists():
+                print 'The DB already exists. Safe return'
+                return 0
 
             db.execute('CREATE DATABASE %s' % self.database_name,
                        ['database "%s" already exists' % self.database_name])


### PR DESCRIPTION
There seems to be a bug in chef on this resource:

``` ruby
execute "Setup PostgreSQL database" do
  command "/home/socorro/source/socorro/external/postgresql/setupdb_app.py --database_name=breakpad"
  not_if "/usr/bin/psql --list breakpad | grep breakpad" 
  cwd '/home/socorro/source'
  environment ({'PYTHONPATH' => '/data/socorro/application:/data/socorro/thirdparty'})
  user "postgres"
  action :run
end
```

It always calls setupdb_app.py --database_name=breakpad even if not_if "/usr/bin/psql --list breakpad | grep breakpad" avoids that

I updated the python script to do nothing if it detects that the DB already exists
