### PR TITLE
Fixes bug 899641 Specify Windows 8.1

### DIFF
--- a/alembic/versions/2645cb324bf4_bug_899641_support_w.py
+++ b/alembic/versions/2645cb324bf4_bug_899641_support_w.py
@@ -51,13 +51,13 @@ def upgrade():
     op.execute("""
         INSERT INTO windows_versions
         (windows_version_name, major_version, minor_version)
-        VALUES('Windows 8', 6, 3)
+        VALUES('Windows 8.1', 6, 3)
     """)
 
 def downgrade():
     op.execute("""
         DELETE FROM windows_versions
-        WHERE windows_version_name = 'Windows 8'
+        WHERE windows_version_name = 'Windows 8.1'
         AND major_version = 6
         AND  minor_version = 3
     """)


### PR DESCRIPTION
Oops! Needed to specify a _new_ Windows version.
