### PR TITLE
Bug 822163: Add NSS.* and nss.* to the prefixSignatureRegEx

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -260,6 +260,8 @@ prefixSignatureRegEx = '|'.join([
   'objc_exception_throw',
   'objc_msgSend',
   'operator new\([^,\)]+\)',
+  'NSS.*',
+  'nss.*',
   'PL_.*',
   'port_.*',
   'PORT_.*',


### PR DESCRIPTION
Investigating the venv problems that keep occurring in the original pull request. Hopefully this will pass Leeroy. There's nothing about the content of the pull request that I expect to cause a virtual env error.
