### PR TITLE
Bug 799953 - Update forced versions for correlations for Firefox cycle starting 2012-10-09

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -25,7 +25,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="16.0 17.0a2 18.0a1"
+MANUAL_VERSION_OVERRIDE="17.0 18.0a2 19.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 799953 - this should go to production ASAP.
