### PR TITLE
bug 860500 Add ON COMMIT DROP to temporary table creation

### DIFF
--- a/sql/upgrade/41.0/README.rst
+++ b/sql/upgrade/41.0/README.rst
@@ -1,0 +1,14 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+41.0 Database Updates
+=====================
+
+bug #860500
+    Add ON COMMIT DROP to CREATE TEMPORARY TABLE
+
+...
+
+The above changes should take only a few minutes to deploy.
+This upgrade does not require a downtime.

--- a/sql/upgrade/41.0/update_correlations.sql
+++ b/sql/upgrade/41.0/update_correlations.sql
@@ -1,0 +1,91 @@
+CREATE OR REPLACE FUNCTION update_correlations(updateday date, checkdata boolean DEFAULT true, check_period interval DEFAULT '01:00:00'::interval) RETURNS boolean
+    LANGUAGE plpgsql
+    SET work_mem TO '512MB'
+    SET client_min_messages TO 'ERROR'
+    AS $$
+BEGIN
+-- this function populates daily matviews
+-- for some of the correlation reports
+-- depends on reports_clean
+
+-- no need to check if we've been run, since the correlations
+-- only hold the last day of data
+
+-- check if reports_clean is complete
+IF NOT reports_clean_done(updateday, check_period) THEN
+    IF checkdata THEN
+        RAISE EXCEPTION 'Reports_clean has not been updated to the end of %',updateday;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END IF;
+
+-- clear the correlations list
+-- can't use TRUNCATE here because of locking
+DELETE FROM correlations;
+
+--create the correlations list
+INSERT INTO correlations ( signature_id, product_version_id,
+	os_name, reason_id, crash_count )
+SELECT signature_id, product_version_id,
+	os_name, reason_id, count(*)
+FROM reports_clean
+	JOIN product_versions USING ( product_version_id )
+WHERE updateday BETWEEN build_date and sunset_date
+	and utc_day_is(date_processed, updateday)
+GROUP BY product_version_id, os_name, reason_id, signature_id
+ORDER BY product_version_id, os_name, reason_id, signature_id;
+
+ANALYZE correlations;
+
+-- create list of UUID-report_id correspondences for the day
+CREATE TEMPORARY TABLE uuid_repid
+ON COMMIT DROP
+AS
+SELECT uuid, id as report_id
+FROM reports
+WHERE utc_day_is(date_processed, updateday)
+ORDER BY uuid, report_id;
+CREATE INDEX uuid_repid_key on uuid_repid(uuid, report_id);
+ANALYZE uuid_repid;
+
+--create the correlation-addons list
+INSERT INTO correlation_addons (
+	correlation_id, addon_key, addon_version, crash_count )
+SELECT correlation_id, extension_id, extension_version, count(*)
+FROM correlations
+	JOIN reports_clean
+		USING ( product_version_id, os_name, reason_id, signature_id )
+	JOIN uuid_repid
+		USING ( uuid )
+	JOIN extensions
+		USING ( report_id )
+	JOIN product_versions
+		USING ( product_version_id )
+WHERE utc_day_is(reports_clean.date_processed, updateday)
+	AND utc_day_is(extensions.date_processed, updateday)
+	AND updateday BETWEEN build_date AND sunset_date
+GROUP BY correlation_id, extension_id, extension_version;
+
+ANALYZE correlation_addons;
+
+--create correlations-cores list
+INSERT INTO correlation_cores (
+	correlation_id, architecture, cores, crash_count )
+SELECT correlation_id, architecture, cores, count(*)
+FROM correlations
+	JOIN reports_clean
+		USING ( product_version_id, os_name, reason_id, signature_id )
+	JOIN product_versions
+		USING ( product_version_id )
+WHERE utc_day_is(reports_clean.date_processed, updateday)
+	AND updateday BETWEEN build_date AND sunset_date
+	AND architecture <> '' AND cores >= 0
+GROUP BY correlation_id, architecture, cores;
+
+ANALYZE correlation_cores;
+
+RETURN TRUE;
+END; $$;
+
+

--- a/sql/upgrade/41.0/update_rank_compare.sql
+++ b/sql/upgrade/41.0/update_rank_compare.sql
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION update_rank_compare(updateday date DEFAULT NULL::date, checkdata boolean DEFAULT true, check_period interval DEFAULT '01:00:00'::interval) RETURNS boolean
+    LANGUAGE plpgsql
+    SET client_min_messages TO 'ERROR'
+    AS $$
+BEGIN
+-- this function populates a daily matview
+-- for rankings of signatures on TCBS
+-- depends on the new reports_clean
+
+-- run for yesterday if not set
+updateday := COALESCE(updateday, ( CURRENT_DATE -1 ));
+
+-- don't care if we've been run
+-- since there's no historical data
+
+-- check if reports_clean is complete
+IF NOT reports_clean_done(updateday, check_period) THEN
+    IF checkdata THEN
+        RAISE EXCEPTION 'Reports_clean has not been updated to the end of %',updateday;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END IF;
+
+-- obtain a lock on the matview so that we can TRUNCATE
+IF NOT try_lock_table('rank_compare', 'ACCESS EXCLUSIVE') THEN
+	RAISE EXCEPTION 'unable to lock the rank_compare table for update.';
+END IF;
+
+-- create temporary table with totals from reports_clean
+
+CREATE TEMPORARY TABLE prod_sig_counts
+ON COMMIT DROP
+AS SELECT product_version_id, signature_id, count(*) as report_count
+FROM reports_clean
+WHERE utc_day_is(date_processed, updateday)
+GROUP BY product_version_id, signature_id;
+
+-- truncate rank_compare since we don't need the old data
+
+TRUNCATE rank_compare CASCADE;
+
+-- now insert the new records
+INSERT INTO rank_compare (
+	product_version_id, signature_id,
+	rank_days,
+	report_count,
+	total_reports,
+	rank_report_count,
+	percent_of_total)
+SELECT product_version_id, signature_id,
+	1,
+	report_count,
+	total_count,
+	count_rank,
+	round(( report_count::numeric / total_count ),5)
+FROM (
+	SELECT product_version_id, signature_id,
+		report_count,
+		sum(report_count) over (partition by product_version_id) as total_count,
+		dense_rank() over (partition by product_version_id
+							order by report_count desc) as count_rank
+	FROM prod_sig_counts
+) as initrank;
+
+RETURN TRUE;
+END; $$;
+
+

--- a/sql/upgrade/41.0/upgrade.sh
+++ b/sql/upgrade/41.0/upgrade.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#please see README
+
+set -e
+
+CURDIR=$(dirname $0)
+DBNAME=$1
+: ${DBNAME:="breakpad"}
+VERSION=41.0
+
+#echo '*********************************************************'
+#echo 'support functions'
+#psql -f ${CURDIR}/support_functions.sql $DBNAME
+
+echo '*********************************************************'
+echo 'add ON COMMIT DROP to temporary tables'
+echo 'bug 860500'
+psql ${DBNAME} -f ${CURDIR}/update_correlations.sql
+psql ${DBNAME} -f ${CURDIR}/update_rank_compare.sql
+
+#change version in DB
+psql -c "SELECT update_socorro_db_version( '$VERSION' )" $DBNAME
+
+echo "$VERSION upgrade done"
+
+exit 0


### PR DESCRIPTION
Fixing a problem we're having on stage with calling backfill routines more than once in a session.
