### PR TITLE
Fixes bug 889639 Make alembic see Bixie and skip partitions

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -25,9 +25,11 @@ target_metadata = DeclarativeBase.metadata
 
 import re
 def include_symbol(tablename, schema):
-    # Ignore anything not in default or bixie schema
-    # Ignore any partitioned tables (ending in '_20130601' for example)
-    return (schema in (None, "bixie")) and (re.search(r'_\d{8}$', tablename) is None)
+    """Return True to include this tablename in the schema reflection, only if:
+        * is in the default or bixie schema,
+        * table is not a partitioned table (ending in '_20130601' for example)
+    """
+    return schema in (None, "bixie") and re.search(r'_\d{8}$', tablename) is None
 
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
@@ -44,8 +46,8 @@ def run_migrations_offline():
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
-        include_schemas = True,
-        include_symbol = include_symbol,
+        include_schemas=True,
+        include_symbol=include_symbol,
     )
 
     with context.begin_transaction():
@@ -67,8 +69,8 @@ def run_migrations_online():
     context.configure(
         connection=connection,
         target_metadata=target_metadata,
-        include_schemas = True,
-        include_symbol = include_symbol
+        include_schemas=True,
+        include_symbol=include_symbol,
     )
 
     try:


### PR DESCRIPTION
This fixes '--autogenerate' runs of alembic so that the tool ignores partitioned tables and correctly finds bixie.\* schemas
