### PR TITLE
Add github to vcsMappings

### DIFF
--- a/webapp-php/application/config/codebases.php-dist
+++ b/webapp-php/application/config/codebases.php-dist
@@ -8,6 +8,11 @@ $config['vcsMappings'] = array(
     'hg' => array(
         'hg.mozilla.org' =>
 	    'http://hg.mozilla.org/%(repo)s/annotate/%(revision)s/%(file)s#l%(line)s'
-));
+    ),
+    'git' => array(
+        'github.com' =>
+            'https://github.com/%(repo)s/blob/%(revision)s/%(file)s#L%(line)s'
+    )
+);
 $config['bugTrackingUrl'] = 'https://bugzilla.mozilla.org/show_bug.cgi?id=';
 ?>


### PR DESCRIPTION
I'm going to be fixing the symbol files for B2G soon so that they contain the right repository info. To make this useful we'll need to be able to translate these into web links. As a first cut, making github links work will be useful.
