### PR TITLE
Create exception test for crashstorage/get_raw_dumps 

### DIFF
--- a/socorro/unittest/external/filesystem/test_crashstorage.py
+++ b/socorro/unittest/external/filesystem/test_crashstorage.py
@@ -135,7 +135,10 @@ class TestFileSystemCrashStorage(unittest.TestCase):
         self.assertRaises(CrashIDNotFound,
                           crashstorage.get_raw_dump,
                           '114559a5-d8e6-428c-8b88-1c1f22120314')
-
+        self.assertRaises(CrashIDNotFound,
+                          crashstorage.get_raw_dumps,
+                          '114559a5-d8e6-428c-8b88-1c1f22120314')
+                          
     def _common_throttle_test(self, config, crashstorage):
         fake_dump = 'this is a fake dump'
         crashstorage = FileSystemThrottledCrashStorage(config)


### PR DESCRIPTION
This test cover 166-167 lines untested of socorro/external/filesystem/crashstorage.py
