### PR TITLE
Fixes bug 923069 - Using a build id no longer breaks supersearch.

### DIFF
--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -417,7 +417,8 @@ class TestViews(BaseTestViews):
             'date': ['>2013-01-01T10:00:00', '<2013-02-01T10:00:00'],
             'product': ['WaterWolf'],
             'version': ['3.0b1', '4.0a', '5.1'],
-            'release_channel': 'aurora'
+            'release_channel': 'aurora',
+            'build_id': ['12345', '~67890'],
         }
         res = get_report_list_parameters(source)
         eq_(res['date'].date(), datetime.date(2013, 2, 1))
@@ -431,3 +432,5 @@ class TestViews(BaseTestViews):
             res['version'],
             ['WaterWolf:3.0b1', 'WaterWolf:4.0a', 'WaterWolf:5.1']
         )
+
+        eq_(res['build_id'], ['12345'])

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -245,11 +245,16 @@ def get_report_list_parameters(source):
             params['release_channels'] = value
 
         elif key == 'build_id':
-            operator, value = get_operator_from_string(value)
-            if operator:
-                # The report/list/ page is unable to understand operators.
-                continue
-            params['build_id'] = value
+            params['build_id'] = []
+            for build in value:
+                operator, build = get_operator_from_string(build)
+                if operator:
+                    # The report/list/ page is unable to understand operators.
+                    continue
+                params['build_id'].append(build)
+
+            if not params['build_id']:
+                del params['build_id']
 
         elif key == 'version':
             if 'product' in source:


### PR DESCRIPTION
@rhelmer or @peterbe or anyone actually, r? :)
