### PR TITLE
added hostname to null registrar

### DIFF
--- a/socorro/processor/registration_client.py
+++ b/socorro/processor/registration_client.py
@@ -29,16 +29,21 @@ class RegistrationError(Exception):
 class ProcessorAppNullRegistrationClient(RequiredConfig):
     """the registrar isn't needed when the monitor is not in use.  This class
     will stub out the registration system of the processor."""
-    
+
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
         """constructor for a registration object that does nothing at all"""
-        pass
+        hostname = os.uname()[1].replace('.', '_')
+        self.processor_name = "%s_%d" % (
+            hostname,
+            os.getpid()
+        )
+
 
     #--------------------------------------------------------------------------
     def checkin(self):
         pass
-    
+
     #--------------------------------------------------------------------------
     def unregister(self):
         pass


### PR DESCRIPTION
One of the jobs of the registrar is to name a processor.  That means the null processor must also be ready to come up with a processor name when a newly created processor wants to know who it really is.  This was neglected when creating the the null registrar.  This PR fixes that oversight.
