### PR TITLE
fixed bug 856148 - converts statsd port to an int

### DIFF
--- a/socorro/lib/statistics.py
+++ b/socorro/lib/statistics.py
@@ -36,7 +36,7 @@ class StatisticsForStatsd(RequiredConfig):
     required_config.add_option(
         'statsd_port',
         doc='the port number for statsd',
-        default=''
+        default=8125
     )
     required_config.add_option(
         'prefix',


### PR DESCRIPTION
this eliminated one source of error in our statistics module. best to get it on master and stage.
