### PR TITLE
Fixes Bug 721254, added crashmover_app and updated old crash mover to multidump

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -33,8 +33,10 @@ from configman.converters import class_converter
 
 from socorro.lib.threaded_task_manager import respond_to_SIGTERM
 from socorro.app.generic_app import App, main  # main not used here, but
-                                               # is imported from here into
-                                               # other apps
+                                               # is imported from generic_app
+                                               # into this scope to offer to
+                                               # apps that derive from the
+                                               # class defined here.
 
 
 #==============================================================================

--- a/socorro/collector/crashmover_app.py
+++ b/socorro/collector/crashmover_app.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""this app will move crashes from one storage location to another"""
+
+from configman import Namespace
+
+from socorro.app.fetch_transform_save_app import FetchTransformSaveApp, main
+
+
+#==============================================================================
+class CrashMoverApp(FetchTransformSaveApp):
+    app_name = 'crashmover'
+    app_version = '2.0'
+    app_description = __doc__
+
+    required_config = Namespace()
+
+
+if __name__ == '__main__':
+    main(CrashMoverApp)

--- a/socorro/storage/storageMover.py
+++ b/socorro/storage/storageMover.py
@@ -9,7 +9,6 @@ except ImportError:
 
 import signal
 
-import socorro.lib.JsonDumpStorage as jds
 import socorro.storage.crashstorage as cstore
 import socorro.lib.util as sutil
 import socorro.lib.iteratorWorkerFramework as iwf
@@ -44,7 +43,6 @@ def move (conf,
 
   #-----------------------------------------------------------------------------
   def doSubmission(ooidTuple):
-    logger.debug('received: %s', str(ooidTuple))
     try:
       sourceStorage = crashStoragePoolForSource.crashStorage()
       destStorage = crashStoragePoolForDest.crashStorage()
@@ -55,7 +53,7 @@ def move (conf,
         logger.warning('the json for %s is degenerate and cannot be loaded'  \
                        ' - saving empty json', ooid)
         jsonContents = {}
-      dumpContents = sourceStorage.get_raw_dump(ooid)
+      dumpContents = sourceStorage.get_raw_dumps(ooid)
       logger.debug('pushing %s to dest', ooid)
       result = destStorage.save_raw(ooid, jsonContents, dumpContents)
       if result == cstore.CrashStorageSystem.ERROR:

--- a/socorro/unittest/collector/test_crash_mover_app.py
+++ b/socorro/unittest/collector/test_crash_mover_app.py
@@ -1,0 +1,268 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from socorro.collector.crashmover_app import CrashMoverApp
+from socorro.lib.threaded_task_manager import ThreadedTaskManager
+from socorro.lib.util import DotDict, SilentFakeLogger
+
+
+class TestCrashMoverApp(unittest.TestCase):
+
+    def test_bogus_source_iter_and_worker(self):
+        class TestCrashMoverClass(CrashMoverApp):
+            def __init__(self, config):
+                super(TestCrashMoverClass, self).__init__(config)
+                self.the_list = []
+
+            def _setup_source_and_destination(self):
+                pass
+
+            def source_iterator(self):
+                for x in xrange(5):
+                    yield ((x,), {})
+
+            def transform(self, anItem):
+                self.the_list.append(anItem)
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'source': DotDict({'crashstorage_class': None}),
+          'destination': DotDict({'crashstorage_class': None}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = TestCrashMoverClass(config)
+        fts_app.main()
+        self.assertTrue(len(fts_app.the_list) == 5,
+                        'expected to do 5 inserts, '
+                          'but %d were done instead' % len(fts_app.the_list))
+        self.assertTrue(sorted(fts_app.the_list) == range(5),
+                        'expected %s, but got %s' % (range(5),
+                                                     sorted(fts_app.the_list)))
+
+    def test_bogus_source_and_destination(self):
+        class NonInfiniteFTSAppClass(CrashMoverApp):
+            def source_iterator(self):
+                for x in self.source.new_crashes():
+                    yield ((x,), {})
+
+        class FakeStorageSource(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict({'1234': DotDict({'ooid': '1234',
+                                                       'Product': 'FireFloozy',
+                                                       'Version': '1.0'}),
+                                      '1235': DotDict({'ooid': '1235',
+                                                       'Product': 'ThunderRat',
+                                                       'Version': '1.0'}),
+                                      '1236': DotDict({'ooid': '1236',
+                                                       'Product': 'Caminimal',
+                                                       'Version': '1.0'}),
+                                      '1237': DotDict({'ooid': '1237',
+                                                       'Product': 'Fennicky',
+                                                       'Version': '1.0'}),
+                                     })
+
+            def get_raw_crash(self, ooid):
+                return self.store[ooid]
+
+            def get_raw_dumps(self, ooid):
+                return {'upload_file_minidump': 'this is a fake dump',
+                        'flash1': 'broken flash dump'}
+
+            def new_crashes(self):
+                for k in self.store.keys():
+                    yield k
+
+        class FakeStorageDestination(object):
+
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+
+            def save_raw_crash(self, raw_crash, dumps, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dumps
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = NonInfiniteFTSAppClass(config)
+        fts_app.main()
+
+        source = fts_app.source
+        destination = fts_app.destination
+
+        self.assertEqual(source.store, destination.store)
+        self.assertEqual(len(destination.dumps), 4)
+        self.assertEqual(destination.dumps['1237'],
+                         source.get_raw_dumps('1237'))
+
+    def test_source_iterator(self):
+
+        class FakeStorageSource(object):
+
+            def __init__(self):
+                self.first = True
+
+            def new_crashes(self):
+                if self.first:
+                    self.first = False
+                else:
+                    for k in range(999):
+                        yield k
+                    for k in range(2):
+                        yield None
+
+        class FakeStorageDestination(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+
+            def save_raw_crash(self, raw_crash, dump, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dump
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = CrashMoverApp(config)
+        fts_app.source = FakeStorageSource()
+        fts_app.destination = FakeStorageDestination
+        error_detected = False
+        for x, y in zip(xrange(1002), (a for a in fts_app.source_iterator())):
+            if x == 0:
+                self.assertTrue(y is None)
+            elif x < 1000:
+                if x - 1 != y[0][0] and not error_detected:
+                    error_detected = True
+                    self.assertEqual(x, y,
+                                     'iterator fails on iteration %d' % x)
+            else:
+                if y is not None and not error_detected:
+                    error_detected = True
+                    self.assertTrue(x is None,
+                                    'iterator fails on iteration %d' % x)
+
+    def test_no_source(self):
+
+        class FakeStorageDestination(object):
+
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+
+            def save_raw_crash(self, raw_crash, dump, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dump
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'source': DotDict({'crashstorage_class':
+                                 None}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = CrashMoverApp(config)
+
+        self.assertRaises(TypeError, fts_app.main)
+
+    def test_no_destination(self):
+        class FakeStorageSource(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict({'1234': DotDict({'ooid': '1234',
+                                                       'Product': 'FireFloozy',
+                                                       'Version': '1.0'}),
+                                      '1235': DotDict({'ooid': '1235',
+                                                       'Product': 'ThunderRat',
+                                                       'Version': '1.0'}),
+                                      '1236': DotDict({'ooid': '1236',
+                                                       'Product': 'Caminimal',
+                                                       'Version': '1.0'}),
+                                      '1237': DotDict({'ooid': '1237',
+                                                       'Product': 'Fennicky',
+                                                       'Version': '1.0'}),
+                                     })
+
+            def get_raw_crash(self, ooid):
+                return self.store[ooid]
+
+            def get_raw_dumps(self, ooid):
+                return {'upload_file_minidump': 'this is a fake dump',
+                        'flash1': 'broken flash dump'}
+
+            def new_ooids(self):
+                for k in self.store.keys():
+                    yield k
+
+
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     None}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+
+        })
+
+        fts_app = CrashMoverApp(config)
+
+        self.assertRaises(TypeError, fts_app.main)


### PR DESCRIPTION
created a configmanized crashmover_app 
modified the old crash mover to handle multidumps

note that this PR does not work by itself.  it depends on the following PRs to be accepted first:

```
multidump2012crashstorage
multidump2012adapter
multidump2012collector
multidump2012submitter
```
