### PR TITLE
fixes Bug 928519 - added missing references to the quit check method

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -319,7 +319,10 @@ class PolyCrashStorage(CrashStorageBase):
         self.stores = DotDict()
         for a_namespace in self.storage_namespaces:
             self.stores[a_namespace] = \
-              config[a_namespace].crashstorage_class(config[a_namespace])
+              config[a_namespace].crashstorage_class(
+                                      config[a_namespace],
+                                      quit_check_callback
+                                 )
 
     #--------------------------------------------------------------------------
     def close(self):
@@ -424,8 +427,14 @@ class FallbackCrashStorage(CrashStorageBase):
     def __init__(self, config, quit_check_callback=None):
         """instantiate the primary and secondary storage systems"""
         super(FallbackCrashStorage, self).__init__(config, quit_check_callback)
-        self.primary_store = config.primary.storage_class(config.primary)
-        self.fallback_store = config.fallback.storage_class(config.fallback)
+        self.primary_store = config.primary.storage_class(
+            config.primary,
+            quit_check_callback
+        )
+        self.fallback_store = config.fallback.storage_class(
+            config.fallback,
+            quit_check_callback
+        )
         self.logger = self.config.logger
 
     #--------------------------------------------------------------------------
@@ -598,9 +607,18 @@ class PrimaryDeferredStorage(CrashStorageBase):
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
         """instantiate the primary and deferred storage systems"""
-        super(PrimaryDeferredStorage, self).__init__(config, quit_check_callback)
-        self.primary_store = config.primary.storage_class(config.primary)
-        self.deferred_store = config.deferred.storage_class(config.deferred)
+        super(PrimaryDeferredStorage, self).__init__(
+            config, 
+            quit_check_callback
+        )
+        self.primary_store = config.primary.storage_class(
+            config.primary,
+            quit_check_callback
+        )
+        self.deferred_store = config.deferred.storage_class(
+            config.deferred,
+            quit_check_callback
+       )
         self.logger = self.config.logger
 
     #--------------------------------------------------------------------------
@@ -734,8 +752,14 @@ class PrimaryDeferredProcessedStorage(PrimaryDeferredStorage):
 
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
-        super(PrimaryDeferredProcessedStorage, self).__init__(config, quit_check_callback)
-        self.processed_store = config.processed.storage_class(config.processed)
+        super(PrimaryDeferredProcessedStorage, self).__init__(
+            config, 
+            quit_check_callback
+        )
+        self.processed_store = config.processed.storage_class(
+            config.processed,
+            quit_check_callback
+        )
 
     #--------------------------------------------------------------------------
     def save_processed(self, processed_crash):

--- a/socorro/external/rabbitmq/rmq_new_crash_source.py
+++ b/socorro/external/rabbitmq/rmq_new_crash_source.py
@@ -22,7 +22,10 @@ class RMQNewCrashSource(RequiredConfig):
 
     #--------------------------------------------------------------------------
     def __init__(self, config, processor_name, quit_check_callback=None):
-        self.crash_store = config.crashstorage_class(config)
+        self.crash_store = config.crashstorage_class(
+            config, 
+            quit_check_callback
+        )
 
     #--------------------------------------------------------------------------
     def close(self):

--- a/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
+++ b/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
@@ -19,8 +19,9 @@ from socorro.lib.util import DotDict
 #==============================================================================
 class FakeCrashStore(object):
 
-    def __init__(self, config):
+    def __init__(self, config, quit_check):
         self.config = config
+        self.quit_check = quit_check
 
     def new_crashes(self):
         for a_crash_id in range(10):

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -26,8 +26,8 @@ class A(CrashStorageBase):
                                default=2
                               )
 
-    def __init__(self, config):
-        super(A, self).__init__(config)
+    def __init__(self, config, quit_check=None):
+        super(A, self).__init__(config, quit_check)
         self.raw_crash_count = 0
 
     def save_raw_crash(self, raw_crash, dump):


### PR DESCRIPTION
The PolyCrashStore class was failing to propagate the 'quit_check' call back function to all the subordinate crash storage instances.  This hampers the ability for the configman apps to react quickly when given a SIGTERM.  The RabbitMQ new crash source also failed to use the quit_check method it was given.

Please note, this is _not_ the PR that introduces killing sub-processes.  This is just a first step to getting to that goal.
