### PR TITLE
fixes bug 883837 - re-enabled stats for starting new jobs

### DIFF
--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -274,8 +274,7 @@ class LegacyCrashProcessor(RequiredConfig):
 
             input parameters:
         """
-        if self.config.with_old_monitor:
-            self._statistics.incr('jobs')
+        self._statistics.incr('jobs')
         processor_notes = [self.config.processor_name]
         try:
             self.quit_check()


### PR DESCRIPTION
the recent change to support RabbitMQ in the processor inadvertently disables statsd for registering counts of crashes being processed.

specifically, the 'if' statement line 277 in legacy_processor.py has been removed.
