### PR TITLE
bug 848680 - add pig support to crontabber

### DIFF
--- a/socorro/cron/base.py
+++ b/socorro/cron/base.py
@@ -5,6 +5,7 @@
 import collections
 import datetime
 import re
+import subprocess
 
 from socorro.lib.datetimeutil import utc_now
 from configman import Namespace, RequiredConfig
@@ -230,3 +231,26 @@ class PostgresTransactionManagedCronApp(BaseCronApp):
 
     def run(self, connection):  # pragma: no cover
         raise NotImplementedError("Your fault!")
+
+
+class SubprocessMixin(object):
+
+    def run_process(self, command, input=None):
+        """
+        Run the command and return a tuple of three things.
+
+        1. exit code - an integer number
+        2. stdout - all output that was sent to stdout
+        2. stderr - all output that was sent to stderr
+        """
+        if isinstance(command, (tuple, list)):
+            command = ' '.join('"%s"' % x for x in command)
+
+        proc = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        out, err = proc.communicate(input=input)
+        return proc.returncode, out.strip(), err.strip()

--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -49,6 +49,7 @@ DEFAULT_JOBS = '''
   socorro.cron.jobs.matviews.ExplosivenessCronApp|1d|10:00
   socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
   socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h
+  #socorro.cron.jobs.modulelist.ModulelistCronApp|1d
 '''
 
 

--- a/socorro/cron/jobs/modulelist.py
+++ b/socorro/cron/jobs/modulelist.py
@@ -1,0 +1,102 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from configman import Namespace
+from socorro.cron.base import BaseBackfillCronApp, SubprocessMixin
+
+
+class CommandError(Exception):
+    pass
+
+
+class ModulelistCronApp(BaseBackfillCronApp, SubprocessMixin):
+    app_name = 'modulelist'
+    app_description = 'Runs the modulelist pig job'
+    app_version = '0.1'
+
+    required_config = Namespace()
+    required_config.add_option(
+        'pig_classpath',
+        default='/data/socorro/analysis/',
+        doc='Sets the PIG_CLASSPATH for running the pig job',
+    )
+    required_config.add_option(
+        'output_file',
+        default='/mnt/crashanalysis/crash_analysis/modulelist/'
+                '%(output_date)s-modulelist.txt',
+        doc='File passed to `hadoop fs -getmerge ...`. The `date` parameter '
+            'becomes the formatted (%Y%m%d) date of the input date'
+    )
+
+    def run(self, date):
+        logger = self.config.logger
+        yesterday = date - datetime.timedelta(days=1)
+
+        data = {
+            'pig_classpath': self.config.pig_classpath,
+            'date': yesterday.strftime('%Y%m%d'),
+        }
+        # This one is a bit odd since it depends on the `output_date`
+        # variable.
+        data['output_file'] = self.config.output_file % data
+
+        pig_command = (
+            'PIG_CLASSPATH=%(pig_classpath)s '
+            'pig -param start_date=%(date)s -param end_date=%(date)s '
+            '%(pig_classpath)s/modulelist.pig'
+            % data
+        )
+
+        hadoop_command_1 = (
+            'PIG_CLASSPATH=%(pig_classpath)s '
+            'hadoop fs -getmerge modulelist-%(date)s-%(date)s %(output_file)s'
+            % data
+        )
+
+        hadoop_command_2 = (
+            'PIG_CLASSPATH=%(pig_classpath)s '
+            'hadoop fs -rmr modulelist-%(date)s-%(date)s'
+            % data
+        )
+
+        exit_code, stdout, stderr = self.run_process(pig_command)
+        if exit_code:
+            stdout and logger.error(stdout)
+            stderr and logger.error(stderr)
+            raise CommandError(
+                'pig run failed (%s)' % (pig_command,)
+            )
+        else:
+            if stdout:
+                logger.info(stdout)
+            if stderr:
+                logger.info(stderr)
+
+        exit_code, stdout, stderr = self.run_process(hadoop_command_1)
+        if exit_code:
+            stdout and logger.error(stdout)
+            stderr and logger.error(stderr)
+            raise CommandError(
+                'hadoop getmerge failed (%s)' % (hadoop_command_1,)
+            )
+        else:
+            if stdout:
+                logger.info(stdout)
+            if stderr:
+                logger.info(stderr)
+
+        exit_code, stdout, stderr = self.run_process(hadoop_command_2)
+        if exit_code:
+            stdout and logger.error(stdout)
+            stderr and logger.error(stderr)
+            raise CommandError(
+                'hadoop cleanup failed (%s)' % (hadoop_command_2,)
+            )
+        else:
+            if stdout:
+                logger.info(stdout)
+            if stderr:
+                logger.info(stderr)

--- a/socorro/unittest/cron/jobs/test_modulelist.py
+++ b/socorro/unittest/cron/jobs/test_modulelist.py
@@ -1,0 +1,217 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import mock
+import functools
+from socorro.cron import crontabber
+from ..base import TestCaseBase
+import datetime
+
+from socorro.lib.datetimeutil import utc_now
+
+
+#==============================================================================
+# Tools for helping with the mocking
+
+class _Proc(object):
+    def __init__(self, exit_code, stdout, stderr):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = exit_code
+
+    def communicate(self, input=None):
+        return (self.stdout, self.stderr)
+
+
+def mocked_Popen(command, **kwargs):
+    kwargs['_commands_sent'].append(command)
+    _exit_code = kwargs['_exit_code']
+    _stdout = kwargs['_stdout']
+    _stderr = kwargs['_stderr']
+    # some might be callables
+    if callable(_exit_code):
+        _exit_code = _exit_code(command)
+    if callable(_stdout):
+        _stdout = _stdout(command)
+    if callable(_stderr):
+        _stderr = _stderr(command)
+
+    return _Proc(
+        _exit_code,
+        _stdout,
+        _stderr
+    )
+
+
+#==============================================================================
+class TestModulelist(TestCaseBase):
+
+    def setUp(self):
+        super(TestModulelist, self).setUp()
+        # needed so that crontabber doesn't use postgres for the crontabbers
+        # JSON backup
+        self.psycopg2_patcher = mock.patch('psycopg2.connect')
+        self.psycopg2 = self.psycopg2_patcher.start()
+        self.Popen_patcher = mock.patch('subprocess.Popen')
+        self.Popen = self.Popen_patcher.start()
+
+    def tearDown(self):
+        super(TestModulelist, self).tearDown()
+        self.psycopg2_patcher.stop()
+        self.Popen_patcher.stop()
+
+    def _setup_config_manager(self):
+        _super = super(TestModulelist, self)._setup_config_manager
+        _source = {}
+        _source['crontabber.class-ModulelistCronApp.pig_classpath'] = (
+            '/some/place'
+        )
+        _source['crontabber.class-ModulelistCronApp.output_file'] = (
+            '/some/other/place/%(date)s-modulelist.txt'
+        )
+        config_manager, json_file = _super(
+            'socorro.cron.jobs.modulelist.ModulelistCronApp|1d',
+            extra_value_source=_source
+        )
+        return config_manager, json_file
+
+    def test_basic_run_no_errors(self):
+        # a mutable where commands sent are stored
+        commands_sent = []
+        self.Popen.side_effect = functools.partial(
+            mocked_Popen,
+            _commands_sent=commands_sent,
+            _exit_code=0,
+            _stdout='Bla bla',
+            _stderr='',
+        )
+
+        config_manager, json_file = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = crontabber.CronTabber(config)
+            tab.run_all()
+
+            information = json.load(open(json_file))
+            assert information['modulelist']
+            #print information['modulelist']['last_error']
+            #print information['modulelist']['last_error']['traceback']
+            if information['modulelist']['last_error']:
+                raise AssertionError(information['modulelist']['last_error'])
+
+            assert len(commands_sent) == 3
+            first = commands_sent[0]
+            second = commands_sent[1]
+            third = commands_sent[2]
+            yesterday = utc_now()
+            yesterday -= datetime.timedelta(days=1)
+            yesterday_fmt = yesterday.strftime('%Y%m%d')
+            self.assertTrue(
+                'PIG_CLASSPATH=/some/place pig' in first
+            )
+            self.assertTrue(
+                '-param start_date=%s' % yesterday_fmt in first
+            )
+            self.assertTrue(
+                '-param end_date=%s' % yesterday_fmt in first
+            )
+            self.assertTrue(
+                '/some/place/modulelist.pig' in first
+            )
+
+            self.assertTrue(
+                'PIG_CLASSPATH=/some/place hadoop fs -getmerge' in second
+            )
+            self.assertTrue(
+                'modulelist-%s-%s' % (yesterday_fmt, yesterday_fmt) in second
+            )
+            self.assertTrue(
+                '/some/other/place/%s-modulelist.txt' % (yesterday_fmt,)
+                in second
+            )
+
+            self.assertTrue(
+                'PIG_CLASSPATH=/some/place hadoop fs ' in third
+            )
+            self.assertTrue(
+                'modulelist-%s-%s' % (yesterday_fmt, yesterday_fmt) in second
+            )
+
+            # note that all jobs spew out 'Bla bla' on stdout
+            config.logger.info.assert_called_with('Bla bla')
+
+    def test_failing_pig_job(self):
+        # a mutable where commands sent are stored
+        commands_sent = []
+        self.Popen.side_effect = functools.partial(
+            mocked_Popen,
+            _commands_sent=commands_sent,
+            _exit_code=1,
+            _stdout='',
+            _stderr='First command failed :(',
+        )
+
+        config_manager, json_file = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = crontabber.CronTabber(config)
+            tab.run_all()
+
+            information = json.load(open(json_file))
+            assert information['modulelist']
+            assert information['modulelist']['last_error']
+            _traceback = information['modulelist']['last_error']['traceback']
+            self.assertTrue('pig run failed' in _traceback)
+            # the other two where cancelled
+            self.assertEqual(len(commands_sent), 1)
+            config.logger.error.assert_called_with('First command failed :(')
+
+    def test_failing_hadoop_getmerge_job(self):
+        # a mutable where commands sent are stored
+        commands_sent = []
+        self.Popen.side_effect = functools.partial(
+            mocked_Popen,
+            _commands_sent=commands_sent,
+            _exit_code=lambda cmd: 1 if cmd.count('getmerge') else 0,
+            _stdout='',
+            _stderr=lambda cmd: 'Shit' if cmd.count('getmerge') else '',
+        )
+
+        config_manager, json_file = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = crontabber.CronTabber(config)
+            tab.run_all()
+
+            information = json.load(open(json_file))
+            assert information['modulelist']
+            assert information['modulelist']['last_error']
+            _traceback = information['modulelist']['last_error']['traceback']
+            self.assertTrue('hadoop getmerge failed' in _traceback)
+            # the other two where cancelled
+            self.assertEqual(len(commands_sent), 2)
+            config.logger.error.assert_called_with('Shit')
+
+    def test_failing_hadoop_cleanup_job(self):
+        # a mutable where commands sent are stored
+        commands_sent = []
+        self.Popen.side_effect = functools.partial(
+            mocked_Popen,
+            _commands_sent=commands_sent,
+            _exit_code=lambda cmd: 1 if cmd.count('-rmr') else 0,
+            _stdout='',
+            _stderr=lambda cmd: 'Poop' if cmd.count('-rmr') else '',
+        )
+
+        config_manager, json_file = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = crontabber.CronTabber(config)
+            tab.run_all()
+
+            information = json.load(open(json_file))
+            assert information['modulelist']
+            assert information['modulelist']['last_error']
+            _traceback = information['modulelist']['last_error']['traceback']
+            self.assertTrue('hadoop cleanup failed' in _traceback)
+            # the other two where cancelled
+            self.assertEqual(len(commands_sent), 3)
+            config.logger.error.assert_called_with('Poop')

--- a/socorro/unittest/cron/sampleapp.py
+++ b/socorro/unittest/cron/sampleapp.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+A sample app that is able to exit and spit out specific messages on stdout
+and stderr exactly as asked for.
+This is used for testing the socorro.cron.base.SubprocessMixin class
+
+To test this app run it like this::
+
+    $ ./sampleapp.py 1 foo bar 1> out.log 2> err.log
+    $ echo $?
+    1
+    $ cat out.log
+    foo
+    $ cat err.log
+    bar
+
+"""
+
+
+if __name__ == '__main__':
+    import sys
+    from optparse import OptionParser
+    parser = OptionParser()
+    parser.add_option("--exit", dest="exit_code", type="int", default=0)
+    parser.add_option("-o", dest="out", default="")
+    parser.add_option("-e", dest="err", default="")
+
+    options, args = parser.parse_args()
+    if options.out:
+        print >>sys.stdout, options.out
+    if options.err:
+        print >>sys.stderr, options.err
+    sys.exit(options.exit_code)

--- a/socorro/unittest/cron/test_subprocess_mixin.py
+++ b/socorro/unittest/cron/test_subprocess_mixin.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import unittest
+
+from socorro.cron.base import SubprocessMixin
+
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), 'sampleapp.py')
+
+
+class TestSubprocessMixin(unittest.TestCase, SubprocessMixin):
+
+    def test_clean_no_errors(self):
+        exit_code, stdout, stderr = self.run_process(
+            [_SCRIPT]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+
+    def test_failing_one_error(self):
+        exit_code, stdout, stderr = self.run_process(
+            [_SCRIPT, '--exit', 1, '-e', 'Error']
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, 'Error')
+
+    def test_clean_some_output(self):
+        exit_code, stdout, stderr = self.run_process(
+            [_SCRIPT, '-o', 'Blather']
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, 'Blather')
+        self.assertEqual(stderr, '')
+
+    def test_as_command_string(self):
+        exit_code, stdout, stderr = self.run_process(
+            '%s --exit=9 -o Blather -e Error' % _SCRIPT
+        )
+        self.assertEqual(exit_code, 9)
+        self.assertEqual(stdout, 'Blather')
+        self.assertEqual(stderr, 'Error')


### PR DESCRIPTION
I perhaps named this branch badly. Basically, it's a replacement of https://github.com/mozilla/socorro/blob/master/scripts/crons/cron_modulelist.sh as a crontabber app. 

The diff is large because with this it adds a `SubprocessMixin` class which is handy for all work with command line things. I like its API. `exit_code, out, err = self.run_process(command, input=None)`

I have NOT tested this manually. I don't have `pig` or `hadoop` installed and I guess I could make fake programs but that faking would just be as solid as the unit tests. 

Please scrutinize the way the backfill date is converted to yesterdays date and inserted into the various commands. 
