### PR TITLE
fixes bug 910831 - truncate paths matching a prefix in analytics middleware

### DIFF
--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -7,9 +7,19 @@ class AnalyticsMiddleware(object):
     """
 
     def process_response(self, request, response):
+        path = request.path_info.lstrip('/').replace('.', '-')
+        # avoid sending lots of low-volume or unique keys
+        prefixes = ('rawdumps/', 'report/index/', 'report/pending/bp',
+                    'report/pending/')
+
+        for prefix in prefixes:
+            if path.startswith(prefix):
+                path = prefix
+                break
+
         metric = "analytics.{0}.{1}.{2}".format(
             request.method,
-            request.path_info.strip('/').replace('.', '-'),
+            path,
             response.status_code
         )
         statsd.incr(metric)

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -10,16 +10,36 @@ from django.test.client import RequestFactory
 class TestAnalyticsMiddleware(TestCase):
 
     def setUp(self):
-        self.req = RequestFactory().get('/firefox-26.a1/')
+        self.simple_req = RequestFactory().get('/firefox/26.a1')
+        self.trailing_slash_req = RequestFactory().get('/firefox/26.a1/')
+        self.unique_req = RequestFactory().get('/report/pending/bp-1bb31a3/')
         self.res = HttpResponse()
 
     def test_process_response(self, incr):
         amw = middleware.AnalyticsMiddleware()
-        amw.process_response(self.req, self.res)
+        amw.process_response(self.simple_req, self.res)
         assert incr.called
 
     def test_dot_conversion(self, incr):
         '''ensure 26.a1 is converted to 26-a1'''
         amw = middleware.AnalyticsMiddleware()
-        amw.process_response(self.req, self.res)
-        incr.assert_called_with('analytics.GET.firefox-26-a1.200')
+        amw.process_response(self.simple_req, self.res)
+        incr.assert_called_with('analytics.GET.firefox/26-a1.200')
+
+    def test_trailing_slash(self, incr):
+        '''ensure trailing slash is only added when present'''
+        amw = middleware.AnalyticsMiddleware()
+        amw.process_response(self.trailing_slash_req, self.res)
+        incr.assert_called_with('analytics.GET.firefox/26-a1/.200')
+
+    def test_rule_order_precedence(self, incr):
+        '''ensure earlier rules are caught before later rules'''
+        amw = middleware.AnalyticsMiddleware()
+        amw.process_response(self.unique_req, self.res)
+        incr.assert_called_with('analytics.GET.report/pending/bp.200')
+
+    def test_truncate_unique_keys(self, incr):
+        '''ensure unique portions of the path are truncated'''
+        amw = middleware.AnalyticsMiddleware()
+        amw.process_response(self.unique_req, self.res)
+        incr.assert_called_with('analytics.GET.report/pending/bp.200')


### PR DESCRIPTION
The analytics middleware sometimes reports uuids. This is harmful to graphite perf for everyone and not useful for analysis. This patch will truncate the UUIDs from these paths.
