### PR TITLE
Add state tables and tracking for matview runs

### DIFF
--- a/sql/upgrade/27.0/README.rst
+++ b/sql/upgrade/27.0/README.rst
@@ -1,0 +1,14 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+27.0 Database Updates
+=====================
+
+This batch makes the following database changes:
+
+bug 773332
+	Make daily matviews more resiliant
+
+The above changes should take only a few minutes to deploy.
+This upgrade does not require a downtime.

--- a/sql/upgrade/27.0/check_daily_adu_run.sql
+++ b/sql/upgrade/27.0/check_daily_adu_run.sql
@@ -1,0 +1,43 @@
+BEGIN;
+
+DROP TABLE IF EXISTS raw_adu_status;
+
+CREATE TABLE raw_adu_status (
+    last_check TIMESTAMPTZ NOT NULL
+    , is_good BOOLEAN NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION check_raw_adu(updateday date) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $function$
+BEGIN
+
+PERFORM 1 FROM raw_adu_status
+WHERE last_check::date = updateday
+AND is_good
+LIMIT 1;
+
+IF NOT FOUND THEN
+    -- We did not find a successful raw_adu check for updateday
+    -- so run the check now
+    PERFORM 1 FROM raw_adu
+    WHERE "date" = updateday
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        INSERT INTO raw_adu_status VALUES(now(), False);
+        RETURN FALSE;
+    ELSE
+        INSERT INTO raw_adu_status VALUES(now(), True);
+        RETURN TRUE;
+    END IF;
+ELSE
+    RETURN TRUE;
+END IF;
+
+-- Delete data that is older than 30 days to keep table small
+DELETE FROM raw_adu_status WHERE last_check < (now() - '30 days'::interval);
+
+END; $function$;
+
+COMMIT;

--- a/sql/upgrade/27.0/matview_status.sql
+++ b/sql/upgrade/27.0/matview_status.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+DROP TABLE IF EXISTS matview_runs;
+DROP TABLE IF EXISTS matview_functions;
+
+-- Let's restrict what gets logged into matview_runs
+CREATE TABLE matview_functions (
+    funcname TEXT UNIQUE NOT NULL
+);
+
+INSERT into matview_functions
+    VALUES('check_raw_adu')
+    , ('update_product_versions')
+    , ('update_signatures')
+    , ('update_os_versions')
+    , ('update_tcbs')
+    , ('update_adu')
+    , ('update_hang_report')
+    , ('update_rank_compare')
+    , ('update_nightly_builds')
+    , ('update_build_adu')
+    , ('update_crashes_by_user')
+    , ('update_crashes_by_user_build')
+    , ('update_correlations')
+    , ('update_home_page_graph')
+    , ('update_home_page_graph_build')
+    , ('update_tcbs_build')
+    , ('update_explosiveness');
+
+CREATE TABLE matview_runs (
+    matview_function TEXT NOT NULL REFERENCES matview_functions(funcname),
+    run_at TIMESTAMPTZ NOT NULL,
+    run_duration INTERVAL NOT NULL,
+    succeeded BOOLEAN NOT NULL
+);
+
+COMMIT;

--- a/sql/upgrade/27.0/upgrade.sh
+++ b/sql/upgrade/27.0/upgrade.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#please see README
+
+set -e
+
+CURDIR=$(dirname $0)
+DBNAME=$1
+: ${DBNAME:="breakpad"}
+VERSION=27.0
+
+echo '*********************************************************'
+echo 'Make daily matviews more resiliant'
+echo 'bug 792904'
+psql -f ${CURDIR}/check_daily_adu_run.sql $DBNAME
+psql -f ${CURDIR}/matview_status.sql $DBNAME
+
+#change version in DB
+psql -c "SELECT update_socorro_db_version( '$VERSION' )" $DBNAME
+
+echo "$VERSION upgrade done"
+
+exit 0


### PR DESCRIPTION
- Adding a state table: raw_adu_status and check function
- Adding logging table: matview_runs
- Adding function list/documentation: matview_functions

Per our new plan -- changes to the cron are in a separate PR.
