### PR TITLE
create new crontabber service for current mware

### DIFF
--- a/scripts/config/webapiconfig.py.dist
+++ b/scripts/config/webapiconfig.py.dist
@@ -157,6 +157,7 @@ import socorro.middleware.releases_featured_service as releases_featured
 import socorro.middleware.server_status_service as server_status
 import socorro.middleware.crashes_daily_service as crashes_daily
 import socorro.middleware.platforms_service as platforms
+import socorro.middleware.crontabber_state_service as crontabber_state
 
 servicesList = cm.Option()
 servicesList.doc = 'a python list of classes to offer as services'
@@ -192,6 +193,7 @@ servicesList.default = [
     server_status.ServerStatus,
     crashes_daily.CrashesDaily,
     platforms.Platforms,
+    crontabber_state.CrontabberState
 ]
 
 crashBaseUrl = cm.Option()

--- a/socorro/external/postgresql/crontabber_state.py
+++ b/socorro/external/postgresql/crontabber_state.py
@@ -15,8 +15,7 @@ class CrontabberState(PostgreSQLBase):
     """Implement the /crontabber_state service with PostgreSQL. """
 
     def get(self, **kwargs):
-        """Return the current state of the server and the revisions of Socorro
-        and Breakpad. """
+        """Return the current state of all Crontabber jobs"""
         sql = (
             '/* socorro.external.postgresql.crontabber_state.CrontabberState'
             '.get */\n'

--- a/socorro/middleware/crontabber_state_service.py
+++ b/socorro/middleware/crontabber_state_service.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+from socorro.middleware.service import DataAPIService
+
+logger = logging.getLogger("webapi")
+
+
+class CrontabberState(DataAPIService):
+    """Return the current state of Crontabber jobs"""
+
+    service_name = "crontabber_state"
+    uri = "/crontabber_state/(.*)"
+
+    def __init__(self, config):
+        super(CrontabberState, self).__init__(config)
+        logger.debug('CrontabberState service __init__')
+
+    def get(self, *args):
+        """Called when a GET HTTP request is executed to /crontabber_state"""
+        params = self.parse_query_string(args[0])
+        module = self.get_module(params)
+        impl = module.CrontabberState(config=self.context)
+        return impl.get(**params)


### PR DESCRIPTION
Peterbe wrote a crontabber service for the new middleware, which won't be turned on until Django (and crontabber) have been adopted in production. This is a shim that enables the service in the current middleware so we can get the crontabber-state page working in the Django app now.
