### PR TITLE
Revert "Bug 792118 - Make sure that new-style plugin hang reports (which...

### DIFF
--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -483,15 +483,9 @@ class LegacyCrashProcessor(RequiredConfig):
         except KeyError:
             pass  # leaving it as None if not in the document
 
-        if int(raw_crash.get('PluginHang', False)):
-            processed_crash.hangid = 'fake-' + uuid
-        else:
-            processed_crash.hangid = raw_crash.get('HangID', None)
-
-        if int(raw_crash.get('Hang', False)):
-            processed_crash.hang_type = 1
-        elif int(raw_crash.get('PluginHang', False)):
-            processed_crash.hang_type = -1
+        processed_crash.hangid = raw_crash.get('HangID', None)
+        if 'Hang' in raw_crash:
+            processed_crash.hang_type = raw_crash.Hang
         elif processed_crash.hangid:
             processed_crash.hang_type = -1
         else:

--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -567,16 +567,10 @@ class Processor(object):
         dumpfilePathname = threadLocalCrashStorage.dumpPathForUuid(jobUuid,
                                                                    self.config.temporaryFileSystemStoragePath)
         #logger.debug('about to doBreakpadStackDumpAnalysis')
-
-        if int(jsonDocument.get("Hang", False)):
-          hangType = 1
-        elif jsonDocument.get("PluginHang", False):
-          hangType = -1
-        elif 'hangid' in newReportRecordAsDict:
-          hangType = -1
-        else:
-          hangType = 0
-
+        isHang = 'hangid' in newReportRecordAsDict and bool(newReportRecordAsDict['hangid'])
+        # hangType values: -1 if old style hang with hangid and Hang not present
+        #                  else hangType == jsonDocument.Hang
+        hangType = int(jsonDocument.get("Hang", -1 if isHang else 0))
         java_stack_trace = jsonDocument.setdefault('JavaStackTrace', None)
         additionalReportValuesAsDict = self.doBreakpadStackDumpAnalysis(reportId, jobUuid, dumpfilePathname, hangType, java_stack_trace, threadLocalCursor, date_processed, processorErrorMessages)
         newReportRecordAsDict.update(additionalReportValuesAsDict)
@@ -744,14 +738,7 @@ class Processor(object):
     crash_date = datetime.datetime.fromtimestamp(crash_time, UTC)
     install_age = crash_time - installTime
     email = sutil.lookupLimitedStringOrNone(jsonDocument, 'Email', 100)
-
-    # Create a fake hangid to keep the queries and webapp working for the time
-    # being.
-    if int(jsonDocument.get('PluginHang', False)):
-      hangid = 'fake-' + uuid
-    else:
-      hangid = jsonDocument.get('HangID', None)
-
+    hangid = jsonDocument.get('HangID',None)
     process_type = sutil.lookupLimitedStringOrNone(jsonDocument, 'ProcessType', 10)
     #logger.debug ('hangid: %s', hangid)
     #logger.debug ('Email: %s', str(jsonDocument))

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -17,8 +17,6 @@ import socorro.unittest.testlib.util as testutil
 import datetime as dt
 import threading as thr
 
-import copy
-
 def setup_module():
     testutil.nosePrintModule(__file__)
 
@@ -1209,48 +1207,6 @@ def testInsertReportIntoDatabase01():
                                    error_list)
     e = expected_report_dict
     assert r == e, 'expected\n%s\nbut got\n%s' % (e, r)
-
-def testInsertReportIntoDatabase02():
-    """testInsertReportIntoDatabase01: success"""
-    p, c = getMockedProcessorAndContext()
-    ooid1 = 'ooid1'
-    date_processed = dt.datetime(2011,2,15,1,0,0, tzinfo=UTC)
-    json_doc = copy.deepcopy(sample_meta_json)
-    json_doc['PluginHang'] = '1'
-    expected_report_list_with_hangid = list(expected_report_tuple)
-    expected_report_list_with_hangid[-3] = 'fake-ooid1'
-    expected_report_tuple_with_hangid = tuple(expected_report_list_with_hangid)
-    error_list = []
-    c.fakeDatabaseConnectionPool.expect('connectionCursorPair', None, None,
-                                        17)
-    fakeReportsTable = exp.DummyObjectWithExpectations()
-    fakeReportsTable.expect('columns',
-                            None,
-                            None,
-                            sch.ReportsTable(logger=c.logger).columns)
-    fakeReportsTable.expect('insert',
-                            (c.fakeCursor,
-                             expected_report_tuple_with_hangid,
-                             17,),
-                            { 'date_processed': date_processed })
-    p.reportsTable = fakeReportsTable
-    c.fakeDatabaseModule.expect('singleValueSql',
-                                (c.fakeCursor,
-                                 "select id from reports where uuid = "
-                                 "'ooid1' and date_processed = timestamp "
-                                 "with time zone '2011-02-15 01:00:00+00:00'"),
-                                {},
-                                234)
-
-    r = p.insertReportIntoDatabase(c.fakeCursor,
-                                   ooid1,
-                                   json_doc,
-                                   date_processed,
-                                   error_list)
-    e = copy.deepcopy(expected_report_dict)
-    e['hangid'] = 'fake-ooid1'
-    assert r == e, 'expected\n%s\nbut got\n%s' % (e, r)
-
 
 def testInsertAdddonsIntoDatabase1():
     """testInsertAdddonsIntoDatabase1: no addons"""

--- a/socorro/unittest/processor/test_legacy_processor.py
+++ b/socorro/unittest/processor/test_legacy_processor.py
@@ -518,51 +518,6 @@ class TestLegacyProcessor(unittest.TestCase):
                 )
                 self.assertEqual(len(processor_notes), 0)
 
-                # test 05
-                processor_notes = []
-                raw_crash_with_pluginhang = copy.deepcopy(raw_crash)
-                raw_crash_with_pluginhang.PluginHang = '1'
-                processed_crash = leg_proc._create_basic_processed_crash(
-                  '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
-                  raw_crash_with_pluginhang,
-                  datetimeFromISOdateString(raw_crash.submitted_timestamp),
-                  started_timestamp,
-                  processor_notes,
-                )
-                processed_crash_with_pluginhang = \
-                    copy.copy(cannonical_basic_processed_crash)
-                processed_crash_with_pluginhang.hangid = \
-                    'fake-3bc4bcaa-b61d-4d1f-85ae-30cb32120504'
-                processed_crash_with_pluginhang.hang_type = -1
-                self.assertEqual(
-                  processed_crash,
-                  processed_crash_with_pluginhang
-                )
-                self.assertEqual(len(processor_notes), 0)
-
-                # test 06
-                processor_notes = []
-                raw_crash_with_hang_only = copy.deepcopy(raw_crash)
-                raw_crash_with_hang_only.Hang = 16
-                processed_crash = leg_proc._create_basic_processed_crash(
-                  '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
-                  raw_crash_with_hang_only,
-                  datetimeFromISOdateString(raw_crash.submitted_timestamp),
-                  started_timestamp,
-                  processor_notes,
-                )
-                processed_crash_with_hang_only = \
-                    copy.copy(cannonical_basic_processed_crash)
-                processed_crash_with_hang_only.hang_type = 1
-                self.assertEqual(
-                  processed_crash,
-                  processed_crash_with_hang_only
-                )
-                self.assertEqual(len(processor_notes), 0)
-
-
-
-
     def test_process_list_of_addons(self):
         config = setup_config_with_mocks()
         config.collect_addon = False


### PR DESCRIPTION
... have PluginHang=1 but no HangID) are processed correctly as plugin hangs."

This reverts commit 84f9772c63fa284b8daa5c03b202b89f06c309eb.

Problem was that all incoming crashes were being marked as hangs.
