### PR TITLE
fixes Bug 854529 - renamed option to a standard name

### DIFF
--- a/config/processor.ini-dist
+++ b/config/processor.ini-dist
@@ -402,10 +402,10 @@
     # converter: configman.converters.timedelta_converter
     check_in_frequency='00:00:01:00'
 
-    # name: database
+    # name: database_class
     # doc: the class of the registrar's database
     # converter: configman.converters.class_converter
-    database='socorro.external.postgresql.connection_context.ConnectionContext'
+    database_class='socorro.external.postgresql.connection_context.ConnectionContext'
 
     # name: database_host
     # doc: the hostname of the database

--- a/socorro/processor/registration_client.py
+++ b/socorro/processor/registration_client.py
@@ -29,7 +29,7 @@ class RegistrationError(Exception):
 class ProcessorAppRegistrationClient(RequiredConfig):
     required_config = Namespace()
     required_config.add_option(
-      'database',
+      'database_class',
       doc="the class of the registrar's database",
       default=ConnectionContext,
       from_string_converter=class_converter
@@ -65,7 +65,7 @@ class ProcessorAppRegistrationClient(RequiredConfig):
                      logger - a logger object"""
         self.config = config
 
-        self.database = config.database(config)
+        self.database = config.database_class(config)
         self.transaction = config.transaction_executor_class(
             config,
             self.database,

--- a/socorro/unittest/processor/test_registration_client.py
+++ b/socorro/unittest/processor/test_registration_client.py
@@ -45,7 +45,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres
+            'database_class': mock_postgres
           }]
         )
         m_registration = mock.Mock()
@@ -74,7 +74,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres
+            'database_class': mock_postgres
           }]
         )
         m_registration = mock.Mock()
@@ -125,7 +125,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres
+            'database_class': mock_postgres
           }]
         )
         m_registration = mock.Mock()
@@ -173,7 +173,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres
+            'database_class': mock_postgres
           }]
         )
         m_registration = mock.Mock()
@@ -230,7 +230,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres,
+            'database_class': mock_postgres,
             'processor_id': 'host',
           }]
         )
@@ -299,7 +299,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres,
+            'database_class': mock_postgres,
             'processor_id': 'forcehost',
           }]
         )
@@ -370,7 +370,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres,
+            'database_class': mock_postgres,
             'processor_id': 'host',
           }]
         )
@@ -445,7 +445,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres,
+            'database_class': mock_postgres,
             'processor_id': 'forcehost',
           }]
         )
@@ -517,7 +517,7 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'database': mock_postgres,
+            'database_class': mock_postgres,
             'processor_id': 'host',
           }]
         )


### PR DESCRIPTION
the configman apps should use standard naming for options of similar use.  All but the registrar_client file use 'database_class' for the name of the database class.  This PR changes the resistrar_client to use the standard name.
