### PR TITLE
Split Breakpad build into a separate script that we can use for the Jenkins build as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,7 @@ clean:
 	rm -rf ./breakpad.tar.gz
 
 minidump_stackwalk:
-	svn co http://google-breakpad.googlecode.com/svn/trunk google-breakpad
-	cd google-breakpad && ./configure --prefix=`pwd`/../stackwalk/
-	cd google-breakpad && make install
-	cd google-breakpad && svn info | grep Revision | cut -d' ' -f 2 > ../stackwalk/revision.txt
+	PREFIX=`pwd`/../stackwalk/ SKIP_TAR=1 ./scripts/build-breakpad.sh
 
 analysis:
 	git submodule update --init socorro-toolbox akela

--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Jenkins build script for building Breakpad
+
+# any failures in this script should cause the build to fail
+set -e
+
+# Checkout and build Breakpad
+echo "PREFIX: ${PREFIX:=`pwd`/build/breakpad}"
+svn co http://google-breakpad.googlecode.com/svn/trunk google-breakpad
+cd google-breakpad
+./configure --prefix=${PREFIX}
+make install
+if test -z "${SKIP_CHECK}"; then
+  #FIXME: Breakpad tests hang on Jenkins CI   
+  #make check
+  true
+fi
+svn info | grep Revision | cut -d' ' -f 2 > ${PREFIX}/revision.txt
+cd ..
+
+# Clone and build exploitable
+if test -d exploitable; then
+  hg -R exploitable pull -u
+else
+  hg clone http://hg.mozilla.org/users/tmielczarek_mozilla.com/exploitable/
+fi
+cd exploitable
+make BREAKPAD_SRCDIR=../google-breakpad BREAKPAD_OBJDIR=../google-breakpad
+cp exploitable ${PREFIX}/bin
+cd ..
+
+# Optionally package everything up
+if test -z "${SKIP_TAR}"; then
+  echo "Creating breakpad.tar.gz"
+  tar -C ${PREFIX}/.. --mode 755 --owner 0 --group 0 -zcf breakpad.tar.gz `basename ${PREFIX}`
+fi


### PR DESCRIPTION
Also pulls and builds the 'exploitable' tool after building Breakpad. This obsoletes PR 905.
