### PR TITLE
fixes bug 792205 - Ratio totals for Crashes per ADU by O/S are incorrect

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
@@ -312,7 +312,7 @@ Crashes per Active Daily User for {{ product }}
                       <td>{{ crash_info.adu | digitgroupseparator }}</td>
                       <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling."
                       >{% if crash_info.throttle %}{{ crash_info.throttle * 100 }}%{% else %}-{% endif %}</td>
-                      <td>{{ crash_info.crash_hadu }}%</td>
+                      <td>{{ crash_info.crash_hadu }}</td>
                             {% do foundversion.append(1) %}
                           {% endif %}
                         {% endfor %}
@@ -362,16 +362,6 @@ Crashes per Active Daily User for {{ product }}
                   {% endif %}
                 </tr>
                 {% endfor %}
-                <tr>
-                    <td class="date"><strong>Total</strong></td>
-                {% for product_version in data_table.totals | sort | reverse %}
-                  {% set total = data_table.totals[product_version] %}
-                    <td class="stat"><strong>{{ total.crashes | digitgroupseparator }}</strong></td>
-                    <td class="stat"><strong>{{ total.adu | digitgroupseparator }}</strong></td>
-                    <td class="stat" title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling."><strong>{{ total.throttle * 100 }}%</strong></td>
-                    <td class="stat"><strong>{{ total.ratio }}%</strong></td>
-                {% endfor %}
-                </tr>
             </table>
           {% else %}
           <p>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -498,14 +498,6 @@ def daily(request, default_context=None):
             if date not in data_table['dates']:
                 data_table['dates'][date] = []
             data_table['dates'][date].append(crash_info)
-            data_table['totals'][
-                product_version]['crashes'] += crash_info['report_count']
-            data_table['totals'][product_version]['adu'] += crash_info['adu']
-            if 'throttle' in crash_info:
-                data_table['totals'][
-                    product_version]['throttle'] = crash_info['throttle']
-            data_table['totals'][
-                product_version]['ratio'] += crash_info['crash_hadu']
 
     if params['date_range_type'] == 'build':
         # for the Date Range = "Build Date" report, we only want to


### PR DESCRIPTION
This change depends on Kairo's feedback on the bug. 

Review can wait. 
