### PR TITLE
Fixes Bug 845865: collector.wsgi chooses wrong ini pathname

### DIFF
--- a/wsgi/collector.wsgi
+++ b/wsgi/collector.wsgi
@@ -1,3 +1,4 @@
+import os
 from socorro.app.generic_app import main
 from socorro.collector.collector_app import CollectorApp
 from socorro.webapi.servers import ApacheModWSGI
@@ -5,11 +6,16 @@ import socorro.collector.collector_app
 
 from configman import ConfigFileFutureProxy
 
+if os.path.isfile('/etc/socorro/collector.ini'):
+    config_path = '/etc/socorro'
+else:
+    config_path = ApacheModWSGI.get_socorro_config_path(__file__)
+
 # invoke the generic main function to create the configman app class and which
 # will then create the wsgi app object.
 main(
-  CollectorApp,  # the socorro app class
-  config_path=ApacheModWSGI.get_socorro_config_path(__file__)
+    CollectorApp,  # the socorro app class
+    config_path=config_path
 )
 
 application = socorro.collector.collector_app.application


### PR DESCRIPTION
Harmonized collector.wsgi with middleware.wsgi : if a config file in /etc/socorro exists, it is chosen first
