### PR TITLE
Bug 794544 - build exploitable tool along with minidump_stackwalk as part of Socorro build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ lint:
 clean:
 	find ./socorro/ -type f -name "*.pyc" -exec rm {} \;
 	rm -rf ./thirdparty/*
-	rm -rf ./google-breakpad/ ./builds/ ./breakpad/ ./stackwalk ./pip-cache
+	rm -rf ./google-breakpad/ ./exploitable/ ./builds/ ./breakpad/ ./stackwalk ./pip-cache
 	rm -rf ./breakpad.tar.gz
 
 minidump_stackwalk:
@@ -88,6 +88,10 @@ minidump_stackwalk:
 	cd google-breakpad && ./configure --prefix=`pwd`/../stackwalk/
 	cd google-breakpad && make install
 	cd google-breakpad && svn info | grep Revision | cut -d' ' -f 2 > ../stackwalk/revision.txt
+	rm -rf exploitable
+	hg clone http://hg.mozilla.org/users/tmielczarek_mozilla.com/exploitable/
+	cd exploitable && make BREAKPAD_SRCDIR=../google-breakpad BREAKPAD_OBJDIR=../google-breakpad
+	cp exploitable/exploitable `pwd`/stackwalk/bin
 
 analysis:
 	git submodule update --init socorro-toolbox akela

--- a/puppet/manifests/classes/socorro-base.pp
+++ b/puppet/manifests/classes/socorro-base.pp
@@ -162,7 +162,7 @@ class socorro-python inherits socorro-base {
 #                default => "puppet://$server/modules/socorro/prod/etc-logrotated/socorro",
 #                };
     package {
-        ['subversion', 'libpq-dev', 'python-virtualenv', 'python-dev']:
+        ['subversion', 'libpq-dev', 'python-virtualenv', 'python-dev', 'mercurial']:
             ensure => latest,
             require => Exec['apt-get-update'];
     }
@@ -175,7 +175,7 @@ class socorro-python inherits socorro-base {
             timeout => '3600',
             require => [Package['libcurl4-openssl-dev'],
                         File['/data/socorro'], Package['build-essential'],
-                        Package['subversion']],
+                        Package['subversion'], Package['mercurial']],
             user => 'socorro';
     }
 


### PR DESCRIPTION
This seems to do the trick. Caveat:
![](http://i1.kym-cdn.com/photos/images/original/000/234/765/b7e.jpg)
