### PR TITLE
fixes bug 899306 - RawCrash == ProcessedCrash === CrashData

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -668,20 +668,13 @@ class ReportList(SocorroMiddleware):
 
 
 class ProcessedCrash(SocorroMiddleware):
-    URL_PREFIX = '/crash_data/'
+    URL_PREFIX = '/crash_data/datatype/processed/'
 
     required_params = (
         'crash_id',
     )
-    possible_params = (
-        'format',
-    )
-    defaults = {
-        'format': 'processed',
-    }
     aliases = {
         'crash_id': 'uuid',
-        'format': 'datatype',
     }
 
     API_WHITELIST = (

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -893,7 +893,6 @@ class TestModels(TestCase):
 
         def mocked_get(url, **options):
             assert '/crash_data/' in url
-            ok_('/datatype/meta' in url)
             return Response("""
                 {
                   "InstallTime": "1339289895",

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -3021,16 +3021,16 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, **options):
             assert '/crash_data/' in url
-            if 'datatype/meta/' in url:
-                return Response("""
-                  {"foo": "bar",
-                   "stuff": 123}
-                """)
             if '/datatype/raw/' in url:
                 return Response("""
                   bla bla bla
                 """.strip())
-            raise NotImplementedError(url)
+            else:
+                # default is datatype/meta
+                return Response("""
+                  {"foo": "bar",
+                   "stuff": 123}
+                """)
 
         rget.side_effect = mocked_get
 
@@ -3051,7 +3051,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(dump_url)
         eq_(response.status_code, 200)
         eq_(response['Content-Type'], 'application/octet-stream')
-        ok_('bla bla bla' in response.content)
+        ok_('bla bla bla' in response.content, response.content)
 
         # dump files are cached.
         # check the mock function and expect no change

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1756,7 +1756,7 @@ def raw_data(request, crash_id, extension):
         format = 'meta'
         content_type = 'application/json'
     elif extension == 'dmp':
-        format = 'raw_crash'
+        format = 'raw'
         content_type = 'application/octet-stream'
     else:
         raise NotImplementedError(extension)


### PR DESCRIPTION
@rhelmer r?

So, for the `ProcessedCrash` you no longer have a choice to set `format=processed` because it's the only sensible default for that. 

For `RawCrash` you can still pass in whatever you like for format. `raw`, `meta` or `processed`. However, if you pass in `processed` you get the same output as `ProcessedCrash`. If you pass in `raw` what's stored better be a JSON looking thing or else the API will not let you have it. The only smart value for `format` is `meta` which is also the default. 

This patch only makes it slightly tidier. Not a huge improvement. It's only really a superficial thing for the API documentation. However, it fills in the default for you anyway. 
