### PR TITLE
minor correction in logging format string

### DIFF
--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -85,7 +85,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
         else:
             self.config.logger.debug(
                 'RabbitMQCrashStorage not saving crash %s, legacy processing '
-                'flag is %d', crash_id, raw_crash.legacy_processing
+                'flag is %s', crash_id, raw_crash.legacy_processing
             )
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
this one character change converts a format string from %d to %s.  This is because the flag that is being logged at that moment is actually a string not an int.
