### PR TITLE
fixes bug 918048 - Search results should show the reports tab by default

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/query.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/query.html
@@ -238,7 +238,7 @@
                 <td>{{ results_offset + loop.index }}</td>
                 <td>
                     {% if hit.signature %}
-                    <a href="{{ url('crashstats.report_list') }}?signature={{ hit.signature|urlencode }}&amp;{{ report_list_query_string }}">
+                    <a href="{{ url('crashstats.report_list') }}?signature={{ hit.signature|urlencode }}&amp;{{ report_list_query_string }}#reports">
                         {{ hit.signature }}
                     </a>
                     {% else %}


### PR DESCRIPTION
That was easy. 

@brandonsavage @rhelmer r?
