### PR TITLE
fix for regression of file system date branch caused by multidump changes

### DIFF
--- a/socorro/external/filesystem/crashstorage.py
+++ b/socorro/external/filesystem/crashstorage.py
@@ -251,7 +251,7 @@ class FileSystemThrottledCrashStorage(FileSystemRawCrashStorage):
             # if 'legacy_processing' is missing, then it assumed that this
             # crash should be processed.  Therefore save it into standard
             # storage
-            self._do_save_raw(self.std_crash_store, raw_crash, dump)
+            self._do_save_raw(self.std_crash_store, raw_crash, dump, crash_id)
 
     #--------------------------------------------------------------------------
     def get_raw_crash(self, crash_id):

--- a/socorro/external/filesystem/json_dump_storage.py
+++ b/socorro/external/filesystem/json_dump_storage.py
@@ -12,6 +12,8 @@ import socorro.external.filesystem.filesystem as socorro_fs
 import socorro.lib.util as socorro_util
 import socorro.lib.ooid as socorro_ooid
 
+from socorro.lib.datetimeutil import datetimeFromISOdateString
+
 from socorro.lib.datetimeutil import utc_now
 
 
@@ -95,7 +97,7 @@ class JsonDumpStorage(socorro_dumpStorage.DumpStorage):
 
         name_dir, date_dir = super(JsonDumpStorage, self).newEntry(
           crash_id,
-          timestamp,
+          datetimeFromISOdateString(raw_crash['submitted_timestamp']),
           webhead_host_name
         )
 

--- a/socorro/unittest/external/filesystem/test_crash_data.py
+++ b/socorro/unittest/external/filesystem/test_crash_data.py
@@ -28,7 +28,8 @@ class IntegrationTestCrashData(unittest.TestCase):
         with self.config_manager.context() as config:
             store = crashstorage.FileSystemCrashStorage(config.filesystem)
             fake_dump = 'this is a fake dump'
-            fake_raw = {'name': 'Peter', 'legacy_processing': 0}
+            fake_raw = {'name': 'Peter', 'legacy_processing': 0,
+                        "submitted_timestamp": '2012-05-04 15:10:33'}
             fake_processed = {
                 'name': 'Peter',
                 'uuid': '114559a5-d8e6-428c-8b88-1c1f22120314'
@@ -42,7 +43,8 @@ class IntegrationTestCrashData(unittest.TestCase):
             store.save_processed(fake_processed)
 
             fake_dump = 'this is another fake dump'
-            fake_raw = {'name': 'Adrian', 'legacy_processing': 0}
+            fake_raw = {'name': 'Adrian', 'legacy_processing': 0,
+                        "submitted_timestamp": '2012-05-04 15:10:33'}
 
             store.save_raw_crash(
                 fake_raw,
@@ -94,7 +96,8 @@ class IntegrationTestCrashData(unittest.TestCase):
 
             # Test 2: get a raw crash
             params['datatype'] = 'meta'
-            res_expected = {'name': 'Peter', 'legacy_processing': 0}
+            res_expected = {'name': 'Peter', 'legacy_processing': 0,
+                            "submitted_timestamp": '2012-05-04 15:10:33'}
             res = service.get(**params)
 
             self.assertEqual(res, res_expected)

--- a/socorro/unittest/external/filesystem/test_crashstorage.py
+++ b/socorro/unittest/external/filesystem/test_crashstorage.py
@@ -66,7 +66,8 @@ class TestFileSystemCrashStorage(unittest.TestCase):
         fake_dump = 'this is a fake dump'
         self.assertEqual(list(crashstorage.new_crashes()), [])
         raw = {"name": "Peter",
-               "legacy_processing": 0}
+               "legacy_processing": 0,
+               "submitted_timestamp": '2012-03-14 15:10:33'}
         crashstorage.save_raw_crash(
           raw,
           fake_dump,
@@ -75,7 +76,8 @@ class TestFileSystemCrashStorage(unittest.TestCase):
 
         fake_dumps = {None: 'this is a fake dump', 'aux01': 'aux01 fake dump'}
         raw = {"name": "Lars",
-               "legacy_processing": 0}
+               "legacy_processing": 0,
+               "submitted_timestamp": '2012-05-04 15:10:33'}
         crashstorage.save_raw_crash(
           raw,
           fake_dumps,
@@ -142,7 +144,8 @@ class TestFileSystemCrashStorage(unittest.TestCase):
         crashstorage = FileSystemThrottledCrashStorage(config)
         self.assertEqual(list(crashstorage.new_crashes()), [])
         raw = {"name": "Peter",
-               "legacy_processing": 1}
+               "legacy_processing": 1,
+               "submitted_timestamp": '2012-05-04 15:10:33'}
         crashstorage.save_raw_crash(
           raw,
           fake_dump,
@@ -151,7 +154,8 @@ class TestFileSystemCrashStorage(unittest.TestCase):
 
         fake_dumps = {None: 'this is a fake dump', 'aux01': 'aux01 fake dump'}
         raw = {"name": "Lars",
-               "legacy_processing": 0}
+               "legacy_processing": 0,
+               "submitted_timestamp": '2012-05-04 15:10:33'}
         crashstorage.save_raw_crash(
           raw,
           fake_dumps,

--- a/socorro/unittest/external/filesystem/test_json_dump_storage.py
+++ b/socorro/unittest/external/filesystem/test_json_dump_storage.py
@@ -363,15 +363,17 @@ class TestJsonDumpStorage(unittest.TestCase):
 
   def _create_multidump_data(self):
     return [ ('0bba61c5-dfc3-3333-dead-8afd20081225',
-                  {'ProductName': 'X'},
+                  {'ProductName': 'X',
+                   'submitted_timestamp': '2012-12-15 11:23:45'},
                   {'upload_file_minidump': 'fake main dump',
                    'aux_dump_0': 'fake aux_dump_0',
                    'aux_dump_1': 'fake aux_dump_1'}),
              ('0bba61c5-dfc3-43e7-dead-8afd20081225',
-                               {'ProductName': 'Y'},
-                               {'upload_file_minidump': '2nd fake main dump',
-                                'aux_dump_0': '2nd fake aux_dump_0',
-                                'aux_dump_1': '2nd fake aux_dump_1'}),
+                  {'ProductName': 'Y',
+                   'submitted_timestamp': '2012-12-15 20:13:33'},
+                  {'upload_file_minidump': '2nd fake main dump',
+                   'aux_dump_0': '2nd fake aux_dump_0',
+                   'aux_dump_1': '2nd fake aux_dump_1'}),
            ]
 
   def _expected_dump_path(self, base_path, crash_id, dump_name):


### PR DESCRIPTION
the  old file system code used an insertion timestamp to build the date branch of the file system storage.  The new crash storage system does not send a time stamp with each storage insert.  The old code was then dropping back to get the time information from the crash_id.  However, the crash_id doesn't have hour and minute information.  The old code then just used 00Hr and 00min for everything.

The solution is for the old code to grab the 'submitted_timestamp'  (date_processed) from the crash itself.  That'll give the file system proper HH and MM so the distribution will be better.  

The change is embodied in socorro/external/filesystem/json_dump_storage.py:100 - the other changes are supporting code and unit tests.
