### PR TITLE
Fixes bug 874648 - Evict unittests that touch external resources

### DIFF
--- a/socorro/unittest/cron/base.py
+++ b/socorro/unittest/cron/base.py
@@ -10,6 +10,7 @@ import unittest
 import mock
 import psycopg2
 from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+from nose.plugins.attrib import attr
 
 from configman import ConfigurationManager
 from socorro.cron import crontabber
@@ -87,6 +88,7 @@ class TestCaseBase(unittest.TestCase):
         db.save(json_file)
 
 
+@attr(integration='postgres')
 class IntegrationTestCaseBase(TestCaseBase):
     """Useful class for running integration tests related to crontabber apps
     since this class takes care of setting up a psycopg connection and it

--- a/socorro/unittest/cron/jobs/test_automatic_emails.py
+++ b/socorro/unittest/cron/jobs/test_automatic_emails.py
@@ -110,11 +110,11 @@ class TestAutomaticEmails(TestCaseBase):
 
 
 #==============================================================================
-@attr(integration='postgres')  # for nosetests
-class TestFunctionalAutomaticEmails(IntegrationTestCaseBase):
+@attr(integration='postgres')
+class IntegrationTestAutomaticEmails(IntegrationTestCaseBase):
 
     def setUp(self):
-        super(TestFunctionalAutomaticEmails, self).setUp()
+        super(IntegrationTestAutomaticEmails, self).setUp()
         # prep a fake table
         now = utc_now() - datetime.timedelta(minutes=30)
         last_month = now - datetime.timedelta(days=31)
@@ -290,7 +290,7 @@ class TestFunctionalAutomaticEmails(IntegrationTestCaseBase):
         self.conn.commit()
 
     def tearDown(self):
-        super(TestFunctionalAutomaticEmails, self).tearDown()
+        super(IntegrationTestAutomaticEmails, self).tearDown()
         self.conn.cursor().execute("""
             TRUNCATE TABLE reports, emails CASCADE;
         """)
@@ -318,7 +318,7 @@ class TestFunctionalAutomaticEmails(IntegrationTestCaseBase):
         }
 
         config_manager, json_file = super(
-            TestFunctionalAutomaticEmails,
+            IntegrationTestAutomaticEmails,
             self
         )._setup_config_manager(
             'socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h',

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -24,14 +24,14 @@ SAMPLE_CSV = [
 
 
 #==============================================================================
-@attr(integration='postgres')  # for nosetests
-class TestFunctionalBugzilla(IntegrationTestCaseBase):
+@attr(integration='postgres')
+class IntegrationTestBugzilla(IntegrationTestCaseBase):
 
     def setUp(self):
-        super(TestFunctionalBugzilla, self).setUp()
+        super(IntegrationTestBugzilla, self).setUp()
 
     def tearDown(self):
-        super(TestFunctionalBugzilla, self).tearDown()
+        super(IntegrationTestBugzilla, self).tearDown()
         self.conn.cursor().execute("""
         TRUNCATE TABLE reports CASCADE;
         TRUNCATE TABLE bugs CASCADE;
@@ -49,7 +49,7 @@ class TestFunctionalBugzilla(IntegrationTestCaseBase):
 
         query = 'file://' + filename.replace(datestring, '%s')
 
-        _super = super(TestFunctionalBugzilla, self)._setup_config_manager
+        _super = super(IntegrationTestBugzilla, self)._setup_config_manager
         config_manager, json_file = _super(
           'socorro.cron.jobs.bugzilla.BugzillaCronApp|1d',
           extra_value_source={

--- a/socorro/unittest/cron/jobs/test_daily_url.py
+++ b/socorro/unittest/cron/jobs/test_daily_url.py
@@ -14,16 +14,16 @@ from ..base import IntegrationTestCaseBase
 
 
 #==============================================================================
-@attr(integration='postgres')  # for nosetests
-class TestFunctionalDailyURL(IntegrationTestCaseBase):
+@attr(integration='postgres')
+class IntegrationTestDailyURL(IntegrationTestCaseBase):
 
     def setUp(self):
-        super(TestFunctionalDailyURL, self).setUp()
+        super(IntegrationTestDailyURL, self).setUp()
         self.Popen_patcher = mock.patch('subprocess.Popen')
         self.Popen = self.Popen_patcher.start()
 
     def tearDown(self):
-        super(TestFunctionalDailyURL, self).tearDown()
+        super(IntegrationTestDailyURL, self).tearDown()
         self.conn.cursor().execute("""
         TRUNCATE TABLE reports CASCADE;
         TRUNCATE TABLE bugs CASCADE;
@@ -44,7 +44,7 @@ class TestFunctionalDailyURL(IntegrationTestCaseBase):
                               #public_server='ftp.mozilla.org',
                               #public_location='/tmp/%Y%m%d/',
                               ):
-        _super = super(TestFunctionalDailyURL, self)._setup_config_manager
+        _super = super(IntegrationTestDailyURL, self)._setup_config_manager
         if output_path is None:
             output_path = self.tempdir
         if public_output_path is None:

--- a/socorro/unittest/cron/test_crontabber.py
+++ b/socorro/unittest/cron/test_crontabber.py
@@ -1641,11 +1641,11 @@ class TestCrontabber(TestCaseBase):
 
 
 #==============================================================================
-@attr(integration='postgres')  # for nosetests
-class TestFunctionalCrontabber(TestCaseBase):
+@attr(integration='postgres')
+class IntegrationTestCrontabber(TestCaseBase):
 
     def setUp(self):
-        super(TestFunctionalCrontabber, self).setUp()
+        super(IntegrationTestCrontabber, self).setUp()
         # prep a fake table
         assert 'test' in DSN['database.database_name']
         dsn = ('host=%(database.database_host)s '
@@ -1674,7 +1674,7 @@ class TestFunctionalCrontabber(TestCaseBase):
         assert self.conn.get_transaction_status() == TRANSACTION_STATUS_IDLE
 
     def tearDown(self):
-        super(TestFunctionalCrontabber, self).tearDown()
+        super(IntegrationTestCrontabber, self).tearDown()
         self.conn.cursor().execute("""
         DROP TABLE IF EXISTS test_cron_victim;
         """)

--- a/socorro/unittest/external/elasticsearch/test_base.py
+++ b/socorro/unittest/external/elasticsearch/test_base.py
@@ -7,6 +7,8 @@ import json
 import mock
 import unittest
 
+from nose.plugins.attrib import attr
+
 from socorro.external.elasticsearch.base import ElasticSearchBase
 
 import socorro.lib.search_common as scommon
@@ -14,7 +16,8 @@ import socorro.lib.util as util
 
 
 #==============================================================================
-class FunctionalTestElasticSearchBase(unittest.TestCase):
+@attr(integration='elasticsearch')
+class IntegrationTestElasticSearchBase(unittest.TestCase):
 
     def _get_default_config(self):
         config = util.DotDict()
@@ -63,6 +66,7 @@ class FunctionalTestElasticSearchBase(unittest.TestCase):
         res = es.query(from_date, to_date, json_query)
 
         self.assertEqual(res, ('', "text/json"))
+
 
 #==============================================================================
 class TestElasticSearchBase(unittest.TestCase):

--- a/socorro/unittest/external/elasticsearch/test_search.py
+++ b/socorro/unittest/external/elasticsearch/test_search.py
@@ -155,8 +155,9 @@ class TestElasticSearchSearch(unittest.TestCase):
         self.assertFalse("is_linux" in res[1])
 
 
-@attr(integration='elasticsearch')  # for nosetests
-class FunctionalElasticsearchSearch(unittest.TestCase):
+#==============================================================================
+@attr(integration='elasticsearch')
+class IntegrationElasticsearchSearch(unittest.TestCase):
     """Test search with an elasticsearch database containing fake data. """
 
     def setUp(self):

--- a/socorro/unittest/lib/testPsycopghelper.py
+++ b/socorro/unittest/lib/testPsycopghelper.py
@@ -12,6 +12,7 @@ import threading
 
 from socorro.unittest.testlib.loggerForTest import TestingLogger
 from createDBforTest import *
+from nose.plugins.attrib import attr
 
 import socorro.lib.ConfigurationManager as cm
 import dbTestconfig as testConfig
@@ -68,7 +69,8 @@ class TestSingleCursor(psycopg2.extensions.cursor):
     return self.result
 
 
-class TestPsycopghelper(unittest.TestCase):
+@attr(integration='postgres')
+class IntegrationTestPsycopghelper(unittest.TestCase):
   def setUp(self):
     self.logger = TestingLogger()
     self.connectionData0 = (config.databaseHost,config.databaseName,config.databaseUserName,config.databasePassword)

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -299,12 +299,12 @@ class ImplementationWrapperTestCase(unittest.TestCase):
         )
 
 
-@attr(integration='postgres')  # for nosetests
-class TestMiddlewareApp(unittest.TestCase):
+@attr(integration='postgres')
+class IntegrationTestMiddlewareApp(unittest.TestCase):
     # test the middleware_app except that we won't start the daemon
 
     def setUp(self):
-        super(TestMiddlewareApp, self).setUp()
+        super(IntegrationTestMiddlewareApp, self).setUp()
         self.uuid = '06a0c9b5-0381-42ce-855a-ccaaa2120116'
         assert 'test' in DSN['database.database_name']
         dsn = ('host=%(database.database_host)s '
@@ -315,7 +315,7 @@ class TestMiddlewareApp(unittest.TestCase):
         assert self.conn.get_transaction_status() == TRANSACTION_STATUS_IDLE
 
     def tearDown(self):
-        super(TestMiddlewareApp, self).tearDown()
+        super(IntegrationTestMiddlewareApp, self).tearDown()
         self.conn.cursor().execute("""
         TRUNCATE TABLE bugs CASCADE;
         TRUNCATE TABLE bug_associations CASCADE;


### PR DESCRIPTION
I changed the name of unittests that touch external resources for Integration.
Some of the integration tests are deprecated, so I haven't changed them.
