### PR TITLE
fixes bug 897628 - Make a link to the public web API

### DIFF
--- a/webapp-django/crashstats/base/templates/crashstats_base.html
+++ b/webapp-django/crashstats/base/templates/crashstats_base.html
@@ -111,6 +111,7 @@
             </div>
             <ul>
                 <li><a href="{{ url('crashstats.status') }}">Server Status</a></li>
+                <li><a href="{{ url('api:documentation') }}">API Documentation</a></li>
                 <li><a href="http://socorro.readthedocs.org/">Project Info</a></li>
                 <li><a href="https://github.com/mozilla/socorro">Source Code</a></li>
                 <li><a href="http://wiki.mozilla.org/Breakpad">Breakpad Wiki</a></li>


### PR DESCRIPTION
Looks like this: http://cl.ly/QRLb
