### PR TITLE
Bug 781136 - Add flashplayerplugin_*.exe to Flash detection

### DIFF
--- a/socorro/processor/externalProcessor.py
+++ b/socorro/processor/externalProcessor.py
@@ -211,7 +211,7 @@ class ProcessorWithExternalBreakpad (processor.Processor):
     return reportUpdateValues
 
 #-----------------------------------------------------------------------------------------------------------------
-  flashRE = re.compile(r'NPSWF32_?(.*)\.dll|libflashplayer(.*)\.(.*)|Flash ?Player-?(.*)')
+  flashRE = re.compile(r'NPSWF32_?(.*)\.dll|FlashPlayerPlugin_?(.*)\.exe|libflashplayer(.*)\.(.*)|Flash ?Player-?(.*)')
   def getVersionIfFlashModule(self,moduleData):
     """If (we recognize this module as Flash and figure out a version): Returns version; else (None or '')"""
     #logger.debug(" flash? %s", moduleData)
@@ -227,9 +227,11 @@ class ProcessorWithExternalBreakpad (processor.Processor):
         if groups[0]:
           version = groups[0].replace('_', '.')
         elif groups[1]:
-          version = groups[1]
-        elif groups[3]:
-          version = groups[3]
+          version = groups[1].replace('_', '.')
+        elif groups[2]:
+          version = groups[2]
+        elif groups[4]:
+          version = groups[4]
         elif 'knownFlashDebugIdentifiers' in self.config:
           version = self.config.knownFlashDebugIdentifiers.get(debugId) # probably a miss
     else:

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -738,7 +738,9 @@ class LegacyCrashProcessor(RequiredConfig):
         return processed_crash_update
 
     #--------------------------------------------------------------------------
-    flash_re = re.compile(r'NPSWF32_?(.*)\.dll|libflashplayer(.*)\.(.*)|'
+    flash_re = re.compile(r'NPSWF32_?(.*)\.dll|'
+                          'FlashPlayerPlugin_?(.*)\.exe|'
+                          'libflashplayer(.*)\.(.*)|'
                           'Flash ?Player-?(.*)')
 
     #--------------------------------------------------------------------------
@@ -757,9 +759,11 @@ class LegacyCrashProcessor(RequiredConfig):
                 if groups[0]:
                     version = groups[0].replace('_', '.')
                 elif groups[1]:
-                    version = groups[1]
-                elif groups[3]:
-                    version = groups[3]
+                    version = groups[1].replace('_', '.')
+                elif groups[2]:
+                    version = groups[2]
+                elif groups[4]:
+                    version = groups[4]
                 elif 'knownFlashDebugIdentifiers' in self.config:
                     version = (
                         self.config.knownFlashDebugIdentifiers


### PR DESCRIPTION
This adds detection of the .exe to both variants of the processor.
In the newer code it looked best to split the regexp to one file match per line, I can adjust that if you like, but not by much to still fit 80 chars.
