### PR TITLE
fixes Bug 853299: added statsd to legacy processor

### DIFF
--- a/socorro/lib/statistics.py
+++ b/socorro/lib/statistics.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+"""
+
+from statsd import StatsClient
+
+from configman import RequiredConfig, Namespace
+
+def str_to_list(string_list):
+    item_list = []
+    for x in string_list.split(','):
+        item_list.append(x.strip())
+    return item_list
+
+
+class StatisticsForStatsd(RequiredConfig):
+    """This class is a wrapper around statsd adding a simple configman
+    compatible interface and stats naming scheme.  Code using this class
+    will distrubute `incr` calls with names associated with them.  When
+    ever an `incr` call is encountered, the name will be paired with the
+    name of the statsd names and the increment action fired off.
+
+    This class will only send stats `incr` calls for names that appear in
+    the configuration parameter `active_counters_list`.  This enables counters
+    to be turned on and off at configuration time."""
+
+    required_config = Namespace()
+    required_config.add_option(
+        'statsd_host',
+        doc='the hostname of statsd',
+        default=''
+    )
+    required_config.add_option(
+        'statsd_port',
+        doc='the port number for statsd',
+        default=''
+    )
+    required_config.add_option(
+        'prefix',
+        doc='a string to be used as the prefix for statsd names',
+        default=''
+    )
+    required_config.add_option(
+        'active_counters_list',
+        default='',
+        #default='restarts, jobs, criticals, errors, mdsw_failures',
+        doc='a comma delimeted list of counters',
+        from_string_converter=str_to_list
+    )
+
+    def __init__(self, config, name):
+        super(StatisticsForStatsd, self).__init__()
+        self.config = config
+        if config.prefix and name:
+            self.prefix = '.'.join((config.prefix, name))
+        elif config.prefix:
+            self.prefix = config.prefix
+        elif name:
+            self.prefix = name
+        else:
+            self.prefix = ''
+        self.statsd = StatsClient(
+            config.statsd_host,
+            config.statsd_port,
+            self.prefix
+        )
+
+    def incr(self, name):
+        if (
+            self.config.statsd_host
+            and name in self.config.active_counters_list
+        ):
+            if self.prefix and name:
+                name = '.'.join((self.prefix, name))
+            elif self.prefix:
+                name = self.prefix
+            elif not name:
+                name = 'unknown'
+            self.statsd.incr(name)
+

--- a/socorro/unittest/lib/test_statistics.py
+++ b/socorro/unittest/lib/test_statistics.py
@@ -1,0 +1,179 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from mock import Mock, patch, call
+
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.statistics import StatisticsForStatsd
+
+class TestStatsd(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = SilentFakeLogger()
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_statistics_all_good(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = 'a.b'
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, 'processor')
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, 'a.b.processor')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.x'),
+                    call.incr('a.b.processor.y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.x'),
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.unknown')
+                ]
+            )
+
+
+
+    def test_statistics_all_missing_prefix(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = None
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, 'processor')
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, 'processor')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('processor.y'),
+                    call.incr('processor.x'),
+                    call.incr('processor.y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('processor.y'),
+                    call.incr('processor.x'),
+                    call.incr('processor.y'),
+                    call.incr('processor.unknown')
+                ]
+            )
+
+
+    def test_statistics_all_missing_prefix_and_missing_name(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = None
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, None)
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, '')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('y'),
+                    call.incr('x'),
+                    call.incr('y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('y'),
+                    call.incr('x'),
+                    call.incr('y'),
+                    call.incr('unknown')
+                ]
+            )
+
+
+
+


### PR DESCRIPTION
This PR adds statsd support to the new processor.  It was evidently not updated when statsd was added to the old processor.  This oversight is corrected.

I added a statsd wrapper class that adds configman support to the StatsClient class.  It offers a dynamic loading of statsd and the ability to turn counters on and off in configuration.
