### PR TITLE
Fixes bug 793885 Limit dependencies on ADU in matviews

### DIFF
--- a/socorro/cron/jobs/matviews.py
+++ b/socorro/cron/jobs/matviews.py
@@ -147,7 +147,7 @@ class ExplosivenessCronApp(_MatViewBackfillBase):
     app_name = 'explosiveness-matview'
     depends_on = (
         'tcbs-matview',
-        'build-adu-matview',
+        'adu-matview',
         'reports-clean'
     )
 
@@ -187,7 +187,6 @@ class ExploitabilityCronApp(_MatViewBackfillBase):
     app_name = 'exploitability-matview'
     depends_on = (
         'tcbs-matview',
-        'build-adu-matview',
         'reports-clean'
     )
 


### PR DESCRIPTION
I reviewed matviews and the jobs in crontabber, and found we could adjust the deps slightly.
