### PR TITLE
fixes Bug 792082 - Ignore the browser side of plugin-hang reports

### DIFF
--- a/scripts/config/collectorconfig.py.dist
+++ b/scripts/config/collectorconfig.py.dist
@@ -136,6 +136,7 @@ neverDiscard.fromStringConverter = cm.booleanConverter
 
 throttleConditions = cm.Option()
 throttleConditions.default = throttleConditions.default = [
+    ("*", lambda d: "HangID" in d and d.get("ProcessType", "browser") == "browser", None),  # drop browser hangs
     ("Comments", lambda x: x, 100), # 100% of crashes with comments
     ("ReleaseChannel", lambda x: x in ("aurora", "beta", "esr"), 100),
     ("ReleaseChannel", lambda x: x.startswith('nightly'), 100),

--- a/socorro/collector/wsgi_collector.py
+++ b/socorro/collector/wsgi_collector.py
@@ -7,7 +7,7 @@ import time
 
 from socorro.lib.ooid import createNewOoid
 from socorro.lib.util import DotDict
-from socorro.collector.throttler import DISCARD
+from socorro.collector.throttler import DISCARD, IGNORE
 from socorro.lib.datetimeutil import utc_now
 
 
@@ -60,6 +60,8 @@ class Collector(object):
         raw_crash.legacy_processing = self.throttler.throttle(raw_crash)
         if raw_crash.legacy_processing == DISCARD:
             return "Discarded=1\n"
+        if raw_crash.legacy_processing == IGNORE:
+            return "Unsupported=1\n"
 
         self.config.crash_storage.save_raw_crash(
           raw_crash,

--- a/socorro/collector/wsgicollector.py
+++ b/socorro/collector/wsgicollector.py
@@ -46,6 +46,11 @@ class Collector(object):
     ooid = sooid.createNewOoid(currentTimestamp)
     jsonDataDictionary.legacy_processing = \
         self.legacyThrottler.throttle(jsonDataDictionary)
+
+    if jsonDataDictionary.legacy_processing == cstore.LegacyThrottler.IGNORE:
+      self.logger.info('%s ignored', ooid)
+      return "Unsupported=1\n"
+
     self.logger.info('%s received', ooid)
     result = crashStorage.save_raw(ooid,
                                    jsonDataDictionary,

--- a/socorro/unittest/collector/test_wsgi_collector.py
+++ b/socorro/unittest/collector/test_wsgi_collector.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from configman.dotdict import DotDict
 
 from socorro.collector.wsgi_collector import Collector
-from socorro.collector.throttler import ACCEPT
+from socorro.collector.throttler import ACCEPT, IGNORE
 
 
 class ObjectWithValue(object):
@@ -106,3 +106,48 @@ class TestProcessorApp(unittest.TestCase):
                             'fake dump',
                             r[11:-1]
                             )
+
+    def test_POST_reject_browser_with_hangid(self):
+        config = self.get_standard_config()
+        c = Collector(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireFloozy'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.HangID = 'xyz'
+        rawform.ProcessType = 'browser'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireFloozy'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc = dict(erc)
+
+        with mock.patch('socorro.collector.wsgi_collector.web') as mocked_web:
+            mocked_web.input.return_value = form
+            with mock.patch('socorro.collector.wsgi_collector.web.webapi') \
+                    as mocked_webapi:
+                mocked_webapi.rawinput.return_value = rawform
+                with mock.patch('socorro.collector.wsgi_collector.utc_now') \
+                        as mocked_utc_now:
+                    mocked_utc_now.return_value = datetime(
+                        2012, 5, 4, 15, 10
+                        )
+                    with mock.patch('socorro.collector.wsgi_collector.time') \
+                            as mocked_time:
+                        mocked_time.time.return_value = 3.0
+                        c.throttler.throttle.return_value = IGNORE
+                        r = c.POST()
+                        self.assertEqual(r, "Unsupported=1\n")
+                        self.assertFalse(
+                          c.crash_storage.save_raw_crash.call_count
+                        )


### PR DESCRIPTION
this PR adds new features to throttling.  Until now, any throttle function accepted only the value of the single key of interest.  Now if the key of interest is a "*", then the function is passed the entire raw crash as a dict.  This allows more than one field to be checked in the predicate function: 

traditional style (not deprecated):
  ("Product", "Firefox", 10),  # accept 10% of crashes where 'Firefox' is the 'Product'

more flexible style:
  ("*", lambda d: d['Product'] == 'Firefox' and d['Version'] == '98.6', 100), # accept 100% of Firefox 98.6 crashes

This PR also adds the ignore parameter.  Instead of a throttling probability, if None appears, then anything matching this rule will be utterly ignored.  The client will receive 'Unsupported=1' instead of a crash id.  

  ("*", lambda d: d['Product'] == 'Firefox' and d['Version'] < "10", None),  # ignore any crashes from FF less than version 10

All of this so that we can ignore the soon to be deprecated browser side hang crash reports.  Notice the new rule in .../scripts/config/collector.py.dist 
