### PR TITLE
fixes bug 896000 - Install Configman from pypi instead of GH

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-git+git://github.com/mozilla/configman@c2179c80be74b1ecb4a6f9c837993d2ce8d4926b#egg=configman
+configman==1.1.4
 configobj==4.7.2
 hbase-thrift==0.20.4
 isodate==0.4.7


### PR DESCRIPTION
@twobraids r?

Let's see if all tests pass. 
1.1.4 is cut the nearest c2179c80be74b1ecb4a6f9c837993d2ce8d4926b I could
