### PR TITLE
bug 914385 - extend explosive graphs to occupy a whole row

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/explosives.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/explosives.less
@@ -7,7 +7,7 @@
 }
 
 .explosive-item {
-    width: calc(~"50% - 44px");
+    width: calc(~"100% - 44px");
     height: 350px;
     margin: 10px;
     padding: 10px;


### PR DESCRIPTION
Before:
![screen shot 2013-09-09 at 3 49 38 pm](https://f.cloud.github.com/assets/21467/1111133/28a5d778-19a2-11e3-89e7-d0434568a1ec.png)

After:
![screen shot 2013-09-09 at 3 29 17 pm](https://f.cloud.github.com/assets/21467/1111126/0e0905ac-19a2-11e3-8c65-4e1df4532bd4.png)
