### PR TITLE
Add pip-cache to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ socorro/cron/crontabber.json
 vagrantconfig_local.yaml
 /config/*.ini
 pip-cache
+build
+.DS_Store
 
 # exclude filesystem storage directories
 primaryCrashStore/


### PR DESCRIPTION
This is showing up in my socorro dir after running `make virtualenv` or something.
