### PR TITLE
Add git.mozilla.org to vcsMappings

### DIFF
--- a/webapp-php/application/config/codebases.php-dist
+++ b/webapp-php/application/config/codebases.php-dist
@@ -10,6 +10,8 @@ $config['vcsMappings'] = array(
 	    'http://hg.mozilla.org/%(repo)s/annotate/%(revision)s/%(file)s#l%(line)s'
     ),
     'git' => array(
+	'git.mozilla.org' =>
+	    'http://git.mozilla.org/?p=%(repo)s;a=blob;f=%(file)s;h=%(revision)s#l%(line)s',
         'github.com' =>
             'https://github.com/%(repo)s/blob/%(revision)s/%(file)s#L%(line)s'
     )


### PR DESCRIPTION
B2G builds are now using git.mozilla.org as the repository of record.
