### PR TITLE
Fixes Bug 906013: make use of transaction executor consistent

### DIFF
--- a/socorro/database/transaction_executor.py
+++ b/socorro/database/transaction_executor.py
@@ -7,6 +7,13 @@ import time
 from configman.config_manager import RequiredConfig
 from configman import Namespace
 
+#------------------------------------------------------------------------------
+def string_to_list_of_ints(a_string):
+    a_string = a_string.replace('"', '')
+    a_string = a_string.replace("'", "")
+    ints_as_strings = a_string.split(',')
+    return [int(x) for x in ints_as_strings]
+
 
 #==============================================================================
 class TransactionExecutor(RequiredConfig):
@@ -45,13 +52,12 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
     # back off times
     required_config = Namespace()
     required_config.add_option('backoff_delays',
-                               default=[10, 30, 60, 120, 300, 300, 300, 300,
-                                        300, 300],
+                               default="10, 30, 60, 120, 300",
                                doc='delays in seconds between retries',
-                               from_string_converter=eval)
+                               from_string_converter=string_to_list_of_ints)
     # wait_log_interval
     required_config.add_option('wait_log_interval',
-                               default=1,
+                               default=10,
                                doc='seconds between log during retries')
 
     #--------------------------------------------------------------------------

--- a/socorro/external/elasticsearch/crashstorage.py
+++ b/socorro/external/elasticsearch/crashstorage.py
@@ -11,12 +11,12 @@ from socorro.external.crashstorage_base import (
     CrashStorageBase,
     CrashIDNotFound
 )
-from socorro.database.transaction_executor import (
-    TransactionExecutorWithLimitedBackoff
-)
 from socorro.lib import datetimeutil
 
-from configman import Namespace
+from configman import (
+    Namespace,
+    class_converter
+)
 
 
 # Temporary solution, this is going to be introduced into configman
@@ -34,8 +34,10 @@ class ElasticSearchCrashStorage(CrashStorageBase):
 
     required_config = Namespace()
     required_config.add_option('transaction_executor_class',
-                               default=TransactionExecutorWithLimitedBackoff,
-                               doc='a class that will manage transactions')
+                               default="socorro.database.transaction_executor."
+                                    "TransactionExecutorWithInfiniteBackoff",
+                               doc='a class that will manage transactions',
+                               from_string_converter=class_converter)
     required_config.add_option('elasticsearch_urls',
                                doc='the urls to the elasticsearch instances '
                                '(leave blank to disable)',

--- a/socorro/external/hb/crashstorage.py
+++ b/socorro/external/hb/crashstorage.py
@@ -10,7 +10,6 @@ import os
 
 from socorro.external.crashstorage_base import (
     CrashStorageBase, CrashIDNotFound)
-from socorro.database.transaction_executor import TransactionExecutor
 from socorro.external.hb.connection_context import \
      HBaseConnectionContext
 from socorro.lib.util import DotDict
@@ -74,7 +73,8 @@ class HBaseCrashStorage(CrashStorageBase):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default=TransactionExecutor,
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will execute transactions',
         from_string_converter=class_converter
     )

--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -10,9 +10,9 @@ from socorro.external.crashstorage_base import (
     CrashStorageBase,
     CrashIDNotFound
 )
-from configman import Namespace
-from socorro.database.transaction_executor import (
-    TransactionExecutor
+from configman import (
+    Namespace,
+    class_converter
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
 from socorro.lib.datetimeutil import uuid_to_date
@@ -34,9 +34,10 @@ class PostgreSQLCrashStorage(CrashStorageBase):
     required_config = Namespace()
 
     required_config.add_option('transaction_executor_class',
-                               #default=TransactionExecutorWithBackoff,
-                               default=TransactionExecutor,
-                               doc='a class that will manage transactions')
+                               default="socorro.database.transaction_executor."
+                                    "TransactionExecutorWithInfiniteBackoff",
+                               doc='a class that will manage transactions',
+                               from_string_converter=class_converter)
     required_config.add_option('database_class',
                                default=ConnectionContext,
                                doc='the class responsible for connecting to'

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -8,12 +8,13 @@ from Queue import (
     Empty
 )
 
-from configman import Namespace
+from configman import (
+    Namespace,
+    class_converter
+)
 from socorro.external.rabbitmq.connection_context import (
     ConnectionContextPooled
 )
-from socorro.database.transaction_executor import \
-    TransactionExecutorWithInfiniteBackoff
 from socorro.external.crashstorage_base import (
     CrashStorageBase,
 )
@@ -46,8 +47,10 @@ class RabbitMQCrashStorage(CrashStorageBase):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default=TransactionExecutorWithInfiniteBackoff,
-        doc='Transaction wrapper class'
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
+        doc='a class that will manage transactions',
+        from_string_converter=class_converter
     )
     required_config.add_option(
         'routing_key',

--- a/socorro/processor/bixie_processor.py
+++ b/socorro/processor/bixie_processor.py
@@ -14,7 +14,6 @@ from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorro.database.transaction_executor import TransactionExecutor
 from socorro.lib.transform_rules import TransformRuleSystem
 
 
@@ -32,7 +31,8 @@ class BixieProcessor(RequiredConfig):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default=TransactionExecutor,
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will manage transactions',
         from_string_converter=class_converter
     )

--- a/socorro/processor/legacy_new_crash_source.py
+++ b/socorro/processor/legacy_new_crash_source.py
@@ -11,7 +11,6 @@ from socorro.external.postgresql.dbapi2_util import (
     single_value_sql
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorro.database.transaction_executor import TransactionExecutor
 from socorro.lib.datetimeutil import utc_now
 
 
@@ -29,7 +28,8 @@ class LegacyNewCrashSource(RequiredConfig):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default=TransactionExecutor,
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will manage transactions',
         from_string_converter=class_converter
     )

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -22,7 +22,6 @@ from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorro.database.transaction_executor import TransactionExecutor
 from socorro.lib.transform_rules import TransformRuleSystem
 from socorro.lib.datetimeutil import datetimeFromISOdateString, UTC
 from socorro.lib.ooid import dateFromOoid
@@ -56,7 +55,8 @@ class LegacyCrashProcessor(RequiredConfig):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default=TransactionExecutor,
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will manage transactions',
         from_string_converter=class_converter
     )

--- a/socorro/processor/registration_client.py
+++ b/socorro/processor/registration_client.py
@@ -60,7 +60,8 @@ class ProcessorAppRegistrationClient(RequiredConfig):
     )
     required_config.add_option(
       'transaction_executor_class',
-      default=TransactionExecutor,
+      default="socorro.database.transaction_executor."
+              "TransactionExecutorWithInfiniteBackoff",
       doc='a class that will manage transactions',
       from_string_converter=class_converter
     )

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -450,7 +450,8 @@ class CSignatureToolDB(CSignatureToolBase):
     )
     required_config.add_option(
         'transaction_executor_class',
-        default='socorro.database.transaction_executor.TransactionExecutor',
+        default="socorro.database.transaction_executor."
+                "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will manage transactions',
         from_string_converter=class_converter
     )


### PR DESCRIPTION
if the defaults for configuration were more consistent, making new ini files would be a lot easier.   This patch changes the defaults for the crashstorage classes and transaction executor to be consistent.
