### PR TITLE
bug 890747 - seperate PID from hostname in processor stats with a "."

### DIFF
--- a/socorro/processor/registration_client.py
+++ b/socorro/processor/registration_client.py
@@ -34,7 +34,7 @@ class ProcessorAppNullRegistrationClient(RequiredConfig):
     def __init__(self, config, quit_check_callback=None):
         """constructor for a registration object that does nothing at all"""
         hostname = os.uname()[1].replace('.', '_')
-        self.processor_name = "%s_%d" % (
+        self.processor_name = "%s.%d" % (
             hostname,
             os.getpid()
         )

--- a/socorro/unittest/processor/test_registration_client.py
+++ b/socorro/unittest/processor/test_registration_client.py
@@ -241,7 +241,8 @@ class TestProcessorAppRegistrationAgent(unittest.TestCase):
 
                 registrar = ProcessorAppRegistrationClient(config)
                 name = registrar.processor_name
-                self.assertTrue('.' not in name)
+                # There should be 1 and only 1 occurance of a '.' in the name
+                self.assertEqual(name.find('.'), name.rfind('.'))
 
                 self.assertEqual(mock_execute.call_count, 4)
 


### PR DESCRIPTION
Also included are some tweaks to the Vagrantfile so I could bootstrap a testing environment. Vagrantfile tweaks should be backwards compatible with Vagrant version < 1.2
