### PR TITLE
fixes Bug 794540 - added support for exploitability tool to original processor

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -66,6 +66,14 @@ minidump_stackwalkPathname = cm.Option()
 minidump_stackwalkPathname.doc = 'the full pathname of the extern program minidump_stackwalk (quote path with embedded spaces)'
 minidump_stackwalkPathname.default = '/data/socorro/stackwalk/bin/minidump_stackwalk'
 
+exploitability_tool_command_line = cm.Option()
+exploitability_tool_command_line.doc = 'the template for the command to invoke the exploitability tool'
+exploitability_tool_command_line.default = '$exploitability_tool_pathname $dumpfilePathname 2>/dev/null'
+
+exploitability_tool_pathname = cm.Option()
+exploitability_tool_pathname.doc = 'the full pathname of the extern program exploitability tool (quote path with embedded spaces)'
+exploitability_tool_pathname.default = '/data/socorro/stackwalk/bin/exploitable'
+
 symbolCachePath = cm.Option()
 symbolCachePath.doc = 'the path where the symbol cache is found (quote path with embedded spaces)'
 symbolCachePath.default = '/mnt/socorro/symbols'

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -168,6 +168,9 @@ class CachingIterator(object):
     self.secondaryCacheSize = 0
     self.useSecondary = False
   #-----------------------------------------------------------------------------------------------------------------
+  def close(self):
+    self.theIterator.close()
+  #-----------------------------------------------------------------------------------------------------------------
   def __iter__(self):
     #try:  #to be used in Python 2.5 or greater
       for x in self.theIterator:

--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -443,7 +443,7 @@ class Processor(object):
 
   #-----------------------------------------------------------------------------------------------------------------
   @staticmethod
-  def sanitizeDict (aDict, listOfForbiddenKeys=['url','email','user_id']):
+  def sanitizeDict (aDict, listOfForbiddenKeys=['url','email','user_id', 'exploitability']):
     for aForbiddenKey in listOfForbiddenKeys:
       if aForbiddenKey in aDict:
         del aDict[aForbiddenKey]
@@ -598,7 +598,8 @@ class Processor(object):
         truncated = %%s,
         topmost_filenames = %%s,
         addons_checked = %%s,
-        flash_version = %%s
+        flash_version = %%s,
+        exploitability = %%s
       where id = %s and date_processed = timestamp with time zone '%s'
       """ % (reportId,date_processed)
       #logger.debug("newReportRecordAsDict %s, %s", newReportRecordAsDict['topmost_filenames'], newReportRecordAsDict['flash_version'])
@@ -620,7 +621,7 @@ class Processor(object):
       flash_version = newReportRecordAsDict.get('flash_version')
       processor_notes = '; '.join(processorErrorMessages)
       newReportRecordAsDict['processor_notes'] = processor_notes
-      infoTuple = (newReportRecordAsDict['signature'], processor_notes, startedDateTime, completedDateTime, newReportRecordAsDict["success"], newReportRecordAsDict["truncated"], topmost_filenames, addons_checked, flash_version)
+      infoTuple = (newReportRecordAsDict['signature'], processor_notes, startedDateTime, completedDateTime, newReportRecordAsDict["success"], newReportRecordAsDict["truncated"], topmost_filenames, addons_checked, flash_version, newReportRecordAsDict["exploitability"],)
       #logger.debug("Updated report %s (%s): %s", reportId, jobUuid, str(infoTuple))
       threadLocalCursor.execute(reportsSql, infoTuple)
       threadLocalDatabaseConnection.commit()

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -811,7 +811,7 @@ def testProcessJob06():
     assert r == e, 'expected\n%s\nbut got\n%s' % (e, r)
 
 def testProcessJob07():
-    """testProcessJobProductIdOverride: success"""
+    """testProcessJob07: success"""
     threadName = thr.currentThread().getName()
     p, c = getMockedProcessorAndContext()
     p.submitOoidToElasticSearch = lambda x: None   # eliminate this call
@@ -864,6 +864,7 @@ def testProcessJob07():
                                 'flash_version': "all.bad",
                                 'truncated': False,
                                 'topmost_filenames': [ 'myfile.cpp' ],
+                                'exploitability': 'HIGH'
                                 #'expected_topmost': 'myfile.cpp',
                                 #'expected_addons_checked': True,
                                }
@@ -901,7 +902,8 @@ def testProcessJob07():
         truncated = %%s,
         topmost_filenames = %%s,
         addons_checked = %%s,
-        flash_version = %%s
+        flash_version = %%s,
+        exploitability = %%s
       where id = %s and date_processed = timestamp with time zone '%s'
       """ % (reportId, date_processed)
     c.fakeCursor.expect('execute',
@@ -917,6 +919,7 @@ def testProcessJob07():
                           #additional_report_values['expected_addons_checked'],
                           True,
                           additional_report_values['flash_version'],
+                          'HIGH',
                           )),
                         {})
     c.fakeConnection.expect('commit', (), {}, None)
@@ -939,6 +942,7 @@ def testProcessJob07():
             'id': 345,
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
+            'exploitability': 'HIGH',
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),
@@ -951,7 +955,7 @@ def testProcessJob07():
     assert r == e, 'expected\n%s\nbut got\n%s' % (e, r)
 
 def testProcessJobProductIdOverride():
-    """testProcessJob07: success"""
+    """testProcessJobProductIdOverride: success"""
     threadName = thr.currentThread().getName()
     p, c = getMockedProcessorAndContext()
     p.productIdMap = {'abcdefg':{'product_name':'WaterWolf',
@@ -1014,6 +1018,7 @@ def testProcessJobProductIdOverride():
                                 'flash_version': "all.bad",
                                 'truncated': False,
                                 'topmost_filenames': [ 'myfile.cpp' ],
+                                'exploitability': None
                                 #'expected_topmost': 'myfile.cpp',
                                 #'expected_addons_checked': True,
                                }
@@ -1051,7 +1056,8 @@ def testProcessJobProductIdOverride():
         truncated = %%s,
         topmost_filenames = %%s,
         addons_checked = %%s,
-        flash_version = %%s
+        flash_version = %%s,
+        exploitability = %%s
       where id = %s and date_processed = timestamp with time zone '%s'
       """ % (reportId, date_processed)
     c.fakeCursor.expect('execute',
@@ -1067,6 +1073,7 @@ def testProcessJobProductIdOverride():
                           #additional_report_values['expected_addons_checked'],
                           True,
                           additional_report_values['flash_version'],
+                          None,
                           )),
                         {})
     c.fakeConnection.expect('commit', (), {}, None)
@@ -1089,6 +1096,7 @@ def testProcessJobProductIdOverride():
             'id': 345,
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
+            'exploitability': None,
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),
@@ -1164,6 +1172,7 @@ def testProcessdJobDefaultIsNotAHang():
                                 'flash_version': "all.bad",
                                 'truncated': False,
                                 'topmost_filenames': [ 'myfile.cpp' ],
+                                'exploitability': None
                                 #'expected_topmost': 'myfile.cpp',
                                 #'expected_addons_checked': True,
                                }
@@ -1201,7 +1210,8 @@ def testProcessdJobDefaultIsNotAHang():
         truncated = %%s,
         topmost_filenames = %%s,
         addons_checked = %%s,
-        flash_version = %%s
+        flash_version = %%s,
+        exploitability = %%s
       where id = %s and date_processed = timestamp with time zone '%s'
       """ % (reportId, date_processed)
     c.fakeCursor.expect('execute',
@@ -1217,6 +1227,7 @@ def testProcessdJobDefaultIsNotAHang():
                           #additional_report_values['expected_addons_checked'],
                           True,
                           additional_report_values['flash_version'],
+                          None
                           )),
                         {})
     c.fakeConnection.expect('commit', (), {}, None)
@@ -1239,6 +1250,7 @@ def testProcessdJobDefaultIsNotAHang():
             'id': 345,
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
+            'exploitability': None,
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),
@@ -1273,11 +1285,8 @@ def testGetJsonOrWarn():
     r = proc.Processor.getJsonOrWarn(d, 'key', message_list)
     assert r == None
     assert len(message_list) == 1
-    print message_list
     assert "'int'" in message_list[0]
-    # the following test line fails under Python 2.5 because the Python 
-    # error message has changed.  
-    assert "subscriptable" in message_list[0]
+    assert "ERROR" in message_list[0]
 
 expected_report_tuple = ('ooid1',
                          dt.datetime(2011, 2, 16, 4, 44, 52, tzinfo=UTC),


### PR DESCRIPTION
this PR adds running the exploitability tool to the original processor (there will a separate PR for the new processor).  The processor runs the MDSW and the exploitability tool in parallel.  The result of the exploitability tool is saved only to postgres in the 'exploitability' column of the reports table.
