### PR TITLE
fixes bug 854511- removed dots from processor name to appease statsd

### DIFF
--- a/socorro/processor/registration_client.py
+++ b/socorro/processor/registration_client.py
@@ -107,8 +107,11 @@ class ProcessorAppRegistrationClient(RequiredConfig):
         requested_id = self._requested_processor_id(
           self.config.processor_id
         )
-        hostname = os.uname()[1]
-        self.processor_name = "%s_%d" % (hostname, os.getpid())
+        hostname = os.uname()[1].replace('.', '_')
+        self.processor_name = "%s_%d" % (
+            hostname,
+            os.getpid()
+        )
 
         threshold = self.transaction(
           single_value_sql,

--- a/socorro/unittest/processor/test_registration_client.py
+++ b/socorro/unittest/processor/test_registration_client.py
@@ -237,10 +237,11 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
         with config_manager.context() as config:
             mock_os_uname_str = 'os.uname'
             with mock.patch(mock_os_uname_str) as mock_uname:
-                mock_uname.return_value = (0, 'wilma')
+                mock_uname.return_value = (0, 'dwight.wilma.sarita')
 
                 registrar = ProcessorAppRegistrationClient(config)
                 name = registrar.processor_name
+                self.assertTrue('.' not in name)
 
                 self.assertEqual(mock_execute.call_count, 4)
 
@@ -248,7 +249,8 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
                     (("select now() - interval %s", (frequency,)),),
                     ((("select id from processors"
                        " where lastseendatetime < %s"
-                       " and name like %s limit 1"), (threshold, 'wilma%')),),
+                       " and name like %s limit 1"),
+                      (threshold, 'dwight_wilma_sarita%')),),
                     ((("update processors set name = %s, "
                        "startdatetime = now(), lastseendatetime = now()"
                        " where id = %s"), (name, 17)),),


### PR DESCRIPTION
the names that the registrar assigns to processors has had the dot characters surgically excised and replaced with Teflon coated underscores.  
