### PR TITLE
make --fakedata create only 7 days of data by default

### DIFF
--- a/socorro/external/postgresql/fakedata.py
+++ b/socorro/external/postgresql/fakedata.py
@@ -43,7 +43,7 @@ class BaseTable(object):
         # use a known seed for PRNG to get deterministic behavior.
         random.seed(5)
 
-        self.days = days or 15
+        self.days = days or 7
         self.end_date = datetime.datetime.utcnow()
         self.start_date = self.end_date - datetime.timedelta(self.days)
 

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -374,7 +374,7 @@ class SocorroDB(App):
 
     required_config.add_option(
         name='fakedata_days',
-        default=15,
+        default=7,
         doc='How many days of synthetic test data to generate'
     )
 


### PR DESCRIPTION
Because most things only ever look at 7 days worth. And making it 15 days takes more than 20 minutes. 
