### PR TITLE
bug 816519 - middleware.wsgi app

### DIFF
--- a/config/middleware.ini-dist
+++ b/config/middleware.ini-dist
@@ -1,8 +1,3 @@
-# name: application
-# doc: the fully qualified module or class of the application
-# converter: configman.converters.class_converter
-application='MiddlewareApp'
-
 [web_server]
 
     # name: ip_address
@@ -19,6 +14,8 @@ application='MiddlewareApp'
     # doc: a class implementing a wsgi web server
     # converter: configman.converters.class_converter
     #wsgi_server_class='socorro.webapi.servers.CherryPy'
+    # If you want to use mod_wsgi enable this:
+    #wsgi_server_class='socorro.webapi.servers.ApacheModWSGI'
 
 [implementations]
 

--- a/wsgi/middleware.wsgi
+++ b/wsgi/middleware.wsgi
@@ -1,0 +1,19 @@
+import os
+from socorro.app.generic_app import main
+from socorro.middleware.middleware_app import MiddlewareApp
+from socorro.webapi.servers import ApacheModWSGI
+import socorro.middleware.middleware_app
+
+if os.path.isfile('/etc/socorro/middleware.ini'):
+    config_path = '/etc/socorro'
+else:
+    config_path = ApacheModWSGI.get_socorro_config_path(__file__)
+
+# invoke the generic main function to create the configman app class and which
+# will then create the wsgi app object.
+main(
+    MiddlewareApp,  # the socorro app class
+    config_path=config_path
+)
+
+application = socorro.middleware.middleware_app.application


### PR DESCRIPTION
@rhelmer r?

I learned something today. What you put in SetEnv in your apache config isn't passed to the xxx.wsgi  script and this value isn't transferred into python's `os.environ`. Surprising, isn't it?!

If you want to have access to anything set with SetEnv it's instead passing into each request. For example, you can do this:

``` python
#application = mywsgihandlerclass().application  
_application = mywsgihandlerclass().application
import os
def application(env, start_response):
    os.environ['MY_ENV'] = env['MY_ENV']  # requires `SetEnv MY_ENV somevalue` in apache
    return _application(env, start_response)
```

However, this won't work in our case because we need `DEFAULT_SOCORRO_CONFIG_PATH` **before** we start passing requests from apache to python.

My hack, as you can see, is VERY mozilla socorro specific but I've confirmed that this works. You can now either put middleware.ini in /etc/socorro or in reporoot/config/. 

I do worry a little bit about some poor guy some day trying to figure out where the config files are. We could opt to use reporoot/config/middleware.ini which could then do an include of /etc/socorro/middleware.ini or something. 

Food for thought. 
