### PR TITLE
corrected exception handling for missing ES config

### DIFF
--- a/socorro/processor/processor.py
+++ b/socorro/processor/processor.py
@@ -947,7 +947,7 @@ class Processor(object):
                           ooid)
           sutil.reportExceptionAndContinue(logger, logging.CRITICAL,
                                            showTraceback=False)
-    except KeyError:
+    except (AttributeError, KeyError):
       self.config.logger.debug('no Elastic Search URL has been configured')
 
 

--- a/socorro/unittest/processor/testProcessor.py
+++ b/socorro/unittest/processor/testProcessor.py
@@ -107,8 +107,9 @@ def createExecutionContext ():
     c.fakeNowFunc = exp.DummyObjectWithExpectations()
     return c
 
-def getMockedProcessorAndContext():
-    c = createExecutionContext()
+def getMockedProcessorAndContext(c=None):
+    if c is None:
+        c = createExecutionContext()
     class MockedProcessor(proc.Processor):
         def registration (self):
             self.processorId = 288
@@ -1761,6 +1762,19 @@ def testSubmitOoidToElasticSearch_3():
     fakeUrllib2.expect('urlopen', (17,), {'timeout':2}, fakeFileLikeObject)
     fakeUrllib2.expect('socket', returnValue=s)
     p.submitOoidToElasticSearch(uuid, fakeUrllib2)
+
+def testSubmitOoidToElasticSearch_4():
+    """testSubmitOoidToElasticSearch_4: submit to ES with missing config"""
+    import socket as s
+    c = createExecutionContext()
+    del c.config['elasticSearchOoidSubmissionUrl']
+    p, c = getMockedProcessorAndContext(c)
+    uuid = 'ef38fe89-43b6-4cd4-b154-392022110607'
+    salted_ooid = 'e110607ef38fe89-43b6-4cd4-b154-392022110607'
+    fakeUrllib2 = exp.DummyObjectWithExpectations()
+    p.submitOoidToElasticSearch(uuid, fakeUrllib2)
+    logs = c.logger.getMessages()
+    assert 'no Elastic Search URL has been configured' in logs
 
 
 from socorro.processor.externalProcessor import ProcessorWithExternalBreakpad


### PR DESCRIPTION
Currently in production, _every_ crash is being marked as failed.  This is because the Elastic Search configuration information is missing for some reason and the ES code in the 2008 processor is looking for KeyErrors rather than AttributeErrors.  This patch corrects the Exception handler to catch either error type.  This makes the missing configuration a recoverable error.  
