### PR TITLE
(no bug) - sanitize django statsd keys to convert intra-key '.' to '-'

### DIFF
--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -9,7 +9,7 @@ class AnalyticsMiddleware(object):
     def process_response(self, request, response):
         metric = "analytics.{0}.{1}.{2}".format(
             request.method,
-            request.path_info.strip('/'),
+            request.path_info.strip('/').replace('.', '-'),
             response.status_code
         )
         statsd.incr(metric)

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -10,10 +10,16 @@ from django.test.client import RequestFactory
 class TestAnalyticsMiddleware(TestCase):
 
     def setUp(self):
-        self.req = RequestFactory().get('/')
+        self.req = RequestFactory().get('/firefox-26.a1/')
         self.res = HttpResponse()
 
     def test_process_response(self, incr):
         amw = middleware.AnalyticsMiddleware()
         amw.process_response(self.req, self.res)
         assert incr.called
+
+    def test_dot_conversion(self, incr):
+        '''ensure 26.a1 is converted to 26-a1'''
+        amw = middleware.AnalyticsMiddleware()
+        amw.process_response(self.req, self.res)
+        incr.assert_called_with('analytics.GET.firefox-26-a1.200')


### PR DESCRIPTION
Just noticed that the recent analytics patch fails to sanitize path_info `.` to `-`, causing unnecessary folders to be created in graphite.
