### PR TITLE
Fixes bug 929197 - Make sure connection closing can happen before doing it.

### DIFF
--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -516,17 +516,14 @@ class Crashes(PostgreSQLBase):
         params = external_common.parse_arguments(filters, kwargs)
         params.logger = logger
 
-        try:
-            connection = self.database.connection()
+        with self.get_connection() as connection:
             cursor = connection.cursor()
             return tcbs.twoPeriodTopCrasherComparison(cursor, params)
-        finally:
-            connection.close()
 
     def get_signature_history(self, **kwargs):
         """Return the history of a signature.
 
-        See http://socorro.readthedocs.org/en/latest/middleware.html#crashes_signature_history
+        See http://socorro.readthedocs.org/en/latest/middleware.html
         """
         now = datetimeutil.utc_now()
         lastweek = now - datetime.timedelta(days=7)

--- a/socorro/external/postgresql/priorityjobs.py
+++ b/socorro/external/postgresql/priorityjobs.py
@@ -68,31 +68,27 @@ class Priorityjobs(PostgreSQLBase):
             SELECT 1 FROM priorityjobs WHERE uuid=%(uuid)s
         """
 
-        connection = None
-        try:
-            connection = self.database.connection()
-            cur = connection.cursor()
+        with self.get_connection() as connection:
+            try:
+                cur = connection.cursor()
 
-            # Verifying that the uuid is not already in the queue
-            cur.execute(sql_exists, params)
-            if cur.rowcount:
-                logger.debug('The uuid %s is already in the priorityjobs '
-                             'table' % params.uuid)
+                # Verifying that the uuid is not already in the queue
+                cur.execute(sql_exists, params)
+                if cur.rowcount:
+                    logger.debug('The uuid %s is already in the priorityjobs '
+                                 'table' % params.uuid)
+                    return False
+
+                logger.debug('Adding the uuid %s to the priorityjobs table' %
+                             params.uuid)
+                cur.execute(sql, params)
+            except psycopg2.Error:
+                error = "Failed inserting priorityjobs data into PostgreSQL"
+                logger.error(error, exc_info=True)
+                connection.rollback()
                 return False
-
-            logger.debug('Adding the uuid %s to the priorityjobs table' %
-                         params.uuid)
-            cur.execute(sql, params)
-        except psycopg2.Error:
-            logger.error("Failed inserting priorityjobs data into PostgreSQL",
-                         exc_info=True)
-            connection.rollback()
-            return False
-        else:
-            connection.commit()
-            return bool(cur.rowcount)
-        finally:
-            if connection:
-                connection.close()
+            else:
+                connection.commit()
+                return bool(cur.rowcount)
 
         return True

--- a/socorro/external/postgresql/releases.py
+++ b/socorro/external/postgresql/releases.py
@@ -82,23 +82,24 @@ class Releases(PostgreSQLBase):
         sql = """/* socorro.external.postgresql.releases.update_featured */
             SELECT edit_featured_versions(%%s, %s)
         """
-        try:
-            connection = self.database.connection()
-            cur = connection.cursor()
+        error_message = "Failed updating featured versions in PostgreSQL"
 
-            for p in releases:
-                query = sql % ", ".join("%s" for i in xrange(len(releases[p])))
-                sql_params = [p] + releases[p]
-                logger.debug(cur.mogrify(query, sql_params))
-                cur.execute(query, sql_params)
+        with self.get_connection() as connection:
+            try:
+                cursor = connection.cursor()
 
-            connection.commit()
-        except psycopg2.Error:
-            connection.rollback()
-            error_message = "Failed updating featured versions in PostgreSQL"
-            logger.error(error_message)
-            raise DatabaseError(error_message)
-        finally:
-            connection.close()
+                for p in releases:
+                    query = sql % ", ".join(
+                        "%s" for i in xrange(len(releases[p]))
+                    )
+                    sql_params = [p] + releases[p]
+                    # logger.debug(cursor.mogrify(query, sql_params))
+                    cursor.execute(query, sql_params)
+
+                connection.commit()
+            except psycopg2.Error:
+                connection.rollback()
+                logger.error(error_message)
+                raise DatabaseError(error_message)
 
         return True


### PR DESCRIPTION
@peterbe r? 

Notably, some files do this:

``` python
connection = self.database.connection()
try:
    # things
finally:
    connection.close() 
```

Is it better than this:

``` python
try:
    connection = self.database.connection()
    # things
finally:
    if connection:
        connection.close()
```

?
