### PR TITLE
bug 828468 - add date and OOID print before trying to connect to hbase

### DIFF
--- a/scripts/crons/cron_submitter.sh
+++ b/scripts/crons/cron_submitter.sh
@@ -27,6 +27,8 @@ function submit_dump() {
     . /etc/socorro/socorro-monitor.conf
     OOID=$1
 
+    date
+    echo $OOID
     python ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost get_json $OOID > /tmp/$OOID.json
     python ${APPDIR}/socorro/external/hbase/hbase_client.py -h $hbaseHost get_dump $OOID > /tmp/$OOID.dump
     python ${APPDIR}/socorro/collector/submitter.py -j /tmp/$OOID.json -d /tmp/$OOID.dump -u $CRASH_REPORT_URL


### PR DESCRIPTION
Just adding a timestamp in lieu of work to overhaul hbase_client.py
