### PR TITLE
bug 884348 Make is_gc_count column add fast

### DIFF
--- a/alembic/versions/2b285e76f71d_bug_803209_add_garag.py
+++ b/alembic/versions/2b285e76f71d_bug_803209_add_garag.py
@@ -49,8 +49,10 @@ class JSON(types.UserDefinedType):
         return "json"
 
 def upgrade():
-    op.add_column(u'tcbs', sa.Column(u'is_gc_count', sa.INTEGER(), server_default='0', nullable=False))
-    op.add_column(u'tcbs_build', sa.Column(u'is_gc_count', sa.INTEGER(), server_default='0', nullable=False))
+    op.add_column(u'tcbs', sa.Column(u'is_gc_count', sa.INTEGER()))
+    op.alter_column(u'tcbs', u'is_gc_count', server_default='0')
+    op.add_column(u'tcbs_build', sa.Column(u'is_gc_count', sa.INTEGER()))
+    op.alter_column(u'tcbs_build', u'is_gc_count', server_default='0')
     app_path=os.getcwd()
     procs = [
         'backfill_matviews.sql',

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -194,7 +194,7 @@ class Tcbs(DeclarativeBase):
     lin_count = Column(u'lin_count', INTEGER(), nullable=False, server_default=text('0'))
     hang_count = Column(u'hang_count', INTEGER(), nullable=False, server_default=text('0'))
     startup_count = Column(u'startup_count', INTEGER())
-    is_gc_count = Column(u'is_gc_count', INTEGER(), nullable=False, server_default=text('0'))
+    is_gc_count = Column(u'is_gc_count', INTEGER(), server_default=text('0'))
 
     idx_tcbs_product_version = Index('idx_tcbs_product_version', product_version_id, report_date)
     tcbs_report_date = Index('tcbs_report_date', report_date)
@@ -1312,7 +1312,7 @@ class TcbsBuild(DeclarativeBase):
     signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     startup_count = Column(u'startup_count', INTEGER())
     win_count = Column(u'win_count', INTEGER(), nullable=False, server_default=text('0'))
-    is_gc_count = Column(u'is_gc_count', INTEGER(), nullable=False, server_default=text('0'))
+    is_gc_count = Column(u'is_gc_count', INTEGER(), server_default=text('0'))
 
     #relationship definitions
 


### PR DESCRIPTION
Separate the column creation and constraint addition to make this schema migration fast. Also remove the 'not null' constraint so that we don't put zeros into this column going back to 2011. 

The production table is 2 GB and kinda slow for adding constrained new columns.
