### PR TITLE
Fixes bug 791889 - More robust middleware decode function, and do not do...

### DIFF
--- a/socorro/middleware/service.py
+++ b/socorro/middleware/service.py
@@ -143,6 +143,9 @@ class DataAPIService(JsonWebServiceBase):
             value = value.replace("%2F", "/")
             value = value.replace("%2B", "+")
         except AttributeError:
-            value = [x.replace("%2F", "/") for x in value]
-            value = [x.replace("%2B", "+") for x in value]
+            try:
+                value = [x.replace("%2F", "/") for x in value]
+                value = [x.replace("%2B", "+") for x in value]
+            except TypeError:
+                pass
         return value

--- a/webapp-php/application/libraries/MY_SearchReportHelper.php
+++ b/webapp-php/application/libraries/MY_SearchReportHelper.php
@@ -44,7 +44,6 @@ class SearchReportHelper{
      * @param array An array of $_GET parameters
      */
     public function normalizeParams( &$params ){
-        $params['query'] = urldecode($params['query']);
         $this->normalizeProduct($params);
         $this->normalizeDateUnitAndValue($params);
     }


### PR DESCRIPTION
...uble-decode the query parameter in the UI.

The fix in the middleware `service.py` file is the one for the actual problem, but when testing I found another problem with `+` being sent to the middleware as spaces. I wonder how this happened, and I wonder why I didn't see that problem when originally testing the pluses fix. Anyhow, this is all logical (the query parameter was decoded twice, thus making `+` characters white spaces) and it now works. I tested with a few complex signatures and didn't run into any problem. 

@Lonnen r?
