### PR TITLE
fixed Bug 851839: removed chatty logging

### DIFF
--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -470,7 +470,9 @@ class FSDatedRadixTreeStorage(FSRadixTreeStorage):
             try:
                 hour_slots = os.listdir(dated_base)
             except OSError:
-                self.logger.info("date root for %s doesn't exist" % date)
+                # it is okay that the date root doesn't exist - skip on to
+                # the next date
+                #self.logger.info("date root for %s doesn't exist" % date)
                 continue
 
             for hour_slot in hour_slots:


### PR DESCRIPTION
when the crash mover walks trees written by the old collector, it complains about the date root being missing.  The date root being missing is not an error and perfectly normal.  It should not even be noted in the logs.  This PR removes the too chatty logging about date root.
