### PR TITLE
bug 781318 - Fix the append/skiplist for "WaitFor" and "BaseGetNamedObjectDirectory" signatures on hangs

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -163,6 +163,7 @@ irrelevantSignatureRegEx.default = '|'.join([
   '___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___',
   'WaitForSingleObjectExImplementation',
   'WaitForMultipleObjectsExImplementation',
+  'RealMsgWaitFor.*'
   '_ZdlPv',
   'zero',
   ])
@@ -301,8 +302,7 @@ prefixSignatureRegEx = '|'.join([
   'TouchBadMemory',
   '_VEC_memcpy',
   '_VEC_memzero',
-  'WaitForMultipleObjects(Ex)?',
-  'WaitForSingleObject(Ex)?',
+  '.*WaitFor.*',
   'wcslen',
   '__wrap_realloc',
   'WSARecv.*',


### PR DESCRIPTION
Modifies the skiplist for better hang processing, https://bugzilla.mozilla.org/show_bug.cgi?id=781317
