### PR TITLE
fixes bug 912011 - colors in front page graph don't match headers below

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
@@ -38,6 +38,8 @@ $(function() {
                 { data: data["ratio" + 3], label: data.labels[2] },
                 { data: data["ratio" + 4], label: data.labels[3] }
             ];
+            // this is a trick to make the legend appear as a list in one single row
+            chartOpts.legend.noColumns = chartData.length;
             $.plot(aduChartContainer, chartData, chartOpts);
         }
     }

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/dashboard_graph.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/dashboard_graph.js
@@ -1,4 +1,4 @@
-/*global $:true, socorro:true, crashReportsByBuildDateTmpl:true, crashReportsByVersionTmpl:true, Mustache:true */
+/*global window:true, $:true, socorro:true, crashReportsByBuildDateTmpl:true, crashReportsByVersionTmpl:true, Mustache:true */
 $(function() {
     "use strict";
     var chartContainer = $("#adu-chart"),
@@ -38,7 +38,10 @@ $(function() {
                 borderColor: '#c0c0c0',
                 borderWidth: 0
             },
-            legend: {}
+            legend: {
+                position: 'ne',
+                noColumns: 4
+            }
         };
 
     var setSelected = function(item, container) {
@@ -136,11 +139,13 @@ $(function() {
 
             if(data.count > 0) {
                 var chartData = [
-                    { data: data["ratio" + 1] },
-                    { data: data["ratio" + 2] },
-                    { data: data["ratio" + 3] },
-                    { data: data["ratio" + 4] }
+                    { data: data["ratio" + 1], label: data.labels[0] },
+                    { data: data["ratio" + 2], label: data.labels[1] },
+                    { data: data["ratio" + 3], label: data.labels[2] },
+                    { data: data["ratio" + 4], label: data.labels[3] }
                 ];
+                // this is a trick to make the legend appear as a list in one single row
+                chartOpts.legend.noColumns = chartData.length;
                 $.plot(chartContainer, chartData, chartOpts);
             } else {
                 chartContainer.empty().append("No Active Daily User crash data is available for this report.");

--- a/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
@@ -272,7 +272,7 @@ Crashes per Active Daily Install for {{ product }}
                 <tr>
                     <th class="date" rowspan="2">Date</th>
                 {% if form_selection == 'by_version' %}
-                  {% for version in versions|reverse %}
+                  {% for version in versions %}
                     <th class="version" colspan="4">{{ version }}</th>
                   {% endfor %}
                 {% else %}
@@ -283,7 +283,7 @@ Crashes per Active Daily Install for {{ product }}
                 </tr>
                 <tr>
                 {% if form_selection == 'by_version' %}
-                  {% for version in versions|reverse %}
+                  {% for version in versions %}
                     <th class="stat">Crashes</th>
                     <th class="stat">ADI</th>
                     <th class="stat" title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">Throttle</th>
@@ -298,12 +298,12 @@ Crashes per Active Daily Install for {{ product }}
                   {% endfor %}
                 {% endif %}
                 </tr>
-                {% for crash_date in dates | reverse %}
+                {% for crash_date in dates %}
                 <tr>
                   <td>{{ crash_date }}</td>
                   {% if form_selection == 'by_version' %}
                     {% if crash_date in data_table.dates %}
-                      {% for version in versions|reverse %}
+                      {% for version in versions %}
                         {% set foundversion = [] %}
                         {% for crash_info in data_table.dates[crash_date] %}
                           {% if crash_info.version == version %}
@@ -323,7 +323,7 @@ Crashes per Active Daily Install for {{ product }}
                         {% endif %}
                       {% endfor %}
                     {% else %}
-                      {% for version in versions|reverse %}
+                      {% for version in versions %}
                       <td>-</td>
                       <td>-</td>
                       <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">-</td>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -90,7 +90,7 @@ def build_data_object_for_adu_graphs(start_date, end_date, response_items,
     }
 
     for count, product_version in enumerate(sorted(response_items,
-                                                   reverse=False),
+                                                   reverse=True),
                                             start=1):
 
         graph_data['ratio%s' % count] = []


### PR DESCRIPTION
@Kairo_at @ossreleasefeed @brandonsavage r?

Kairo, 
I don't want to bother you with the code changes. Instead if you can sign off on these two screenshots:
[home page](http://cl.ly/RHZb)
[daily report](http://cl.ly/RI3O)

What's note worthy is that the left-most color on both graphs now becomes the "highest" version (e.g. 26.0a1). That this now stays consistent across both reports. 

I changed the daily report so that the whole table below is reversed. The 23 version is the right now now instead. That's so that it follows the same pattern as the home page. 

Also, for both graphs I changed (added to home page, edited on daily report) the legend to be a single row across 4 columns for the legends. I think this looks better and prevents the legend from covering the graph lines. 
