### PR TITLE
Bug895928 signature summary to udf

### DIFF
--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -47,6 +47,7 @@ DEFAULT_JOBS = '''
   socorro.cron.jobs.matviews.HomePageGraphBuildCronApp|1d|10:00
   socorro.cron.jobs.matviews.TCBSBuildCronApp|1d|10:00
   socorro.cron.jobs.matviews.ExplosivenessCronApp|1d|10:00
+  socorro.cron.jobs.matviews.SignatureSummaryCronApp|1d|10:00
   socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
   socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h
   #socorro.cron.jobs.modulelist.ModulelistCronApp|1d

--- a/socorro/cron/jobs/matviews.py
+++ b/socorro/cron/jobs/matviews.py
@@ -190,3 +190,12 @@ class ExploitabilityCronApp(_MatViewBackfillBase):
         'build-adu-matview',
         'reports-clean'
     )
+
+
+class SignatureSummaryCronApp(_MatViewBackfillBase):
+    proc_name = 'update_signature_summary'
+    app_name = 'signature-summary-matview'
+    depends_on = (
+        'reports-clean',
+        'product-versions-matview'
+    )

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1082,6 +1082,83 @@ class SignatureProductsRollup(DeclarativeBase):
     signatures = relationship('Signature', primaryjoin='SignatureProductsRollup.signature_id==Signature.signature_id')
 
 
+class SignatureSummaryArchitecture(DeclarativeBase):
+    __tablename__ = 'signature_summary_architecture'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    architecture = Column(u'architecture', TEXT(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryFlashVersion(DeclarativeBase):
+    __tablename__ = 'signature_summary_flash_version'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    flash_version = Column(u'flash_version', TEXT(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryInstallations(DeclarativeBase):
+    __tablename__ = 'signature_summary_installations'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), primary_key=True, nullable=False)
+    version_string = Column(u'version_string', TEXT(), primary_key=True, nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    crash_count = Column(u'crash_count', INTEGER(), nullable=False)
+    install_count = Column(u'install_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryOS(DeclarativeBase):
+    __tablename__ = 'signature_summary_os'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    os_version_string = Column(u'os_version_string', TEXT(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryProcessType(DeclarativeBase):
+    __tablename__ = 'signature_summary_process_type'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    process_type = Column(u'process_type', TEXT(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryProducts(DeclarativeBase):
+    __tablename__ = 'signature_summary_products'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    version_string = Column(u'version_string', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
+class SignatureSummaryUptime(DeclarativeBase):
+    __tablename__ = 'signature_summary_uptime'
+
+    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    uptime_string = Column(u'uptime_string', TEXT(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_name = Column(u'product_name', TEXT(), nullable=False)
+    report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
+    report_count = Column(u'report_count', INTEGER(), nullable=False)
+
+
 class Skiplist(DeclarativeBase):
     __tablename__ = 'skiplist'
 

--- a/socorro/external/postgresql/raw_sql/procs/backfill_matviews.sql
+++ b/socorro/external/postgresql/raw_sql/procs/backfill_matviews.sql
@@ -81,6 +81,7 @@ WHILE thisday <= lastday LOOP
 	PERFORM backfill_nightly_builds(thisday);
 	RAISE INFO 'exploitability';
 	PERFORM backfill_exploitability(thisday);
+	PERFORM backfill_signature_summary(thisday);
 
 	thisday := thisday + 1;
 

--- a/socorro/external/postgresql/raw_sql/procs/backfill_signature_summary.sql
+++ b/socorro/external/postgresql/raw_sql/procs/backfill_signature_summary.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION backfill_signature_summary(updateday date) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+
+-- Deletes and replaces signature_summary for selected date
+
+DELETE FROM signature_summary_products
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_installations
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_uptime
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_os
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_process_type
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_architecture
+WHERE report_date = updateday;
+
+DELETE FROM signature_summary_flash_version
+WHERE report_date = updateday;
+
+PERFORM update_signature_summary(updateday, false);
+
+RETURN TRUE;
+
+END;$$;

--- a/socorro/external/postgresql/raw_sql/procs/update_signature_summary.sql
+++ b/socorro/external/postgresql/raw_sql/procs/update_signature_summary.sql
@@ -1,0 +1,200 @@
+CREATE OR REPLACE FUNCTION update_signature_summary(updateday date, checkdata boolean DEFAULT True)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SET client_min_messages to 'ERROR'
+ -- common options:  IMMUTABLE  STABLE  STRICT  SECURITY DEFINER
+AS $function$
+
+-- Provide signature_summary_* matviews which provide signature-specific
+-- rollups of interesting data
+
+BEGIN
+
+-- check if we've been run
+IF checkdata THEN
+	PERFORM 1 FROM signature_summary_products WHERE report_date = updateday LIMIT 1;
+	IF FOUND THEN
+		RAISE INFO 'signature_summary has already been run for %.',updateday;
+	END IF;
+END IF;
+
+-- tables needed:
+-- reports_clean
+-- product_versions
+-- os_versions
+-- flash_versions
+
+-- signature summary by products
+INSERT INTO signature_summary_products (
+    signature_id
+    , product_version_id
+    , product_name
+    , version_string
+    , report_count
+    , report_date
+)
+SELECT
+    signature_id
+    , product_version_id
+    , product_name
+    , version_string
+    , count(*) AS report_count
+    , updateday AS report_date
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY product_version_id, product_name, version_string, signature_id, updateday
+;
+
+-- signature summary by distinct_install
+INSERT into signature_summary_installations (
+    signature_id
+    , product_name
+    , version_string
+    , crash_count
+    , install_count
+    , report_date
+)
+SELECT
+    signature_id
+    , product_name
+    , version_string
+    , COUNT(*) AS crash_count
+    , COUNT(DISTINCT client_crash_date - install_age) as install_count
+    , updateday AS report_date
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY product_name, version_string, signature_id
+;
+
+-- uptime_string
+INSERT into signature_summary_uptime (
+    uptime_string
+    , signature_id
+    , product_name
+    , product_version_id
+    , report_count
+    , report_date
+)
+SELECT
+    uptime_string
+    , signature_id
+    , product_versions.product_name as product_name
+    , product_versions.product_version_id as product_version_id
+    , count(*) AS report_count
+    , updateday AS report_date
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+    JOIN uptime_levels ON
+        reports_clean.uptime >= min_uptime AND
+        reports_clean.uptime < max_uptime
+WHERE
+    date_processed::date = updateday
+GROUP BY
+    uptime_string, signature_id, product_versions.product_name, product_versions.product_version_id, report_date
+;
+
+-- os
+INSERT into signature_summary_os (
+    os_version_string
+    , signature_id
+    , product_name
+    , product_version_id
+    , report_count
+    , report_date
+)
+SELECT
+    os_version_string
+    , signature_id
+    , product_versions.product_name AS product_name
+    , product_versions.product_version_id AS product_version_id
+    , count(*) AS report_count
+    , updateday AS report_date
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+    JOIN os_versions USING (os_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY
+    os_version_string, signature_id, product_versions.product_name, product_versions.product_version_id, report_date
+;
+
+-- process_type
+INSERT into signature_summary_process_type (
+    process_type
+    , signature_id
+    , product_name
+    , product_version_id
+    , report_count
+    , report_date
+)
+SELECT
+    process_type
+    , signature_id
+    , product_versions.product_name AS product_name
+    , product_versions.product_version_id AS product_version_id
+    , count(*) AS report_count
+    , updateday AS report_date
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY
+    process_type, signature_id, product_versions.product_name, product_versions.product_version_id, report_date
+;
+-- architecture
+INSERT into signature_summary_architecture (
+    architecture
+    , signature_id
+    , product_name
+    , product_version_id
+    , report_date
+    , report_count
+)
+SELECT
+    architecture
+    , signature_id
+    , product_versions.product_name AS product_name
+    , product_versions.product_version_id AS product_version_id
+    , updateday AS report_date
+    , count(*) AS report_count
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY
+    architecture, signature_id, product_versions.product_name, product_versions.product_version_id, report_date
+;
+-- flash_version
+INSERT into signature_summary_flash_version (
+    flash_version
+    , signature_id
+    , product_name
+    , product_version_id
+    , report_date
+    , report_count
+)
+SELECT
+    CASE WHEN flash_version = '' THEN 'Unknown/No Flash' ELSE flash_version END
+    , signature_id
+    , product_versions.product_name AS product_name
+    , product_versions.product_version_id AS product_version_id
+    , updateday AS report_date
+    , count(*) AS report_count
+FROM reports_clean
+    JOIN product_versions USING (product_version_id)
+    LEFT OUTER JOIN flash_versions USING (flash_version_id)
+WHERE
+    date_processed::date = updateday
+GROUP BY
+    flash_version, signature_id, product_versions.product_name, product_versions.product_version_id, report_date
+;
+
+RETURN TRUE;
+
+END;
+$function$
+;


### PR DESCRIPTION
Creating signature summary tables to replace queries currently in the signature summary middleware service.

After this, we can update the middleware.
