### PR TITLE
fixed bug 856148 - converts statsd port to an int

### DIFF
--- a/socorro/lib/statistics.py
+++ b/socorro/lib/statistics.py
@@ -36,7 +36,7 @@ class StatisticsForStatsd(RequiredConfig):
     required_config.add_option(
         'statsd_port',
         doc='the port number for statsd',
-        default=''
+        default=8125
     )
     required_config.add_option(
         'prefix',


### PR DESCRIPTION
I cannot reproduce this issue on dev so I'm sending this direct to stage. I will back it out or apply it to master as soon as its clear if this fixes the issue.
