### PR TITLE
bug 857100 - reset time by seconds and microseconds too

### DIFF
--- a/socorro/cron/base.py
+++ b/socorro/cron/base.py
@@ -160,7 +160,12 @@ class BaseCronApp(RequiredConfig):
                     # So, reset the hour/minute part to always match the
                     # intention.
                     h, m = [int(x) for x in self.config.time.split(':')]
-                    when = when.replace(hour=h, minute=m)
+                    when = when.replace(
+                        hour=h,
+                        minute=m,
+                        second=0,
+                        microsecond=0
+                    )
                 seconds = convert_frequency(self.config.frequency)
                 interval = datetime.timedelta(seconds=seconds)
                 while (when + interval) < now:


### PR DESCRIPTION
@rhelmer r?

From the comment  around line 146 in socorro/cron/base.py:

```
# The last_success datetime is originally based on the
# first_run. From then onwards it just adds the interval to
# it so the hour is not likely to drift from that original
# time.
# However, what can happen is that on a given day, "now" is
# LESS than the day before. This can happen because the jobs
# that are run BEFORE are variable in terms of how long it
# takes. Thus, one day, now might be "18:02" and the next day
# the it's "18:01". If this happens the original difference
# will prevent it from running the backfill again.
```

That example shows how the "resetting" of the hour and minute solves the problem of potential drift when the job is initiated the second time 1 minute earlier than the day before. 

However, what happened in https://bugzilla.mozilla.org/show_bug.cgi?id=857100#c8 (I think) is that it started 7 seconds earlier than normal. 

By removing the seconds and microseconds entirely we avoid this problem when under 1 minute. 
