### PR TITLE
fixes bug 918157 - plugin_query must be double escaped

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -289,7 +289,9 @@ class SocorroMiddleware(SocorroCommon):
             value = kwargs.get(param)
             if not value:
                 continue
-            if param in ('signature', 'reasons', 'terms'):  # XXX factor out
+            if param in ('signature', 'reasons', 'terms', 'plugin_terms'):
+                # these are basically free text which can contain characters
+                # like / that need special attention
                 value = self.encode_special_chars(value)
             if isinstance(value, (list, tuple)):
                 value = '+'.join(unicode(x) for x in value)


### PR DESCRIPTION
@AdrianGaudebert r?

This change looks simple but was very very hard to spot. 

Basically, any time we take a `forms.Charfield()` input and pass it onto models.py to be sent as a URL to the middleware we need to watch out since that needs to be in the of keys we treat with special care. 

Can you think of any more Adrian?
