### PR TITLE
fixes bug 857638 - write out OK message to nagios

### DIFF
--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -30,25 +30,25 @@ from socorro.cron.base import (
 
 
 DEFAULT_JOBS = '''
-    socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
-    socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|10:00
-    socorro.cron.jobs.matviews.SignaturesCronApp|1d|10:00
-    socorro.cron.jobs.matviews.TCBSCronApp|1d|10:00
-    socorro.cron.jobs.matviews.ADUCronApp|1d|10:00
-    socorro.cron.jobs.matviews.NightlyBuildsCronApp|1d|10:00
-    socorro.cron.jobs.matviews.DuplicatesCronApp|1h
-    socorro.cron.jobs.matviews.ReportsCleanCronApp|1h
-    socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
-    socorro.cron.jobs.matviews.BuildADUCronApp|1d|10:00
-    socorro.cron.jobs.matviews.CrashesByUserCronApp|1d|10:00
-    socorro.cron.jobs.matviews.CrashesByUserBuildCronApp|1d|10:00
-    socorro.cron.jobs.matviews.CorrelationsCronApp|1d|10:00
-    socorro.cron.jobs.matviews.HomePageGraphCronApp|1d|10:00
-    socorro.cron.jobs.matviews.HomePageGraphBuildCronApp|1d|10:00
-    socorro.cron.jobs.matviews.TCBSBuildCronApp|1d|10:00
-    socorro.cron.jobs.matviews.ExplosivenessCronApp|1d|10:00
-    socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
-    socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h
+  socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
+  socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|10:00
+  socorro.cron.jobs.matviews.SignaturesCronApp|1d|10:00
+  socorro.cron.jobs.matviews.TCBSCronApp|1d|10:00
+  socorro.cron.jobs.matviews.ADUCronApp|1d|10:00
+  socorro.cron.jobs.matviews.NightlyBuildsCronApp|1d|10:00
+  socorro.cron.jobs.matviews.DuplicatesCronApp|1h
+  socorro.cron.jobs.matviews.ReportsCleanCronApp|1h
+  socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
+  socorro.cron.jobs.matviews.BuildADUCronApp|1d|10:00
+  socorro.cron.jobs.matviews.CrashesByUserCronApp|1d|10:00
+  socorro.cron.jobs.matviews.CrashesByUserBuildCronApp|1d|10:00
+  socorro.cron.jobs.matviews.CorrelationsCronApp|1d|10:00
+  socorro.cron.jobs.matviews.HomePageGraphCronApp|1d|10:00
+  socorro.cron.jobs.matviews.HomePageGraphBuildCronApp|1d|10:00
+  socorro.cron.jobs.matviews.TCBSBuildCronApp|1d|10:00
+  socorro.cron.jobs.matviews.ExplosivenessCronApp|1d|10:00
+  socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
+  socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h
 '''
 
 
@@ -575,15 +575,14 @@ class CronTabber(App):
             stream.write('CRITICAL - ')
             stream.write('; '.join(criticals))
             stream.write('\n')
+            return 2
         elif warnings:
             stream.write('WARNING - ')
             stream.write('; '.join(warnings))
             stream.write('\n')
-
-        if criticals:
-            return 2
-        elif warnings:
             return 1
+        stream.write('OK - All systems nominal')
+        stream.write('\n')
         return 0
 
     def list_jobs(self, stream=None):

--- a/socorro/unittest/cron/test_crontabber.py
+++ b/socorro/unittest/cron/test_crontabber.py
@@ -1423,7 +1423,7 @@ class TestCrontabber(TestCaseBase):
             stream = StringIO()
             exit_code = tab.nagios(stream=stream)
             self.assertEqual(exit_code, 0)
-            self.assertEqual(stream.getvalue(), '')
+            self.assertEqual(stream.getvalue(), 'OK - All systems nominal\n')
 
     def test_nagios_warning(self):
         config_manager, json_file = self._setup_config_manager(


### PR DESCRIPTION
also adjusts spacing in the multiline string containing job names to
comply with pep8 line length limitations

the diff algorithm is kind of janky. best to look directly at the file.
