### PR TITLE
changes to multidump support - errata 2

### DIFF
--- a/scripts/startProcessor.py
+++ b/scripts/startProcessor.py
@@ -86,7 +86,9 @@ def processor2012(config):
     # name: destination.storage0.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.destination.storage0.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.destination.storage0.backoff_delays = [10, 30, 60, 120, 300,
+                                                        300, 300, 300, 300,
+                                                        300]
 
     # name: destination.storage0.crashstorage_class
     # doc: None
@@ -148,7 +150,9 @@ def processor2012(config):
     # name: destination.storage1.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.destination.storage1.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.destination.storage1.backoff_delays = [10, 30, 60, 120, 300,
+                                                        300, 300, 300, 300,
+                                                        300]
 
     # name: destination.storage1.crashstorage_class
     # doc: None
@@ -298,7 +302,8 @@ def processor2012(config):
     # name: new_crash_source.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.new_crash_source.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.new_crash_source.backoff_delays = [10, 30, 60, 120, 300, 300,
+                                                    300, 300, 300, 300]
 
     # name: new_crash_source.batchJobLimit
     # doc: the number of jobs to pull in a time
@@ -363,7 +368,8 @@ def processor2012(config):
     # name: processor.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.processor.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.processor.backoff_delays = [10, 30, 60, 120, 300, 300, 300,
+                                             300, 300, 300]
 
     # name: processor.collect_addon
     # doc: boolean indictating if information about add-ons should be collected
@@ -578,7 +584,8 @@ def processor2012(config):
     # name: registrar.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.registrar.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.registrar.backoff_delays = [10, 30, 60, 120, 300, 300, 300,
+                                             300, 300, 300]
 
     # name: registrar.check_in_frequency
     # doc: how often the processor is required to reregister (hh:mm:ss)
@@ -650,7 +657,8 @@ def processor2012(config):
     # name: source.backoff_delays
     # doc: delays in seconds between retries
     # converter: eval
-    trans_config.source.backoff_delays = [10, 30, 60, 120, 300]
+    trans_config.source.backoff_delays = [10, 30, 60, 120, 300, 300, 300, 300,
+                                          300, 300]
 
     # name: source.crashstorage_class
     # doc: the source storage class

--- a/socorro/database/transaction_executor.py
+++ b/socorro/database/transaction_executor.py
@@ -48,7 +48,8 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
     # back off times
     required_config = Namespace()
     required_config.add_option('backoff_delays',
-                               default=[10, 30, 60, 120, 300],
+                               default=[10, 30, 60, 120, 300, 300, 300, 300,
+                                        300, 300],
                                doc='delays in seconds between retries',
                                from_string_converter=eval)
     # wait_log_interval

--- a/socorro/external/hbase/crashstorage.py
+++ b/socorro/external/hbase/crashstorage.py
@@ -136,7 +136,7 @@ class HBaseCrashStorage(CrashStorageBase):
         return name_to_pathname_mapping
 
     #--------------------------------------------------------------------------
-    def get_processed_crash(self, crash_id):
+    def get_processed(self, crash_id):
         try:
             return DotDict(self.transaction_executor(
                hbase_client.HBaseConnectionForCrashReports.get_processed_json,

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -283,7 +283,11 @@ class LegacyCrashProcessor(RequiredConfig):
             )
             processed_crash.uuid = raw_crash.uuid
 
+            processed_crash.additional_minidumps = []
+
             for name, dump_pathname in raw_dumps.iteritems():
+                if name != self.config.dump_field:
+                    processed_crash.additional_minidumps.append(name)
                 with self._temp_file_context(dump_pathname) as temp_pathname:
                     dump_analysis = self._do_breakpad_stack_dump_analysis(
                         crash_id,
@@ -326,6 +330,7 @@ class LegacyCrashProcessor(RequiredConfig):
         processed_crash = DotDict()
         processed_crash.addons = None
         processed_crash.addons_checked = None
+        processed_crash.additional_minidumps = []
         processed_crash.address = None
         processed_crash.app_notes = None
         processed_crash.build = None
@@ -709,14 +714,14 @@ class LegacyCrashProcessor(RequiredConfig):
                 exploitability = a_line.strip().replace('exploitability: ', '')
         returncode = exploitability_subprocess_handle.wait()
         if exploitability is not None and 'ERROR' in exploitability:
-            error_messages.append("exploitablity tool: %s" %
+            error_messages.append("exploitability tool: %s" %
                                   (exploitability,))
-            # the rule is that if there was an error in exploitablity
+            # the rule is that if the output contains ERROR
             # then value should be None.
             exploitability = None
         if returncode is not None and returncode != 0:
             error_messages.append(
-                "exploitability tool failed with return code %s" %
+                "exploitability tool failed: %s" %
                 (returncode,)
             )
         return exploitability

--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -586,8 +586,11 @@ class Processor(object):
 
         java_stack_trace = jsonDocument.setdefault('JavaStackTrace', None)
 
+        newReportRecordAsDict['additional_minidumps'] = []
         dumps_mapping = threadLocalCrashStorage.get_raw_dumps(jobUuid)
         for name, dump in dumps_mapping.iteritems():
+          if name != self.config.dumpField:
+            newReportRecordAsDict['additional_minidumps'].append(name)
           # write a temp copy of the dump out for analysis
           temp_pathname = os.path.join(
             self.config.temporaryFileSystemStoragePath,
@@ -813,7 +816,7 @@ class Processor(object):
       self.reportsTable.insert(threadLocalCursor, newReportRecordAsTuple, self.databaseConnectionPool.connectionCursorPair, date_processed=date_processed)
     except sdb.db_module.IntegrityError, x:
       #logger.debug("psycopg2.IntegrityError %s", str(x))
-      logger.debug("replacing record that already exsited: %s", uuid)
+      logger.debug("replacing record that already existed: %s", uuid)
       threadLocalCursor.connection.rollback()
       # the following code fragment can prevent a crash from being processed a second time
       #previousTrialWasSuccessful = self.sdb.singleValueSql(threadLocalCursor, "select success from reports where uuid = '%s' and date_processed = timestamp with time zone '%s'" % (uuid, date_processed))

--- a/socorro/unittest/external/hbase/test_crashstorage.py
+++ b/socorro/unittest/external/hbase/test_crashstorage.py
@@ -136,7 +136,7 @@ else:
 
                 # hasn't been processed yet
                 self.assertRaises(CrashIDNotFound,
-                                  crashstorage.get_processed_crash,
+                                  crashstorage.get_processed,
                                   'abc123')
 
                 pro = ('{"name":"Peter","uuid":"abc123", '
@@ -145,7 +145,7 @@ else:
                        (time.time(), time.time()))
 
                 crashstorage.save_processed(json.loads(pro))
-                data = crashstorage.get_processed_crash('abc123')
+                data = crashstorage.get_processed('abc123')
                 self.assertEqual(data['name'], u'Peter')
                 assert crashstorage.hbaseConnectionPool.transport.isOpen()
                 crashstorage.close()
@@ -407,10 +407,10 @@ class TestHBaseCrashStorage(unittest.TestCase):
                                      'aux_1':
                                          expected_dump_2})
 
-                # test get_processed_crash
+                # test get_processed
                 m = mock.Mock(return_value=expected_processed_crash)
                 klass.get_processed_json = m
-                r = crashstorage.get_processed_crash("abc123")
+                r = crashstorage.get_processed("abc123")
                 self.assertTrue(isinstance(r, DotDict))
                 a = klass.get_processed_json.call_args
                 self.assertEqual(len(a[0]), 2)

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -940,6 +940,7 @@ def testProcessJob07():
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
             'exploitability': 'HIGH',
+            'additional_minidumps': [],
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),
@@ -1094,6 +1095,7 @@ def testProcessJobProductIdOverride():
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
             'exploitability': None,
+            'additional_minidumps': [],
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),
@@ -1249,6 +1251,7 @@ def testProcessdJobDefaultIsNotAHang():
             'completeddatetime': dt.datetime(2011, 2, 15, 1, 1, tzinfo=UTC),
             'ReleaseChannel': 'release',
             'exploitability': None,
+            'additional_minidumps': [],
            }
     fakeSaveProcessedDumpJson.expect('__call__',
                                      (nrr, c.fakeCrashStorage),


### PR DESCRIPTION
last minute changes to multidump support:
- added 'additional_minidumps' field to processed_crash - enumerates the names of additional dumps
  (as requested by bsmedberg via IRC)
- extended transaction retry behavior (both hbase & postgres) to retry delays of 10, 30, 60, 120, 300 \* 6
- corrected spelling error in old processor logging
- shortened exploitability comment in processor notes
- corrected inconsistency in crashstorage API naming for HBase
