### PR TITLE
Fixed incorrect processing of the redirect chain

### DIFF
--- a/webapp-php/application/libraries/CrashReportDump.php
+++ b/webapp-php/application/libraries/CrashReportDump.php
@@ -125,7 +125,6 @@ class CrashReportDump {
         foreach($meta['wrapper_data'] as $header) {
             if(preg_match($regex, $header)) {
                 $status = $header;
-                break;
             }
         }
 


### PR DESCRIPTION
For example wrapper_data after a chain of two redirects is:
["HTTP/1.1 302 Moved Temporarily",
 "Server: nginx/1.2.1",
 "Date: Wed, 01 Aug 2012 12:17:22 GMT",
 "Content-Type: text/html",
 "Content-Length: 160",
 "Connection: close",
 "Location: http://*.net:8080/crash/processed/by/uuid/d4c94252-7a29-4f9d-899b-eece72120731",
 "HTTP/1.1 200 OK",
 "Server: nginx/1.2.1",
 "Date: Wed, 01 Aug 2012 12:17:22 GMT",
 "Content-Type: application/json",
 "Connection: close"]

Another solution is back-travercing of the array, but I've choisen the simplest one.
