### PR TITLE
Bug 781317 - Add BaseGetNamedObjectDirectory to the append list for better signatures from bug 763896

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -308,7 +308,7 @@ prefixSignatureRegEx = '|'.join([
   'WSARecv.*',
   'WSASend.*',
   '_ZdaPvRKSt9nothrow_t\"',
-
+  'BaseGetNamedObjectDirectory',
   ])
 
 signaturesWithLineNumbersRegEx = cm.Option()


### PR DESCRIPTION
Through some kind of personal gitfail I managed to get the WaitFor bits in the first patch but not this change.
