### PR TITLE
Fixed exception in JsonWebServiceBase.get

### DIFF
--- a/socorro/webapi/webapiService.py
+++ b/socorro/webapi/webapiService.py
@@ -83,7 +83,7 @@ class JsonWebServiceBase(object):
 
     def get(self, *args):
         raise NotImplementedError(
-                    "The GET function has not been implemented for %s" % args)
+                    "The GET function has not been implemented for %s" % repr(args))
 
     def POST(self, *args):
         """


### PR DESCRIPTION
`args` is a tuple, so `%` operator, applied to the tuple, expects that string contains `len(args)` `"%s"` substrings in the first argument.
I think that expected behaviour is a string representation for `args`.
