### PR TITLE
Fixes bug 923049 - Removed risk of sensitive data exposure.

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -188,6 +188,9 @@ class BaseTestViews(TestCase):
         User.objects.create_user('test', 'test@mozilla.com', 'secret')
         assert self.client.login(username='test', password='secret')
 
+    def _logout(self):
+        self.client.logout()
+
 
 class TestViews(BaseTestViews):
 

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -361,29 +361,12 @@ class TestViews(BaseTestViews):
 
         url = reverse('supersearch.search_results')
 
-        # Logged out user, cannot see the email field
-        response = self.client.get(
-            url,
-            {
-                '_columns': ['version', 'email'],
-                '_facets': ['url', 'platform']
-            }
-        )
-
-        eq_(response.status_code, 200)
-        ok_('Email' not in response.content)
-        ok_('bob@example.org' not in response.content)
-        ok_('Url facet' not in response.content)
-        ok_('http://example.org' not in response.content)
-        ok_('Version' in response.content)
-        ok_('1.0' in response.content)
-
         # Logged in user, can see the email field
         self._login()
         response = self.client.get(
             url,
             {
-                '_columns': ['version', 'email'],
+                '_columns': ['version', 'email', 'url'],
                 '_facets': ['url', 'platform']
             }
         )
@@ -393,6 +376,24 @@ class TestViews(BaseTestViews):
         ok_('bob@example.org' in response.content)
         ok_('Url facet' in response.content)
         ok_('http://example.org' in response.content)
+        ok_('Version' in response.content)
+        ok_('1.0' in response.content)
+
+        # Logged out user, cannot see the email field
+        self._logout()
+        response = self.client.get(
+            url,
+            {
+                '_columns': ['version', 'email', 'url'],
+                '_facets': ['url', 'platform']
+            }
+        )
+
+        eq_(response.status_code, 200)
+        ok_('Email' not in response.content)
+        ok_('bob@example.org' not in response.content)
+        ok_('Url facet' not in response.content)
+        ok_('http://example.org' not in response.content)
         ok_('Version' in response.content)
         ok_('1.0' in response.content)
 

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -18,7 +18,7 @@ from .form_fields import get_operator_from_string
 from .models import SuperSearch
 
 
-ALL_POSSIBLE_FIELDS = [
+ALL_POSSIBLE_FIELDS = (
     'address',
     'app_notes',
     'build_id',
@@ -47,30 +47,30 @@ ALL_POSSIBLE_FIELDS = [
     'user_comments',
     'version',
     'winsock_lsp',
-]
+)
 
-ADMIN_RESTRICTED_FIELDS = [
+ADMIN_RESTRICTED_FIELDS = (
     'email',
     'url',
-]
+)
 
-DEFAULT_COLUMNS = [
+DEFAULT_COLUMNS = (
     'date',
     'signature',
     'product',
     'version',
     'build_id',
     'platform',
-]
+)
 
-DEFAULT_FACETS = [
+DEFAULT_FACETS = (
     'signature',
-]
+)
 
 # Facetting on those fields doesn't provide useful information.
-EXCLUDED_FIELDS_FROM_FACETS = [
+EXCLUDED_FIELDS_FROM_FACETS = (
     'date',
-]
+)
 
 
 @waffle_switch('supersearch-all')


### PR DESCRIPTION
@peterbe r?

This bug was a bit hard to find: the cause is that `ALL_POSSIBLE_FIELDS` was not a constant, and I would simply extend it with restricted fields whenever a user would log in. As that is a module variable, it is not reloaded at every page call. So, if a user logs in, the list gets updated with the restricted fields for every single visitor. That led to people being able to see emails and urls without being logged in. 

SuperSearch is currently disabled, we will turn it back on when this is merged / released. 
