### PR TITLE
Don't assume that crash source iterators return only a single arg anymor...

### DIFF
--- a/socorro/processor/legacy_new_crash_source.py
+++ b/socorro/processor/legacy_new_crash_source.py
@@ -247,7 +247,7 @@ class LegacyNewCrashSource(RequiredConfig):
         fetch_transform_save app"""
         for a_legacy_job_tuple in self._job_iter():
             if a_legacy_job_tuple:
-                yield a_legacy_job_tuple[1]
+                yield (a_legacy_job_tuple[1],), {}
             else:
                 yield None
 

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -44,7 +44,7 @@ def create_symbol_path_str(input_str):
 #==============================================================================
 class LegacyCrashProcessor(RequiredConfig):
     """this class is a refactoring of the original processor algorithm into
-    a single class.  This class is suitble for use in the 'processor_app'
+    a single class.  This class is suitable for use in the 'processor_app'
     introducted in 2012."""
 
     required_config = Namespace()

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -91,7 +91,7 @@ class ProcessorApp(FetchTransformSaveApp):
                 if x is None:
                     yield None
                 else:
-                    yield ((x,), {})  # (args, kwargs)
+                    yield x  # (args, kwargs)
             else:
                 yield None  # if the inner iterator yielded nothing at all,
                             # yield None to give the caller the chance to sleep

--- a/socorro/unittest/processor/test_legacy_new_crash_source.py
+++ b/socorro/unittest/processor/test_legacy_new_crash_source.py
@@ -77,7 +77,7 @@ class TestLegacyNewCrashSource(unittest.TestCase):
                     yield x
 
         new_crash_source = StubbedIterators(config,
-                                       processor_name='sherman1234')
+                                            processor_name='sherman1234')
         expected = ('1234',
                     '2345',
                     '3456',
@@ -85,7 +85,7 @@ class TestLegacyNewCrashSource(unittest.TestCase):
                     '5678',
                    )
         for x, y in zip(new_crash_source, expected):
-            self.assertEqual(x, y)
+            self.assertEqual(x, ((y,), {}))
 
         self.assertEqual(len([x for x in new_crash_source]), 5)
 
@@ -121,7 +121,7 @@ class TestLegacyNewCrashSource(unittest.TestCase):
                     '5678',
                    )
         for x, y in zip(new_crash_source, expected):
-            self.assertEqual(x, y)
+            self.assertEqual(x, ((y,), {}))
 
         self.assertEqual(len([x for x in new_crash_source]), 5)
 
@@ -163,7 +163,7 @@ class TestLegacyNewCrashSource(unittest.TestCase):
                     yield x
 
         new_crash_source = StubbedIterators(config,
-                                       processor_name='sherman1234')
+                                            processor_name='sherman1234')
         expected = ('1234',
                     'p1234',
                     'p2345',
@@ -176,7 +176,7 @@ class TestLegacyNewCrashSource(unittest.TestCase):
                     '5678',
                    )
         for x, y in zip(new_crash_source, expected):
-            self.assertEqual(x, y)
+            self.assertEqual(x, ((y,), {}))
 
         self.assertEqual(len([x for x in new_crash_source]), 10)
 

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -45,7 +45,10 @@ class TestProcessorApp(unittest.TestCase):
         )
 
         config.new_crash_source = DotDict()
-        sequence_generator = sequencer(1, 2, None, 3)
+        sequence_generator = sequencer(((1,), {}),
+                                       ((2,), {}),
+                                       None,
+                                       ((3,), {}))
         mocked_new_crash_source = mock.Mock(side_effect=sequence_generator)
         mocked_new_crash_source.id = 'mocked_new_crash_source'
         config.new_crash_source.new_crash_source_class = mock.Mock(


### PR DESCRIPTION
...e.

We need to be able to return a kwarg that has an "ack" function in it.
