### PR TITLE
fixes Bug 864396 - signature generation tool w/ skiplist from a database

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -79,6 +79,15 @@ class FetchTransformSaveApp(App):
       from_string_converter=class_converter
     )
 
+    ###########################################################################
+    ### TODO: add a feature where clients of this class may register a waiting
+    ### function.  The MainThread will run all the registered waiting
+    ### functions at their configured interval.  A first application of this
+    ### feature will be to allow periodic reloading of config data from a
+    ### database.  Specifically, the skip list rules could be reloaded without
+    ### having to restart the processor.
+    ###########################################################################
+
     #--------------------------------------------------------------------------
     def __init__(self, config):
         super(FetchTransformSaveApp, self).__init__(config)
@@ -139,7 +148,7 @@ class FetchTransformSaveApp(App):
                     str(x),
                     exc_info=True
                 )
-                
+
 
     #--------------------------------------------------------------------------
     def quit_check(self):

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -77,6 +77,13 @@ class ProcessorApp(FetchTransformSaveApp):
       from_string_converter=class_converter
     )
 
+    ###########################################################################
+    ### TODO: implement an __init__ and a waiting func.  The waiting func
+    ### will take registrations of periodic things to do over some time
+    ### interval.  the first periodic thing is the rereading of the
+    ### signature generation stuff from the database.
+    ###########################################################################
+
     #--------------------------------------------------------------------------
     def source_iterator(self):
         """this iterator yields individual crash_ids from the source

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -3,196 +3,376 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import unittest
+import mock
 
 import socorro.processor.signature_utilities as sig
 import socorro.lib.util as sutil
 
+from socorro.database.transaction_executor import TransactionExecutor
 from socorro.lib.util import DotDict
 from socorro.processor.signature_utilities import JavaSignatureTool
 
 import re
 
-def assert_expected (expected, received):
-    assert expected == received, 'expected:\n(%s)\nbut got:\n(%s)' % (expected,
-                                                                  received)
+from mock import (Mock, patch, call)
 
-def setupSigUtil(ig='ignored1', pr='pre1|pre2', si='fnNeedNumber'):
-    config = sutil.DotDict()
-    config.logger = sutil.FakeLogger()
-    config.irrelevant_signature_re = ig
-    config.prefix_signature_re = pr
-    config.signatures_with_line_numbers_re = si
-    config.signature_sentinels = ('sentinel',
-                                  ('sentinel2', lambda x: 'ff' in x),
-                                 )
-    s = sig.CSignatureTool(config)
-    return s, config
 
-def testInit():
-    """testInit: constructor test"""
-    expectedRegEx = sutil.DotDict()
-    expectedRegEx.irrelevant_signature_re = re.compile('ignored1')
-    expectedRegEx.prefix_signature_re = re.compile('pre1|pre2')
-    expectedRegEx.signatures_with_line_numbers_re = re.compile('fnNeedNumber')
-    fixupSpace = re.compile(r' (?=[\*&,])')
-    fixupComma = re.compile(r',(?! )')
-    fixupInteger = re.compile(r'(<|, )(\d+)([uUlL]?)([^\w])')
+class BaseTestClass(unittest.TestCase):
 
-    s, c = setupSigUtil(expectedRegEx.irrelevant_signature_re,
-                        expectedRegEx.prefix_signature_re,
-                        expectedRegEx.signatures_with_line_numbers_re)
+    def assert_equal_with_nicer_output (self, expected, received):
+        self.assertEqual(
+            expected,
+            received,
+            'expected:\n%s\nbut got:\n%s' % (expected, received)
+        )
 
-    assert_expected(c, s.config)
-    assert_expected(expectedRegEx.irrelevant_signature_re,
-                    s.irrelevant_signature_re)
-    assert_expected(expectedRegEx.prefix_signature_re,
-                    s.prefix_signature_re)
-    assert_expected(expectedRegEx.signatures_with_line_numbers_re,
-                    s.signatures_with_line_numbers_re)
-    assert_expected(fixupSpace,
-                    s.fixupSpace)
-    assert_expected(fixupComma,
-                    s.fixupComma)
-    assert_expected(fixupInteger,
-                    s.fixupInteger)
+class TestCSignatureTool(BaseTestClass):
 
-def testNormalize():
-    """testNormalize: bunch of variations"""
-    s, c = setupSigUtil()
-    a = [ (('module', 'fn', 'source', '23', '0xFFF'), 'fn'),
-          (('module', 'fnNeedNumber', 's', '23', '0xFFF'), 'fnNeedNumber:23'),
-          (('module', 'f( *s)', 's', '23', '0xFFF'), 'f(*s)'),
-          (('module', 'f( &s)', 's', '23', '0xFFF'), 'f(&s)'),
-          (('module', 'f( *s , &n)', 's', '23', '0xFFF'), 'f(*s, &n)'),
-          # this next one looks like a bug to me, but perhaps the situation
-          # never comes up
-          #(('module', 'f(  *s , &n)', 's', '23', '0xFFF'), 'f(*s, &n)'),
-          (('module', 'f3(s,t,u)', 's', '23', '0xFFF'), 'f3(s, t, u)'),
-          (('module', 'f<3>(s,t,u)', 's', '23', '0xFFF'), 'f<int>(s, t, u)'),
-          (('module', '', 'source/', '23', '0xFFF'), 'source#23'),
-          (('module', '', 'source\\', '23', '0xFFF'), 'source#23'),
-          (('module', '', '/a/b/c/source', '23', '0xFFF'), 'source#23'),
-          (('module', '', '\\a\\b\\c\\source', '23', '0xFFF'), 'source#23'),
-          (('module', '', '\\a\\b\\c\\source', '23', '0xFFF'), 'source#23'),
-          (('module', '', '\\a\\b\\c\\source', '', '0xFFF'), 'module@0xFFF'),
-          (('module', '', '', '23', '0xFFF'), 'module@0xFFF'),
-          (('module', '', '', '', '0xFFF'), 'module@0xFFF'),
-          ((None, '', '', '', '0xFFF'), '@0xFFF'),
+    @staticmethod
+    def setup_config_C_sig_tool(
+        ig='ignored1',
+        pr='pre1|pre2',
+        si='fnNeedNumber',
+        ss=('sentinel', ('sentinel2', lambda x: 'ff' in x)),
+    ):
+        config = sutil.DotDict()
+        config.logger = sutil.FakeLogger()
+        config.irrelevant_signature_re = ig
+        config.prefix_signature_re = pr
+        config.signatures_with_line_numbers_re = si
+        config.signature_sentinels = ss
+        s = sig.CSignatureTool(config)
+        return s, config
+
+    @staticmethod
+    def setup_db_C_sig_tool(
+        ig='ignored1',
+        pr='pre1|pre2',
+        si='fnNeedNumber',
+        ss=('sentinel', "('sentinel2', lambda x: 'ff' in x)")
+    ):
+        config = sutil.DotDict()
+        config.logger = sutil.FakeLogger()
+        config.database_class = mock.MagicMock()
+        config.transaction_executor_class = TransactionExecutor
+        patch_target = 'socorro.processor.signature_utilities.' \
+                       'execute_query_fetchall'
+        with mock.patch(patch_target) as mocked_query:
+            # these become the results of four successive calls to
+            # execute_query_fetchall
+            mocked_query.side_effect = [
+                [(pr,),],
+                [(ig,), ],
+                [(si,), ],
+                [(x,) for x in ss],
+            ]
+            s = sig.CSignatureToolDB(config)
+            return s, config
+
+
+    def test_C_config_tool_init(self):
+        """test_C_config_tool_init: constructor test"""
+        expectedRegEx = sutil.DotDict()
+        expectedRegEx.irrelevant_signature_re = re.compile('ignored1')
+        expectedRegEx.prefix_signature_re = re.compile('pre1|pre2')
+        expectedRegEx.signatures_with_line_numbers_re = re.compile(
+            'fnNeedNumber'
+        )
+        fixupSpace = re.compile(r' (?=[\*&,])')
+        fixupComma = re.compile(r',(?! )')
+        fixupInteger = re.compile(r'(<|, )(\d+)([uUlL]?)([^\w])')
+
+        s, c = self.setup_config_C_sig_tool(
+            expectedRegEx.irrelevant_signature_re,
+            expectedRegEx.prefix_signature_re,
+            expectedRegEx.signatures_with_line_numbers_re
+        )
+
+        self.assert_equal_with_nicer_output(c, s.config)
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.irrelevant_signature_re,
+            s.irrelevant_signature_re
+        )
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.prefix_signature_re,
+            s.prefix_signature_re
+        )
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.signatures_with_line_numbers_re,
+            s.signatures_with_line_numbers_re
+        )
+        self.assert_equal_with_nicer_output(fixupSpace, s.fixup_space)
+        self.assert_equal_with_nicer_output(fixupComma, s.fixup_comma)
+        self.assert_equal_with_nicer_output(fixupInteger, s.fixup_integer)
+
+    def test_C_db_tool_init(self):
+        """test_C_db_tool_init: constructor test"""
+        expectedRegEx = sutil.DotDict()
+        expectedRegEx.irrelevant_signature_re = re.compile('ignored1')
+        expectedRegEx.prefix_signature_re = re.compile('pre1|pre2')
+        expectedRegEx.signatures_with_line_numbers_re = re.compile(
+            'fnNeedNumber'
+        )
+        fixupSpace = re.compile(r' (?=[\*&,])')
+        fixupComma = re.compile(r',(?! )')
+        fixupInteger = re.compile(r'(<|, )(\d+)([uUlL]?)([^\w])')
+
+        s, c = self.setup_db_C_sig_tool()
+
+        self.assert_equal_with_nicer_output(c, s.config)
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.irrelevant_signature_re,
+            s.irrelevant_signature_re
+        )
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.prefix_signature_re,
+            s.prefix_signature_re
+        )
+        self.assert_equal_with_nicer_output(
+            expectedRegEx.signatures_with_line_numbers_re,
+            s.signatures_with_line_numbers_re
+        )
+        self.assert_equal_with_nicer_output(fixupSpace, s.fixup_space)
+        self.assert_equal_with_nicer_output(fixupComma, s.fixup_comma)
+        self.assert_equal_with_nicer_output(fixupInteger, s.fixup_integer)
+
+
+    def test_normalize(self):
+        """test_normalize: bunch of variations"""
+        s, c = self.setup_config_C_sig_tool()
+        a = [
+            (('module', 'fn', 'source', '23', '0xFFF'), 'fn'),
+            (('module', 'fnNeedNumber', 's', '23', '0xFFF'),
+             'fnNeedNumber:23'),
+            (('module', 'f( *s)', 's', '23', '0xFFF'), 'f(*s)'),
+            (('module', 'f( &s)', 's', '23', '0xFFF'), 'f(&s)'),
+            (('module', 'f( *s , &n)', 's', '23', '0xFFF'), 'f(*s, &n)'),
+            # this next one looks like a bug to me, but perhaps the situation
+            # never comes up
+            #(('module', 'f(  *s , &n)', 's', '23', '0xFFF'), 'f(*s, &n)'),
+            (('module', 'f3(s,t,u)', 's', '23', '0xFFF'), 'f3(s, t, u)'),
+            (('module', 'f<3>(s,t,u)', 's', '23', '0xFFF'), 'f<int>(s, t, u)'),
+            (('module', '', 'source/', '23', '0xFFF'), 'source#23'),
+            (('module', '', 'source\\', '23', '0xFFF'), 'source#23'),
+            (('module', '', '/a/b/c/source', '23', '0xFFF'), 'source#23'),
+            (('module', '', '\\a\\b\\c\\source', '23', '0xFFF'), 'source#23'),
+            (('module', '', '\\a\\b\\c\\source', '23', '0xFFF'), 'source#23'),
+            (('module', '', '\\a\\b\\c\\source', '', '0xFFF'), 'module@0xFFF'),
+            (('module', '', '', '23', '0xFFF'), 'module@0xFFF'),
+            (('module', '', '', '', '0xFFF'), 'module@0xFFF'),
+            ((None, '', '', '', '0xFFF'), '@0xFFF'),
         ]
-    for args, e in a:
-        r = s.normalize_signature(*args)
-        assert_expected(e,r)
+        for args, e in a:
+            r = s.normalize_signature(*args)
+            self.assert_equal_with_nicer_output(e,r)
 
-def testGenerate1():
-    """testGenerate1: simple"""
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
-    e = 'd | e | f | g'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
+    def test_generate_1(self):
+        """test_generate_1: simple"""
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
+            e = 'd | e | f | g'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
 
-    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
-    e = 'd | e | f | g'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
+            a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+            e = 'd | e | f | g'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
 
-def testGenerate2():
-    """testGenerate2: hang"""
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
-    e = 'hang | d | e | f | g'
-    sig, notes = s.generate(a, hang_type=-1)
-    assert_expected(e,sig)
+    def test_generate_2(self):
+        """test_generate_2: hang"""
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
+            e = 'hang | d | e | f | g'
+            sig, notes = s.generate(a, hang_type=-1)
+            self.assert_equal_with_nicer_output(e,sig)
 
-    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
-    e = 'hang | d | e | f | g'
-    sig, notes = s.generate(a, hang_type=-1)
-    assert_expected(e,sig)
+            a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+            e = 'hang | d | e | f | g'
+            sig, notes = s.generate(a, hang_type=-1)
+            self.assert_equal_with_nicer_output(e,sig)
 
-    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
-    e = 'd | e | f | g'
-    sig, notes = s.generate(a, hang_type=0)
-    assert_expected(e,sig)
+            a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+            e = 'd | e | f | g'
+            sig, notes = s.generate(a, hang_type=0)
+            self.assert_equal_with_nicer_output(e,sig)
 
-    a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
-    e = 'chromehang | d | e | f | g'
-    sig, notes = s.generate(a, hang_type=1)
-    assert_expected(e,sig)
-
-
-def testGenerate2a():
-    """testGenerate2a: way too long"""
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
-    a[3] = a[3] * 70
-    a[4] = a[4] * 70
-    a[5] = a[5] * 70
-    a[6] = a[6] * 70
-    a[7] = a[7] * 70
-    e = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" \
-        "dd | eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" \
-        "eeeeeee | ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" \
-        "ffffffffffff | ggggggggggggggggggggggggggggggggg..."
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
-    e = "hang | ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" \
-        "ddddddddd | eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" \
-        "eeeeeeeeeeeeee | fffffffffffffffffffffffffffffffffffffffffffffffffff" \
-        "fffffffffffffffffff | gggggggggggggggggggggggggg..."
-    sig, notes = s.generate(a, hang_type=-1)
-    assert_expected(e,sig)
-
-def testGenerate3():
-    """testGenerate3: simple sentinel"""
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
-    a[7] = 'sentinel'
-    e = 'sentinel'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
-
-    s, c  = setupSigUtil('a|b|c|sentinel', 'd|e|f')
-    e = 'f | e | d | i'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
-
-def testGenerate4():
-    """testGenerate4: tuple sentinel"""
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
-    a[7] = 'sentinel2'
-    e = 'd | e | f | g'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
-
-    s, c = setupSigUtil('a|b|c', 'd|e|f')
-    a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
-    a[7] = 'sentinel2'
-    a[22] = 'ff'
-    e = 'sentinel2'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
-
-    s, c = setupSigUtil('a|b|c|sentinel2', 'd|e|f')
-    a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
-    a[7] = 'sentinel2'
-    a[22] = 'ff'
-    e = 'f | e | d | i'
-    sig, notes = s.generate(a)
-    assert_expected(e,sig)
+            a = [x for x in 'abcdaeafagahijklmnopqrstuvwxyz']
+            e = 'chromehang | d | e | f | g'
+            sig, notes = s.generate(a, hang_type=1)
+            self.assert_equal_with_nicer_output(e,sig)
 
 
-class TestCase(unittest.TestCase):
+    def test_generate_2a(self):
+        """test_generate_2a: way too long"""
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghijklmnopqrstuvwxyz']
+            a[3] = a[3] * 70
+            a[4] = a[4] * 70
+            a[5] = a[5] * 70
+            a[6] = a[6] * 70
+            a[7] = a[7] * 70
+            e = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" \
+                "dddddddddddd " \
+                "| eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" \
+                "eeeeeeeeeeeeee " \
+                "| ffffffffffffffffffffffffffffffffffffffffffffffffffffffff" \
+                "ffffffffffffff | ggggggggggggggggggggggggggggggggg..."
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+            e = "hang | ddddddddddddddddddddddddddddddddddddddddddddddddddd" \
+                "ddddddddddddddddddd " \
+                "| eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" \
+                "eeeeeeeeeeeeee " \
+                "| ffffffffffffffffffffffffffffffffffffffffffffffffffffffff" \
+                "ffffffffffffff | gggggggggggggggggggggggggg..."
+            sig, notes = s.generate(a, hang_type=-1)
+            self.assert_equal_with_nicer_output(e,sig)
+
+    def test_generate_3(self):
+        """test_generate_3: simple sentinel"""
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
+            a[7] = 'sentinel'
+            e = 'sentinel'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+
+            s, c  = self.setup_config_C_sig_tool('a|b|c|sentinel', 'd|e|f')
+            e = 'f | e | d | i'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+
+    def test_generate_4(self):
+        """test_generate_4: tuple sentinel"""
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
+            a[7] = 'sentinel2'
+            e = 'd | e | f | g'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+
+        for s, c in (self.setup_config_C_sig_tool('a|b|c', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c', 'd|e|f')):
+            a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
+            a[7] = 'sentinel2'
+            a[22] = 'ff'
+            e = 'sentinel2'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+
+        for s, c in (self.setup_config_C_sig_tool('a|b|c|sentinel2', 'd|e|f'),
+                     self.setup_db_C_sig_tool('a|b|c|sentinel2', 'd|e|f')):
+            a = [x for x in 'abcdefghabcfaeabdijklmnopqrstuvwxyz']
+            a[7] = 'sentinel2'
+            a[22] = 'ff'
+            e = 'f | e | d | i'
+            sig, notes = s.generate(a)
+            self.assert_equal_with_nicer_output(e,sig)
+
+
+class TestCSignatureToolDB(BaseTestClass):
+
+    @staticmethod
+    def setup_config():
+        config = sutil.DotDict()
+        config.logger = sutil.FakeLogger()
+        config.database_class = Mock()
+        config.transaction_executor_class = Mock()
+        return config
+
+
+    def test__init__(self):
+        """This class ought to load its values from the database at the time
+        of initialization. This test assures us that it really happens."""
+        query_results = [
+            (('@0x0',), ('.*abort',), ('(libxul\.so|xul\.dll|XUL)@0x.*',)),
+            (('@0x[0-9a-fA-F]{2,}',), ('app_process@0x.*',), ('libc\.so@.*',)),
+            (('js_Interpret',),),
+            (('_purecall',),
+             ("('sentinel', lambda x: 'mmm' in x)",),
+             ('fake sentinel',),),
+        ]
+        def query_results_mock_fn(dummy1, dummy2, dummy3=None):
+            return query_results.pop(0)
+        expected_re_dict = {
+            'signatures_with_line_numbers_re': 'js_Interpret',
+            'prefix_signature_re':
+                '@0x0|.*abort|(libxul\.so|xul\.dll|XUL)@0x.*',
+            'irrelevant_signature_re':
+                '@0x[0-9a-fA-F]{2,}|app_process@0x.*|libc\.so@.*',
+            'signature_sentinels': [
+                '_purecall',
+                ('sentinel', lambda x: 'mmm' in x),
+                'fake sentinel',
+            ]
+        }
+        with patch(
+            'socorro.processor.signature_utilities.execute_query_fetchall'
+        ) as execute_query_mock:
+            execute_query_mock.side_effect = query_results_mock_fn
+            config = self.setup_config()
+            c_sig_tool = sig.CSignatureToolDB(config)
+            c_sig_tool._read_signature_rules_from_database(Mock())
+
+            config.database_class.assert_called_once_with(config)
+            config.transaction_executor_class.assert_called_once_with(
+                config,
+                c_sig_tool.database,
+                None
+            )
+            self.assertEqual(
+                c_sig_tool.signatures_with_line_numbers_re.pattern,
+                expected_re_dict['signatures_with_line_numbers_re']
+            )
+            self.assertEqual(
+                c_sig_tool.irrelevant_signature_re.pattern,
+                expected_re_dict['irrelevant_signature_re']
+            )
+            self.assertEqual(
+                c_sig_tool.prefix_signature_re.pattern,
+                expected_re_dict['prefix_signature_re']
+            )
+            self.assertEqual(len(c_sig_tool.signature_sentinels), 3)
+            self.assertEqual(
+                c_sig_tool.signature_sentinels[0],
+                expected_re_dict['signature_sentinels'][0]
+            )
+            self.assertEqual(
+                c_sig_tool.signature_sentinels[1][0],
+                expected_re_dict['signature_sentinels'][1][0]
+            )
+            self.assertEqual(
+                c_sig_tool.signature_sentinels[2],
+                expected_re_dict['signature_sentinels'][2]
+            )
+            actual_fn = c_sig_tool.signature_sentinels[1][1]
+            # can't test directly for equality of lambdas - so test
+            # functionality instead
+            self.assertTrue(
+                actual_fn(['x', 'y', 'z', 'mmm', 'i', 'j', 'k'])
+            )
+            self.assertFalse(
+                actual_fn(['x', 'y', 'z', 'i', 'j', 'k'])
+            )
+
+
+class TestJavaSignatureTool(BaseTestClass):
     def test_generate_signature_1(self):
         config = DotDict()
         j = JavaSignatureTool(config)
         java_stack_trace = 17
         sig, notes = j.generate(java_stack_trace, delimiter=': ')
         e = "EMPTY: Java stack trace not in expected format"
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: stack trace not '
              'in expected format']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_2(self):
         config = DotDict()
@@ -204,9 +384,9 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: totally made up '
              'at org.mozilla.lars.myInvention('
              'larsFile.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_3(self):
         config = DotDict()
@@ -218,9 +398,9 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: totally made up '
              'at org.mozilla.lars.myInvention('
              'larsFile.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_4(self):
         config = DotDict()
@@ -232,10 +412,10 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: '
              'at org.mozilla.lars.myInvention('
              'larsFile.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: dropped Java exception description due to '
              'length']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_4_2(self):
         config = DotDict()
@@ -247,10 +427,10 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: '
              'at org.mozilla.lars.myInvention('
              'larsFile.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: dropped Java exception description due to '
              'length']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_5(self):
         config = DotDict()
@@ -262,10 +442,10 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: '
              'at org.mozilla.lars.myInvention('
              'larsFile.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: stack trace line 1 is '
              'not in the expected format']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_6(self):
         config = DotDict()
@@ -273,9 +453,10 @@ class TestCase(unittest.TestCase):
         java_stack_trace = 'SomeJavaException: totally made up  \n'
         sig, notes = j.generate(java_stack_trace, delimiter=': ')
         e = 'SomeJavaException: totally made up'
-        assert_expected(e, sig)
+
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: stack trace line 2 is missing']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_7(self):
         config = DotDict()
@@ -283,9 +464,9 @@ class TestCase(unittest.TestCase):
         java_stack_trace = 'SomeJavaException: totally made up  '
         sig, notes = j.generate(java_stack_trace, delimiter=': ')
         e = 'SomeJavaException: totally made up'
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: stack trace line 2 is missing']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_8(self):
         config = DotDict()
@@ -293,9 +474,9 @@ class TestCase(unittest.TestCase):
         java_stack_trace = 'SomeJavaException: totally made up  '
         sig, notes = j.generate(java_stack_trace, delimiter=': ')
         e = 'SomeJavaException: totally made up'
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: stack trace line 2 is missing']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_9(self):
         config = DotDict()
@@ -307,13 +488,27 @@ class TestCase(unittest.TestCase):
         e = ('SomeJavaException: '
              'at org.mozilla.lars.myInvention('
              '%s...' % ('t' * 201))
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = ['JavaSignatureTool: dropped Java exception description due to '
              'length',
              'SignatureTool: signature truncated due to length']
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
-
+    def test_generate_signature_10_no_interference(self):
+        """In general addresses of the form @xxxxxxxx are to be replaced with
+        the literal "<addr>", however in this case, the hex address is not in
+        the expected location and should therefore be left alone"""
+        config = DotDict()
+        j = JavaSignatureTool(config)
+        java_stack_trace = ('SomeJavaException: totally made up  \n'
+                            'at org.mozilla.lars.myInvention('
+                            'larsFile.java:@abef1234)')
+        sig, notes = j.generate(java_stack_trace, delimiter=' ')
+        e = ('SomeJavaException totally made up '
+             'at org.mozilla.lars.myInvention('
+             'larsFile.java:@abef1234)')
+        self.assert_equal_with_nicer_output(e, sig)
+        self.assert_equal_with_nicer_output([], notes)
 
     def test_generate_signature_11_replace_address(self):
         config = DotDict()
@@ -340,9 +535,9 @@ class TestCase(unittest.TestCase):
         e = ('java.lang.IllegalArgumentException: '
              'Given view not a child of android.widget.AbsoluteLayout@<addr>: '
              'at android.view.ViewGroup.updateViewLayout(ViewGroup.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
 
     def test_generate_signature_12_replace_address(self):
@@ -370,9 +565,9 @@ class TestCase(unittest.TestCase):
         e = ('java.lang.IllegalArgumentException: '
              'Given view not a child of android.widget.AbsoluteLayout@<addr>: '
              'at android.view.ViewGroup.updateViewLayout(ViewGroup.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_13_replace_address(self):
         config = DotDict()
@@ -405,9 +600,9 @@ class TestCase(unittest.TestCase):
              'org.mozilla.gecko.GeckoConnectivityReceiver@<addr>: '
              'at android.app.LoadedApk.forgetReceiverDispatcher'
              '(LoadedApk.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_14_replace_address(self):
         config = DotDict()
@@ -435,9 +630,9 @@ class TestCase(unittest.TestCase):
              'Unable to add window -- token android.os.BinderProxy@<addr> '
              'is not valid; is your activity running? '
              'at android.view.ViewRoot.setView(ViewRoot.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)
 
     def test_generate_signature_15_replace_address(self):
         config = DotDict()
@@ -473,6 +668,6 @@ class TestCase(unittest.TestCase):
              'Receiver not registered: '
              'org.mozilla.gecko.GeckoNetworkManager@<addr>: '
              'at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java)')
-        assert_expected(e, sig)
+        self.assert_equal_with_nicer_output(e, sig)
         e = []
-        assert_expected(e, notes)
+        self.assert_equal_with_nicer_output(e, notes)


### PR DESCRIPTION
This represents a new class for C signature generation that gets its skip list rules from a database rather than from configuration.  

This class can be just loaded by configman as a replacement for the current C signature tool class.  It will need to have database configuration parameters added to the ini file and existing skip list definitions removed.  
