### PR TITLE
Skiplist32

### DIFF
--- a/scripts/config/processorconfig.py.dist
+++ b/scripts/config/processorconfig.py.dist
@@ -190,6 +190,7 @@ prefixSignatureRegEx = '|'.join([
   '_alloca_probe.*',
   '__android_log_assert',
   'arena_.*',
+  'BaseGetNamedObjectDirectory',
   '.*calloc',
   'cert_.*',
   'CERT_.*',
@@ -317,7 +318,6 @@ prefixSignatureRegEx = '|'.join([
   'WSASend.*',
   '_ZdaPvRKSt9nothrow_t\"',
   'zzz_AsmCodeRange_.*',
-  'BaseGetNamedObjectDirectory',
   ])
 
 signaturesWithLineNumbersRegEx = cm.Option()


### PR DESCRIPTION
Fixes bug 823700, fixes bug 823951, and fixes bug 793430, and puts the skiplist back in alpha order.
