### PR TITLE
accounted for change of hbaseClient name and location in shell scripts

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -16,7 +16,7 @@ do
   VERSIONS=`psql -t -U $databaseUserName -h $databaseHost $databaseName -c "select version, count(*) as counts from reports_${WEEK}  where completed_datetime < NOW() and completed_datetime > (NOW() - interval '24 hours') and product = '${I}' group by version order by counts desc limit 3" | awk '{print $1}'`
   for J in $VERSIONS
   do
-    psql -t -U $databaseUserName -h $databaseHost $databaseName -c "select uuid from reports_${WEEK} where completed_datetime < NOW() and completed_datetime > (NOW() - interval '24 hours') and product = '${I}' and version = '${J}'" | $PYTHON ${APPDIR}/socorro/storage/hbaseClient.py -h $hbaseHost export_jsonz_tarball_for_ooids /tmp /tmp/${I}_${J}.tar > /tmp/${I}_${J}.log 2>&1
+    psql -t -U $databaseUserName -h $databaseHost $databaseName -c "select uuid from reports_${WEEK} where completed_datetime < NOW() and completed_datetime > (NOW() - interval '24 hours') and product = '${I}' and version = '${J}'" | $PYTHON ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost export_jsonz_tarball_for_ooids /tmp /tmp/${I}_${J}.tar > /tmp/${I}_${J}.log 2>&1
     $PYTHON /data/crash-data-tools/per-crash-core-count.py -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-core-counts.txt
     $PYTHON /data/crash-data-tools/per-crash-interesting-modules.py -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-interesting-modules.txt
     $PYTHON /data/crash-data-tools/per-crash-interesting-modules.py -v -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-interesting-modules-with-versions.txt
@@ -30,7 +30,7 @@ for I in Firefox
 do
   for J in $MANUAL_VERSION_OVERRIDE
   do
-    psql -t -U $databaseUserName -h $databaseHost $databaseName -c "select uuid from reports_${WEEK} where completed_datetime < NOW() and completed_datetime > (NOW() - interval '24 hours') and product = '${I}' and version = '${J}'" | $PYTHON ${APPDIR}/socorro/storage/hbaseClient.py -h $hbaseHost export_jsonz_tarball_for_ooids /tmp /tmp/${I}_${J}.tar > /tmp/${I}_${J}.log 2>&1
+    psql -t -U $databaseUserName -h $databaseHost $databaseName -c "select uuid from reports_${WEEK} where completed_datetime < NOW() and completed_datetime > (NOW() - interval '24 hours') and product = '${I}' and version = '${J}'" | $PYTHON ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost export_jsonz_tarball_for_ooids /tmp /tmp/${I}_${J}.tar > /tmp/${I}_${J}.log 2>&1
     $PYTHON /data/crash-data-tools/per-crash-core-count.py -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-core-counts.txt
     $PYTHON /data/crash-data-tools/per-crash-interesting-modules.py -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-interesting-modules.txt
     $PYTHON /data/crash-data-tools/per-crash-interesting-modules.py -v -p ${I} -r ${J} -f /tmp/${I}_${J}.tar > /tmp/${DATE}_${I}_${J}-interesting-modules-with-versions.txt

--- a/scripts/crons/cron_submitter.sh
+++ b/scripts/crons/cron_submitter.sh
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Pull raw, unprocessed crashes from an existing Socorro install 
+# Pull raw, unprocessed crashes from an existing Socorro install
 # and re-submit to an existing (dev, staging) instance elsewhere.
-         
+
 # Import settings
 . /etc/socorro/socorrorc
 export PGPASSWORD=$databasePassword
-        
+
 if [ $# != 2 ]
-then         
+then
     echo "Syntax: cron_submitter.sh <crash_reports_url> <number_to_submit>"
     exit 1
 fi
@@ -27,13 +27,13 @@ function submit_dump() {
     . /etc/socorro/socorro-monitor.conf
     OOID=$1
 
-    python ${APPDIR}/socorro/storage/hbaseClient.py -h $hbaseHost get_json $OOID > /tmp/$OOID.json
-    python ${APPDIR}/socorro/storage/hbaseClient.py -h $hbaseHost get_dump $OOID > /tmp/$OOID.dump
+    python ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost get_json $OOID > /tmp/$OOID.json
+    python ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost get_dump $OOID > /tmp/$OOID.dump
     python ${APPDIR}/socorro/collector/submitter.py -j /tmp/$OOID.json -d /tmp/$OOID.dump -u $CRASH_REPORT_URL
     rm -f /tmp/$OOID.json /tmp/$OOID.dump
 }
 
-( 
+(
 if $(flock -n 200)
 then
     SQL="SELECT uuid FROM jobs ORDER BY queueddatetime DESC LIMIT $NUM_TO_SUBMIT"
@@ -43,7 +43,7 @@ then
     do
         submit_dump $UUID >> $LOG 2>&1
         sleep 1
-    done 
+    done
 fi
 ) 200>$LOCK
 


### PR DESCRIPTION
the shell scripts need to know the new location of the hbaseClient library

.../socorro/storage/hbaseClient.py  -->  .../socorro/external/hbase/hbase_client.py

sorry, my IDE stripped off trailing spaces on lines making this PR look bigger than it really is.
