### PR TITLE
Fixes Bug 929198 - made sure that truncation gets copied from the json_dump

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -813,6 +813,15 @@ class HybridCrashProcessor(RequiredConfig):
             except KeyError:
                 processed_crash_update.exploitability = 'unknown'
                 processor_notes.append("exploitablity information missing")
+                
+            try:
+                processed_crash_update.truncated = (
+                    processed_crash_update.json_dump
+                        ['crashing_thread']['frames_truncated']
+                )
+            except KeyError:
+                processed_crash_update.truncated = False
+                
             mdsw_error_string = processed_crash_update.json_dump.setdefault(
                 'status',
                 'unknown error'


### PR DESCRIPTION
the older versions of the processors all did the stack frame truncation themselves and placed a boolean "truncated" key in the top level of the processed_crash.  

The new stackwalker now does the truncation of abnormally long stacks.  It places its own 'frames_truncated' boolean in the json_dump at the thread level.  We still need to make sure that the old 'truncated' field gets an appropriate value.
