### PR TITLE
Bug 822768 - Update forced versions for correlations for Firefox cycle starting 2013-01-08

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -69,7 +69,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="18.0 19.0a2 20.0a1"
+MANUAL_VERSION_OVERRIDE="19.0 20.0a2 21.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 822768 - this should go to production on Jan 8th or 9th.
