### PR TITLE
Updated PREFIX of target minidump_stackwalk to create the stackwalk fold...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	rm -rf ./breakpad.tar.gz
 
 minidump_stackwalk:
-	PREFIX=`pwd`/../stackwalk/ SKIP_TAR=1 ./scripts/build-breakpad.sh
+	PREFIX=`pwd`/stackwalk/ SKIP_TAR=1 ./scripts/build-breakpad.sh
 
 analysis:
 	git submodule update --init socorro-toolbox akela


### PR DESCRIPTION
With the default value, when following the installation instructions, running make minidump_stackwalk would create the stackwalk folder in /home/$USER$/stackwalk, whereas the reinstall target of make calls rsync on the /home/$USER$/socorro/stackwalk
