### PR TITLE
fixes bug 918929 - can't sort columns in reports view

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list.js
@@ -21,52 +21,6 @@ var Panels = (function() {
 
 $(document).ready(function () {
 
-    $('#reportsList .hang-pair-btn').click(function() {
-        var tr = $(this).parent().parent().parent();
-
-        var url = $('input.ajax_endpoint', tr).val();
-
-        $('.hang-pair', tr).html("<img src='/static/img/ajax-loader16x16.gif' alt='Loading data' />");
-        $.getJSON(url, function(data) {
-            if (data.length > 0 ) {
-                for (var i=0; data.length; i++) {
-                    var hangType = data[i].processType && data[i].processType == 'plugin' ? 'Plugin' : 'Browser';
-                    $('.hang-pair', tr).html(hangType + " Hang:<br /><a href='" + data[i].uuid + "'>" + data[i].display_date_processed  + "</a>");
-                    $('img', tr).unbind('click');
-                    break;
-                }
-            } else {
-                $('.hang-pair', tr).html("Unable to locate other Hang Part.");
-            }
-        });
-        return false;
-    });
-
-    $('#buildid-table').tablesorter();
-
-    $.tablesorter.addParser({
-        id: "hexToInt",
-        is: function(s) {
-            return false;
-        },
-        format: function(s) {
-            return parseInt(s, 16);
-        },
-        type: "digit"
-    });
-
-    $('#sigurls-tbl').tablesorter();
-
-    $('#reportsList').tablesorter({
-        textExtraction: "complex",
-        headers: {
-			3: { sorter: "floating" }, //version
-            8: { sorter: "hexToInt" },  // Address
-            10: { sorter: "digit" }      // Uptime
-        },
-        sortList : [[12,1]]
-    });
-
     // load the tabs and use a cookie to keep state.
     // the cookie will live for 1 day
     $('#report-list').tabs({

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_reports.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_reports.js
@@ -4,6 +4,50 @@
 var Reports = (function() {
     var loaded = false;
 
+    function post_activate($panel) {
+
+        // update the select widget
+        $wrapper = $('.wrapper', $panel);
+        var columns = $wrapper.data('columns');
+        var $source = $('select[name="available"]', $panel);
+        var $destination = $('select[name="chosen"]', $panel);
+        $.each(columns.split(','), function(i, value) {
+            var $op = $('option[value="' + value + '"]', $source).appendTo($destination);
+        });
+        $('.visually-hidden', $panel).removeClass('visually-hidden');
+
+        // set up table sort on the big table
+        $.tablesorter.addParser({
+            id: "hexToInt",
+            is: function(s) {
+                return false;
+            },
+            format: function(s) {
+                return parseInt(s, 16);
+            },
+            type: "digit"
+        });
+        var ths = $('#reportsList thead th', $panel);
+        var headers = {};
+        ths.each(function(i, each) {
+            var label = $(each).text();
+            if (label === 'Version') {
+                headers[i] = { sorter: 'floating' };
+            } else if (label === 'Address') {
+                headers[i] = { sorter: 'hexToInt' };
+            } else if (label === 'Uptime') {
+                headers[i] = { sorter: 'digit' };
+            } else {
+                headers[i] = { sorter: 'text' };  // default
+            }
+        });
+        $('#reportsList').tablesorter({
+            textExtraction: "complex",
+            headers: headers
+        });
+
+    }
+
     return {
        reload: function() {
            loaded = false;
@@ -36,15 +80,7 @@ var Reports = (function() {
                $('.loading-placeholder', $panel).hide();
                $('.inner', $panel).html(response);
 
-               // update the select widget
-               $wrapper = $('.wrapper', $panel);
-               var columns = $wrapper.data('columns');
-               var $source = $('select[name="available"]', $panel);
-               var $destination = $('select[name="chosen"]', $panel);
-               $.each(columns.split(','), function(i, value) {
-                   var $op = $('option[value="' + value + '"]', $source).appendTo($destination);
-               });
-               $('.visually-hidden', $panel).removeClass('visually-hidden');
+               post_activate($panel);
                deferred.resolve();
            });
            req.fail(function(data, textStatus, errorThrown) {

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_sigurls.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_sigurls.js
@@ -3,6 +3,10 @@
 var SignatureURLs = (function() {
     var loaded = null;
 
+    function post_activate($panel) {
+        $('#sigurls-tbl').tablesorter();
+    }
+
     return {
        activate: function() {
            if (loaded) return;
@@ -17,6 +21,7 @@ var SignatureURLs = (function() {
            req.done(function(response) {
                $('.loading-placeholder', $panel).hide();
                $('.inner', $panel).html(response);
+               post_activate($panel);
                deferred.resolve();
            });
            req.fail(function(data, textStatus, errorThrown) {

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_table.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_table.js
@@ -3,6 +3,10 @@
 var Table = (function() {
     var loaded = null;
 
+    function post_activate($panel) {
+        $('#buildid-table').tablesorter();
+    }
+
     return {
        activate: function() {
            if (loaded) return;
@@ -17,6 +21,7 @@ var Table = (function() {
            req.done(function(response) {
                $('.loading-placeholder', $panel).hide();
                $('.inner', $panel).html(response);
+               post_activate($panel);
                deferred.resolve();
            });
            req.fail(function(data, textStatus, errorThrown) {


### PR DESCRIPTION
@rhelmer @AdrianGaudebert r?

I can't believe I missed this. Basically, the certain things we did in `$(function() { ...` now has to be done after the HTML has been loaded by AJAX. 

Also, we can't hard-code specific fields for custom sorting on the Reports tab. That's why I loop over the `<th>` tags. 
