### PR TITLE
Bug 784094 - Update forced versions for correlations for Firefox cycle starting 2012-08-28

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -25,7 +25,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="15.0 16.0a2 17.0a1"
+MANUAL_VERSION_OVERRIDE="16.0 17.0a2 18.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 784094 - this should go to production ASAP after 2012-08-27/28, so probably needs to go out before Mobeta.
