### PR TITLE
Add BaseGetNamedObjectDirectory to the append list for better signatures...

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -308,7 +308,7 @@ prefixSignatureRegEx = '|'.join([
   'WSARecv.*',
   'WSASend.*',
   '_ZdaPvRKSt9nothrow_t\"',
-
+  'BaseGetNamedObjectDirectory',
   ])
 
 signaturesWithLineNumbersRegEx = cm.Option()


### PR DESCRIPTION
... from bug 763896
