### PR TITLE
fixes Bug 768700: restored the saving of ProductID into Postgres

### DIFF
--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -67,6 +67,7 @@ class PostgreSQLCrashStorage(CrashStorageBase):
         ("processor_notes", "processor_notes"),
         ("process_type", "process_type"),
         ("product", "product"),
+        ("productid", "productid"),
         ("reason", "reason"),
         ("release_channel", "release_channel"),
         ("signature", "signature"),

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -372,6 +372,7 @@ class LegacyCrashProcessor(RequiredConfig):
         processed_crash.processor_notes = ''
         processed_crash.process_type = None
         processed_crash.product = None
+        processed_crash.productid = None
         processed_crash.reason = None
         processed_crash.release_channel = None
         processed_crash.signature = 'EMPTY: crash failed to process'
@@ -401,8 +402,8 @@ class LegacyCrashProcessor(RequiredConfig):
           input parameters:
             uuid: the unique id identifying the job - corresponds with the
                   uuid column in the 'jobs' and the 'reports' tables
-            jsonDocument: an object with a dictionary interface for fetching
-                          the components of the json document
+            raw_crash: an object with a dictionary interface for fetching
+                       the components of the json document
             submitted_timestamp: when job came in (a key used in partitioning)
             processor_notes: list of strings of error messages
         """
@@ -415,6 +416,10 @@ class LegacyCrashProcessor(RequiredConfig):
             processor_notes,
             None,
             30
+        )
+        processed_crash.productid = raw_crash.get(
+            'ProductID',
+            None
         )
         processed_crash.version = self._get_truncate_or_warn(
             raw_crash,

--- a/socorro/unittest/external/postgresql/test_crashstorage.py
+++ b/socorro/unittest/external/postgresql/test_crashstorage.py
@@ -62,6 +62,7 @@ a_processed_crash = {
     "processor_notes": "SignatureTool: signature truncated due to length",
     "process_type": "plugin",
     "product": "FennecAndroid",
+    "productid": "FA-888888",
     "PluginFilename": "dwight.txt",
     "PluginName": "wilma",
     "PluginVersion": "69",
@@ -74,7 +75,7 @@ a_processed_crash = {
     "topmost_filenames": [],
     "truncated": False,
     "uptime": 170,
-    "url": "http://embarasing.porn.com",
+    "url": "http://embarrassing.porn.com",
     "user_comments": None,
     "user_id": None,
     "uuid": "936ce666-ff3b-4c7a-9674-367fe2120408",
@@ -360,8 +361,8 @@ class TestPostgresCrashStorage(unittest.TestCase):
 
             expected_execute_args = (
                 (('savepoint MainThread', None),),
-                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
-                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarasing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
+                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, productid, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
+                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'FA-888888', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarrassing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
                 (('release savepoint MainThread', None),),
                 (('select id from plugins where filename = %s and name = %s',
                      ('dwight.txt', 'wilma')),),
@@ -416,8 +417,8 @@ class TestPostgresCrashStorage(unittest.TestCase):
 
             expected_execute_args = (
                 (('savepoint MainThread', None),),
-                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
-                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarasing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
+                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, productid, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
+                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'FA-888888', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarrassing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
                 (('release savepoint MainThread', None),),
                 (('select id from plugins where filename = %s and name = %s',
                      ('dwight.txt', 'wilma')),),
@@ -535,8 +536,8 @@ class TestPostgresCrashStorage(unittest.TestCase):
 
             expected_execute_args = (
                 (('savepoint MainThread', None),),
-                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
-                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarasing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
+                (('insert into reports_20120402 (addons_checked, address, app_notes, build, client_crash_date, completed_datetime, cpu_info, cpu_name, date_processed, distributor, distributor_version, email, exploitability, flash_version, hangid, install_age, last_crash, os_name, os_version, processor_notes, process_type, product, productid, reason, release_channel, signature, started_datetime, success, topmost_filenames, truncated, uptime, user_comments, user_id, url, uuid, version) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) returning id',
+                     [None, '0x1c', '...', '20120309050057', '2012-04-08 10:52:42.0', '2012-04-08 10:56:50.902884', 'None | 0', 'arm', '2012-04-08 10:56:41.558922', None, None, 'bogus@bogus.com', 'high', '[blank]', None, 22385, None, 'Linux', '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ', 'SignatureTool: signature truncated due to length', 'plugin', 'FennecAndroid', 'FA-888888', 'SIGSEGV', 'default', 'libxul.so@0x117441c', '2012-04-08 10:56:50.440752', True, [], False, 170, None, None, 'http://embarrassing.porn.com', '936ce666-ff3b-4c7a-9674-367fe2120408', '13.0a1']),),
                 (('release savepoint MainThread', None),),
                 (('select id from plugins where filename = %s and name = %s',
                      ('dwight.txt', 'wilma')),),

--- a/socorro/unittest/processor/test_legacy_processor.py
+++ b/socorro/unittest/processor/test_legacy_processor.py
@@ -158,6 +158,7 @@ cannonical_basic_processed_crash = DotDict({
     'process_type': None,
     'processor_notes': '',
     'product': 'Firefox',
+    'productid': '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}',
     'reason': None,
     'release_channel': 'release',
     'ReleaseChannel': 'release',


### PR DESCRIPTION
this has been hanging around as a bug for nearly a year.  It was a easy fix.  I didn't follow how ProductID got dropped, but it's interesting that it being missing was propagated to the new processor.
