### PR TITLE
Bug 778162 - The change from nsILocalFile to nsIFile altered the CrashReporter::CreatePairedMinidumps sentinel for brower hangs. r?lars

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -114,7 +114,7 @@ signatureSentinels = cm.Option()
 signatureSentinels.doc = 'a list of frame signatures that should always be considered top of the stack if present in the stack'
 signatureSentinels.default = ['_purecall',
                               ('mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)',
-                                  lambda sourcelist: any((sourceitem.find('CreatePairedMinidumps') != -1 for sourceitem in sourcelist))),
+                                  lambda stack: any('CreatePairedMinidumps' in signature for signature in stack)),
                               'Java_org_mozilla_gecko_GeckoAppShell_reportJavaCrash',
                               'google_breakpad::ExceptionHandler::HandleInvalidParameter(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned int)']
 


### PR DESCRIPTION
Make the sentinel function more lenient in general.
