### PR TITLE
fixes bug 913012 - Update forced versions for correlations for Firefox c...

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="24.0 25.0a2 26.0a1"
+MANUAL_VERSION_OVERRIDE="25.0 26.0a2 27.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
...ycle starting 2013-09-17 (re-reversion)

This puts back the change that @Kairo-at  first prepared. 

DON'T LAND TILL _AFTER_ 59. 
