### PR TITLE
Fixes Bug 874505 - added new rule to copy Plugin url and comment...

### DIFF
--- a/alembic/versions/e4d30f140ed_add_new_rule_to_copy.py
+++ b/alembic/versions/e4d30f140ed_add_new_rule_to_copy.py
@@ -1,0 +1,78 @@
+"""Add new rule to copy Plugin url and comment
+
+Revision ID: e4d30f140ed
+Revises: 22e4e60e03f
+Create Date: 2013-05-22 08:01:54.873655
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e4d30f140ed'
+down_revision = '22e4e60e03f'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import sqlalchemy.types as types
+from sqlalchemy.sql import table, column
+
+class CITEXT(types.UserDefinedType):
+    name = 'citext'
+
+    def get_col_spec(self):
+        return 'CITEXT'
+
+    def bind_processor(self, dialect):
+        def process(value):
+            return value
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            return value
+        return process
+
+    def __repr__(self):
+        return "citext"
+
+
+def upgrade():
+    transform_rule = table('transform_rules',
+        column(u'transform_rule_id', sa.INTEGER()),
+        column(u'category', CITEXT()),
+        column(u'rule_order', sa.INTEGER()),
+        column(u'action', sa.TEXT()),
+        column(u'action_args', sa.TEXT()),
+        column(u'action_kwargs', sa.TEXT()),
+        column(u'predicate', sa.TEXT()),
+        column(u'predicate_args', sa.TEXT()),
+        column(u'predicate_kwargs', sa.TEXT()))
+
+        # Indexes
+    op.bulk_insert(transform_rule, [{
+        "category": 'processor.json_rewrite'
+        , "predicate": 'socorro.lib.transform_rules.is_not_null_predicate'
+        , "predicate_args": ''
+        , "predicate_kwargs": 'key="PluginContentURL"'
+        , "action": 'socorro.processor.processor.json_reformat_action'
+        , "action_args": ''
+        , "action_kwargs": 'key="URL", format_str="%(PluginContentURL)s"'
+        , "rule_order": '5'
+    }, {
+        "category": 'processor.json_rewrite'
+        , "predicate": 'socorro.lib.transform_rules.is_not_null_predicate'
+        , "predicate_args": ''
+        , "predicate_kwargs": 'key="PluginUserComment"'
+        , "action": 'socorro.processor.processor.json_reformat_action'
+        , "action_args": ''
+        , "action_kwargs": 'key="Comments", format_str="%(PluginUserComment)s"'
+        , "rule_order": '6'
+    }])
+
+def downgrade():
+    op.execute("""
+        DELETE from transform_rules
+        where action_kwargs IN
+        ('key="Comments", format_str="%(PluginUserComment)s"'
+        , 'key="URL", format_str="%(PluginContentURL)s"');
+    """)

--- a/config/alembic.ini-dist
+++ b/config/alembic.ini-dist
@@ -11,7 +11,7 @@ file_template = %%(rev)s_%%(slug)s
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://breakpad_rw@localhost/breakpad
+sqlalchemy.url = postgresql://postgres@localhost/breakpad
 
 # Logging configuration
 [loggers]

--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -273,3 +273,19 @@ def eq_key_predicate(left_mapping, right_mapping, left_mapping_key='',
         left_mapping_key - the key into the source for the first value
         right_mapping_key - the key into the second data source"""
     return left_mapping[left_mapping_key] == right_mapping[right_mapping_key]
+
+
+# (is_not_null_predicate, '', 'key="fred",
+# ...)
+#------------------------------------------------------------------------------
+def is_not_null_predicate(source, other, key=''):
+    """a predicate that converts the key'd source to boolean.
+
+    parameters:
+        source - the mapping containing the value to test
+        other - unused
+        key - the key into the source for the first value"""
+    try:
+        return bool(source[key])
+    except KeyError:
+        return False

--- a/socorro/unittest/lib/test_transform_rules.py
+++ b/socorro/unittest/lib/test_transform_rules.py
@@ -343,8 +343,24 @@ class TestTransformRules(unittest.TestCase):
         rules.apply_until_predicate_fails(s, d)
         assert_expected(d, {'one': 1})
 
-
-
-
-
-
+    def test_is_not_null_predicate(self):
+        self.assertTrue(
+            transform_rules.is_not_null_predicate(
+                {'alpha': 'hello'}, None, 'alpha'
+            )
+        )
+        self.assertFalse(
+            transform_rules.is_not_null_predicate(
+                {'alpha': 'hello'}, None, 'beta'
+            )
+        )
+        self.assertFalse(
+            transform_rules.is_not_null_predicate(
+                {'alpha': ''}, None, 'alpha'
+            )
+        )
+        self.assertFalse(
+            transform_rules.is_not_null_predicate(
+                {'alpha': None}, None, 'alpha'
+            )
+        )


### PR DESCRIPTION
This PR adds two new rulesto the processor rewrite rules to copy these fields:

```
PluginContentURL --> URL
PluginUserComment  -->  Comments
```

In either case, if a source key does not exist, the rule is not applied
