### PR TITLE
uprading configman for bug 813734

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,5 @@
 # configman moves too fast for pypi right now
 git+git://github.com/mozilla/configman@c2179c80be74b1ecb4a6f9c837993d2ce8d4926b#egg=configman
-
 configobj==4.7.2
 hbase-thrift==0.20.4
 isodate==0.4.7


### PR DESCRIPTION
r? @twobraids

The only difference is the new feature that configman will err if you try to supply a `--admin.conf=` value that is an non-existent file. 
