### PR TITLE
fixes Bug 836753: added 'throttle_rate' to raw crash

### DIFF
--- a/socorro/collector/wsgi_collector.py
+++ b/socorro/collector/wsgi_collector.py
@@ -52,7 +52,9 @@ class Collector(object):
         crash_id = createNewOoid(current_timestamp)
         self.logger.info('%s received', crash_id)
 
-        raw_crash.legacy_processing = self.throttler.throttle(raw_crash)
+        raw_crash.legacy_processing, raw_crash.throttle_rate = (
+            self.throttler.throttle(raw_crash)
+        )
         if raw_crash.legacy_processing == DISCARD:
             self.logger.info('%s discarded', crash_id)
             return "Discarded=1\n"

--- a/socorro/unittest/collector/test_throttler.py
+++ b/socorro/unittest/collector/test_throttler.py
@@ -56,7 +56,7 @@ def testLegacyThrottler():
     assert expected == actual, \
       "understand refusal expected %d, but got %d instead" % (expected, actual)
 
-    expected = ACCEPT
+    expected = (ACCEPT, 100)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "regexp throttle expected %d, but got %d instead" % (expected, actual)
@@ -65,7 +65,7 @@ def testLegacyThrottler():
                           'Version':'3.4',
                           'alpha':'not correct',
                           })
-    expected = DEFER
+    expected = (DEFER, 0)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "regexp throttle expected %d, but got %d instead" % (expected, actual)
@@ -74,7 +74,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'alpha':'not correct',
                           })
-    expected = DISCARD
+    expected = (DISCARD, 0)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "regexp throttle expected %d, but got %d instead" % (expected, actual)
@@ -83,7 +83,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'beta':'BETA',
                           })
-    expected = ACCEPT
+    expected = (ACCEPT, 100)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "string equality throttle expected %d, but got %d instead" % \
@@ -93,7 +93,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'beta':'not BETA',
                           })
-    expected = DISCARD
+    expected = (DISCARD, 0)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "string equality throttle expected %d, but got %d instead" % \
@@ -103,7 +103,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'gamma':'GAMMA',
                           })
-    expected = ACCEPT
+    expected = (ACCEPT, 100)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "string equality throttle expected %d, but got %d instead" % \
@@ -113,7 +113,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'gamma':'not GAMMA',
                           })
-    expected = DISCARD
+    expected = (DISCARD, 0)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "string equality throttle expected %d, but got %d instead" % \
@@ -123,7 +123,7 @@ def testLegacyThrottler():
                           'Version':'3.6',
                           'delta':"value doesn't matter",
                           })
-    expected = ACCEPT
+    expected = (ACCEPT, 100)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "string equality throttle expected %d, but got %d instead" % \
@@ -154,7 +154,7 @@ def testLegacyThrottler():
                           'beta': 'ugh',
                           'alpha':"value doesn't matter",
                           })
-    expected = IGNORE
+    expected = (IGNORE, None)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "IGNORE expected %d, but got %d instead" % \
@@ -165,7 +165,7 @@ def testLegacyThrottler():
                           'beta': 'ugh',
                           'delta':"value doesn't matter",
                           })
-    expected = DEFER
+    expected = (DEFER, 0)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "DEFER expected %d, but got %d instead" % \
@@ -176,7 +176,7 @@ def testLegacyThrottler():
                           'beta': 'BETA',
                           'alpha':"value doesn't matter",
                           })
-    expected = IGNORE
+    expected = (IGNORE, None)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "IGNORE expected %d, but got %d instead" % \
@@ -186,7 +186,7 @@ def testLegacyThrottler():
                           'beta': 'BETA',
                           'delta':"value doesn't matter",
                           })
-    expected = ACCEPT
+    expected = (ACCEPT, 100)
     actual = thr.throttle(raw_crash)
     assert expected == actual, \
       "ACCEPT expected %d, but got %d instead" % \

--- a/socorro/unittest/collector/test_wsgi_collector.py
+++ b/socorro/unittest/collector/test_wsgi_collector.py
@@ -83,6 +83,7 @@ class TestProcessorApp(unittest.TestCase):
         erc.legacy_processing = ACCEPT
         erc.timestamp = 3.0
         erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
         erc = dict(erc)
 
         with mock.patch('socorro.collector.wsgi_collector.web') as mocked_web:
@@ -98,7 +99,7 @@ class TestProcessorApp(unittest.TestCase):
                     with mock.patch('socorro.collector.wsgi_collector.time') \
                             as mocked_time:
                         mocked_time.time.return_value = 3.0
-                        c.throttler.throttle.return_value = ACCEPT
+                        c.throttler.throttle.return_value = (ACCEPT, 100)
                         r = c.POST()
                         self.assertTrue(r.startswith('CrashID=bp-'))
                         self.assertTrue(r.endswith('120504\n'))
@@ -129,6 +130,7 @@ class TestProcessorApp(unittest.TestCase):
         erc.some_field = '23'
         erc.some_other_field = 'XYZ'
         erc.legacy_processing = ACCEPT
+        erc.throttle_rate = None
         erc.timestamp = 3.0
         erc.submitted_timestamp = '2012-05-04T15:10:00'
         erc = dict(erc)
@@ -146,7 +148,7 @@ class TestProcessorApp(unittest.TestCase):
                     with mock.patch('socorro.collector.wsgi_collector.time') \
                             as mocked_time:
                         mocked_time.time.return_value = 3.0
-                        c.throttler.throttle.return_value = IGNORE
+                        c.throttler.throttle.return_value = (IGNORE, None)
                         r = c.POST()
                         self.assertEqual(r, "Unsupported=1\n")
                         self.assertFalse(


### PR DESCRIPTION
this PR adds a new field, 'throttle_rate', to the raw crash.  When a crash is collected, it is passed through the throttler.  The throttler makes the decision if a crash is to be processed or not.  When compiling stats and comparing different versions, it is useful to know what throttle value was used for a given crash.  That rate is now saved in the raw_crash as the value of 'throttle_rate'
