### PR TITLE
Fixes Bug 865791 - skunk classifier system added to processor

### DIFF
--- a/socorro/processor/breakpad_pipe_to_json.py
+++ b/socorro/processor/breakpad_pipe_to_json.py
@@ -1,0 +1,240 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module provides a function that will transate Minidump Stackwalk pipe
+dump into a json format.
+
+{
+  # "status": string, // OK | ERROR_* | SYMBOL_SUPPLIER_INTERRUPTED
+  "system_info": {
+    "os": string,
+    "os_ver": string,
+    "cpu_arch": string, // x86 | amd64 | arm | ppc | sparc
+    "cpu_info": string,
+    "cpu_count": int
+  },
+  "crash_info": {
+    "type": string,
+    "crash_address": string, // 0x[[:xdigit:]]+
+    "crashing_thread": int // | null
+  }
+  "main_module": int, // index into modules
+  "modules": [
+         // zero or more
+    {
+      "base_addr": string, // 0x[[:xdigit:]]+
+      "debug_file": string,
+      "debug_id": string, // [[:xdigit:]]{33}
+      "end_addr": string, // 0x[[:xdigit:]]+
+      "filename": string,
+      "version": string
+    }
+  ],
+  "thread_count": int,
+  "threads": [
+    // for i in range(thread_count)
+    {
+      "frame_count": int,
+      "frames": [
+        // for i in range(frame_count)
+        {
+          "frame": int,
+          "module": string,   // optional
+          "function": string, // optional
+          "file": string,     // optional
+          "line": int,        // optional
+          "offset": string,         // 0x[[:xdigit:]]+
+          "module_offset": string,  // 0x[[:xdigit:]]+ , optional
+          "function_offset": string // 0x[[:xdigit:]]+ , optional
+        }
+      ]
+    }
+  ],
+  // repeated here for ease of searching
+  // (max 10 frames)
+  "crashing_thread": {
+    "threads_index": int,
+    "total_frames": int,
+    "frames": [
+      // for i in range(length)
+      {
+        // as per "frames" entries from "threads" above
+      }
+    ]
+  }
+}
+"""
+
+from socorro.lib.util import DotDict
+
+
+#==============================================================================
+class DotDictWithPut(DotDict):
+    #--------------------------------------------------------------------------
+    def put_if_not_none(self, key, value):
+        if value is not None and value != '':
+            self[key] = value
+
+
+#------------------------------------------------------------------------------
+def pipe_dump_to_json_dump(pipe_dump_iterable):
+    """given a list (or any iterable) of strings representing a MDSW pipe dump,
+    this function will convert it into a json format."""
+    json_dump = DotDict()
+    crashing_thread = None
+    module_counter = 0
+    thread_counter = 0
+    for a_line in pipe_dump_iterable:
+        parts = a_line.split('|')
+        if parts[0] == 'OS':
+            _extract_OS_info(parts, json_dump)
+        elif parts[0] == 'CPU':
+            _extract_CPU_info(parts, json_dump)
+        elif parts[0] == 'Crash':
+            crashing_thread = _extract_crash_info(parts, json_dump)
+        elif parts[0] == 'Module':
+            _extract_module_info(parts, json_dump, module_counter)
+            module_counter += 1
+        else:
+            try:
+                thread_number = int(parts[0])
+            except (ValueError, IndexError):
+                continue  # unknow line type, ignore it
+            _extract_frame_info(parts, json_dump)
+    try:
+        json_dump.thread_count = len(json_dump.threads)
+    except KeyError:  # no threads were over found, 'threads' key was not made
+        json_dump.thread_count = 0
+    if crashing_thread is not None:
+        crashing_thread_frames = DotDict()
+        crashing_thread_frames.threads_index = crashing_thread
+        crashing_thread_frames.total_frames = \
+            len(json_dump.threads[crashing_thread].frames)
+        crashing_thread_frames.frames = \
+            json_dump.threads[crashing_thread].frames[:10]
+        json_dump.crashing_thread = crashing_thread_frames
+    return json_dump
+
+
+#------------------------------------------------------------------------------
+def _get(indexable_container, index, default):
+    """like 'get' on a dict, but it works on lists, too"""
+    try:
+        return indexable_container[index]
+    except (IndexError, KeyError):
+        return default
+
+#------------------------------------------------------------------------------
+def _get_int(indexable_container, index, default):
+    """try to get an int from an indexable container.  If that fails
+    return the default"""
+    try:
+        return int(indexable_container[index])
+    # exceptions separated to make case coverage clearer
+    except (IndexError, KeyError):
+        # item not found in the container
+        return default
+    except ValueError:
+        # conversion to integer has failed
+        return default
+
+#------------------------------------------------------------------------------
+def _extract_OS_info(os_line, json_dump):
+    """given a pipe dump OS line, extract the parts and put them in their
+    proper location within the json_dump"""
+    system_info = DotDictWithPut()
+    system_info.put_if_not_none('os', _get(os_line, 1, None))
+    system_info.put_if_not_none('os_ver', _get(os_line, 2, None))
+    if 'system_info' in json_dump:
+        json_dump.system_info.update(system_info)
+    else:
+        json_dump.system_info = system_info
+
+#------------------------------------------------------------------------------
+def _extract_CPU_info(cpu_line, json_dump):
+    """given a pipe dump CPU line, extract the parts and put them in their
+    proper location within the json_dump"""
+    system_info = DotDictWithPut()
+    system_info.put_if_not_none('cpu_arch', _get(cpu_line, 1, None))
+    system_info.put_if_not_none('cpu_info', _get(cpu_line, 2, None))
+    system_info.put_if_not_none('cpu_count', _get_int(cpu_line, 3, None))
+    if 'system_info' in json_dump:
+        json_dump.system_info.update(system_info)
+    else:
+        json_dump.system_info = system_info
+
+#------------------------------------------------------------------------------
+def _extract_crash_info(crash_line, json_dump):
+    """given a pipe dump CRASH line, extract the parts and put them in their
+    proper location within the json_dump"""
+    crash_info = DotDictWithPut()
+    crash_info.put_if_not_none('type', _get(crash_line, 1, None))
+    crash_info.put_if_not_none('crash_address', _get(crash_line, 2, None))
+    crash_info.put_if_not_none('crashing_thread', _get_int(crash_line, 3, None))
+    json_dump.crash_info = crash_info
+    return crash_info.get('crashing_thread', None)
+
+
+#------------------------------------------------------------------------------
+def _extract_module_info(module_line, json_dump, module_counter):
+    """given a pipe dump Module line, extract the parts and put them in their
+    proper location within the json_dump"""
+    module = DotDictWithPut()
+    module.put_if_not_none('filename', _get(module_line, 1, None))
+    module.put_if_not_none('version', _get(module_line, 2, None))
+    module.put_if_not_none('debug_file', _get(module_line, 3, None))
+    module.put_if_not_none('debug_id', _get(module_line, 4, None))
+    module.put_if_not_none('base_addr', _get(module_line, 5, None))
+    module.put_if_not_none('end_addr', _get(module_line, 6, None))
+    is_main_module = _get_int(module_line, 7, 0)
+    if is_main_module:
+        json_dump.main_module = module_counter
+    if 'modules' not in json_dump:
+        json_dump.modules = []
+    json_dump.modules.append(module)
+
+#------------------------------------------------------------------------------
+def _extract_frame_info(frame_line, json_dump):
+    """given a pipe dump Frame line, extract the parts and put them in their
+    proper location within the json_dump"""
+    if 'threads' not in json_dump:
+        json_dump.threads = []
+    thread_number = _get_int(frame_line, 0, None)
+    if thread_number is None:
+        return
+    if thread_number >=len(json_dump.threads):
+        # threads are supposed to arrive in order.  We've not seen this thread
+        # before, fill in a new entry in the 'threads' section of the json_dump
+        # making sure that intervening missing threads have empty thread data
+        for i in range(thread_number - len(json_dump.threads) + 1):
+            thread = DotDict()
+            thread.frame_count = 0
+            thread.frames = []
+            json_dump.threads.append(thread)
+    # collect frame info from the pipe dump line
+    tmp_frame = _get_int(frame_line, 1, None)
+    tmp_module = _get(frame_line, 2, None)
+    tmp_function = _get(frame_line, 3, None)
+    tmp_file = _get(frame_line, 4, None)
+    tmp_line = _get_int(frame_line, 5, None)
+    tmp_offset = _get(frame_line, 6, None)
+    frame = DotDictWithPut()
+    frame.put_if_not_none('frame', tmp_frame)
+    frame.put_if_not_none('module', tmp_module)
+    frame.put_if_not_none('function', tmp_function)
+    frame.put_if_not_none('file', tmp_file)
+    frame.put_if_not_none('line', tmp_line)
+    if tmp_file and tmp_line is not None:
+        # skip offset entirely
+        pass
+    elif not tmp_file and tmp_function:
+        frame.function_offset = tmp_offset
+    elif not tmp_function and tmp_module:
+        frame.module_offset = tmp_offset
+    else:
+        frame.offset = tmp_offset
+    # save the frame info into the json
+    json_dump.threads[thread_number].frames.append(frame)
+    json_dump.threads[thread_number].frame_count += 1
+

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -86,13 +86,13 @@ class CSignatureToolBase(SignatureTool):
     #--------------------------------------------------------------------------
     def normalize_signature(
         self,
-        module,
-        function,
-        file,
-        line,
-        offset,
-        module_offset='unknown',
-        function_offset='unknown',
+        module=None,
+        function=None,
+        file=None,
+        line=None,
+        offset=None,
+        module_offset=None,
+        function_offset=None,
         normalized=None,
         **kwargs  # eat any extra kwargs passed in
     ):

--- a/socorro/processor/skunk_classifiers.py
+++ b/socorro/processor/skunk_classifiers.py
@@ -1,0 +1,707 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This package is a Socorro implementation of bsmedberg's skunk processor
+crash classification system.  This package is intended for use in Socorro
+Processor2012.  It is implemented on top of the Processor TransformRule
+System.  It is intended that this package demonstrate the implementation
+technique for all future enhancements to Processor2012 and well as how
+the entirety of the future BixieProcessor2013 and SocorroProcessor2014
+implementations.
+
+The intent is to provide a framework for which ad hoc classification rules
+can be added to the processor easily.  The rules, that all follow the same
+programatic form, are executed one at a time, in order, until one of the rules
+reports that it succeeds.  At that point, execution of classificiation rules
+stops.
+
+Classification rules are applied after all other processing of a crash is
+complete.  Classification rules are given access to both the raw_crash and the
+processed_crash.  In this version, the classification rule has complete read
+and write access to all fields with in both versions two versions of the crash.
+Rules should probably refrain from making modifications and instead use the
+base class API for adding a classification to the processed_cash.
+
+All rules have two major components: a predicate and an action.
+
+The predicate: this method is used to initially determine if the rule should
+be applied.
+
+The action: if the predicate succeeds, the 'action' function is executed.  If
+this method succeeds, it uses the '_add_classification' method from the base
+class to tag the crash with new data and return True.  If this method fails or
+otherwise decides that its action should not apply, it just quits returning
+False.  The act of returning False tells the underlying TransformRule system to
+continue trying to apply rules.
+
+Successful application of an action results in the following structure to be
+added to the processed crash:
+
+{...
+    'classifications': {
+        'skunk_works': {
+            'classification': 'some classification',
+            'classification_data': 'extra information saved by rule',
+            'classificaiton_version': '0.0',
+        }
+    }
+
+...}
+"""
+
+import datetime
+
+from socorro.lib.util import DotDict
+
+
+#==============================================================================
+class SkunkClassificationRule(object):
+    """the base class for Skunk Rules.  It provides the framework for the rules
+    'predicate', 'action', and 'version' as well as utilites to help rules do
+    their jobs."""
+
+    #--------------------------------------------------------------------------
+    def predicate(self, raw_crash,  processed_crash, processor):
+        """the default predicate for Skunk Classifiers invokes any derivied
+        _predicate function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity act.  An error during the predicate application is a
+        failure of the rule, not a failure of the classification system itself
+        """
+        try:
+            return self._predicate(raw_crash,  processed_crash, processor)
+        except Exception, x:
+            processor.config.logger.debug(
+                'skunk_classifier: %s predicate rejection - consideration of '
+                '%s failed because of "%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+                exc_info=True
+            )
+            return False
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash,  processed_crash, processor):
+        """"The default predicate is too look into the processed crash to see
+        if the 'skunk_works' classification has already been applied.
+        parameters:
+            raw_crash - a mapping representing the raw crash data originally
+                        submitted by the client
+            processed_crash - the ultimate result of the processor, this is the
+                              analized version of a crash.  It contains the
+                              output of the MDSW program for each of the dumps
+                              within the crash.
+            processor - a reference to the processor object that is assigned
+                        to working on the current crash. This object contains
+                        resources that might be useful to a classifier rule.
+                        'processor.config' is the configuration for the
+                        processor in which database connection paramaters can
+                        be found.  'processor.logger' is useful for any logging
+                        of debug information. 'processor.c_signature_tool' or
+                        'processor.java_signature_tool' contain utilities that
+                        might be useful during classification.
+
+        returns:
+            True - this rule should be applied
+            False - this rule should not be applied
+        """
+        try:
+            if 'classification' in processed_crash.classifications.skunk_works:
+                return False
+            return True
+        except KeyError:
+            return True
+
+    #--------------------------------------------------------------------------
+    def action(self, raw_crash,  processed_crash, processor):
+        """the default action for Skunk Classifiers invokes any derivied
+        _action function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity act and perhaps (mitigate the error).  An error during the
+        action application is a failure of the rule, not a failure of the
+        classification system itself."""
+        try:
+            return self._action(raw_crash,  processed_crash, processor)
+        except Exception, x:
+            processor.config.logger.debug(
+                'skunk_classifier: %s action failure - %s failed because of '
+                '"%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+                exc_info=True
+            )
+            return False
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        """Rules derived from this base class ought to override this method
+        with an actual classification rule.  Successful application of this
+        method should include a call to '_add_classification'.
+
+        parameters:
+            raw_crash - a mapping representing the raw crash data originally
+                        submitted by the client
+            processed_crash - the ultimate result of the processor, this is the
+                              analized version of a crash.  It contains the
+                              output of the MDSW program for each of the dumps
+                              within the crash.
+            processor - a reference to the processor object that is assigned
+                        to working on the current crash. This object contains
+                        resources that might be useful to a classifier rule.
+                        'processor.config' is the configuration for the
+                        processor in which database connection paramaters can
+                        be found.  'processor.logger' is useful for any logging
+                        of debug information. 'processor.c_signature_tool' or
+                        'processor.java_signature_tool' contain utilities that
+                        might be useful during classification.
+
+        returns:
+            True - this rule was applied successfully and no further rules
+                   should be applied
+            False - this rule did not succeed and further rules should be
+                    tried
+        """
+        return True
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        """This method should be overridden in a base class."""
+        return '0.0'
+
+    #--------------------------------------------------------------------------
+    def _add_classification(
+        self,
+        processed_crash,
+        classification,
+        classification_data
+    ):
+        """This method adds a 'skunk_works' classification to a processed
+        crash.
+
+        parameters:
+            processed_crash - a reference to the processed crash to which the
+                              classification is to be added.
+            classification - a string that is the classification.
+            classification_data - a string of extra data that goes along with a
+                                  classification
+        """
+        if 'classifications' not in processed_crash:
+            processed_crash.classifications = DotDict()
+        processed_crash.classifications['skunk_works'] = DotDict({
+            'classification': classification,
+            'classification_data': classification_data,
+            'classification_version': self.version()
+        })
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _get_stack(processed_crash, dump_name='upload_file_minidump_plugin'):
+        """This utility method offers derived classes a way to fetch the stack
+        for the thread that caused the crash
+
+        parameters:
+            processed_crash - this is the mapping that contains the MDSW output
+            dump_name - each dump within a crash has a name.
+
+        returns:
+            False - if something goes wrong in trying to get the stack
+            a list of frames from the crashing thread of the specified dump in
+            this form:
+                [
+                    {
+                        'module': '...',
+                        'function': '...',
+                        'file': '...',
+                        'line': '...',
+                        'offset': '...',
+                        'module_offset': '...',
+                        'funtion_offset': '...',
+                    }, ...
+                ]
+
+        """
+        try:
+            if (dump_name == 'upload_file_minidump_plugin'
+                and processed_crash.process_type == 'plugin'
+            ):
+                a_json_dump = processed_crash.json_dump
+            else:
+                a_json_dump = processed_crash[dump_name].json_dump
+        except KeyError:
+            # no plugin or plugin json dump
+            return False
+        try:
+            stack = \
+                a_json_dump['threads'][
+                    a_json_dump['crash_info']['crashing_thread']
+                ]['frames']
+        # these exceptions are kept as separate cases just to help keep track
+        # of what situations they cover
+        except KeyError:
+            # no threads or no crash_info or no crashing_thread
+            return False
+        except IndexError:
+            # no stack for crashing_thread
+            return False
+        except ValueError:
+            # crashing_thread is not an integer
+            return False
+        return stack
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _stack_contains(
+        stack,
+        signature,
+        a_signature_tool,
+        cache_normalizations=True
+    ):
+        """this utility will return a boolean indicitating if a string
+        appears at the beginning of any of the nomalized frame signatures
+        within a stack.
+
+        parameters:
+            stack - the stack to examine
+            signature - the string to search for
+            a_signature_tool - a reference to an object having a
+                               'normalize_signature' method.  This is applied
+                               to each frame of the stack prior to testing
+            cache_normalizations - sometimes many rules will need to do the
+                                   same normalizations over and over.  This
+                                   method will save the normalized form of a
+                                   stack frame within the processed_crash's
+                                   copy of the processed stack.  This cache
+                                   will persist and get saved to processed
+                                   crash storage.
+        """
+        for a_frame in stack:
+            try:
+                normalized_frame = a_frame['normalized']
+            except KeyError:
+                normalized_frame = a_signature_tool.normalize_signature(
+                    **a_frame
+                )
+                if cache_normalizations:
+                    a_frame['normalized'] = normalized_frame
+            if normalized_frame.startswith(signature):
+                return True
+        return False
+
+#==============================================================================
+class DontConsiderTheseFilter(SkunkClassificationRule):
+    """This classifier is meant to match every crash that is of no interest.
+    Once identified by the predicate, these uninteresting crashes are passed
+    on to the action.  The action does nothing but declare the classification
+    process as being done.  This derails any further consideration of matching
+    crashes"""
+    first19 = datetime.date(2012, 10, 17)
+    first18 = datetime.date(2012, 10, 23)
+
+    #--------------------------------------------------------------------------
+    def predicate(self, raw_crash,  processed_crash, processor):
+        """this method overrides the base class predicate.  The base class
+        assumes that an exception raised during the predicate is a failure of
+        the predicate.  In this case, the logic is the opposite, an exception
+        means the success of the predicate.
+
+        This class is to find all crashes that are not Firefox Plugin crashes
+        of with certian qualities.  If an error happens during the
+        determination, then we consider the crash in question to be
+        not of the proper type.  So the predicate returns true, forcing the
+        rule system to take the action (which does nothing) and stops the rule
+        application process.
+        """
+        try:
+            return self._predicate(raw_crash,  processed_crash, processor)
+        except Exception, x:
+            processor.config.logger.debug(
+                'skunk_classifier: %s predicate rejection - consideration of '
+                '%s failed because of "%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+                exc_info=True
+            )
+            return False
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash,  processed_crash, processor):
+        """this predicate matches all crashes that are NOT Firefox Plugin
+        crashes of a certain vintage.  This prediciate was adapted from
+        bsmedberg's skunk processor.
+
+        Predicates normally return True for accepting and False for rejecting.
+        Somewhat counter intuitively, in this predicate, we return True when we
+        ultimately want to reject the crash in question.  Think of it this way,
+        the predicate is saying "yes, we want to reject this crash".  By saying
+        'yes', the crash gets passed to the action where the ulimate rejection
+        actually happens."""
+
+        plugin_hang = raw_crash.get('PluginHang', '0')
+        if plugin_hang == '0':
+            processor.config.logger.debug(
+                'skunk_classifier: reject - not a plugin crash'
+            )
+            return True
+
+        product_name = raw_crash.get('ProductName', None)
+        if product_name != 'Firefox':
+            processor.config.logger.debug(
+                'skunk_classifier: reject - Product "%s" is not Firefox',
+                product_name
+            )
+            return True
+
+        version = raw_crash.get('Version', None)
+        if version is None:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - Version missing'
+            )
+            return True
+
+        try:
+            majorversion = int(version.split('.')[0])
+        except ValueError:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - bad Version string "%s"',
+                version
+            )
+            return True
+
+        buildid = raw_crash.get('BuildID', None)
+        if buildid is None:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - BuiltID missing'
+            )
+            return True
+
+        try:
+            builddate = datetime.date(
+                int(buildid[0:4]),
+                int(buildid[4:6]),
+                int(buildid[6:8])
+            )
+        except ValueError:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - bad BuildID "%s"',
+                buildid
+            )
+            return True
+
+        if majorversion < 17:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - not accepting Version '
+                '"%s"',
+                majorversion
+            )
+            return True
+        elif majorversion == 18:
+            if builddate < self.first18:
+                processor.config.logger.debug(
+                    'skunk_classifier: reject - not accepting Version'
+                    ' "%s" with old BuildID',
+                    majorversion
+                )
+                return True
+        elif builddate < self.first19:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - not accepting old BuildID '
+                '"%s"',
+                buildid
+            )
+            return True
+
+        # bsmedberg's code stores dumps differently than Socorro does.  In
+        # Socorro, a 'plugin' crash has the 'plugin' dump as the primary
+        # dump named 'dump' rather than stored with the name 'plugin'
+        if 'dump' not in processed_crash:
+            processor.config.logger.debug(
+                'skunk_classifier: reject - plugin dump missing',
+            )
+            return True
+
+        try:
+            if processed_crash.json_dump.system_info.cpu_arch == 'amd64':
+                processor.config.logger.debug(
+                    'skunk_classifier: reject - not accepting amd64 '
+                    'architecture',
+                )
+                return True
+        except (KeyError, AttributeError):
+            processor.config.logger.debug(
+                'skunk_classifier: reject - no architecture info found',
+            )
+            return True
+
+        if not processed_crash.get('success', False):
+            return True
+
+        for a_dump_name in processed_crash.additional_minidumps:
+            # in the original code, this section made sure that all
+            # dumps had identified 'crashing threads'.  Socorro doesn't
+            # work that way.  Ulitimately, this section asks the question,
+            # "were all dump successful in processing by MDSW?"
+            try:
+                if not processed_crash[a_dump_name].success:
+                    processor.config.logger.debug(
+                        'skunk_classifier: reject - all dumps must have '
+                        'processed correctly: %s has MDSW errors',
+                        a_dump_name
+                    )
+                    return True
+            except (KeyError, AttributeError):
+                processor.config.logger.debug(
+                    'skunk_classifier: reject - all dumps must have '
+                    'processed correctly: %s is missing components',
+                    a_dump_name
+                )
+                return True
+
+        # by getting this far, this crash is interesting.  declare that this
+        # rule does not apply by returning False.  This means that the
+        # classification process will continue by applying further rules.
+        return False
+
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        """the predicate has determined that the crash is uninteresting to
+        the SkunkClassifiers.  Don't do anything but return true to stop any
+        further application of rules."""
+        return True
+
+
+#==============================================================================
+class UpdateWindowAttributes(SkunkClassificationRule):
+    """"""
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        stack = self._get_stack(processed_crash, 'upload_file_minidump_plugin')
+        if stack is False:
+            return False
+
+        # normalize the stack of the crashing thread
+        # then look for these 3 target frames
+        target_signatures = [
+            "F_1152915508___________________________________",
+            "mozilla::plugins::PluginInstanceChild::UpdateWindowAttributes"
+                "(bool)",
+            "mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)"
+        ]
+
+        current_target_signature = target_signatures.pop(0)
+        for i, a_frame in enumerate(stack):
+            normalized_signature = \
+                processor.c_signature_tool.normalize_signature(**a_frame)
+            if (current_target_signature in normalized_signature):
+                current_target_signature = target_signatures.pop(0)
+                if not target_signatures:
+                    break
+        if target_signatures:
+            return False
+
+        try:
+            classification_data = \
+                processor.c_signature_tool.normalize_signature(**stack[i + 1])
+        except IndexError:
+            classification_data = None
+
+        self._add_classification(
+            processed_crash,
+            'adbe-3355131',
+            classification_data
+        )
+
+        return True
+
+
+#==============================================================================
+class SetWindowPos(SkunkClassificationRule):
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        found = self._do_set_window_pos_classification(
+            processed_crash,
+            processor.c_signature_tool,
+            'upload_file_minidump_plugin',
+            ('F_320940052', 'F_1378698112', 'F_468782153')
+        )
+        if not found:
+            found = self._do_set_window_pos_classification(
+                processed_crash,
+                processor.c_signature_tool,
+                'upload_file_minidump_flash2',
+                ('F455544145',)
+            )
+        return found
+
+    #--------------------------------------------------------------------------
+    def _do_set_window_pos_classification(
+        self,
+        processed_crash,
+        signature_normalization_tool,
+        dump_name,
+        secondary_sentinels
+    ):
+        stack = self._get_stack(processed_crash, dump_name)
+        if stack is False:
+            return False
+        truncated_stack = self._get_stack(processed_crash, dump_name)[:5]
+        stack_contains_sentinel = self._stack_contains(
+            truncated_stack,
+            'NtUserSetWindowPos',
+            signature_normalization_tool,
+        )
+        if stack_contains_sentinel:
+            for a_second_sentinel in secondary_sentinels:
+                stack_contains_secondary = self._stack_contains(
+                    truncated_stack,
+                    a_second_sentinel,
+                    signature_normalization_tool,
+                )
+                if stack_contains_secondary:
+                        self._add_classification(
+                            processed_crash,
+                            'NtUserSetWindowPos | %s' % a_second_sentinel,
+                            None
+                        )
+                        return True
+            self._add_classification(
+                processed_crash,
+                'NtUserSetWindowPos | other',
+                None
+            )
+            return True
+        return False
+
+
+#==============================================================================
+class SendWaitReceivePort(SkunkClassificationRule):
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+
+        stack = self._get_stack(processed_crash, 'upload_file_minidump_flash2')
+        if stack is False:
+            return False
+
+        if self._stack_contains(
+            stack[:5],
+            'NtAlpcSendWaitReceivePort',
+            processor.c_signature_tool,
+        ):
+            self._add_classification(
+                processed_crash,
+                'NtAlpcSendWaitReceivePort',
+                None
+            )
+
+            return True
+        return False
+
+
+#==============================================================================
+class Bug811804(SkunkClassificationRule):
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+
+        try:
+            signature = processed_crash.upload_file_minidump_flash2.signature
+        except KeyError:
+            return False
+
+        if (signature == 'hang | NtUserWaitMessage | F34033164'
+                         '________________________________'):
+            self._add_classification(
+                processed_crash,
+                'bug811804-NtUserWaitMessage',
+                None
+            )
+            return True
+        return False
+
+
+#==============================================================================
+class Bug812318(SkunkClassificationRule):
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        stack = self._get_stack(processed_crash, 'upload_file_minidump_flash2')
+        if stack is False:
+            return False
+
+        primary_found = self._stack_contains(
+            stack[:5],
+            'NtUserPeekMessage',
+            processor.c_signature_tool,
+        )
+        if not primary_found:
+            return False
+
+        secondary_found = self._stack_contains(
+            stack[:5],
+            'F849276792______________________________',
+            processor.c_signature_tool,
+        )
+        if secondary_found:
+            classification = 'bug812318-PeekMessage'
+        else:
+            classification = 'NtUserPeekMessage-other'
+        self._add_classification(
+            processed_crash,
+            classification,
+            None
+        )
+        return True
+
+
+#==============================================================================
+class NullClassification(SkunkClassificationRule):
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '0.1'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash,  processed_crash, processor):
+        self._add_classification(
+            processed_crash,
+            'not classified',
+            None
+        )
+        return True
+
+
+
+default_classifier_rules = (
+    (DontConsiderTheseFilter, (), {}, DontConsiderTheseFilter, (), {}),
+    (UpdateWindowAttributes, (), {}, UpdateWindowAttributes, (), {}),
+    (SetWindowPos, (), {}, SetWindowPos, (), {}),
+    (SendWaitReceivePort, (), {}, SendWaitReceivePort, (), {}),
+    (Bug811804, (), {}, Bug811804, (), {}),
+    (Bug812318, (), {}, Bug812318, (), {}),
+    (NullClassification, (), {}, NullClassification, (), {}),
+)

--- a/socorro/unittest/processor/test_breakpad_pipe_to_json.py
+++ b/socorro/unittest/processor/test_breakpad_pipe_to_json.py
@@ -1,0 +1,452 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+import socorro.processor.breakpad_pipe_to_json as bpj
+
+from socorro.lib.util import DotDict
+
+cannonical_json_dump = {
+    #"status": ,
+    "system_info": {
+        'os': 'Windows NT',
+        'os_ver': '5.1.2600 Service Pack 2',
+        "cpu_arch": 'x86',
+        "cpu_info": 'GenuineIntel family 6 model 22 stepping 1',
+        "cpu_count": 4
+    },
+    "crash_info": {
+        "type": 'EXCEPTION_ACCESS_VIOLATION_READ',
+        "crash_address": '0x676c',
+        "crashing_thread": 0
+    },
+    "main_module": 0,
+    "modules": [
+        {
+            "filename": 'firefox.exe',
+            "version": '24.0.0.4925',
+            "debug_file": 'firefox.pdb',
+            "debug_id": '9FFDDF56AADE45988C759EF5ABAE53862',
+            "base_addr": '0x00400000',
+            "end_addr": '0x004e0fff',
+        },
+        {
+            "filename": 'nss3.dll',
+            "version": '24.0.0.4925',
+            "debug_file": 'nss3.pdb',
+            "debug_id": '30EAD90FEEBD495398D46EFA41814E261',
+            "base_addr": '0x00a00000',
+            "end_addr": '0x00bb5fff',
+        },
+        {
+            "filename": 'mozjs.dll',
+            "debug_file": 'mozjs.pdb',
+            "debug_id": 'CC7AA5DA1FB144C4B40C2DF1B08709232',
+            "base_addr": '0x00bd0000',
+            "end_addr": '0x00ef9fff',
+        },
+        {
+            "filename": 'mozalloc.dll',
+            "version": '24.0.0.4925',
+            "debug_file": 'mozalloc.pdb',
+            "debug_id": 'F4C1BFD2BA3A487CA37EBF3D7E543F7B1',
+            "base_addr": '0x01000000',
+            "end_addr": '0x01005fff',
+        },
+        {
+            "filename": 'gkmedias.dll',
+            "version": '24.0.0.4925',
+            "debug_file": 'gkmedias.pdb',
+            "debug_id": '02FE96BEFEAE4570AA12E766CF2C8A361',
+            "base_addr": '0x01010000',
+            "end_addr": '0x01337fff',
+        },
+    ],
+    "thread_count": 2,
+    "threads": [
+        {
+            "frame_count": 13,
+            "frames": [
+                {
+                    "frame": 0,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_1",
+                    "file": "jsinferinlines.h:17666746e8cc",
+                    "line": 1321,
+                },
+                {
+                    "frame": 1,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_2",
+                    "file": "jsobj.cpp:17666746e8cc",
+                    "line": 1552,
+                },
+                {
+                    "frame": 2,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_3",
+                    "file": "CodeGenerator.cpp:17666746e8cc",
+                    "line": 3119,
+                },
+                {
+                    "frame": 3,
+                    "module": "mozjs.dll",
+                    "module_offset": "0xcc9d0",
+                },
+                {
+                    "frame": 4,
+                    "offset": "0x80b6fe0",
+                },
+                {
+                    "frame": 5,
+                    "offset": "0x3cf5ee6",
+                },
+                {
+                    "frame": 6,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_7",
+                    "file": "BaselineJIT.cpp:17666746e8cc",
+                    "line": 105,
+                },
+                {
+                    "frame": 7,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_8",
+                    "file": "BaselineCompiler-shared.cpp:17666746e8cc",
+                    "line": 71,
+                },
+                {
+                    "frame": 8,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_9",
+                    "file": "Ion.cpp:17666746e8cc",
+                    "line": 1708,
+                },
+                {
+                    "frame": 9,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_10",
+                    "file": "Interpreter.cpp:17666746e8cc",
+                    "line": 2586,
+                },
+                {
+                    "frame": 10,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_11",
+                    "file": "Interpreter.cpp:17666746e8cc",
+                    "line": 438,
+                },
+                {
+                    "frame": 11,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_12",
+                    "file": "Interpreter.cpp:17666746e8cc",
+                    "line": 622,
+                },
+                {
+                    "frame": 12,
+                    "module": "mozjs.dll",
+                    "function": "bogus_sig_13",
+                    "file": "Interpreter.cpp:17666746e8cc",
+                    "line": 659,
+                },
+            ]
+        },
+        {
+            "frame_count": 2,
+            "frames": [
+                {
+                    "frame": 0,
+                    "module": "lars_crash.dll",
+                    "function": "ha_ha",
+                    "file": "no source",
+                    "line": 0,
+                },
+                {
+                    "frame": 1,
+                    "module": "lars_crash.dll",
+                    "function": "ha_ha2",
+                    "file": "no source",
+                    "line": 0,
+                },
+            ]
+        }
+
+    ],
+    "crashing_thread": {
+        "threads_index": 0,
+        "total_frames": 13,
+        "frames": [
+            {
+                "frame": 0,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_1",
+                "file": "jsinferinlines.h:17666746e8cc",
+                "line": 1321,
+            },
+            {
+                "frame": 1,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_2",
+                "file": "jsobj.cpp:17666746e8cc",
+                "line": 1552,
+            },
+            {
+                "frame": 2,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_3",
+                "file": "CodeGenerator.cpp:17666746e8cc",
+                "line": 3119,
+            },
+            {
+                "frame": 3,
+                "module": "mozjs.dll",
+                "module_offset": "0xcc9d0",
+            },
+            {
+                "frame": 4,
+                "offset": "0x80b6fe0",
+            },
+            {
+                "frame": 5,
+                "offset": "0x3cf5ee6",
+            },
+            {
+                "frame": 6,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_7",
+                "file": "BaselineJIT.cpp:17666746e8cc",
+                "line": 105,
+            },
+            {
+                "frame": 7,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_8",
+                "file": "BaselineCompiler-shared.cpp:17666746e8cc",
+                "line": 71,
+            },
+            {
+                "frame": 8,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_9",
+                "file": "Ion.cpp:17666746e8cc",
+                "line": 1708,
+            },
+            {
+                "frame": 9,
+                "module": "mozjs.dll",
+                "function": "bogus_sig_10",
+                "file": "Interpreter.cpp:17666746e8cc",
+                "line": 2586,
+            },
+        ]
+    }
+}
+
+
+class TestCase(unittest.TestCase):
+    def test_get(self):
+        a_list = ['a', 'b', 'c']
+        self.assertEqual(bpj._get(a_list, 0, None), 'a')
+        self.assertEqual(bpj._get(a_list, 1, None), 'b')
+        self.assertEqual(bpj._get(a_list, 2, None), 'c')
+        self.assertEqual(bpj._get(a_list, 3, None), None)
+
+    def test_get_int(self):
+        a_list = ['a', '1', 'c']
+        self.assertEqual(bpj._get_int(a_list, 0, None), None)
+        self.assertEqual(bpj._get_int(a_list, 1, None), 1)
+        self.assertEqual(bpj._get_int(a_list, 2, None), None)
+        self.assertEqual(bpj._get_int(a_list, 3, None), None)
+
+
+    def test_extract_OS_info(self):
+        info = ['OS', 'Windows NT', '5.1.2600 Service Pack 2']
+        d = DotDict()
+        bpj._extract_OS_info(info, d)
+        self.assertTrue('system_info' in d)
+        self.assertEqual(
+            d.system_info,
+            {
+                'os': 'Windows NT',
+                'os_ver': '5.1.2600 Service Pack 2'
+            }
+        )
+
+    def test_extract_OS_info_fail(self):
+        info = ['OS',]
+        d = DotDict()
+        bpj._extract_OS_info(info, d)
+        self.assertTrue('system_info' in d)
+        self.assertEqual(d.system_info, {})
+
+    def test_extract_CPU_info(self):
+        info = ['CPU', 'x86', 'GenuineIntel family 6 model 22 stepping 1', 1]
+        d = DotDict()
+        bpj._extract_CPU_info(info, d)
+        self.assertTrue('system_info' in d)
+        self.assertEqual(
+            d.system_info,
+            {
+                "cpu_arch": 'x86',
+                "cpu_info": 'GenuineIntel family 6 model 22 stepping 1',
+                "cpu_count": 1
+            }
+        )
+
+    def test_extract_OS_and_CPU_info(self):
+        info = ['OS', 'Windows NT', '5.1.2600 Service Pack 2']
+        d = DotDict()
+        bpj._extract_OS_info(info, d)
+        info = ['CPU', 'x86', 'GenuineIntel family 6 model 22 stepping 1', 1]
+        bpj._extract_CPU_info(info, d)
+        self.assertTrue('system_info' in d)
+        self.assertEqual(
+            d.system_info,
+            {
+                'os': 'Windows NT',
+                'os_ver': '5.1.2600 Service Pack 2',
+                "cpu_arch": 'x86',
+                "cpu_info": 'GenuineIntel family 6 model 22 stepping 1',
+                "cpu_count": 1
+            }
+        )
+
+    def test_extract_crash_info(self):
+        info = ['Crash', 'EXCEPTION_ACCESS_VIOLATION_READ', '0x676c', 1]
+        d = DotDict()
+        crashing_thread = bpj._extract_crash_info(info, d)
+        self.assertTrue('crash_info' in d)
+        self.assertEqual(
+            d.crash_info,
+            {
+                "type": 'EXCEPTION_ACCESS_VIOLATION_READ',
+                "crash_address": '0x676c',
+                "crashing_thread": 1
+            }
+        )
+        self.assertEqual(crashing_thread, 1)
+
+    def test_extract_module_info(self):
+        info = ['Module', 'firefox.exe', '24.0.0.4925', 'firefox.pdb',
+                '9FFDDF56AADE45988C759EF5ABAE53862', '0x00400000',
+                '0x004e0fff', '1']
+        d = DotDict()
+        bpj._extract_module_info(info, d, 17)
+        self.assertTrue('modules' in d)
+        self.assertTrue(len(d.modules), 1)
+        self.assertEqual(d.main_module, 17)
+        self.assertEqual(
+            d.modules[0],
+            {
+                "filename": 'firefox.exe',
+                "version": '24.0.0.4925',
+                "debug_file": 'firefox.pdb',
+                "debug_id": '9FFDDF56AADE45988C759EF5ABAE53862',
+                "base_addr": '0x00400000',
+                "end_addr": '0x004e0fff',
+            }
+        )
+
+    def test_extract_module_info_not_main(self):
+        info = ['Module', 'firefloosy.exe', '24.0.0.4925', 'firefox.pdb',
+                '9FFDDF56AADE45988C759EF5ABAE53862', '0x00400000',
+                '0x004e0fff', '0']
+        d = DotDict()
+        bpj._extract_module_info(info, d, 17)
+        self.assertTrue('modules' in d)
+        self.assertTrue(len(d.modules), 1)
+        self.assertTrue('main_module' not in d)
+        self.assertEqual(
+            d.modules[0],
+            {
+                "filename": 'firefloosy.exe',
+                "version": '24.0.0.4925',
+                "debug_file": 'firefox.pdb',
+                "debug_id": '9FFDDF56AADE45988C759EF5ABAE53862',
+                "base_addr": '0x00400000',
+                "end_addr": '0x004e0fff',
+            }
+        )
+
+
+    def test_extract_frame_inf(self):
+        info = ['0', '12', 'msvcr100.dll', '_callthreadstartex',
+                'f:\\src\\threadex.c', '314', '0x6']
+        d = DotDict()
+        bpj._extract_frame_info(info, d)
+        self.assertTrue('threads' in d)
+        self.assertEqual(len(d.threads), 1)
+        self.assertEqual(
+            d.threads[0],
+            {
+                "frame_count": 1,
+                "frames": [
+                    {
+                        "frame": 12,
+                        "module": 'msvcr100.dll',
+                        "function": '_callthreadstartex',
+                        "file": 'f:\\src\\threadex.c',
+                        "line": 314,
+                    }
+                ]
+            }
+        )
+
+    def test_extract_frame_info_frames_missing(self):
+        info = ['4', '12', 'msvcr100.dll', '_callthreadstartex',
+                'f:\\src\\threadex.c', '314', '0x6']
+        d = DotDict()
+        bpj._extract_frame_info(info, d)
+        self.assertTrue('threads' in d)
+        self.assertEqual(len(d.threads), 5)
+        self.assertEqual(
+            d.threads[4],
+            {
+                "frame_count": 1,
+                "frames": [
+                    {
+                        "frame": 12,
+                        "module": 'msvcr100.dll',
+                        "function": '_callthreadstartex',
+                        "file": 'f:\\src\\threadex.c',
+                        "line": 314,
+                    }
+                ]
+            }
+        )
+
+
+
+    def test_pipe_dump_to_json_dump(self):
+        pipe_dump = [
+            "OS|Windows NT|5.1.2600 Service Pack 2",
+            "CPU|x86|GenuineIntel family 6 model 22 stepping 1|4",
+            "Crash|EXCEPTION_ACCESS_VIOLATION_READ|0x676c|0",
+            "Module|firefox.exe|24.0.0.4925|firefox.pdb|9FFDDF56AADE45988C759EF5ABAE53862|0x00400000|0x004e0fff|1",
+            "Module|nss3.dll|24.0.0.4925|nss3.pdb|30EAD90FEEBD495398D46EFA41814E261|0x00a00000|0x00bb5fff|0",
+            "Module|mozjs.dll||mozjs.pdb|CC7AA5DA1FB144C4B40C2DF1B08709232|0x00bd0000|0x00ef9fff|0",
+            "Module|mozalloc.dll|24.0.0.4925|mozalloc.pdb|F4C1BFD2BA3A487CA37EBF3D7E543F7B1|0x01000000|0x01005fff|0",
+            "Module|gkmedias.dll|24.0.0.4925|gkmedias.pdb|02FE96BEFEAE4570AA12E766CF2C8A361|0x01010000|0x01337fff|0",
+            "",
+            "0|0|mozjs.dll|bogus_sig_1|jsinferinlines.h:17666746e8cc|1321|0x0",
+            "0|1|mozjs.dll|bogus_sig_2|jsobj.cpp:17666746e8cc|1552|0x2d",
+            "0|2|mozjs.dll|bogus_sig_3|CodeGenerator.cpp:17666746e8cc|3119|0x13",
+            "0|3|mozjs.dll||||0xcc9d0",
+            "0|4|||||0x80b6fe0",
+            "0|5|||||0x3cf5ee6",
+            "0|6|mozjs.dll|bogus_sig_7|BaselineJIT.cpp:17666746e8cc|105|0x20",
+            "0|7|mozjs.dll|bogus_sig_8|BaselineCompiler-shared.cpp:17666746e8cc|71|0x3d",
+            "0|8|mozjs.dll|bogus_sig_9|Ion.cpp:17666746e8cc|1708|0x1b",
+            "0|9|mozjs.dll|bogus_sig_10|Interpreter.cpp:17666746e8cc|2586|0x26",
+            "0|10|mozjs.dll|bogus_sig_11|Interpreter.cpp:17666746e8cc|438|0x9",
+            "0|11|mozjs.dll|bogus_sig_12|Interpreter.cpp:17666746e8cc|622|0x37",
+            "0|12|mozjs.dll|bogus_sig_13|Interpreter.cpp:17666746e8cc|659|0x1b",
+            "1|0|lars_crash.dll|ha_ha|no source|0|0x3|0x2|0x1",
+            "1|1|lars_crash.dll|ha_ha2|no source|0|0x5|0x1|0x3",
+        ]
+        json_dump = bpj.pipe_dump_to_json_dump(pipe_dump)
+        self.assertEqual(json_dump, cannonical_json_dump)
+

--- a/socorro/unittest/processor/test_skunk_classifiers.py
+++ b/socorro/unittest/processor/test_skunk_classifiers.py
@@ -1,0 +1,789 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+import copy
+import datetime
+
+from socorro.lib.util import DotDict, FakeLogger, SilentFakeLogger
+from socorro.processor.skunk_classifiers import (
+    SkunkClassificationRule,
+    DontConsiderTheseFilter,
+    UpdateWindowAttributes,
+    SetWindowPos,
+    SendWaitReceivePort,
+    Bug811804,
+    Bug812318,
+)
+from socorro.processor.signature_utilities import CSignatureTool
+from socorro.unittest.processor.test_breakpad_pipe_to_json import (
+    cannonical_json_dump
+)
+
+csig_config = DotDict()
+csig_config.irrelevant_signature_re = ''
+csig_config.prefix_signature_re = ''
+csig_config.signatures_with_line_numbers_re = ''
+csig_config.signature_sentinels = []
+c_signature_tool = CSignatureTool(csig_config)
+
+def create_basic_fake_processor():
+    fake_processor = DotDict()
+    fake_processor.c_signature_tool = c_signature_tool
+    fake_processor.config = DotDict()
+    # need help figuring out failures? switch to FakeLogger and read stdout
+    fake_processor.config.logger = SilentFakeLogger()
+    #fake_processor.config.logger = FakeLogger()
+    return fake_processor
+
+
+class TestSkunkClassificationRule(unittest.TestCase):
+
+    def test_predicate(self):
+        rc = DotDict()
+        pc = DotDict()
+        pc.classifications = DotDict()
+        processor = None
+
+        skunk_rule = SkunkClassificationRule()
+        self.assertTrue(skunk_rule.predicate(rc, pc, processor))
+
+        pc.classifications.skunk_works = DotDict()
+        self.assertTrue(skunk_rule.predicate(rc, pc, processor))
+
+        pc.classifications.skunk_works.classification = 'stupid'
+        self.assertFalse(skunk_rule.predicate(rc, pc, processor))
+
+    def test_action(self):
+        rc = DotDict()
+        pc = DotDict()
+        processor = None
+
+        skunk_rule = SkunkClassificationRule()
+        self.assertTrue(skunk_rule.action(rc, pc, processor))
+
+    def test_version(self):
+        skunk_rule = SkunkClassificationRule()
+        self.assertEqual(skunk_rule.version(), '0.0')
+
+    def test_add_classification_to_processed_crash(self):
+        rc = DotDict()
+        pc = DotDict()
+        pc.classifications = DotDict()
+        processor = None
+
+        skunk_rule = SkunkClassificationRule()
+        skunk_rule._add_classification(
+            pc,
+            'stupid',
+            'extra stuff'
+        )
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc.classifications)
+        self.assertEqual(
+            'stupid',
+            pc.classifications.skunk_works.classification
+        )
+        self.assertEqual(
+            'extra stuff',
+            pc.classifications.skunk_works.classification_data
+        )
+        self.assertEqual(
+            '0.0',
+            pc.classifications.skunk_works.classification_version
+        )
+
+    def test_get_stack(self):
+        pc = DotDict()
+        pc.process_type = 'plugin'
+        skunk_rule = SkunkClassificationRule()
+        processor = DotDict()
+
+        self.assertFalse(skunk_rule._get_stack(pc, 'upload_file_minidump_plugin'))
+
+        pc.json_dump = DotDict()
+        pc.json_dump.threads = []
+        self.assertFalse(skunk_rule._get_stack(pc, 'upload_file_minidump_plugin'))
+
+        pc.json_dump.crash_info = DotDict()
+        pc.json_dump.crash_info.crashing_thread = 1
+        self.assertFalse(skunk_rule._get_stack(pc, 'upload_file_minidump_plugin'))
+
+        pc.json_dump = cannonical_json_dump
+        self.assertEqual(
+            skunk_rule._get_stack(pc, 'upload_file_minidump_plugin'),
+            cannonical_json_dump['threads'][0]['frames']
+        )
+
+    def test_stack_contains(self):
+        stack = cannonical_json_dump['threads'][1]['frames']
+
+        skunk_rule = SkunkClassificationRule()
+        self.assertTrue(
+            skunk_rule._stack_contains(
+                stack,
+                'ha_',
+                c_signature_tool,
+                cache_normalizations=False
+            ),
+        )
+        self.assertFalse(
+            skunk_rule._stack_contains(
+                stack,
+                'heh_',
+                c_signature_tool,
+                cache_normalizations=False
+            ),
+        )
+        self.assertFalse('normalized' in stack[0])
+        self.assertTrue(
+            skunk_rule._stack_contains(
+                stack,
+                'ha_ha2',
+                c_signature_tool,
+            ),
+        )
+        self.assertTrue('normalized' in stack[0])
+
+
+class TestDontConsiderTheseFilter(unittest.TestCase):
+
+    def test_action_predicate_accept(self):
+        """test all of the case where the predicate should return True"""
+        filter_rule = DontConsiderTheseFilter()
+
+        fake_processor = create_basic_fake_processor()
+
+        # find non-plugin crashes
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '0'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find non-Firefox crashes
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Internet Explorer"
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with no Version info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with faulty Version info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = 'dwight'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with no BuildID info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '17.1'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with faulty BuildID info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '17.1'
+        test_raw_crash.BuildID = '201307E2'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with faulty BuildID info (not integer)
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '17.1'
+        test_raw_crash.BuildID = '201307E2'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with faulty BuildID info (bad month & day)
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '17.1'
+        test_raw_crash.BuildID = '20131458'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with pre-17 version
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '15'
+        test_raw_crash.BuildID = '20121015'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with 18 version but build date less than 2012-10-23
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '18'
+        test_raw_crash.BuildID = '20121015'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with build date less than 2012-10-17
+        # and version 17 or above
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '17'
+        test_raw_crash.BuildID = '20121015'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            DotDict(),
+            fake_processor
+        ))
+
+        # find crashes with no default dump
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with no architecture info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with amd64 architecture info
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.cpu_arch = 'amd64'
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with main dump processing errors
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.system_info.cpu_arch = 'x86'
+        test_processed_crash.success = False
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with extra dump processing errors
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.system_info.cpu_arch = 'x86'
+        test_processed_crash.success = True
+        test_processed_crash.additional_minidumps = ['a', 'b', 'c']
+        test_processed_crash.a = DotDict()
+        test_processed_crash.a.success = True
+        test_processed_crash.b = DotDict()
+        test_processed_crash.b.success = True
+        test_processed_crash.c = DotDict()
+        test_processed_crash.c.success = False
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with missing critical attribute
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.system_info.cpu_arch = 'x86'
+        test_processed_crash.success = True
+        test_processed_crash.additional_minidumps = ['a', 'b', 'c']
+        test_processed_crash.a = DotDict()
+        test_processed_crash.a.success = True
+        test_processed_crash.b = DotDict()
+        test_processed_crash.b.success = True
+        test_processed_crash.c = DotDict()
+        test_processed_crash.c.success = False
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # find crashes with missing critical attribute
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.system_info.cpu_arch = 'x86'
+        test_processed_crash.success = True
+        test_processed_crash.additional_minidumps = ['a', 'b', 'c']
+        test_processed_crash.a = DotDict()
+        test_processed_crash.a.success = True
+        test_processed_crash.b = DotDict()
+        test_processed_crash.b.success = True
+        test_processed_crash.c = DotDict()
+        test_processed_crash.c.success = False
+        self.assertTrue(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+        # reject the perfect crash
+        test_raw_crash = DotDict()
+        test_raw_crash.PluginHang = '1'
+        test_raw_crash.ProductName = "Firefox"
+        test_raw_crash.Version = '19'
+        test_raw_crash.BuildID = '20121031'
+        test_processed_crash = DotDict()
+        test_processed_crash.dump = 'fake dump'
+        test_processed_crash.json_dump = DotDict()
+        test_processed_crash.json_dump.system_info = DotDict()
+        test_processed_crash.json_dump.system_info.cpu_arch = 'x86'
+        test_processed_crash.success = True
+        test_processed_crash.additional_minidumps = ['a', 'b', 'c']
+        test_processed_crash.a = DotDict()
+        test_processed_crash.a.success = True
+        test_processed_crash.b = DotDict()
+        test_processed_crash.b.success = True
+        test_processed_crash.c = DotDict()
+        test_processed_crash.c.success = True
+        self.assertFalse(filter_rule.predicate(
+            test_raw_crash,
+            test_processed_crash,
+            fake_processor
+        ))
+
+class TestUpdateWindowAttributes(unittest.TestCase):
+
+    def test_action_success(self):
+        jd = copy.deepcopy(cannonical_json_dump)
+        jd['threads'][0]['frames'][1]['function'] = \
+            "F_1152915508___________________________________"
+        jd['threads'][0]['frames'][3]['function'] = \
+            "mozilla::plugins::PluginInstanceChild::UpdateWindowAttributes" \
+                "(bool)"
+        jd['threads'][0]['frames'][5]['function'] = \
+            "mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)"
+        pc = DotDict()
+        pc.process_type = 'plugin'
+        pc.json_dump = jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = UpdateWindowAttributes()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc['classifications'])
+
+    def test_action_wrong_order(self):
+        jd = copy.deepcopy(cannonical_json_dump)
+        jd['threads'][0]['frames'][4]['function'] = \
+            "F_1152915508___________________________________"
+        jd['threads'][0]['frames'][3]['function'] = \
+            "mozilla::plugins::PluginInstanceChild::UpdateWindowAttributes" \
+                "(bool)"
+        jd['threads'][0]['frames'][5]['function'] = \
+            "mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)"
+        pc = DotDict()
+        pc.dump = DotDict()
+        pc.dump.json_dump = jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = UpdateWindowAttributes()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertFalse(action_result)
+        self.assertFalse('classifications' in pc)
+
+
+
+class TestSetWindowPos(unittest.TestCase):
+
+    def test_action_case_1(self):
+        """sentinel exsits in stack, but no secondaries"""
+        pc = DotDict()
+        pc.process_type = 'plugin'
+        pijd = copy.deepcopy(cannonical_json_dump)
+        pc.json_dump = pijd
+        pc.json_dump['threads'][0]['frames'][2]['function'] = \
+            'NtUserSetWindowPos'
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SetWindowPos()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc.classifications)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'NtUserSetWindowPos | other'
+        )
+
+    def test_action_case_2(self):
+        """sentinel exsits in stack, plus one secondary"""
+        pc = DotDict()
+        pc.process_type = 'plugin'
+        pijd = copy.deepcopy(cannonical_json_dump)
+        pc.json_dump = pijd
+        pc.json_dump['threads'][0]['frames'][2]['function'] = \
+            'NtUserSetWindowPos'
+        pc.json_dump['threads'][0]['frames'][4]['function'] = \
+            'F_1378698112'
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SetWindowPos()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc.classifications)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'NtUserSetWindowPos | F_1378698112'
+        )
+
+    def test_action_case_3(self):
+        """nothing in 1st dump, sentinel and secondary in
+        upload_file_minidump_flash2 dump"""
+        pc = DotDict()
+        pc.dump = DotDict()
+        pijd = copy.deepcopy(cannonical_json_dump)
+        pc.dump.json_dump = pijd
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][2] \
+            ['function'] = 'NtUserSetWindowPos'
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][4] \
+            ['function'] = 'F455544145'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SetWindowPos()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc.classifications)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'NtUserSetWindowPos | F455544145'
+        )
+
+    def test_action_case_4(self):
+        """nothing in 1st dump, sentinel but no secondary in
+        upload_file_minidump_flash2 dump"""
+        pc = DotDict()
+        pc.dump = DotDict()
+        pijd = copy.deepcopy(cannonical_json_dump)
+        pc.dump.json_dump = pijd
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][2] \
+            ['function'] = 'NtUserSetWindowPos'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SetWindowPos()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertTrue('skunk_works' in pc.classifications)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'NtUserSetWindowPos | other'
+        )
+
+    def test_action_case_5(self):
+        """nothing in either dump"""
+        pc = DotDict()
+        pc.dump = DotDict()
+        pijd = copy.deepcopy(cannonical_json_dump)
+        pc.dump.json_dump = pijd
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SetWindowPos()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertFalse(action_result)
+        self.assertFalse('classifications' in pc)
+
+
+
+class TestSendWaitReceivePort(unittest.TestCase):
+
+    def test_action_case_1(self):
+        """success - target found in top 5 frames of stack"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][2] \
+            ['function'] = 'NtAlpcSendWaitReceivePort'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SendWaitReceivePort()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+
+    def test_action_case_2(self):
+        """failure - target not found in top 5 frames of stack"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][6] \
+            ['function'] = 'NtAlpcSendWaitReceivePort'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = SendWaitReceivePort()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertFalse(action_result)
+        self.assertFalse('classifications' in pc)
+
+
+
+class TestBug811804(unittest.TestCase):
+
+    def test_action_success(self):
+        """success - target signature fonud"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.signature = \
+            'hang | NtUserWaitMessage | F34033164' \
+            '________________________________'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = Bug811804()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'bug811804-NtUserWaitMessage'
+        )
+
+    def test_action_failure(self):
+        """success - target signature not found"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.signature = 'lars was here'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = Bug811804()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertFalse(action_result)
+        self.assertFalse('classifications' in pc)
+
+
+class TestBug812318(unittest.TestCase):
+
+    def test_action_case_1(self):
+        """success - both targets found in top 5 frames of stack"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][1] \
+            ['function'] = 'NtUserPeekMessage'
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][2] \
+            ['function'] = 'F849276792______________________________'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = Bug812318()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'bug812318-PeekMessage'
+        )
+
+    def test_action_case_2(self):
+        """success - only 1st target found in top 5 frames of stack"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+        pc.upload_file_minidump_flash2.json_dump['threads'][0]['frames'][1] \
+            ['function'] = 'NtUserPeekMessage'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = Bug812318()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertTrue(action_result)
+        self.assertTrue('classifications' in pc)
+        self.assertEqual(
+            pc.classifications.skunk_works.classification,
+            'NtUserPeekMessage-other'
+        )
+
+    def test_action_case_3(self):
+        """failure - no targets found in top 5 frames of stack"""
+        pc = DotDict()
+        f2jd = copy.deepcopy(cannonical_json_dump)
+        pc.upload_file_minidump_flash2 = DotDict()
+        pc.upload_file_minidump_flash2.json_dump = f2jd
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = Bug812318()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        self.assertFalse(action_result)
+        self.assertFalse('classifications' in pc)
+
+
+


### PR DESCRIPTION
this PR adds the skunk classifier system to the processor.  It is implemented on top of the existing TransformRule  system.  The changes consist of three major parts:

1) the addition of code to translate MDSW pipe dump output into the forward looking jsonMDSW form.  I'd like :ted to take a look at `socorro/processor/breakpad_pipe_to_json.py` and `socorro/unittest/processor/test_breakpad_pipe_to_json.py`

2) the skunk classifiers themselves.  I'd like :bsmedberg to look at: `socorro/processor/skunk_classifiers.py` and `socorro/unittest/processor/test_skunk_classifiers.py`

3) changes to `socorro/processor/legacy_processor.py` and `socorro/unittest/processor/test_legacy_processor.py` to use the new parts introduced in 1 & 2
