### PR TITLE
Fixes 902142 - adds support for partitioning matviews

### DIFF
--- a/alembic/versions/36abe253f8b3_fixes_902142_partiti.py
+++ b/alembic/versions/36abe253f8b3_fixes_902142_partiti.py
@@ -1,0 +1,199 @@
+"""Fixes 902142 partition matviews
+
+Revision ID: 36abe253f8b3
+Revises: 2645cb324bf4
+Create Date: 2013-08-07 10:17:05.769404
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '36abe253f8b3'
+down_revision = '2645cb324bf4'
+
+import os
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy import types
+from sqlalchemy.sql import table, column
+
+
+class CITEXT(types.UserDefinedType):
+    name = 'citext'
+
+    def get_col_spec(self):
+        return 'CITEXT'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return "citext"
+
+class JSON(types.UserDefinedType):
+    name = 'json'
+
+    def get_col_spec(self):
+        return 'JSON'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return "json"
+
+def upgrade():
+    op.add_column(u'report_partition_info', sa.Column(u'partition_column', sa.TEXT()))
+
+    # Drop FK constraints on parent tables
+    op.drop_constraint('signature_summary_architecture_product_version_id_fkey', 'signature_summary_architecture')
+    op.drop_constraint('signature_summary_architecture_signature_id_fkey', 'signature_summary_architecture')
+    op.drop_constraint('signature_summary_flash_version_product_version_id_fkey', 'signature_summary_flash_version')
+    op.drop_constraint('signature_summary_flash_version_signature_id_fkey', 'signature_summary_flash_version')
+    op.drop_constraint('signature_summary_installations_signature_id_fkey', 'signature_summary_installations')
+    op.drop_constraint('signature_summary_os_product_version_id_fkey', 'signature_summary_os')
+    op.drop_constraint('signature_summary_os_signature_id_fkey', 'signature_summary_os')
+    op.drop_constraint('signature_summary_process_type_product_version_id_fkey', 'signature_summary_process_type')
+    op.drop_constraint('signature_summary_process_type_signature_id_fkey', 'signature_summary_process_type')
+    op.drop_constraint('signature_summary_products_product_version_id_fkey', 'signature_summary_products')
+    op.drop_constraint('signature_summary_products_signature_id_fkey', 'signature_summary_products')
+    op.drop_constraint('signature_summary_uptime_product_version_id_fkey', 'signature_summary_uptime')
+    op.drop_constraint('signature_summary_uptime_signature_id_fkey', 'signature_summary_uptime')
+
+    app_path=os.getcwd()
+    procs = ['weekly_report_partitions.sql',
+             'backfill_weekly_report_partitions.sql']
+    for myfile in [app_path + '/socorro/external/postgresql/raw_sql/procs/' + line for line in procs]:
+        proc = open(myfile, 'r').read()
+        op.execute(proc)
+    # Now run this against the raw_crashes table
+    op.execute("""
+        UPDATE report_partition_info
+        SET partition_column = 'date_processed'
+    """)
+
+    report_partition_info = table(u'report_partition_info',
+        column(u'build_order', sa.INTEGER()),
+        column(u'fkeys', postgresql.ARRAY(sa.TEXT())),
+        column(u'indexes', postgresql.ARRAY(sa.TEXT())),
+        column(u'keys', postgresql.ARRAY(sa.TEXT())),
+        column(u'table_name', CITEXT()),
+        column(u'partition_column', sa.TEXT()),
+    )
+    op.bulk_insert(report_partition_info, [
+            {'table_name':  u'signature_summary_installations',
+             'build_order': 5,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id,product_name,version_string,report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_architecture',
+             'build_order': 6,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, architecture, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_flash_version',
+             'build_order': 7,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, flash_version, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_os',
+             'build_order': 8,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, os_version_string, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_process_type',
+             'build_order': 9,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, process_type, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_products',
+             'build_order': 10,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+            {'table_name':  u'signature_summary_uptime',
+             'build_order': 11,
+             'fkeys': ["(signature_id) REFERENCES signatures(signature_id)", "(product_version_id) REFERENCES product_versions(product_version_id)"],
+             'partition_column': 'report_date',
+             'keys': ["signature_id, uptime_string, product_version_id, report_date"],
+             'indexes': ["report_date"],
+            },
+    ])
+
+    op.alter_column(u'report_partition_info', u'partition_column',
+               existing_type=sa.TEXT(),
+               nullable=False)
+
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_architecture')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_flash_version')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_installations')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_os')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_process_type')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_products')
+    """)
+    op.execute("""
+        SELECT backfill_weekly_report_partitions('2013-06-03', '2013-08-12', 'signature_summary_uptime')
+    """)
+
+def downgrade():
+    op.execute("""
+        DELETE from report_partition_info
+        WHERE table_name ~ '^signature_summary_'
+    """)
+    op.drop_column(u'report_partition_info', u'partition_column')
+
+    # Drop all child tables (?)
+    op.execute("""
+        DO  $$DECLARE mytable record;
+        BEGIN
+            FOR mytable IN SELECT relname FROM pg_class
+                WHERE relname ~ '^signature_summary_*201*' and relkind = 'r'
+            LOOP
+                EXECUTE 'DROP TABLE ' || quote_ident(mytable.relname) || ' CASCADE';
+            END LOOP;
+        END$$
+    """)
+
+    # Drop FK constraints on parent tables
+    op.create_foreign_key('signature_summary_architecture_product_version_id_fkey', 'signature_summary_architecture', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_architecture_signature_id_fkey', 'signature_summary_architecture', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_flash_version_product_version_id_fkey', 'signature_summary_flash_version', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_flash_version_signature_id_fkey', 'signature_summary_flash_version', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_installations_signature_id_fkey', 'signature_summary_installations', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_os_product_version_id_fkey', 'signature_summary_os', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_os_signature_id_fkey', 'signature_summary_os', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_process_type_product_version_id_fkey', 'signature_summary_process_type', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_process_type_signature_id_fkey', 'signature_summary_process_type', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_products_product_version_id_fkey', 'signature_summary_products', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_products_signature_id_fkey', 'signature_summary_products', 'signatures', ["signature_id"], ["signature_id"])
+    op.create_foreign_key('signature_summary_uptime_product_version_id_fkey', 'signature_summary_uptime', 'product_versions', ["product_version_id"], ["product_version_id"])
+    op.create_foreign_key('signature_summary_uptime_signature_id_fkey', 'signature_summary_uptime', 'signatures', ["signature_id"], ["signature_id"])

--- a/socorro/external/postgresql/fakedata.py
+++ b/socorro/external/postgresql/fakedata.py
@@ -660,18 +660,25 @@ class CrashTypes(BaseTable):
 
 class ReportPartitionInfo(BaseTable):
     table = 'report_partition_info'
-    columns = ['table_name', 'build_order', 'keys', 'indexes', 'fkeys']
+    columns = ['table_name', 'build_order', 'keys', 'indexes',
+               'fkeys', 'partition_column']
     rows = [['reports', '1', '{id,uuid}',
              '{date_processed,hangid,"product,version",reason,signature,url}',
-             '{}'],
+             '{}', 'date_processed'],
             ['plugins_reports', '2', '{"report_id,plugin_id"}',
              '{"report_id,date_processed"}',
              ('{"(plugin_id) REFERENCES plugins(id)","(report_id)'
-              ' REFERENCES reports_WEEKNUM(id)"}')],
+              ' REFERENCES reports_WEEKNUM(id)"}'), 'date_processed'],
             ['extensions', '3', '{"report_id,extension_key"}',
              '{"report_id,date_processed"}',
-             '{"(report_id) REFERENCES reports_WEEKNUM(id)"}'],
-            ['raw_crashes', '4', '{uuid}', '{}', '{}']]
+             '{"(report_id) REFERENCES reports_WEEKNUM(id)"}',
+             'date_processed'],
+            ['raw_crashes', '4', '{uuid}', '{}', '{}', 'date_processed'],
+            ['signature_summary_installations', '5',
+             '{"signature_id,product_name,version_string,report_date"}',
+            '{}',
+            '{"(signature_id) REFERENCES signatures(signature_id)"}', 'report_date' ]]
+
 
 class Skiplist(BaseTable):
     table = 'skiplist'

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -961,6 +961,7 @@ class ReportPartitionInfo(DeclarativeBase):
     indexes = Column(u'indexes', ARRAY(TEXT()), nullable=False, server_default=text("'{}'::text[]"))
     keys = Column(u'keys', ARRAY(TEXT()), nullable=False, server_default=text("'{}'::text[]"))
     table_name = Column(u'table_name', CITEXT(), primary_key=True, nullable=False)
+    partition_column = Column(u'partition_column', TEXT(), nullable=False)
 
 
 class ReportsClean(DeclarativeBase):
@@ -1085,9 +1086,9 @@ class SignatureProductsRollup(DeclarativeBase):
 class SignatureSummaryArchitecture(DeclarativeBase):
     __tablename__ = 'signature_summary_architecture'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     architecture = Column(u'architecture', TEXT(), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
     report_count = Column(u'report_count', INTEGER(), nullable=False)
@@ -1096,9 +1097,9 @@ class SignatureSummaryArchitecture(DeclarativeBase):
 class SignatureSummaryFlashVersion(DeclarativeBase):
     __tablename__ = 'signature_summary_flash_version'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     flash_version = Column(u'flash_version', TEXT(), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
     report_count = Column(u'report_count', INTEGER(), nullable=False)
@@ -1107,7 +1108,7 @@ class SignatureSummaryFlashVersion(DeclarativeBase):
 class SignatureSummaryInstallations(DeclarativeBase):
     __tablename__ = 'signature_summary_installations'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), primary_key=True, nullable=False)
     version_string = Column(u'version_string', TEXT(), primary_key=True, nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
@@ -1118,9 +1119,9 @@ class SignatureSummaryInstallations(DeclarativeBase):
 class SignatureSummaryOS(DeclarativeBase):
     __tablename__ = 'signature_summary_os'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     os_version_string = Column(u'os_version_string', TEXT(), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
     report_count = Column(u'report_count', INTEGER(), nullable=False)
@@ -1129,9 +1130,9 @@ class SignatureSummaryOS(DeclarativeBase):
 class SignatureSummaryProcessType(DeclarativeBase):
     __tablename__ = 'signature_summary_process_type'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     process_type = Column(u'process_type', TEXT(), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
     report_count = Column(u'report_count', INTEGER(), nullable=False)
@@ -1140,8 +1141,8 @@ class SignatureSummaryProcessType(DeclarativeBase):
 class SignatureSummaryProducts(DeclarativeBase):
     __tablename__ = 'signature_summary_products'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     version_string = Column(u'version_string', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
@@ -1151,9 +1152,9 @@ class SignatureSummaryProducts(DeclarativeBase):
 class SignatureSummaryUptime(DeclarativeBase):
     __tablename__ = 'signature_summary_uptime'
 
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey('signatures.signature_id'), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=True, nullable=False)
     uptime_string = Column(u'uptime_string', TEXT(), primary_key=True, nullable=False)
-    product_version_id = Column(u'product_version_id', INTEGER(), ForeignKey('product_versions.product_version_id'), primary_key=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), primary_key=True, nullable=False)
     product_name = Column(u'product_name', TEXT(), nullable=False)
     report_date = Column(u'report_date', DATE(), primary_key=True, nullable=False, index=True)
     report_count = Column(u'report_count', INTEGER(), nullable=False)

--- a/socorro/external/postgresql/raw_sql/procs/backfill_weekly_report_partitions.sql
+++ b/socorro/external/postgresql/raw_sql/procs/backfill_weekly_report_partitions.sql
@@ -11,26 +11,27 @@ AS $$
 -- Controlled by the data in the reports_partition_info table
 --
 DECLARE
-	thisweek DATE;
-	tabinfo RECORD;
+    thisweek DATE;
+    tabinfo RECORD;
 BEGIN
-	thisweek := date_trunc('week', startweek)::date;
+    thisweek := date_trunc('week', startweek)::date;
 
-	SELECT INTO tabinfo * FROM report_partition_info
+    SELECT INTO tabinfo * FROM report_partition_info
         WHERE table_name = tablename LIMIT 1;
 
-	WHILE thisweek <= endweek LOOP
+    WHILE thisweek <= endweek LOOP
         PERFORM create_weekly_partition (
             tablename := tabinfo.table_name,
             theweek := thisweek,
             uniques := tabinfo.keys,
             indexes := tabinfo.indexes,
             fkeys := tabinfo.fkeys,
-            tableowner := 'breakpad_rw'
+            tableowner := 'breakpad_rw',
+            partcol := tabinfo.partition_column
         );
         thisweek := thisweek + 7;
-	END LOOP;
+    END LOOP;
 
-	RETURN TRUE;
+    RETURN TRUE;
 END; $$;
 

--- a/socorro/external/postgresql/raw_sql/procs/create_weekly_partition.sql
+++ b/socorro/external/postgresql/raw_sql/procs/create_weekly_partition.sql
@@ -2,9 +2,9 @@ CREATE OR REPLACE FUNCTION create_weekly_partition(tablename citext, theweek dat
     LANGUAGE plpgsql
     AS $_$
 DECLARE dex INT := 1;
-	thispart TEXT;
-	zonestring TEXT := '';
-	fkstring TEXT;
+    thispart TEXT;
+    zonestring TEXT := '';
+    fkstring TEXT;
 BEGIN
 -- this function allows you to create a new weekly partition
 -- of an existing master table.  it checks if the table is already
@@ -13,56 +13,56 @@ BEGIN
 -- currently only handles single-column indexes and unique declarations
 -- supports date, timestamp, timestamptz/utc through the various options
 
-	thispart := tablename || '_' || to_char(theweek, 'YYYYMMDD');
-	
-	PERFORM 1 FROM pg_stat_user_tables
-	WHERE relname = thispart;
-	IF FOUND THEN
-		RETURN TRUE;
-	END IF;
-	
-	IF is_utc THEN
-		timetype := ' TIMESTAMP';
-		zonestring := ' AT TIME ZONE UTC ';
-	END IF;
-	
-	EXECUTE 'CREATE TABLE ' || thispart || ' ( CONSTRAINT ' || thispart 
-		|| '_date_check CHECK ( ' || partcol || ' BETWEEN ' 
-		|| timetype || ' ' || quote_literal(to_char(theweek, 'YYYY-MM-DD'))
-		|| ' AND ' || timetype || ' ' 
-		|| quote_literal(to_char(theweek + 7, 'YYYY-MM-DD'))
-		|| ' ) ) INHERITS ( ' || tablename || ');';
-	
-	IF tableowner <> '' THEN
-		EXECUTE 'ALTER TABLE ' || thispart || ' OWNER TO ' || tableowner;
-	END IF;
-	
-	dex := 1;
-	WHILE uniques[dex] IS NOT NULL LOOP
-		EXECUTE 'CREATE UNIQUE INDEX ' || thispart || '_'
-		|| regexp_replace(uniques[dex], $$[,\s]+$$, '_', 'g') 
-		|| ' ON ' || thispart || '(' || uniques[dex] || ')';
-		dex := dex + 1;
-	END LOOP;
-	
-	dex := 1;
-	WHILE indexes[dex] IS NOT NULL LOOP
-		EXECUTE 'CREATE INDEX ' || thispart || '_' 
-		|| regexp_replace(indexes[dex], $$[,\s]+$$, '_', 'g') 
-		|| ' ON ' || thispart || '(' || indexes[dex] || ')';
-		dex := dex + 1;
-	END LOOP;
-	
-	dex := 1;
-	WHILE fkeys[dex] IS NOT NULL LOOP
-		fkstring := regexp_replace(fkeys[dex], 'WEEKNUM', to_char(theweek, 'YYYYMMDD'), 'g');
-		EXECUTE 'ALTER TABLE ' || thispart || ' ADD CONSTRAINT ' 
-			|| thispart || '_fk_' || dex || ' FOREIGN KEY '
-			|| fkstring || ' ON DELETE CASCADE ON UPDATE CASCADE';
-		dex := dex + 1;
-	END LOOP;
-	
-	RETURN TRUE;
+    thispart := tablename || '_' || to_char(theweek, 'YYYYMMDD');
+
+    PERFORM 1 FROM pg_stat_user_tables
+    WHERE relname = thispart;
+    IF FOUND THEN
+        RETURN TRUE;
+    END IF;
+
+    IF is_utc THEN
+        timetype := ' TIMESTAMP';
+        zonestring := ' AT TIME ZONE UTC ';
+    END IF;
+
+    EXECUTE 'CREATE TABLE ' || thispart || ' ( CONSTRAINT ' || thispart
+        || '_date_check CHECK ( ' || partcol || ' BETWEEN '
+        || timetype || ' ' || quote_literal(to_char(theweek, 'YYYY-MM-DD'))
+        || ' AND ' || timetype || ' '
+        || quote_literal(to_char(theweek + 7, 'YYYY-MM-DD'))
+        || ' ) ) INHERITS ( ' || tablename || ');';
+
+    IF tableowner <> '' THEN
+        EXECUTE 'ALTER TABLE ' || thispart || ' OWNER TO ' || tableowner;
+    END IF;
+
+    dex := 1;
+    WHILE uniques[dex] IS NOT NULL LOOP
+        EXECUTE 'CREATE UNIQUE INDEX ' || thispart ||'_'
+        || regexp_replace(uniques[dex], $$[,(\s]+$$, '_', 'g')
+        || ' ON ' || thispart || '(' || uniques[dex] || ')';
+        dex := dex + 1;
+    END LOOP;
+
+    dex := 1;
+    WHILE indexes[dex] IS NOT NULL LOOP
+        EXECUTE 'CREATE INDEX ' || thispart || '_'
+        || regexp_replace(indexes[dex], $$[,\s]+$$, '_', 'g')
+        || ' ON ' || thispart || '(' || indexes[dex] || ')';
+        dex := dex + 1;
+    END LOOP;
+
+    dex := 1;
+    WHILE fkeys[dex] IS NOT NULL LOOP
+        fkstring := regexp_replace(fkeys[dex], 'WEEKNUM', to_char(theweek, 'YYYYMMDD'), 'g');
+        EXECUTE 'ALTER TABLE ' || thispart || ' ADD CONSTRAINT '
+            || thispart || '_fk_' || dex || ' FOREIGN KEY '
+            || fkstring || ' ON DELETE CASCADE ON UPDATE CASCADE';
+        dex := dex + 1;
+    END LOOP;
+
+    RETURN TRUE;
 END;
 $_$;
 

--- a/socorro/external/postgresql/raw_sql/procs/weekly_report_partitions.sql
+++ b/socorro/external/postgresql/raw_sql/procs/weekly_report_partitions.sql
@@ -6,34 +6,34 @@ CREATE OR REPLACE FUNCTION weekly_report_partitions(numweeks integer DEFAULT 2, 
 -- reports
 -- designed to be called as a cronjob once a week
 -- controlled by the data in the reports_partition_info table
-DECLARE 
-	thisweek DATE;
-	dex INT := 1;
-	weeknum INT := 0;
-	tabinfo RECORD;
+DECLARE
+    thisweek DATE;
+    dex INT := 1;
+    weeknum INT := 0;
+    tabinfo RECORD;
 BEGIN
-	targetdate := COALESCE(targetdate, now());
-	thisweek := date_trunc('week', targetdate)::date;
-	
-	WHILE weeknum <= numweeks LOOP
-		FOR tabinfo IN SELECT * FROM report_partition_info
-			ORDER BY build_order LOOP
-			
-			PERFORM create_weekly_partition ( 
-				tablename := tabinfo.table_name,
-				theweek := thisweek,
-				uniques := tabinfo.keys,
-				indexes := tabinfo.indexes,
-				fkeys := tabinfo.fkeys,
-				tableowner := 'breakpad_rw'
-			);
+    targetdate := COALESCE(targetdate, now());
+    thisweek := date_trunc('week', targetdate)::date;
 
-		END LOOP;
-		weeknum := weeknum + 1;
-		thisweek := thisweek + 7;
-	END LOOP;
+    WHILE weeknum <= numweeks LOOP
+        FOR tabinfo IN SELECT * FROM report_partition_info
+            ORDER BY build_order LOOP
 
-	RETURN TRUE;
-	
+            PERFORM create_weekly_partition (
+                tablename := tabinfo.table_name,
+                theweek := thisweek,
+                uniques := tabinfo.keys,
+                indexes := tabinfo.indexes,
+                fkeys := tabinfo.fkeys,
+                tableowner := 'breakpad_rw',
+                partcol := tabinfo.partition_column
+            );
+
+        END LOOP;
+        weeknum := weeknum + 1;
+        thisweek := thisweek + 7;
+    END LOOP;
+
+    RETURN TRUE;
+
 END; $$;
-


### PR DESCRIPTION
This is a performance enhancement for the signature_summary reports and adds support for any matviews that we'd like to partition in the future. 
- Includes a migration that drops foreign keys on  parent signature_summary tables
- Downgrade restores the FKs
- Also runs backfill_weekly_partitions() for signature_summary tables
