### PR TITLE
bug 865691 - crontabber matviews should log possible output

### DIFF
--- a/socorro/cron/jobs/matviews.py
+++ b/socorro/cron/jobs/matviews.py
@@ -19,8 +19,21 @@ class _Base(object):
         cursor = connection.cursor()
         if signature:
             cursor.callproc(self.get_proc_name(), signature)
+            _calling = '%s(%r)' % (self.get_proc_name(), signature)
         else:
             cursor.callproc(self.get_proc_name())
+            _calling = '%s()' % (self.get_proc_name(),)
+
+        self.config.logger.info(
+            'Result from calling %s: %r' %
+            (_calling, cursor.fetchone())
+        )
+        if connection.notices:
+            self.config.logger.info(
+                'Notices from calling %s: %s' %
+                (_calling, connection.notices)
+            )
+
         connection.commit()
 
 


### PR DESCRIPTION
@selenamarie or @rhelmer r?

FYI, I created some fake jobs that used this base class any the output looks like this:

```
2013-04-25 09:26:55,666 INFO - MainThread - Result from calling my_testing_backfill_procedure([datetime.date(2013, 4, 24)]): (True,)
2013-04-25 09:26:55,666 INFO - MainThread - Notices from calling my_testing_backfill_procedure([datetime.date(2013, 4, 24)]): ['NOTICE:  I am a stored backfill procedure getting 2013-04-24 00:00:00+00\n']
```

and 

```
2013-04-25 09:26:50,918 INFO - MainThread - Result from calling my_testing_procedure(): (False,)
2013-04-25 09:26:50,918 INFO - MainThread - Notices from calling my_testing_procedure(): ['NOTICE:  Bla bla bla. I am a stored procedure\n']
```

Here are the functions I created if that helps:

``` sql
CREATE OR REPLACE FUNCTION my_testing_procedure() RETURNS boolean
    LANGUAGE plpgsql
    AS $$
BEGIN
RAISE NOTICE 'Bla bla bla. I am a stored procedure';

RETURN false;
END; $$;



CREATE OR REPLACE FUNCTION my_testing_backfill_procedure(fromtime timestamp with time zone) RETURNS boolean
    LANGUAGE plpgsql
    AS $$
BEGIN
RAISE NOTICE 'I am a stored backfill procedure getting %',fromtime;

RETURN TRUE;
END; $$;
```
