### PR TITLE
Fixes Bug 828609 - modified submitter_app to take on cron_submitter's role

### DIFF
--- a/config/cron_submitter.ini-dist
+++ b/config/cron_submitter.ini-dist
@@ -1,0 +1,188 @@
+# this ini file is for the app .../socorro/collector/submitter_app.py to get that app
+# to do the same thing that the cron_submitter.sh script used to do.
+
+# name: application
+# doc: the fully qualified module or class of the application
+# converter: configman.converters.class_converter
+#application='SubmitterApp'
+
+[destination]
+
+    # name: crashstorage_class
+    # doc: the destination storage class
+    # converter: configman.converters.class_converter
+    crashstorage_class='socorro.collector.submitter_app.SubmitterCrashStorageDestination'
+
+    # name: url
+    # doc: The url of the Socorro collector to submit to
+    # converter: str
+    url='http://127.0.0.1:8882/submit'
+
+[logging]
+
+    # name: stderr_error_logging_level
+    # doc: logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # converter: int
+    stderr_error_logging_level='10'
+
+    # name: stderr_line_format_string
+    # doc: python logging system format for logging to stderr
+    # converter: str
+    stderr_line_format_string='{asctime} {levelname} - {threadName} - {message}'
+
+    # name: syslog_error_logging_level
+    # doc: logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # converter: int
+    syslog_error_logging_level='40'
+
+    # name: syslog_facility_string
+    # doc: syslog facility string ("user", "local0", etc)
+    # converter: str
+    syslog_facility_string='user'
+
+    # name: syslog_host
+    # doc: syslog hostname
+    # converter: str
+    syslog_host='localhost'
+
+    # name: syslog_line_format_string
+    # doc: python logging system format for syslog entries
+    # converter: str
+    syslog_line_format_string='submitter_app (pid {process}): {asctime} {levelname} - {threadName} - {message}'
+
+    # name: syslog_port
+    # doc: syslog port
+    # converter: int
+    syslog_port='514'
+
+[producer_consumer]
+
+    # name: idle_delay
+    # doc: the delay in seconds if no job is found
+    # converter: int
+    idle_delay='7'
+
+    # name: maximum_queue_size
+    # doc: the maximum size of the internal queue
+    # converter: int
+    maximum_queue_size='8'
+
+    # name: number_of_threads
+    # doc: the number of threads
+    # converter: int
+    number_of_threads='4'
+
+    # name: producer_consumer_class
+    # doc: the class implements a threaded producer consumer queue
+    # converter: configman.converters.class_converter
+    producer_consumer_class='socorro.lib.threaded_task_manager.ThreadedTaskManager'
+
+[source]
+
+    # name: crashstorage_class
+    # doc: the source storage class
+    # converter: configman.converters.class_converter
+    crashstorage_class='socorro.collector.submitter_app.SamplingCrashStorageSource'
+
+    # name: database_class
+    # doc: the class that connects to the database
+    # converter: configman.converters.class_converter
+    database_class='socorro.external.postgresql.connection_context.ConnectionContext'
+
+    # name: database_host
+    # doc: the hostname of the database
+    # converter: str
+    database_host='localhost'
+
+    # name: database_name
+    # doc: the name of the database
+    # converter: str
+    database_name='breakpad'
+
+    # name: database_password
+    # doc: the user's database password
+    # converter: str
+    database_password='aPassword'
+
+    # name: database_port
+    # doc: the port for the database
+    # converter: int
+    database_port='5432'
+
+    # name: database_user
+    # doc: the name of the user within the database
+    # converter: str
+    database_user='breakpad_rw'
+
+    # name: dump_file_suffix
+    # doc: the suffix used to identify a dump file (for use in temp files)
+    # converter: str
+    dump_file_suffix='.dump'
+
+    # name: forbidden_keys
+    # doc: a comma delimited list of keys banned from the processed crash in HBase
+    # converter: socorro.external.hbase.connection_context.<lambda>
+    forbidden_keys='email, url, user_id, exploitability'
+
+    # name: hbase_connection_pool_class
+    # doc: the class responsible for pooling and giving out HBaseconnections
+    # converter: configman.converters.class_converter
+    hbase_connection_pool_class='socorro.external.hbase.connection_context.HBaseConnectionContextPooled'
+
+    # name: hbase_host
+    # doc: Host to HBase server
+    # converter: str
+    hbase_host='localhost'
+
+    # name: hbase_port
+    # doc: Port to HBase server
+    # converter: int
+    hbase_port='9090'
+
+    # name: hbase_timeout
+    # doc: timeout in milliseconds for an HBase connection
+    # converter: int
+    hbase_timeout='5000'
+
+    # name: number_of_retries
+    # doc: Max. number of retries when fetching from hbaseClient
+    # converter: int
+    number_of_retries='0'
+
+    # name: source_implementation
+    # doc: a class for a source of raw crashes
+    # converter: configman.converters.class_converter
+    source_implementation='socorro.external.hbase.crashstorage.HBaseCrashStorage'
+
+    # name: sql
+    # doc: an sql string that selects crash_ids
+    # converter: str
+    sql='select uuid from jobs order by queueddatetime DESC limit 1000'
+
+    # name: temporary_file_system_storage_path
+    # doc: a local filesystem path where dumps temporarily during processing
+    # converter: str
+    temporary_file_system_storage_path='/home/socorro/temp'
+
+    # name: transaction_executor_class
+    # doc: a class that will execute transactions
+    # converter: configman.converters.class_converter
+    transaction_executor_class='socorro.database.transaction_executor.TransactionExecutor'
+
+[submitter]
+
+    # name: delay
+    # doc: pause between submission queuing in milliseconds
+    # converter: <lambda>
+    delay='0.0'
+
+    # name: dry_run
+    # doc: don't actually submit, just print product/version from raw crash
+    # converter: configman.converters.boolean_converter
+    dry_run='False'
+
+    # name: number_of_submissions
+    # doc: the number of crashes to submit (all, forever, 1...)
+    # converter: str
+    number_of_submissions='all'
+

--- a/socorro/collector/submitter_app.py
+++ b/socorro/collector/submitter_app.py
@@ -11,49 +11,50 @@ import os.path
 import json
 import urllib2
 
-from configman import Namespace
+from configman import Namespace, RequiredConfig
+from configman.converters import class_converter
 
 from socorro.app.fetch_transform_save_app import FetchTransformSaveApp, main
 from socorro.external.crashstorage_base import CrashStorageBase
 from socorro.external.filesystem.filesystem import findFileGenerator
 from socorro.lib.util import DotDict
+from socorro.external.postgresql.dbapi2_util import execute_query_iter
 
 poster.streaminghttp.register_openers()
 
 
 #==============================================================================
-class CrashStorageSubmitter(CrashStorageBase):
+class SubmitterCrashStorageDestination(CrashStorageBase):
+    """this a crashstorage derivative that just pushes a crash out to a
+    Socorro collector waiting at a url"""
     required_config = Namespace()
     required_config.add_option(
-      'url',
-      short_form='u',
-      doc="The url of the Socorro collector to submit to",
-      default="http://127.0.0.1:8882/submit"
+        'url',
+        short_form='u',
+        doc="The url of the Socorro collector to submit to",
+        default="http://127.0.0.1:8882/submit"
     )
 
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
-        super(CrashStorageSubmitter, self).__init__(
-          config,
-          quit_check_callback
+        super(SubmitterCrashStorageDestination, self).__init__(
+            config,
+            quit_check_callback
         )
         self.hang_id_cache = dict()
-        self.dump_field = config.dump_field
 
     #--------------------------------------------------------------------------
     def save_raw_crash(self, raw_crash, dumps, crash_id):
-        if self.config.submitter.dry_run:
-            print raw_crash.ProductName, raw_crash.Version
-        else:
+        try:
             for dump_name, dump_pathname in dumps.iteritems():
                 if not dump_name:
-                    dump_name = self.dump_field
+                    dump_name = self.config.source.dump_field
                 raw_crash[dump_name] = open(dump_pathname, 'rb')
             datagen, headers = poster.encode.multipart_encode(raw_crash)
             request = urllib2.Request(
-              self.config.url,
-              datagen,
-              headers
+                self.config.url,
+                datagen,
+                headers
             )
             print urllib2.urlopen(request).read(),
             try:
@@ -61,20 +62,42 @@ class CrashStorageSubmitter(CrashStorageBase):
                                          raw_crash['uuid'])
             except KeyError:
                 self.config.logger.debug('submitted crash')
+        finally:
+            for dump_name, dump_pathname in dumps.iteritems():
+                if "TEMPORARY" in dump_pathname:
+                    os.unlink(dump_pathname)
 
 
 #==============================================================================
-class SubmitterCrashReader(CrashStorageBase):
+class SubmitterFileSystemWalkerSource(CrashStorageBase):
+    """This is a crashstorage derivative that can walk an arbitrary file
+    system path looking for crashes.  The new_crashes generator yields
+    pathnames rather than crash_ids - so it is not compatible with other
+    instances of the CrashStorageSystem."""
     required_config = Namespace()
+    required_config.add_option(
+        'search_root',
+        doc="a filesystem location to begin a search for raw crash/dump sets",
+        short_form='s',
+        default=None
+    )
+    required_config.add_option(
+        'dump_suffix',
+        doc="the standard file extension for dumps",
+        default='.dump'
+    )
+    required_config.add_option(
+        'dump_field',
+        doc="the default name for the main dump",
+        default='upload_file_minidump'
+    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
-        super(SubmitterCrashReader, self).__init__(
-          config,
-          quit_check_callback
+        super(SubmitterFileSystemWalkerSource, self).__init__(
+            config,
+            quit_check_callback
         )
-        self.dump_suffix = config.dump_suffix
-        self.dump_field = config.dump_field
 
     #--------------------------------------------------------------------------
     def get_raw_crash(self, path_tuple):
@@ -86,11 +109,12 @@ class SubmitterCrashReader(CrashStorageBase):
             return DotDict(json.load(raw_crash_fp))
 
     #--------------------------------------------------------------------------
-    def get_raw_dumps(self, dump_pathnames):
+    def get_raw_dumps_as_files(self, dump_pathnames):
         """the default implemntation of fetching a dump.
         parameters:
         dump_pathnames - a tuple of paths. the second element and beyond are
                          the dump pathnames"""
+        # TODO: read the dumps not just echo the paths
         return dict(zip(self._dump_names_from_pathnames(dump_pathnames[1:]),
                         dump_pathnames[1:]))
 
@@ -120,95 +144,20 @@ class SubmitterCrashReader(CrashStorageBase):
         dump_names = []
         for a_pathname in pathnames:
             base_name = os.path.basename(a_pathname)
-            dump_name = base_name[prefix_length:-len(self.dump_suffix)]
+            dump_name = base_name[prefix_length:-len(self.config.dump_suffix)]
             if not dump_name:
-                dump_name = self.dump_field
+                dump_name = self.config.dump_field
             dump_names.append(dump_name)
         return dump_names
 
-
-#==============================================================================
-class SubmitterApp(FetchTransformSaveApp):
-    app_name = 'submitter_app'
-    app_version = '3.0'
-    app_description = __doc__
-
-    # set the Option defaults in the parent class to values that make sense
-    # for the context of this app
-    FetchTransformSaveApp.required_config.source.crashstorage_class. \
-      set_default(
-      SubmitterCrashReader
-    )
-    FetchTransformSaveApp.required_config.destination.crashstorage_class \
-      .set_default(
-      CrashStorageSubmitter
-    )
-
-    required_config = Namespace()
-    required_config.namespace('submitter')
-    required_config.submitter.add_option(
-      'delay',
-      doc="pause between submission queing in milliseconds",
-      default='0',
-      from_string_converter=lambda x: float(x) / 1000.0
-    )
-    required_config.submitter.add_option(
-      'dry_run',
-      doc="don't actually submit, just print product/version from raw crash",
-      short_form='D',
-      default=False
-    )
-    required_config.submitter.add_option(
-      'number_of_submissions',
-      doc="the number of crashes to submit (all, forever, 1...)",
-      short_form='n',
-      default='all'
-    )
-    required_config.submitter.add_option(
-      'search_root',
-      doc="a filesystem location to begin a search for raw crash / dump sets",
-      short_form='s',
-      default=None
-    )
-    # note these are in the base namespace. That's so that the
-    # crash source class SubmitterCrashReader can see it.
-    required_config.add_option(
-      'dump_suffix',
-      doc="the standard file extension for dumps",
-      default='.dump'
-    )
-    required_config.add_option(
-      'dump_field',
-      doc="the default name for the main dump",
-      default='upload_file_minidump'
-    )
-
     #--------------------------------------------------------------------------
-    def __init__(self, config):
-        super(SubmitterApp, self).__init__(config)
-        if config.submitter.number_of_submissions == 'forever':
-            self._crash_set_iter = \
-              self._create_infinite_file_system_iterator()
-        elif config.submitter.number_of_submissions == 'all':
-            self._crash_set_iter = self._create_file_system_iterator()
-        else:
-            self._crash_set_iter = self._create_limited_file_system_iterator()
-            self.number_of_submissions = int(
-              config.submitter.number_of_submissions
-            )
-
-    #--------------------------------------------------------------------------
-    def source_iterator(self):
-        """this iterator yields pathname pairs for raw crashes and raw dumps"""
-        for x in self._crash_set_iter():
-            yield ((x,), {})  # (raw_crash_pathname, raw_dump_pathname0, ...)
-
-    #--------------------------------------------------------------------------
-    def _create_file_system_iterator(self):
-        def an_iter():
+    def new_crashes(self):
+        while True:
+            # loop over all files under the search_root that have a suffix of
+            # ".json"
             for a_path, a_file_name, raw_crash_pathname in findFileGenerator(
-              self.config.submitter.search_root,
-              lambda x: x[2].endswith(".json")
+                self.config.search_root,
+                lambda x: x[2].endswith(".json")
             ):
                 prefix = os.path.splitext(a_file_name)[0]
                 crash_pathnames = [raw_crash_pathname]
@@ -217,31 +166,153 @@ class SubmitterApp(FetchTransformSaveApp):
                         dumpfilename.endswith(self.config.dump_suffix)):
                         crash_pathnames.append(os.path.join(a_path,
                                                             dumpfilename))
-                yield tuple(crash_pathnames)
-                if self.config.submitter.delay:
-                    time.sleep(self.config.submitter.delay)
-        return an_iter
+                # yield the pathnames of all the crash parts
+                yield crash_pathnames
+
+
+#==============================================================================
+class SamplingCrashStorageSource(RequiredConfig):
+    """this class will take a random sample of crashes in the jobs table
+    and then pull them from whatever primary storages is in use. """
+
+    required_config = Namespace()
+    required_config.add_option(
+        'source_implementation',
+        default='socorro.external.hbase.crashstorage.HBaseCrashStorage',
+        doc='a class for a source of raw crashes',
+        from_string_converter=class_converter
+    )
+    required_config.add_option(
+        'database_class',
+        default='socorro.external.postgresql.connection_context'
+                '.ConnectionContext',
+        doc='the class that connects to the database',
+        from_string_converter=class_converter
+    )
+    required_config.add_option(
+        'sql',
+        default='select uuid from jobs order by queueddatetime DESC '
+                'limit 1000',
+        doc='an sql string that selects crash_ids',
+    )
 
     #--------------------------------------------------------------------------
-    def _create_infinite_file_system_iterator(self):
-        an_iterator = self._create_file_system_iterator()
-
-        def infinite_iterator():
-            while True:
-                for x in an_iterator():
-                    yield x
-        return infinite_iterator
+    def __init__(self, config, quit_check_callback=None):
+        self._implementation = config.source_implementation(
+            config,
+            quit_check_callback
+        )
+        self.config = config
+        self.quit_check = quit_check_callback
 
     #--------------------------------------------------------------------------
-    def _create_limited_file_system_iterator(self):
-        an_iterator = self._create_infinite_file_system_iterator()
+    def new_crashes(self):
+        while True:
+            with self.config.database_class(self.config)() as conn:
+                self.quit_check()
+                for a_crash_id in execute_query_iter(conn, self.config.sql):
+                    self.quit_check()
+                    yield a_crash_id[0]
+                else:
+                    yield None
 
-        def limited_iterator():
-            for i, x in enumerate(an_iterator()):
-                if i >= self.number_of_submissions:
-                    break
-                yield x
-        return limited_iterator
+    #--------------------------------------------------------------------------
+    def get_raw_crash(self, crash_id):
+        """forward the request to the underlying implementation"""
+        return self._implementation.get_raw_crash(crash_id)
+
+    #--------------------------------------------------------------------------
+    def get_raw_dumps_as_files(self, crash_id):
+        """forward the request to the underlying implementation"""
+        return self._implementation.get_raw_dumps_as_files(crash_id)
+
+
+#==============================================================================
+class SubmitterApp(FetchTransformSaveApp):
+    app_name = 'submitter_app'
+    app_version = '3.1'
+    app_description = __doc__
+
+    # set the Option defaults in the parent class to values that make sense
+    # for the context of this app
+    FetchTransformSaveApp.required_config.source.crashstorage_class. \
+        set_default(
+            SubmitterFileSystemWalkerSource,
+            force=True,
+        )
+    FetchTransformSaveApp.required_config.destination.crashstorage_class \
+        .set_default(
+            SubmitterCrashStorageDestination,
+            force=True,
+        )
+
+    required_config = Namespace()
+    required_config.namespace('submitter')
+    required_config.submitter.add_option(
+        'delay',
+        doc="pause between submission queuing in milliseconds",
+        default='0',
+        from_string_converter=lambda x: float(x) / 1000.0
+    )
+    required_config.submitter.add_option(
+        'dry_run',
+        doc="don't actually submit, just print product/version from raw crash",
+        short_form='D',
+        default=False
+    )
+    required_config.submitter.add_option(
+        'number_of_submissions',
+        doc="the number of crashes to submit (all, forever, 1...)",
+        short_form='n',
+        default='all'
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        super(SubmitterApp, self).__init__(config)
+        if config.submitter.number_of_submissions == 'forever':
+            self._crash_set_iter = self._infinite_iterator
+        elif config.submitter.number_of_submissions == 'all':
+            self._crash_set_iter = self._all_iterator
+        else:
+            self._crash_set_iter = self._limited_iterator
+
+    #--------------------------------------------------------------------------
+    def transform(self, crash_id):
+        """this transform function only transfers raw data from the
+        source to the destination without changing the data."""
+        if self.config.submitter.dry_run:
+            print crash_id
+        else:
+            raw_crash = self.source.get_raw_crash(crash_id)
+            dumps = self.source.get_raw_dumps_as_files(crash_id)
+            self.destination.save_raw_crash(raw_crash, dumps, crash_id)
+
+    #--------------------------------------------------------------------------
+    def source_iterator(self):
+        """this iterator yields pathname pairs for raw crashes and raw dumps"""
+        for x in self._crash_set_iter():
+            yield ((x,), {})  # (raw_crash_pathname, raw_dump_pathname0, ...)
+            if self.config.submitter.delay:
+                time.sleep(self.config.submitter.delay)
+
+    #--------------------------------------------------------------------------
+    def _infinite_iterator(self):
+        while True:
+            for crash_id in self.source.new_crashes():
+                yield crash_id
+
+    #--------------------------------------------------------------------------
+    def _all_iterator(self):
+        for crash_id in self.source.new_crashes():
+            yield crash_id
+
+    #--------------------------------------------------------------------------
+    def _limited_iterator(self):
+        for i, crash_id in enumerate(self.source.new_crashes()):
+            if i == int(self.config.submitter.number_of_submissions):
+                break
+            yield crash_id
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The submitter_app has been modified so that it can do the same thing that the cron_submitter.sh script could do.  

Using an SQL SELECT that returns a list of crash_ids, the submitter will fetch the crashes from HBase and then resubmit the crashes to the waiting staging collector.

the file .../config/cron_submitter.ini-dist gives the details to configure the submitter_app to do this.  Just fixup the PG credentials, HBase host, and staging submission URL, invoke

```
python $SOCORRO_HOME/socorro/collector/submitter_app.py --admin.conf=$SOCORRO_HOME/config/cron_submitter.ini
```

This enhanced submitter has other uses too.  Since it can accept arbitrary SQL, crashes with any special criteria that PG knows about can be resubmitted to any collector anywhere. 
