### PR TITLE
corrected relocated import targets

### DIFF
--- a/socorro/cron/fixBrokenDumps.py
+++ b/socorro/cron/fixBrokenDumps.py
@@ -14,7 +14,7 @@ import psycopg2
 import psycopg2.extras
 
 import socorro.lib.util
-import socorro.storage.hbaseClient as hbaseClient
+import socorro.external.hbase.hbase_client as hbaseClient
 
 from datetime import datetime, timedelta
 

--- a/socorro/monitor/monitor.py
+++ b/socorro/monitor/monitor.py
@@ -19,7 +19,7 @@ import socorro.lib.filesystem
 import socorro.lib.psycopghelper as psy
 import socorro.database.database as sdb
 import socorro.storage.crashstorage as cstore
-import socorro.storage.hbaseClient as hbc
+import socorro.external.hbase.hbase_client as hbc
 
 from socorro.lib.datetimeutil import utc_now
 

--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -26,7 +26,7 @@ import socorro.database.database as sdb
 import socorro.lib.ooid as ooid
 import socorro.lib.datetimeutil as sdt
 import socorro.storage.crashstorage as cstore
-import socorro.storage.hbaseClient as hbc
+import socorro.external.hbase.hbase_client as hbc
 import socorro.processor.signatureUtilities as sig
 import socorro.processor.registration as reg
 
@@ -927,7 +927,7 @@ class Processor(object):
     try:
       if self.config.elasticSearchOoidSubmissionUrl:
         #import poster
-        import socorro.storage.hbaseClient as hbc
+        import socorro.external.hbase.hbase_client as hbc
         dummy_form_data = {}
         row_id = hbc.ooid_to_row_id(ooid)
         url = self.config.elasticSearchOoidSubmissionUrl % row_id

--- a/socorro/unittest/external/filesystem/test_crashstorage.py
+++ b/socorro/unittest/external/filesystem/test_crashstorage.py
@@ -81,10 +81,10 @@ class TestFileSystemCrashStorage(unittest.TestCase):
           fake_dumps,
           "114559a5-d8e6-428c-8b88-1c1f22120504"
         )
-        self.assertEqual(list(crashstorage.new_crashes()),
-                         ["114559a5-d8e6-428c-8b88-1c1f22120504",
-                          "114559a5-d8e6-428c-8b88-1c1f22120314",
-                         ])
+        self.assertEqual(sorted(list(crashstorage.new_crashes())),
+                         sorted(["114559a5-d8e6-428c-8b88-1c1f22120314",
+                          "114559a5-d8e6-428c-8b88-1c1f22120504",
+                         ]))
 
         self.assertTrue(
           os.path.exists(

--- a/socorro/unittest/external/filesystem/test_create_json_dump_store.py
+++ b/socorro/unittest/external/filesystem/test_create_json_dump_store.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import socorro.unittest.external.filesystem.createJsonDumpStore as createJDS
+import socorro.unittest.external.filesystem.create_json_dump_store as createJDS
 
 import os
 import shutil

--- a/socorro/unittest/external/hbase/test_crashstorage.py
+++ b/socorro/unittest/external/hbase/test_crashstorage.py
@@ -42,8 +42,8 @@ else:
         If you ever get this::
             Traceback (most recent call last):
             ...
-            socorro.storage.hbaseClient.FatalException: the connection is not
-            viable.  retries fail:
+            socorro.external.hbase.hbase_client.FatalException: the connection
+            is not viable.  retries fail:
 
         Then try the following:
 

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -6,7 +6,7 @@ import socorro.unittest.testlib.expectations as exp
 import socorro.lib.util as sutil
 import socorro.processor.processor as proc
 import socorro.database.database as sdb
-import socorro.storage.hbaseClient as hbc
+import socorro.external.hbase.hbase_client as hbc
 import socorro.storage.crashstorage as cstore
 import socorro.lib.datetimeutil as sdt
 import socorro.database.schema as sch

--- a/socorro/unittest/testlib/createJsonDumpStore.py
+++ b/socorro/unittest/testlib/createJsonDumpStore.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
   import simplejson as json
 
-import socorro.lib.JsonDumpStorage as JDS
+import socorro.external.filesystem.json_dump_storage as JDS
 from socorro.lib.datetimeutil import utc_now, UTC
 
 jsonFileData = {

--- a/tools/loadjsonz.py
+++ b/tools/loadjsonz.py
@@ -5,7 +5,7 @@
 
 
 import sys
-import socorro.storage.hbaseClient as hbase
+import socorro.external.hbase.hbase_client as hbase
 import gzip
 
 class JsonzLoader(object):


### PR DESCRIPTION
testing for multidumps was succeeding locally because of lingering .pyc files for relocated modules. Once those were removed, many test failures were revealed.  This PR reflects correcting imports for the relocated modules.  

also fixed failing unittest that unnecessarily depended on ordering of elements in a list.
