### PR TITLE
fixes Bug 636868:  support for json dump from new MDSW

### DIFF
--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import datetime
 import time
+import json
 from urllib import unquote_plus
 from contextlib import closing, contextmanager
 
@@ -31,6 +32,20 @@ from socorro.lib.util import (
     StrCachingIterator
 )
 from socorro.processor.breakpad_pipe_to_json import pipe_dump_to_json_dump
+
+
+#------------------------------------------------------------------------------
+mdsw_error_strings = {
+    None: "MDSW_UNKNOWN_ERROR",
+    0: "MDSW_OK",
+    1: "MDSW_ERROR_MINIDUMP_NOT_FOUND",
+    2: "MDSW_ERROR_NO_MINIDUMP_HEADER",
+    3: "MDSW_ERROR_NO_THREAD_LIST",
+    4: "MDSW_ERROR_GETTING_THREAD",
+    5: "MDSW_ERROR_GETTING_THREAD_ID",
+    6: "MDSW_ERROR_DUPLICATE_REQUESTING_THREADS",
+    7: "MDSW_SYMBOL_SUPPLIER_INTERRUPTED",
+}
 
 #------------------------------------------------------------------------------
 def create_symbol_path_str(input_str):
@@ -61,27 +76,16 @@ class LegacyCrashProcessor(RequiredConfig):
         from_string_converter=class_converter
     )
     required_config.add_option(
-        'exploitability_tool_command_line',
-        doc='the template for the command to invoke the exploitability tool',
-        default='$exploitability_tool_pathname $dumpfilePathname 2>/dev/null',
-    )
-    required_config.add_option(
-        'exploitability_tool_pathname',
-        doc='the full pathname of the extern program exploitability tool '
-        '(quote path with embedded spaces)',
-        default='/data/socorro/stackwalk/bin/exploitability',
-    )
-    required_config.add_option(
         'stackwalk_command_line',
-        doc='the template for the command to invoke minidump_stackwalk',
-        default='$minidump_stackwalk_pathname -m $dumpfilePathname '
+        doc='the template for the command to invoke stackwalker',
+        default='$minidump_stackwalk_pathname --pipe $dumpfilePathname '
         '$processor_symbols_pathname_list 2>/dev/null',
     )
     required_config.add_option(
         'minidump_stackwalk_pathname',
-        doc='the full pathname of the extern program minidump_stackwalk '
+        doc='the full pathname of the extern program stackwalker '
         '(quote path with embedded spaces)',
-        default='/data/socorro/stackwalk/bin/minidump_stackwalk',
+        default='/data/socorro/stackwalk/bin/stackwalker',
     )
     required_config.add_option(
         'symbol_cache_path',
@@ -188,12 +192,6 @@ class LegacyCrashProcessor(RequiredConfig):
         doc='boolean indictating if we are using the old monitor_app.py',
         default=True,
     )
-    required_config.add_option(
-        'save_mdsw_json',
-        doc='boolean if the json version of the MDSW pipe dump should be saved'
-            'with the pipedump',
-        default=False,
-    )
     required_config.namespace('statistics')
     required_config.statistics.add_option(
         'stats_class',
@@ -248,15 +246,6 @@ class LegacyCrashProcessor(RequiredConfig):
         # finally, convert any remaining $param to pythonic %(param)s
         tmp = convert_to_python_substitution_format_re.sub(r'%(\1)s', tmp)
         self.mdsw_command_line = tmp % config
-
-        # Canonical form of $(param) is $param. Convert any that are needed
-        tmp = strip_parens_re.sub(r'$\2',
-                                  config.exploitability_tool_command_line)
-        # Convert canonical $dumpfilePathname to DUMPFILEPATHNAME
-        tmp = tmp.replace('$dumpfilePathname', 'DUMPFILEPATHNAME')
-        # finally, convert any remaining $param to pythonic %(param)s
-        tmp = convert_to_python_substitution_format_re.sub(r'%(\1)s', tmp)
-        self.exploitability_command_line = tmp % config
 
         # *** end from ExternalProcessor
 
@@ -333,21 +322,6 @@ class LegacyCrashProcessor(RequiredConfig):
                         submitted_timestamp,
                         processor_notes
                     )
-                try:
-                    dump_analysis.json_dump = pipe_dump_to_json_dump(
-                        dump_analysis.dump.split('\n')
-                    )
-                except (KeyError, AttributeError):
-                    processor_notes.append(
-                        "Pipe dump missing from '%s'" % name)
-                except Exception, x:
-                    error_message = (
-                        "Conversion to json dump format has failed for '%s'" %
-                        name
-                    )
-                    processor_notes.append(error_message)
-                    self.config.logger.info(error_message)
-
                 if name == self.config.dump_field:
                     processed_crash.update(dump_analysis)
                 else:
@@ -390,16 +364,6 @@ class LegacyCrashProcessor(RequiredConfig):
         processed_crash.processor_notes = processor_notes
         completed_datetime = utc_now()
         processed_crash.completeddatetime = completed_datetime
-        if not self.config.save_mdsw_json:
-            try:
-                del processed_crash['json_dump']
-            except (KeyError, AttributeError):
-                pass
-            for a_dump_name in processed_crash.additional_minidumps:
-                try:
-                    del processed_crash[a_dump_name]['json_dump']
-                except (KeyError, AttributeError):
-                    pass
 
         self._log_job_end(
             completed_datetime,
@@ -750,28 +714,6 @@ class LegacyCrashProcessor(RequiredConfig):
                 subprocess_handle)
 
     #--------------------------------------------------------------------------
-    def _invoke_exploitability(self, dump_pathname):
-        """ This function invokes breakpad_stackdump as an external process
-        capturing and returning the text output of stdout.  This version
-        represses the stderr output.
-
-              input parameters:
-                dump_pathname: the complete pathname of the dumpfile to be
-                                  analyzed
-        """
-        command_line = self.exploitability_command_line.replace(
-                         "DUMPFILEPATHNAME",
-                         dump_pathname
-                       )
-        subprocess_handle = subprocess.Popen(
-            command_line,
-            shell=True,
-            stdout=subprocess.PIPE
-        )
-        return (StrCachingIterator(subprocess_handle.stdout),
-                subprocess_handle)
-
-    #--------------------------------------------------------------------------
     def _do_breakpad_stack_dump_analysis(self, crash_id, dump_pathname,
                                          is_hang, java_stack_trace,
                                          submitted_timestamp,
@@ -797,9 +739,6 @@ class LegacyCrashProcessor(RequiredConfig):
         dump_analysis_line_iterator.secondaryCacheMaximumSize = \
             self.config.crashing_thread_tail_frame_threshold + 1
 
-        exploitability_line_iterator, exploitability_subprocess_handle = \
-            self._invoke_exploitability(dump_pathname)
-
         processed_crash_update = self._stackwalk_analysis(
             dump_analysis_line_iterator,
             mdsw_subprocess_handle,
@@ -809,36 +748,7 @@ class LegacyCrashProcessor(RequiredConfig):
             submitted_timestamp,
             processor_notes
         )
-        processed_crash_update['exploitability'] = \
-            self._exploitability_analysis(
-                exploitability_line_iterator,
-                exploitability_subprocess_handle,
-                processor_notes
-            )
         return processed_crash_update
-
-    #--------------------------------------------------------------------------
-    def _exploitability_analysis(self,
-                                 exploitability_line_iterator,
-                                 exploitability_subprocess_handle,
-                                 error_messages):
-        exploitability = None
-        with closing(exploitability_line_iterator) as the_iter:
-            for a_line in the_iter:
-                exploitability = a_line.strip().replace('exploitability: ', '')
-        returncode = exploitability_subprocess_handle.wait()
-        if exploitability is not None and 'ERROR' in exploitability:
-            error_messages.append("exploitability tool: %s" %
-                                  (exploitability,))
-            # the rule is that if the output contains ERROR
-            # then value should be None.
-            exploitability = None
-        if returncode is not None and returncode != 0:
-            error_messages.append(
-                "exploitability tool failed: %s" %
-                (returncode,)
-            )
-        return exploitability
 
     #--------------------------------------------------------------------------
     def _stackwalk_analysis(
@@ -874,24 +784,49 @@ class LegacyCrashProcessor(RequiredConfig):
                 processor_notes
             )
             processed_crash_update.update(processed_crash_from_frames)
-            for x in mdsw_iter:
-                pass  # need to spool out the rest of the stream so the
-                        # cache doesn't get truncated
             pipe_dump_str = ('\n'.join(mdsw_iter.cache))
             processed_crash_update.dump = pipe_dump_str
-            processed_crash_update.json_dump = pipe_dump_to_json_dump(
-                mdsw_iter.cache
+
+            json_dump_lines = []
+            for x in mdsw_iter:
+                json_dump_lines.append(x)
+            json_dump_str = ''.join(json_dump_lines)
+            try:
+                processed_crash_update.json_dump = json.loads(json_dump_str)
+            except ValueError, x:
+                processed_crash_update.json_dump = {}
+                processor_notes.append("no json output found from MDSW")
+            try:
+                processed_crash_update.exploitability = (
+                    processed_crash_update.json_dump
+                        ['sensitive']['exploitability']
+                )
+            except KeyError:
+                processed_crash_update.exploitability = 'unknown'
+                processor_notes.append("exploitablity information missing")
+            mdsw_error_code = processed_crash_update.json_dump.setdefault(
+                'status',
+                None
             )
 
         return_code = mdsw_subprocess_handle.wait()
-        if return_code is not None and return_code != 0:
+        if ((return_code is not None and return_code != 0) or mdsw_error_code):
             self._statistics.incr('mdsw_failures')
+            mdsw_error_string = mdsw_error_strings.setdefault(
+                mdsw_error_code,
+                "MDSW_UNKNOWN_ERROR"
+            )
             processor_notes.append(
-                "MDSW failed: %s" % mdsw_subprocess_handle.returncode
+                "MDSW failed: %s - %s" % (mdsw_error_code, mdsw_error_string)
             )
             processed_crash_update.success = False
             if processed_crash_update.signature.startswith("EMPTY"):
-                processed_crash_update.signature += "; corrupt dump"
+                processed_crash_update.signature = (
+                    "%s; %s" % (
+                        processed_crash_update.signature,
+                        mdsw_error_string
+                    )
+                )
         return processed_crash_update
 
     #--------------------------------------------------------------------------
@@ -1075,8 +1010,10 @@ class LegacyCrashProcessor(RequiredConfig):
             line = line.strip()
             if line == '':
                 continue  # ignore unexpected blank lines
+            if line == '====PIPE DUMP ENDS===':
+                break  # there is more data coming move on to the next stage
             (thread_num, frame_num, module_name, function, source, source_line,
-             instruction) = [emptyFilter(x) for x in line.split("|")]
+             instruction) = [emptyFilter(x) for x in line.split("|")][:7]
             if len(topmost_sourcefiles) < max_topmost_sourcefiles and source:
                 topmost_sourcefiles.append(source)
             if thread_for_signature == int(thread_num):


### PR DESCRIPTION
this is a big, but incremental change to the processor.  It adds support for a version of MDSW that emits both pipe dump (pDump) and json dump (jDump).  The json version of the dump becomes is added to the processed_crash json as the key `json_dump`.  The pipe dump remains with the key `dump`.  

The two systems are supported in parallel so that the transition can be as painless as possible.  

Due to time constraints, I've had very little opportunity to test beyond the unit tests.  The new MDSW wasn't delivered to me until the final hour before my vacation.  I don't know if someone wants to take over the responsibility for this or if it will bit rot during my absence. 
