### PR TITLE
Bug 897506 - Update forced versions for correlations for Firefox cycle starting 2013-08-06

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="23.0 24.0a2 25.0a1"
+MANUAL_VERSION_OVERRIDE="24.0 25.0a2 26.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 897506 - it should go to production the week of Aug 5 (not before!).
