### PR TITLE
Bug 811806 - Update forced versions for correlations for Firefox cycle starting 2012-11-20

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -25,7 +25,7 @@ do
   done
 done
 
-MANUAL_VERSION_OVERRIDE="17.0 18.0a2 19.0a1"
+MANUAL_VERSION_OVERRIDE="18.0 19.0a2 20.0a1"
 for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE


### PR DESCRIPTION
This commit fixes bug 811806 - this should go to production on Nov 20th or 21st.
