### PR TITLE
bug 731598 - add uuid to extensions table

### DIFF
--- a/sql/upgrade/38.0/README.rst
+++ b/sql/upgrade/38.0/README.rst
@@ -1,0 +1,14 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+38.0 Database Updates
+=====================
+
+bug #731598
+    Add uuid to extensions table
+
+...
+
+The above changes should take only a few minutes to deploy.
+This upgrade does not require a downtime.

--- a/sql/upgrade/38.0/add_uuid_to_extensions.py
+++ b/sql/upgrade/38.0/add_uuid_to_extensions.py
@@ -1,0 +1,27 @@
+import psycopg2
+import os, sys
+import csv
+
+search = "extensions_201"
+connectionstring = "user=postgres dbname=breakpad host=127.0.0.1"
+
+conn = psycopg2.connect(connectionstring)
+cur = conn.cursor()
+
+cur.execute("select relname from pg_class where relkind = 'r' and relname ~ '^%s'" % search)
+tables = cur.fetchall()
+
+for relname, in tables:
+    print "Altering %s" % relname
+    cur.execute("ALTER TABLE %s ADD COLUMN uuid TEXT" % relname)
+
+cur.execute("ALTER TABLE extensions ADD COLUMN uuid TEXT")
+
+conn.commit()
+
+#print "The next part is going to take a while."
+#for relname, in tables:
+    #parts = relname.split('_')
+    #print "Adding uuids to %s" % relname
+    #cur.execute("update extensions_%s e SET uuid = r.uuid FROM reports_%s r WHERE r.id = e.report_id" % parts[1])
+    #conn.commit()

--- a/sql/upgrade/38.0/upgrade.sh
+++ b/sql/upgrade/38.0/upgrade.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#please see README
+
+set -e
+
+CURDIR=$(dirname $0)
+DBNAME=$1
+: ${DBNAME:="breakpad"}
+VERSION=38.0
+
+#echo '*********************************************************'
+#echo 'support functions'
+#psql -f ${CURDIR}/support_functions.sql $DBNAME
+
+echo '*********************************************************'
+echo 'add uuid column to extensions'
+echo 'bug 731598'
+python add_uuid_to_extensions.py
+
+#change version in DB
+psql -c "SELECT update_socorro_db_version( '$VERSION' )" $DBNAME
+
+echo "$VERSION upgrade done"
+
+exit 0


### PR DESCRIPTION
This is to make the changes to the tables. We don't need to (and probably shouldn't) backfill the column until the UI and/or middleware starts actually using the column.

I left the code to backfill in there as some lazy documentation.

This changes requires a short maintenance window for prod when applied because of locks taken out on the extensions table.
