### PR TITLE
fixes Bug 896000 - get configman from pypi instead of github

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-git+git://github.com/mozilla/configman@c2179c80be74b1ecb4a6f9c837993d2ce8d4926b#egg=configman
+configman==1.1.7
 configobj==4.7.2
 hbase-thrift==0.20.4
 isodate==0.4.7

--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -16,6 +16,7 @@ import json
 import copy
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
+from configman.config_exceptions import CannotConvertError
 from socorro.database.transaction_executor import TransactionExecutor
 from socorro.external.postgresql.connection_context import ConnectionContext
 from socorro.app.generic_app import App, main
@@ -304,7 +305,7 @@ def classes_in_namespaces_converter_with_compression(
                     a_class = class_converter(
                         class_extractor(class_list_element)
                     )
-                except AttributeError:
+                except (AttributeError, CannotConvertError):
                     raise JobNotFoundError(class_list_element)
                 class_list.append((a_class.__name__, a_class))
                 # figure out the Namespace name

--- a/socorro/lib/ConfigurationManager.py
+++ b/socorro/lib/ConfigurationManager.py
@@ -190,6 +190,7 @@ class Config (dict):
       options, ignoreArgs = getopt.getopt(sys.argv[1:], self.internal.singleLetterCommandLineOptionsForGetopt, self.internal.expandedCommandLineOptionsForGetopt)
     except getopt.GetoptError, e:
       pass  #TODO - temporary measure
+      options = []
       #raise NotAnOptionError, e
     commandLineEnvironment = {} # save these options for merging later
     for x in options:

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -393,12 +393,18 @@ class LegacyCrashProcessor(RequiredConfig):
         if not self.config.save_mdsw_json:
             try:
                 del processed_crash['json_dump']
-            except KeyError:
+            except (AttributeError, KeyError):
+                # if a processed crash is represented as DotDict is will
+                # likely raise an AttributeError, if instead, it is a regular
+                # dict object, it will be a Key Error.
                 pass
             for a_dump_name in processed_crash.additional_minidumps:
                 try:
                     del processed_crash[a_dump_name]['json_dump']
-                except KeyError:
+                except (AttributeError, KeyError):
+                    # if a processed crash is represented as DotDict is will
+                    # likely raise an AttributeError, if instead, it is a
+                    # regular dict object, it will be a Key Error.
                     pass
 
         self._log_job_end(

--- a/socorro/unittest/cron/base.py
+++ b/socorro/unittest/cron/base.py
@@ -12,6 +12,7 @@ import psycopg2
 from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 
 from configman import ConfigurationManager
+from configman.dotdict import DotDict
 from socorro.cron import crontabber
 from socorro.unittest.config.commonconfig import (
     databaseHost,

--- a/socorro/unittest/cron/jobs/test_cleanup_radix.py
+++ b/socorro/unittest/cron/jobs/test_cleanup_radix.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 import mock
 import shutil
 import os
@@ -55,9 +54,8 @@ class TestCleanupRadix(TestCaseBase):
         config_manager, json_file = _super(
             'socorro.cron.jobs.cleanup_radix.RadixCleanupCronApp|1d',
             {
-                'crontabber.class-RadixCleanupCronApp.storage0': {
-                    'crashstorage_class': FSDatedRadixTreeStorage
-                }
+                'crontabber.class-RadixCleanupCronApp.dated_storage_classes':
+                    'socorro.external.fs.crashstorage.FSDatedRadixTreeStorage'
             }
         )
         return config_manager, json_file

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -395,24 +395,22 @@ class TestMiddlewareApp(unittest.TestCase):
                 middleware_app.ImplementationConfigurationError,
                 app.main
             )
-
-        default = (middleware_app.MiddlewareApp.required_config
-                   .implementations.implementation_list.default)
-        prev_impl_list = ', '.join('%s: %s' % (x, y) for (x, y) in default)
-        default_overrides = (
+        default_impl_list_as_str = (
             middleware_app.MiddlewareApp.required_config
-            .implementations.service_overrides.default
+                .implementations.implementation_list.default
         )
-        prev_overrides_list = (
-            ', '.join('%s: %s' % (x, y) for (x, y) in default_overrides)
+
+        default_overrides_list_as_str = (
+            middleware_app.MiddlewareApp.required_config
+                .implementations.service_overrides.default
         )
 
         config_manager = self._setup_config_manager({
             'implementations.service_overrides': (
-                prev_overrides_list + ', Crash: testy'
+                default_overrides_list_as_str + ', Crash: testy'
             ),
             'implementations.implementation_list': (
-                prev_impl_list + ', testy: socorro.uTYPO.middleware'
+                default_impl_list_as_str + ', testy: socorro.uTYPO.middleware'
             )
         })
 
@@ -422,10 +420,11 @@ class TestMiddlewareApp(unittest.TestCase):
 
         config_manager = self._setup_config_manager({
             'implementations.service_overrides': (
-                prev_overrides_list + ', Crash: testy'
+                default_overrides_list_as_str + ', Crash: testy'
             ),
             'implementations.implementation_list': (
-                prev_impl_list + ', testy: socorro.unittest.middleware'
+                default_impl_list_as_str +
+                    ', testy: socorro.unittest.middleware'
             )
         })
 
@@ -438,9 +437,8 @@ class TestMiddlewareApp(unittest.TestCase):
             self.assertEqual(response.data, ['all', 'your', 'base'])
 
     def test_overriding_implementation_class_at_runtime(self):
-        default = (middleware_app.MiddlewareApp.required_config
-                   .implementations.implementation_list.default)
-        prev_impl_list = ', '.join('%s: %s' % (x, y) for (x, y) in default)
+        prev_impl_list = (middleware_app.MiddlewareApp.required_config
+                          .implementations.implementation_list.default)
 
         config_manager = self._setup_config_manager({
             'implementations.implementation_list': (


### PR DESCRIPTION
move to the latest version of configman

this includes several changes to unittests.  Versions of configman prior to 1.1.7 had the unfortunate side effect of changing the default values in the 'required_config' class variables of configman enabled classes.  Version 1.1.7 corrects that side effect by always insuring that the 'required_config' is safely copied.  Several unit tests relied on the side effect.
