### PR TITLE
Fixes bug 838897 - Fixed the versions filter in search with elasticsearch.

### DIFF
--- a/config/middleware.ini-dist
+++ b/config/middleware.ini-dist
@@ -288,7 +288,7 @@
     # name: channels
     # doc: List of release channels, excluding the `release` one.
     # converter: string_to_list
-    #channels='Beta, Aurora, Nightly, beta, aurora, nightly'
+    #channels='beta, aurora, nightly'
 
     # name: elasticSearchHostname
     # doc: String containing the URI of the Elastic Search instance.
@@ -308,7 +308,7 @@
     # name: restricted_channels
     # doc: List of release channels to restrict based on build ids.
     # converter: string_to_list
-    #restricted_channels='Beta, beta'
+    #restricted_channels='beta'
 
     # name: searchMaxNumberOfDistinctSignatures
     # doc: Integer containing the maximum allowed number of distinct signatures the system should retrieve. Used mainly for performances in ElasticSearch

--- a/scripts/config/webapiconfig.py.dist
+++ b/scripts/config/webapiconfig.py.dist
@@ -245,8 +245,8 @@ platforms.default = (
 # Release Channels
 channels = cm.Option()
 channels.doc = 'List of release channels, excluding the `release` one.'
-channels.default = ['Beta', 'Aurora', 'Nightly', 'beta', 'aurora', 'nightly']
+channels.default = ['beta', 'aurora', 'nightly']
 
 restricted_channels = cm.Option()
 restricted_channels.doc = 'List of release channels to restrict based on build ids.'
-restricted_channels.default = ['Beta', 'beta']
+restricted_channels.default = ['beta']

--- a/socorro/external/elasticsearch/search.py
+++ b/socorro/external/elasticsearch/search.py
@@ -136,15 +136,15 @@ class Search(ElasticSearchBase):
                                             params["result_offset"], maxsize,
                                             self.config.platforms)
 
-        results = {
+        hits = [signatures[x] for x in range(params["result_offset"], maxsize)]
+
+        # sort results by count *and* signatures
+        hits.sort(key=lambda x: (-x['count'], x['signature'].lower()))
+
+        return {
             "total": signature_count,
-            "hits": []
+            "hits": hits
         }
-
-        for i in range(params["result_offset"], maxsize):
-            results["hits"].append(signatures[i])
-
-        return results
 
     @staticmethod
     def get_signatures_facet(size):

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -210,13 +210,13 @@ class MiddlewareApp(App):
     )
     required_config.webapi.add_option(
         'channels',
-        default=['Beta', 'Aurora', 'Nightly', 'beta', 'aurora', 'nightly'],
+        default=['beta', 'aurora', 'nightly'],
         doc='List of release channels, excluding the `release` one.',
         from_string_converter=string_to_list
     )
     required_config.webapi.add_option(
         'restricted_channels',
-        default=['Beta', 'beta'],
+        default=['beta'],
         doc='List of release channels to restrict based on build ids.',
         from_string_converter=string_to_list
     )


### PR DESCRIPTION
This PR adds integration tests for elasticsearch. They are disabled by default though, so we can pass jenkins' build. If you want to run them locally, you need an elasticsearch instance working on port 9200, and to run `RUN_ES_INTEGRATION_TESTS=1 make test`. 

@ErikRose r?
