### PR TITLE
fixes bug 925197 - ensured that jobs are ack'd even if the jobs fail

### DIFF
--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -112,7 +112,7 @@ class TestProcessorApp(unittest.TestCase):
           fake_dump
         )
         pa.destination.save_raw_and_processed.assert_called_with(fake_raw_crash, None, 7, 17)
-        finished_func.assert_called_once()
+        self.assertEqual(finished_func.call_count, 1)
 
     def test_transform_crash_id_missing(self):
         config = self.get_standard_config()
@@ -122,14 +122,13 @@ class TestProcessorApp(unittest.TestCase):
         pa.source.get_raw_crash = mocked_get_raw_crash
 
         finished_func = mock.Mock()
-        pa.transform(17)
+        pa.transform(17, finished_func)
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.reject_raw_crash.assert_called_with(
           17,
           'this crash cannot be found in raw crash storage'
         )
-        finished_func.assert_called_once()
-        self.assertEqual(finished_func.call_count, 0)
+        self.assertEqual(finished_func.call_count, 1)
 
     def test_transform_unexpected_exception(self):
         config = self.get_standard_config()
@@ -138,10 +137,12 @@ class TestProcessorApp(unittest.TestCase):
         mocked_get_raw_crash = mock.Mock(side_effect=Exception('bummer'))
         pa.source.get_raw_crash = mocked_get_raw_crash
 
-        pa.transform(17)
+        finished_func = mock.Mock()
+        pa.transform(17, finished_func)
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.reject_raw_crash.assert_called_with(
           17,
           'error in loading: bummer'
         )
+        self.assertEqual(finished_func.call_count, 1)
 


### PR DESCRIPTION
the processor's `transform` method did not ack crashes for RabbitMQ even if the function exited abnormally.  this meant that pending crashes would accumulate in the queue and eventually bring down the rabbit client for the processor.  

This change wraps the method in a try-finally block ensuring that the crash is acknowledged no matter what happens.
