### PR TITLE
Fixes Bug 929096 - changed to non-escaping caching iter wrapper for stackwalker

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -29,7 +29,7 @@ from socorro.lib.ooid import dateFromOoid
 from socorro.lib.util import (
     DotDict,
     emptyFilter,
-    StrCachingIterator
+    CachingIterator
 )
 from socorro.processor.breakpad_pipe_to_json import pipe_dump_to_json_dump
 
@@ -707,7 +707,7 @@ class HybridCrashProcessor(RequiredConfig):
             stdout=subprocess.PIPE
         )
         #self.config.logger.debug('STACKWALKER STARTS %s', command_line)
-        return (StrCachingIterator(subprocess_handle.stdout),
+        return (CachingIterator(subprocess_handle.stdout),
                 subprocess_handle)
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
the json output from the stackwalker was being given weirdly inappropriate escape sequence by the caching iterator wrapper employed by the processor.  This iter wrapper has been swapped out for one that faithfully delivers the streaming output from the subprocess without any modifications.
