### PR TITLE
allow more fields in processed and raw crash

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -712,6 +712,24 @@ class ProcessedCrash(SocorroMiddleware):
         'user_comments',
         'uuid',
         'version',
+        'install_age'
+        'startedDateTime',
+        'java_stack_trace',
+        'crashedThread',
+        'cpu_info',
+        'pluginVersion',
+        'hang_type',
+        'distributor',
+        'topmost_filenames',
+        'additional_minidumps',
+        'processor_notes',
+        'app_notes',
+        'crash_time',
+        'Winsock_LSP',
+        'productid',
+        'pluginFilename',
+        'pluginName',
+        'addons',
     )
 
     API_CLEAN_SCRUB = (
@@ -802,6 +820,7 @@ class RawCrash(SocorroMiddleware):
         'Android_Manufacturer',
         'Android_CPU_ABI',
         'Android_CPU_ABI2',
+        'throttle_rate',
     )
 
     def get(self, **kwargs):


### PR DESCRIPTION
@bsmedberg @rhelmer

I did some poking around at the fields that we filter out in the `ProcessedCrash` and `RawCrash` endpoints of a randomly picked crash. 

They all seem so innocent that I couldn't imagine they'd ever contain any PII and missing them out would be a shame in case somebody needs them. 

Also, I wrote down what the values (if parsed) were for all these new fields for this particular crash in case that helps:

```
IN PROCESSED CRASH
------------------

'install_age': VALUE 11231
'startedDateTime': VALUE u'2013-07-29 22:23:12.214943'
'java_stack_trace': VALUE None
'crashedThread': VALUE 0
'cpu_info': VALUE u'family 6 model 37 stepping 5 | 4'
'pluginVersion': VALUE None
'hang_type': VALUE 0
'distributor': VALUE None
'topmost_filenames': VALUE u'/builds/slave/m-in-osx64-0000000000000000000/build/obj-firefox/x86_64/memory/mozalloc/../../../../memory/mozalloc/mozalloc.cpp'
'additional_minidumps': VALUE []
'processor_notes': VALUE u'socorro1_dev_dmz_phx1_mozilla_com_19191:2012; exploitability tool failed: 127'
'app_notes': VALUE u'AdapterVendorID: 0x8086, AdapterDeviceID: 0x  46GL Layers? GL Context? GL Context+ GL Layers+ '
'crash_time': VALUE 1366703112
'Winsock_LSP': VALUE None
'productid': VALUE u'{ec8030f7-c20a-464f-9b0e-13a3a9e97384}'
'pluginFilename': VALUE None
'pluginName': VALUE None
'addons': VALUE [[u'activities@gaiamobile.org', u'0.1'], [u'alarms@gaiamobile.org', u'0.1'], [u'keyboard@gaiamobile.org', u'0.1'], [u'{972ce4c6-7e08-4474-a285-3208198ce$



IN RAW CRASH
---------------

'throttle_rate': VALUE 100
```
