### PR TITLE
fixes Bug 854456 - Processor2012 C skiplist regex ini configman converter change

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -61,7 +61,7 @@ class CSignatureTool(SignatureTool):
       'irrelevant_signature_re',
       doc='a regular expression matching frame signatures that should be '
           'ignored when generating an overall signature',
-      default='|'.join([
+      default="""'|'.join([
           '@0x[0-9a-fA-F]{2,}',
           '@0x[1-9a-fA-F]',
           'ashmem',
@@ -107,14 +107,15 @@ class CSignatureTool(SignatureTool):
           'RealMsgWaitFor.*'
           '_ZdlPv',
           'zero',
-          ])
+          ])""",
+      from_string_converter=eval
     )
     required_config.add_option(
       'prefix_signature_re',
       doc='a regular expression matching frame signatures that should always '
           'be coupled with the following frame signature when generating an '
           'overall signature',
-      default='|'.join([
+      default="""'|'.join([
           '@0x0',
           '.*abort',
           '_alloca_probe.*',
@@ -253,7 +254,9 @@ class CSignatureTool(SignatureTool):
           'WSARecv.*',
           'WSASend.*',
           '_ZdaPvRKSt9nothrow_t\"',
-    ]))
+        ])""",
+      from_string_converter=eval
+    )
     required_config.add_option(
       'signatures_with_line_numbers_re',
       doc='any signatures that match this list should be combined with their '


### PR DESCRIPTION
The skip list values in ini files are difficult to work with because they're just strings that have been escaped several times over.  To simplify them, I've recast them as a python expressions to be evaluated at configuration load time in the same manner that the skip list option "signature_sentinels".  This will make them easier to edit and maintain in the ini files.
