### PR TITLE
Fixes Bug 836986 - call the right delete in file system storage

### DIFF
--- a/socorro/external/filesystem/crashstorage.py
+++ b/socorro/external/filesystem/crashstorage.py
@@ -183,7 +183,7 @@ class FileSystemRawCrashStorage(CrashStorageBase):
     def remove(self, crash_id):
         """delegate removal of a raw crash to the underlying filesystem"""
         try:
-            self.std_crash_store.remove(crash_id)
+            self.std_crash_store.quickDelete(crash_id)
         except NoSuchUuidFound:
             raise CrashIDNotFound(crash_id)
 

--- a/socorro/unittest/external/filesystem/test_crashstorage.py
+++ b/socorro/unittest/external/filesystem/test_crashstorage.py
@@ -130,9 +130,6 @@ class TestFileSystemCrashStorage(unittest.TestCase):
                           crashstorage.std_crash_store.getDump,
                           '114559a5-d8e6-428c-8b88-1c1f22120314')
         self.assertRaises(CrashIDNotFound,
-                          crashstorage.remove,
-                          '114559a5-d8e6-428c-8b88-1c1f22120314')
-        self.assertRaises(CrashIDNotFound,
                           crashstorage.get_raw_crash,
                           '114559a5-d8e6-428c-8b88-1c1f22120314')
         self.assertRaises(CrashIDNotFound,


### PR DESCRIPTION
resolves the embarrassing problem of deletions being slow in file system storage, by calling `quickDelete` instead of `remove` 
