### PR TITLE
bug 735496 update bugzilla api 0.9 to 1.1

### DIFF
--- a/webapp-php/application/config/bzapi.php-dist
+++ b/webapp-php/application/config/bzapi.php-dist
@@ -8,10 +8,9 @@
  */
 
 // Root url for the bugzilla REST api you're interested in querying
-$config['url'] = 'https://api-dev.bugzilla.mozilla.org/0.9/';
+$config['url'] = 'https://api-dev.bugzilla.mozilla.org/1.1/';
 
 // How long to cache REST calls, in seconds, if different from global cache.
 // Setting the time out to 0 disables it.
 $config['timeout'] = 900; // default 15 minutes
-
 


### PR DESCRIPTION
Difficult to test because of bug 774777. Call `https://crash-stats/buginfo/bug?id=731846,&include_fields=summary,status,id,resolution` directly.
