### PR TITLE
longer caching for raw and processed crashes

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -732,6 +732,9 @@ class ReportList(SocorroMiddleware):
 
 
 class ProcessedCrash(SocorroMiddleware):
+
+    cache_seconds = 60 * 60 * 24  # 1 day
+
     URL_PREFIX = '/crash_data/datatype/processed/'
 
     required_params = (
@@ -796,6 +799,8 @@ class ProcessedCrash(SocorroMiddleware):
 
 
 class RawCrash(SocorroMiddleware):
+
+    cache_seconds = 60 * 60 * 24  # 1 day
 
     URL_PREFIX = '/crash_data/'
 


### PR DESCRIPTION
@rhelmer @AdrianGaudebert r?

Raw crashes and processed crashes are extremely unlikely to change. 
We could cache for even longer but why flood memcache's memory. 
