### PR TITLE
Fixes bug 913238 - elasticsearch crashstorage does not use infinite back...

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,12 +44,13 @@ export RABBITMQ_USERNAME="socorro-jenkins"
 export RABBITMQ_PASSWORD="aPassword"
 export RABBITMQ_VHOST="socorro-jenkins"
 export ES_HOST="jenkins-es20"
+export ES_URLS="http://jenkins-es20:9200"
 
 # RHEL postgres 9 RPM installs pg_config here, psycopg2 needs it
 export PATH=/usr/pgsql-9.2/bin:$PATH
 echo "My path is $PATH"
 # run unit tests
-make test database_username=test database_hostname=$DB_HOST database_password=aPassword database_port=5432 database_superusername=test database_superuserpassword=aPassword elasticSearchHostname=$ES_HOST
+make test database_username=test database_hostname=$DB_HOST database_password=aPassword database_port=5432 database_superusername=test database_superuserpassword=aPassword elasticSearchHostname=$ES_HOST elasticsearch_urls=$ES_URLS
 
 if [ "$1" != "leeroy" ]
 then

--- a/socorro/external/elasticsearch/crashstorage.py
+++ b/socorro/external/elasticsearch/crashstorage.py
@@ -35,7 +35,7 @@ class ElasticSearchCrashStorage(CrashStorageBase):
     required_config = Namespace()
     required_config.add_option('transaction_executor_class',
                                default="socorro.database.transaction_executor."
-                                    "TransactionExecutorWithInfiniteBackoff",
+                                    "TransactionExecutorWithLimitedBackoff",
                                doc='a class that will manage transactions',
                                from_string_converter=class_converter)
     required_config.add_option('elasticsearch_urls',
@@ -87,7 +87,9 @@ class ElasticSearchCrashStorage(CrashStorageBase):
                 timeout=self.config.timeout
             )
 
-            settings_json = open(self.config.elasticsearch_index_settings).read()
+            settings_json = open(
+                self.config.elasticsearch_index_settings
+            ).read()
             self.index_settings = json.loads(
                 settings_json % self.config.elasticsearch_doctype
             )
@@ -200,7 +202,8 @@ class ElasticSearchCrashStorage(CrashStorageBase):
             # Cache the list of existing indices to avoid HTTP requests
             self.indices_cache.add(es_index)
 
-    # TODO: Kill these connection-like methods. What are they doing in a crash storage?
+    # TODO: Kill these connection-like methods.
+    # What are they doing in a crash storage?
     #--------------------------------------------------------------------------
     def commit(self):
         """elasticsearch doesn't support transactions so this silently

--- a/socorro/unittest/external/elasticsearch/test_search.py
+++ b/socorro/unittest/external/elasticsearch/test_search.py
@@ -286,8 +286,10 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
         for opt in [
             'elasticSearchHostname',
             'elasticSearchPort',
+            'elasticsearch_urls',
             'elasticsearch_index',
             'elasticsearch_doctype',
+            'elasticsearch_timeout',
             'searchMaxNumberOfDistinctSignatures',
             'platforms',
             'channels',
@@ -297,8 +299,6 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
 
         required_config.webapi = webapi
 
-        urls = 'http://' + self.config.elasticSearchHostname + ':9200'
-
         config_manager = ConfigurationManager(
             [required_config],
             app_name='testapp',
@@ -307,7 +307,8 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
             values_source_list=[{
                 'logger': mock_logging,
                 'elasticsearch_index': webapi.elasticsearch_index,
-                'elasticsearch_urls': urls,
+                'elasticsearch_urls': webapi.elasticsearch_urls,
+                'backoff_delays': [1, 2],
             }]
         )
 

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -61,6 +61,7 @@ def _get_config_manager(config, es_index=None):
             'logger': mock_logging,
             'elasticsearch_index': es_index,
             'elasticsearch_urls': elasticsearch_url,
+            'backoff_delays': [1, 2],
         }]
     )
 

--- a/socorro/unittest/external/elasticsearch/unittestbase.py
+++ b/socorro/unittest/external/elasticsearch/unittestbase.py
@@ -58,7 +58,7 @@ class ElasticSearchTestCase(unittest.TestCase):
 
     required_config.add_option(
         name='elasticsearch_timeout',
-        default=30,
+        default=5,
         doc='The time in seconds before a query to elasticsearch fails.',
     )
 


### PR DESCRIPTION
...off, and can now fail during unit tests.

@selenamarie, @peterbe or @twobraids r?
