### PR TITLE
test_crontabber_state assumed that the crontabber_state contained something

### DIFF
--- a/socorro/unittest/external/postgresql/test_crontabber_state.py
+++ b/socorro/unittest/external/postgresql/test_crontabber_state.py
@@ -50,10 +50,18 @@ class IntegrationTestCrontabberStatus(PostgreSQLTestCase):
         super(IntegrationTestCrontabberStatus, self).setUp()
 
         cursor = self.connection.cursor()
-        cursor.execute("""
-            UPDATE crontabber_state
-            SET state = %s
-        """, (_SAMPLE_JSON,))
+        cursor.execute("select count(*) from crontabber_state")
+        count, = cursor.fetchone()
+        if count:
+            cursor.execute("""
+                UPDATE crontabber_state
+                SET state = %s
+            """, (_SAMPLE_JSON,))
+        else:
+            cursor.execute("""
+                INSERT INTO crontabber_state
+                (state, last_updated) VALUES (%s, NOW())
+            """, (_SAMPLE_JSON,))
         self.connection.commit()
 
     def tearDown(self):


### PR DESCRIPTION
When I added the test_crontabber_state I used an existing postgres that had something in the `crontabber_state` table. 

If you run a fresh `setupdb_app.py --dropdb ...` it will create a `crontabber_state` table but it contains no rows. 

Arguably, perhaps this is a bug in setupdb_app and the fact that the create table should be followed by an initial insert to `crontabber_state`

r? @selenamarie @rhelmer 
