### PR TITLE
Make raw dump link point to .dmp instead of .dump from web UI

### DIFF
--- a/webapp-php/application/models/report.php
+++ b/webapp-php/application/models/report.php
@@ -127,7 +127,7 @@ class Report_Model extends Model {
         if ($uuid_timestamp = $this->uuidTimestamp($uuid)) {
             if ($uuid_timestamp > (time() - Kohana::config('application.raw_dump_availability'))) {
                 return array(
-                    Kohana::config('application.raw_dump_url') . $uuid . '.dump',
+                    Kohana::config('application.raw_dump_url') . $uuid . '.dmp',
                     Kohana::config('application.raw_dump_url') . $uuid . '.json',
                 );
             }


### PR DESCRIPTION
This fixes the web UI to request raw dumps as .dmp.
