### PR TITLE
Fixes bug 863458 - Sorted versions by descending order in products service.

### DIFF
--- a/socorro/external/postgresql/products.py
+++ b/socorro/external/postgresql/products.py
@@ -35,7 +35,7 @@ class Products(PostgreSQLBase):
                 build_type,
                 has_builds
             FROM product_info
-            ORDER BY product_sort, version_sort, channel_sort
+            ORDER BY product_sort, version_sort DESC, channel_sort
         """
 
         error_message = "Failed to retrieve products/versions from PostgreSQL"


### PR DESCRIPTION
@rhelmer r?

Sorry I did a bit of refactoring of the tests, there is a comment near the test covering this new behavior. 
