### PR TITLE
Fixes bug 913126 - Rapid betas in search-based systems

### DIFF
--- a/scripts/config/webapiconfig.py.dist
+++ b/scripts/config/webapiconfig.py.dist
@@ -312,12 +312,12 @@ platforms.default = (
 
 #---------------------------------------------------------------------------
 # Release Channels
-channels = cm.Option()
-channels.doc = 'List of release channels, excluding the `release` one.'
-channels.default = ['beta', 'aurora', 'nightly']
+non_release_channels = cm.Option()
+non_release_channels.doc = 'List of channels, excluding the `release` one.'
+non_release_channels.default = ['beta', 'aurora', 'nightly']
 
 restricted_channels = cm.Option()
-restricted_channels.doc = 'List of release channels to restrict based on build ids.'
+restricted_channels.doc = 'List of channels to restrict based on build ids.'
 restricted_channels.default = ['beta']
 
 

--- a/socorro/external/elasticsearch/base.py
+++ b/socorro/external/elasticsearch/base.py
@@ -250,52 +250,51 @@ class ElasticSearchBase(object):
             # There are several pairs product:version
             or_filter = []
             for v in versions:
-                if not v["version"]:
+                version = v["version"]
+                product = v["product"]
+
+                if not version:
+                    # There is no valid version here.
                     continue
 
-                and_filter = []
-                channel = None
-                key = ":".join((v["product"], v["version"]))
-                if key in versions_info:
-                    version_info = versions_info[key]
-                    if version_info["release_channel"]:
-                        channel = version_info["release_channel"].lower()
+                key = "%s:%s" % (product, version)
 
-                if channel and channel.startswith(tuple(config.channels)):
-                    # this version is not a release
-                    # first use the major version instead
-                    v["version"] = versions_info[key]["major_version"]
-                    # then make sure it's in the right release channel
-                    and_filter.append(
-                        ElasticSearchBase.build_terms_query(
-                            "release_channel",
-                            channel
+                version_data = {}
+                if key in versions_info:
+                    version_data = versions_info[key]
+
+                if version_data and version_data["is_rapid_beta"]:
+                    # If the version is a rapid beta, that means it's an
+                    # alias for a list of other versions. We thus don't filter
+                    # on that version, but on all versions listed in the
+                    # version_data that we have.
+
+                    # Get all versions that are linked to this rapid beta.
+                    rapid_beta_versions = [
+                        x for x in versions_info
+                        if versions_info[x]["from_beta_version"] == key
+                        and not versions_info[x]["is_rapid_beta"]
+                    ]
+
+                    for rapid_beta in rapid_beta_versions:
+                        and_filter = ElasticSearchBase.build_version_filters(
+                            product,
+                            versions_info[rapid_beta]["version_string"],
+                            versions_info[rapid_beta],
+                            config
                         )
+
+                        or_filter.append({"and": and_filter})
+                else:
+                    # This is a "normal" version, let's filter on it
+                    and_filter = ElasticSearchBase.build_version_filters(
+                        product,
+                        version,
+                        version_data,
+                        config
                     )
 
-                    if channel.startswith(tuple(config.restricted_channels)):
-                        # if it's a beta, verify the build id
-                        and_filter.append(
-                            ElasticSearchBase.build_terms_query(
-                                "build",
-                                versions_info[key]["build_id"]
-                            )
-                        )
-
-                elif channel:
-                    # this version is a release
-                    and_filter.append({
-                        "not":
-                            ElasticSearchBase.build_terms_query(
-                                    "release_channel",
-                                    config.channels)
-                    })
-
-                and_filter.append(ElasticSearchBase.build_terms_query(
-                                        "product", v["product"].lower()))
-                and_filter.append(ElasticSearchBase.build_terms_query(
-                                        "version", v["version"].lower()))
-                or_filter.append({"and": and_filter})
+                    or_filter.append({"and": and_filter})
 
             if or_filter:
                 filters["and"].append({"or": or_filter})
@@ -423,3 +422,58 @@ class ElasticSearchBase(object):
         elif search_mode == "is_exactly":
             terms = " ".join(terms)
         return terms
+
+    @staticmethod
+    def build_version_filters(product, version, version_data, config):
+        and_filter = []
+
+        channel = None
+        if (
+            "release_channel" in version_data and
+            version_data["release_channel"]
+        ):
+            channel = version_data["release_channel"].lower()
+
+        if channel and channel.startswith(
+            tuple(config.non_release_channels)
+        ):
+            # this version is not a release
+            # first use the major version instead
+            version = version_data["major_version"]
+
+            # then make sure it's in the right release channel
+            and_filter.append(
+                ElasticSearchBase.build_terms_query(
+                    "release_channel",
+                    channel
+                )
+            )
+
+            if channel.startswith(tuple(config.restricted_channels)):
+                # if it's a beta, verify the build id
+                and_filter.append(
+                    ElasticSearchBase.build_terms_query(
+                        "build",
+                        version_data["build_id"]
+                    )
+                )
+
+        elif channel:
+            # this version is a release
+            and_filter.append({
+                "not":
+                    ElasticSearchBase.build_terms_query(
+                            "release_channel",
+                            config.non_release_channels)
+            })
+
+        and_filter.append(ElasticSearchBase.build_terms_query(
+            "product",
+            product.lower()
+        ))
+        and_filter.append(ElasticSearchBase.build_terms_query(
+            "version",
+            version.lower()
+        ))
+
+        return and_filter

--- a/socorro/external/postgresql/base.py
+++ b/socorro/external/postgresql/base.py
@@ -194,8 +194,12 @@ class PostgreSQLBase(object):
 
     @staticmethod
     def build_reports_sql_where(params, sql_params, config):
+        """Return a string containing the WHERE part of a search-related SQL
+        query.
         """
-        """
+        if hasattr(config, "webapi"):
+            config = config.webapi
+
         sql_where = ["""
             WHERE r.date_processed BETWEEN %(from_date)s AND %(to_date)s
         """]
@@ -228,30 +232,59 @@ class PostgreSQLBase(object):
 
         ## Adding versions to where clause
         if params["versions"]:
-            sql_params = add_param_to_dict(sql_params, "version",
-                                           params["versions"])
-
             versions_where = []
+            version_index = 0
 
-            for x in range(0, len(params["versions"]), 2):
-                version_where = []
-                version_where.append(str(x).join(("r.product=%(version",
-                                                  ")s")))
+            # For each version, get information about it
+            for i in range(0, len(params["versions"]), 2):
+                versions_info = params["versions_info"]
+                product = params["versions"][i]
+                version = params["versions"][i + 1]
 
-                key = "%s:%s" % (params["versions"][x],
-                                 params["versions"][x + 1])
-                version_where = PostgreSQLBase.build_reports_sql_version_where(
-                    key,
-                    params,
-                    config,
-                    x,
-                    sql_params,
-                    version_where
-                )
+                key = "%s:%s" % (product, version)
 
-                version_where.append(str(x + 1).join((
-                                        "r.version=%(version", ")s")))
-                versions_where.append("(%s)" % " AND ".join(version_where))
+                version_data = None
+                if key in versions_info:
+                    version_data = versions_info[key]
+
+                if version_data and version_data["is_rapid_beta"]:
+                    # If the version is a rapid beta, that means it's an
+                    # alias for a list of other versions. We thus don't filter
+                    # on that version, but on all versions listed in the
+                    # version_data that we have.
+
+                    # Get all versions that are linked to this rapid beta.
+                    rapid_beta_versions = [
+                        x for x in versions_info
+                        if versions_info[x]["from_beta_version"] == key
+                        and not versions_info[x]["is_rapid_beta"]
+                    ]
+
+                    for rapid_beta in rapid_beta_versions:
+                        versions_where.append(
+                            PostgreSQLBase.build_version_where(
+                                product,
+                                versions_info[rapid_beta]["version_string"],
+                                version_index,
+                                sql_params,
+                                versions_info[rapid_beta],
+                                config
+                            )
+                        )
+                        version_index += 2
+                else:
+                    # This is a "normal" version, let's filter on it
+                    versions_where.append(
+                        PostgreSQLBase.build_version_where(
+                            product,
+                            version,
+                            version_index,
+                            sql_params,
+                            version_data,
+                            config
+                        )
+                    )
+                    version_index += 2
 
             sql_where.append("(%s)" % " OR ".join(versions_where))
 
@@ -338,43 +371,55 @@ class PostgreSQLBase(object):
         return (sql_limit, sql_params)
 
     @staticmethod
-    def build_reports_sql_version_where(key, params, config, x, sql_params,
-                                        version_where):
-        """
-        Return a list of strings for version restrictions.
-        """
-        if key in params["versions_info"]:
-            version_info = params["versions_info"][key]
-        else:
-            version_info = None
+    def build_version_where(
+        product,
+        version,
+        version_index,
+        sql_params,
+        version_data,
+        config
+    ):
+        """Return the content of WHERE of a SQL query for a given version. """
+        version_where = []
 
-        if x is None:
-            version_param = "version"
-        else:
-            version_param = "version%s" % (x + 1)
+        product_param = "version%s" % version_index
+        version_param = "version%s" % (version_index + 1)
 
-        if hasattr(config, 'webapi'):
-            context = config.webapi
-        else:
-            # old middleware
-            context = config
+        sql_params[product_param] = product
+        sql_params[version_param] = version
 
-        if version_info and version_info["release_channel"]:
-            channel = version_info["release_channel"].lower()
-            if channel.startswith(tuple(context.channels)):
-                # Use major_version instead of full version
-                sql_params[version_param] = version_info["major_version"]
-                # Restrict by release_channel
+        if version_data and version_data["release_channel"]:
+            # If we have data about that version, and it has a release channel,
+            # we will want to add some more specific filters to the SQL query.
+
+            channel = version_data["release_channel"].lower()
+
+            if channel.startswith(tuple(config.non_release_channels)):
+                # This is a non-release channel.
+
+                # Use major_version instead of full version.
+                sql_params[version_param] = version_data["major_version"]
+
+                # Restrict by release_channel.
                 version_where.append("r.release_channel ILIKE '%s'" % channel)
-                if channel.startswith(tuple(context.restricted_channels)):
-                    # Restrict to a list of build_id
-                    version_where.append("r.build IN ('%s')" % (
-                        "', '".join([
-                            str(bid) for bid in version_info["build_id"]])))
 
+                if (
+                    channel.startswith(tuple(config.restricted_channels)) and
+                    version_data["build_id"]
+                ):
+                    # Restrict to a list of build_id.
+                    builds = ", ".join(
+                        "'%s'" % b for b in version_data["build_id"]
+                    )
+                    version_where.append("r.build IN (%s)" % builds)
             else:
-                # it's a release
-                version_where.append(("r.release_channel NOT IN %s" %
-                                      (tuple(context.channels),)))
+                # It's a release.
+                version_where.append((
+                    "r.release_channel NOT IN %s" %
+                    (tuple(config.non_release_channels),)
+                ))
 
-        return version_where
+        version_where.append("r.product=%%(version%s)s" % version_index)
+        version_where.append("r.version=%%(version%s)s" % (version_index + 1))
+
+        return "(%s)" % " AND ".join(version_where)

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -254,15 +254,15 @@ class MiddlewareApp(App):
         from_string_converter=lambda x: json.loads(x)
     )
     required_config.webapi.add_option(
-        'channels',
+        'non_release_channels',
         default=['beta', 'aurora', 'nightly'],
-        doc='List of release channels, excluding the `release` one.',
+        doc='List of channels, excluding the `release` one.',
         from_string_converter=string_to_list
     )
     required_config.webapi.add_option(
         'restricted_channels',
         default=['beta'],
-        doc='List of release channels to restrict based on build ids.',
+        doc='List of channels to restrict based on build ids.',
         from_string_converter=string_to_list
     )
 

--- a/socorro/unittest/config/commonconfig.py.dist
+++ b/socorro/unittest/config/commonconfig.py.dist
@@ -163,10 +163,10 @@ platforms.default = (
 
 #---------------------------------------------------------------------------
 # Release Channels
-channels = cm.Option()
-channels.doc = 'List of release channels, excluding the `release` one.'
-channels.default = ['beta', 'aurora', 'nightly']
+non_release_channels = cm.Option()
+non_release_channels.doc = 'List of channels, excluding the `release` one.'
+non_release_channels.default = ['beta', 'aurora', 'nightly']
 
 restricted_channels = cm.Option()
-restricted_channels.doc = 'List of release channels to restrict based on build ids.'
+restricted_channels.doc = 'List of channels to restrict based on build ids.'
 restricted_channels.default = ['beta']

--- a/socorro/unittest/config/jenkins.py.dist
+++ b/socorro/unittest/config/jenkins.py.dist
@@ -163,9 +163,9 @@ platforms.default = (
 
 #---------------------------------------------------------------------------
 # Release Channels
-channels = cm.Option()
-channels.doc = 'List of release channels, excluding the `release` one.'
-channels.default = ['beta', 'aurora', 'nightly']
+non_release_channels = cm.Option()
+non_release_channels.doc = 'List of release channels, excluding the `release` one.'
+non_release_channels.default = ['beta', 'aurora', 'nightly']
 
 restricted_channels = cm.Option()
 restricted_channels.doc = 'List of release channels to restrict based on build ids.'

--- a/socorro/unittest/external/elasticsearch/test_base.py
+++ b/socorro/unittest/external/elasticsearch/test_base.py
@@ -90,7 +90,7 @@ class TestElasticSearchBase(unittest.TestCase):
                 "name": "Linux"
             }
         )
-        context.channels = ['beta', 'aurora', 'nightly']
+        context.non_release_channels = ['beta', 'aurora', 'nightly']
         context.restricted_channels = ['beta']
         return context
 
@@ -135,13 +135,17 @@ class TestElasticSearchBase(unittest.TestCase):
             "versions": "WaterWolf:1.0a1"
         }
         params = scommon.get_parameters(params)
-        params['versions_info'] = {
-            'WaterWolf:1.0a1': {
+        params["versions_info"] = {
+            "WaterWolf:1.0a1": {
+                "product_version_id": 1,
                 "version_string": "1.0a1",
                 "product_name": "WaterWolf",
                 "major_version": "1.0a1",
                 "release_channel": "nightly-water",
-                "build_id": None
+                "build_id": None,
+                "is_rapid_beta": False,
+                "is_from_rapid_beta": False,
+                "from_beta_version": "WaterWolf:1.0a1",
             }
         }
         query = ElasticSearchBase.build_query_from_params(params, config)
@@ -165,7 +169,10 @@ class TestElasticSearchBase(unittest.TestCase):
                 "product_name": "WaterWolf",
                 "major_version": "2.0",
                 "release_channel": None,
-                "build_id": None
+                "build_id": None,
+                "is_rapid_beta": False,
+                "is_from_rapid_beta": False,
+                "from_beta_version": "WaterWolf:2.0",
             }
         }
         query = ElasticSearchBase.build_query_from_params(params, config)

--- a/socorro/unittest/external/elasticsearch/test_search.py
+++ b/socorro/unittest/external/elasticsearch/test_search.py
@@ -14,6 +14,11 @@ from socorro.external.elasticsearch import crashstorage
 from socorro.external.elasticsearch.search import Search
 from socorro.lib import util, datetimeutil
 
+# Remove debugging noise during development
+# import logging
+# logging.getLogger('pyelasticsearch').setLevel(logging.ERROR)
+# logging.getLogger('elasticutils').setLevel(logging.ERROR)
+
 
 #==============================================================================
 class TestElasticSearchSearch(unittest.TestCase):
@@ -264,6 +269,26 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
             )
         )
 
+        self.storage.save_processed(
+            dict(
+                default_crash_report,
+                uuid=13,
+                product='EarlyOwl',
+                version='11.0b1',
+                release_channel='beta',
+            )
+        )
+
+        self.storage.save_processed(
+            dict(
+                default_crash_report,
+                uuid=14,
+                product='EarlyOwl',
+                version='11.0b2',
+                release_channel='beta',
+            )
+        )
+
         # As indexing is asynchronous, we need to force elasticsearch to
         # make the newly created content searchable before we run the tests
         self.storage.es.refresh()
@@ -292,7 +317,7 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
             'elasticsearch_timeout',
             'searchMaxNumberOfDistinctSignatures',
             'platforms',
-            'channels',
+            'non_release_channels',
             'restricted_channels',
         ]:
             webapi[opt] = self.config.get(opt)
@@ -333,7 +358,7 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
                 res['hits'][1]['signature'],
                 'my_bad'
             )
-            self.assertEqual(res['hits'][0]['is_linux'], 10)
+            self.assertEqual(res['hits'][0]['is_linux'], 12)
             self.assertEqual(res['hits'][0]['is_windows'], 1)
             self.assertEqual(res['hits'][0]['is_mac'], 0)
 
@@ -640,3 +665,61 @@ class IntegrationElasticsearchSearch(ElasticSearchTestCase):
             self.assertEqual(hit['pluginname'], 'Hey I just met you')
             self.assertEqual(hit['pluginfilename'], 'carly.dll')
             self.assertEqual(hit['pluginversion'], '1.2')
+
+    @mock.patch('socorro.external.elasticsearch.search.Util')
+    def test_search_versions(self, mock_psql_util):
+        mock_psql_util.return_value.versions_info.return_value = {
+            'EarlyOwl:11.0b1': {
+                'product_version_id': 1,
+                'product_name': 'EarlyOwl',
+                'version_string': '11.0b1',
+                'major_version': '11.0b1',
+                'release_channel': 'Beta',
+                'build_id': [1234567890],
+                'is_rapid_beta': False,
+                'is_from_rapid_beta': True,
+                'from_beta_version': 'EarlyOwl:11.0b',
+            },
+            'EarlyOwl:11.0b2': {
+                'product_version_id': 2,
+                'product_name': 'EarlyOwl',
+                'version_string': '11.0b2',
+                'major_version': '11.0b1',
+                'release_channel': 'Beta',
+                'build_id': [1234567890],
+                'is_rapid_beta': False,
+                'is_from_rapid_beta': True,
+                'from_beta_version': 'EarlyOwl:11.0b',
+            },
+            'EarlyOwl:11.0b': {
+                'product_version_id': 3,
+                'product_name': 'EarlyOwl',
+                'version_string': '11.0b',
+                'major_version': '11.0',
+                'release_channel': 'Beta',
+                'build_id': None,
+                'is_rapid_beta': True,
+                'is_from_rapid_beta': True,
+                'from_beta_version': 'EarlyOwl:11.0b',
+            }
+        }
+
+        with self.get_config_manager().context() as config:
+            api = Search(config=config)
+
+            # Get all from the different beta versions
+            params = dict(
+                versions=['EarlyOwl:11.0b1', 'EarlyOwl:11.0b2'],
+            )
+            res1 = api.get(**params)
+            self.assertEqual(res1['total'], 1)
+
+            # Get all from the rapid beta alias
+            params = dict(
+                versions='EarlyOwl:11.0b',
+            )
+            res2 = api.get(**params)
+            self.assertEqual(res2['total'], 1)
+
+            # The results should be identical
+            self.assertEqual(res1, res2)

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -43,7 +43,7 @@ def _get_config_manager(config, es_index=None):
         'facets_max_number',
         'searchMaxNumberOfDistinctSignatures',
         'platforms',
-        'channels',
+        'non_release_channels',
         'restricted_channels',
     ]:
         webapi[opt] = config.get(opt)

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -37,7 +37,7 @@ class TestPostgreSQLBase(unittest.TestCase):
                 "name": "Linux"
             }
         )
-        context.channels = ['beta', 'aurora', 'nightly']
+        context.non_release_channels = ['beta', 'aurora', 'nightly']
         context.restricted_channels = ['beta']
         return context
 
@@ -303,32 +303,56 @@ class TestPostgreSQLBase(unittest.TestCase):
                 "product_name": "Firefox",
                 "major_version": "12.0",
                 "release_channel": "Nightly",
-                "build_id": ["20120101123456"]
+                "build_id": ["20120101123456"],
+                "is_rapid_beta": False,
+                "from_rapid_beta": False,
+                "rapid_beta_version": "Firefox:12.0a1",
             },
             "Fennec:11.0": {
                 "version_string": "11.0",
                 "product_name": "Fennec",
                 "major_version": None,
                 "release_channel": None,
-                "build_id": None
+                "build_id": None,
+                "is_rapid_beta": False,
+                "from_rapid_beta": False,
+                "rapid_beta_version": "Fennec:11.0",
             },
             "Firefox:13.0(beta)": {
                 "version_string": "13.0(beta)",
                 "product_name": "Firefox",
                 "major_version": "13.0",
                 "release_channel": "Beta",
-                "build_id": ["20120101123456", "20120101098765"]
+                "build_id": ["20120101123456", "20120101098765"],
+                "is_rapid_beta": False,
+                "from_rapid_beta": True,
+                "rapid_beta_version": "Firefox:13.0b",
+            },
+            "Firefox:13.0b": {
+                "version_string": "13.0b",
+                "product_name": "Firefox",
+                "major_version": "13.0b",
+                "release_channel": "Beta",
+                "build_id": None,
+                "is_rapid_beta": True,
+                "from_rapid_beta": True,
+                "rapid_beta_version": "Firefox:13.0b",
             }
         }
 
-        sql_exp = "WHERE r.date_processed BETWEEN %(from_date)s AND " \
-                  "%(to_date)s AND ((r.product=%(version0)s AND " \
-                  "r.release_channel ILIKE 'nightly' AND " \
-                  "r.version=%(version1)s) OR (r.product=%(version2)s AND " \
-                  "r.version=%(version3)s) OR (r.product=%(version4)s AND " \
-                  "r.release_channel ILIKE 'beta' AND r.build IN " \
-                  "('20120101123456', '20120101098765') AND " \
-                  "r.version=%(version5)s))"
+        sql_exp = """
+            WHERE r.date_processed BETWEEN %(from_date)s AND %(to_date)s
+            AND
+                ((r.release_channel ILIKE 'nightly'
+                    AND r.product=%(version0)s
+                    AND r.version=%(version1)s)
+                OR (r.product=%(version2)s
+                    AND r.version=%(version3)s)
+                OR (r.release_channel ILIKE 'beta'
+                    AND r.build IN ('20120101123456', '20120101098765')
+                    AND r.product=%(version4)s
+                    AND r.version=%(version5)s))
+        """
         sql_params_exp = {
             "from_date": params.from_date,
             "to_date": params.to_date,
@@ -342,7 +366,10 @@ class TestPostgreSQLBase(unittest.TestCase):
 
         (sql, sql_params) = pgbase.build_reports_sql_where(params, sql_params,
                                                            config)
-        sql = " ".join(sql.split())  # squeeze all \s, \r, \t...
+
+        # squeeze all \s, \r, \t...
+        sql = " ".join(sql.split())
+        sql_exp = " ".join(sql_exp.split())
 
         self.assertEqual(sql, sql_exp)
         self.assertEqual(sql_params, sql_params_exp)
@@ -416,7 +443,7 @@ class TestPostgreSQLBase(unittest.TestCase):
         self.assertEqual(sql_params, sql_params_exp)
 
     #--------------------------------------------------------------------------
-    def test_build_reports_sql_version_where(self):
+    def test_build_version_where(self):
         """Test PostgreSQLBase.build_reports_sql_version_where()."""
         config = self.get_dummy_context()
         pgbase = self.get_instance()
@@ -473,16 +500,22 @@ class TestPostgreSQLBase(unittest.TestCase):
             "version1": "13.0"
         }
         version_where = []
-        version_where_exp = ["r.release_channel ILIKE 'beta'",
-                             "r.build IN ('20120101123456', '20120101098765')"]
+        version_where_exp = (
+            "("
+            "r.release_channel ILIKE 'beta'"
+            " AND r.build IN ('20120101123456', '20120101098765')"
+            " AND r.product=%(version0)s"
+            " AND r.version=%(version1)s"
+            ")"
+        )
 
-        version_where = pgbase.build_reports_sql_version_where(
-            key,
-            params,
-            config,
+        version_where = pgbase.build_version_where(
+            "Firefox",
+            "13.0",
             x,
             sql_params,
-            version_where
+            params["versions_info"][key],
+            config,
         )
 
         self.assertEqual(version_where, version_where_exp)
@@ -501,15 +534,21 @@ class TestPostgreSQLBase(unittest.TestCase):
             "version1": "1.0a1"
         }
         version_where = []
-        version_where_exp = ["r.release_channel ILIKE 'nightly-water'"]
+        version_where_exp = (
+            "("
+            "r.release_channel ILIKE 'nightly-water'"
+            " AND r.product=%(version0)s"
+            " AND r.version=%(version1)s"
+            ")"
+        )
 
-        version_where = pgbase.build_reports_sql_version_where(
-            key,
-            params,
-            config,
+        version_where = pgbase.build_version_where(
+            "WaterWolf",
+            "1.0a1",
             x,
             sql_params,
-            version_where
+            params["versions_info"][key],
+            config,
         )
 
         self.assertEqual(version_where, version_where_exp)
@@ -527,16 +566,20 @@ class TestPostgreSQLBase(unittest.TestCase):
             "version0": "WaterWolf",
             "version1": "2.0"
         }
-        version_where = []
-        version_where_exp = []
+        version_where_exp = (
+            "("
+            "r.product=%(version0)s"
+            " AND r.version=%(version1)s"
+            ")"
+        )
 
-        version_where = pgbase.build_reports_sql_version_where(
-            key,
-            params,
-            config,
+        version_where = pgbase.build_version_where(
+            "WaterWolf",
+            "2.0",
             x,
             sql_params,
-            version_where
+            params["versions_info"][key],
+            config,
         )
 
         self.assertEqual(version_where, version_where_exp)
@@ -598,10 +641,12 @@ class IntegrationTestBase(PostgreSQLTestCase):
         # Verify that we've got 'timezone=utc' set
         sql = 'SHOW TIMEZONE'
         results = base.query(sql)
-        self.assertTrue('UTC' in results[0],
+        self.assertTrue(
+            'UTC' in results[0],
             """Please set PostgreSQL to use the UTC timezone.
                Documentation on how to do this is included in
-               the INSTALL instructions.""")
+               the INSTALL instructions."""
+        )
 
     #--------------------------------------------------------------------------
     def test_query(self):

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -1200,7 +1200,7 @@ class IntegrationTestMiddlewareApp(unittest.TestCase):
 
         config_manager = self._setup_config_manager(
             extra_value_source={
-                'webapi.channels': 'Foo, Bar',
+                'webapi.non_release_channels': 'Foo, Bar',
                 'webapi.restricted_channels': 'foo , bar',
                 'webapi.platforms': platforms_json_dump
             }
@@ -1209,7 +1209,7 @@ class IntegrationTestMiddlewareApp(unittest.TestCase):
         with config_manager.context() as config:
             app = middleware_app.MiddlewareApp(config)
             self.assertEqual(
-                app.config.webapi.channels,
+                app.config.webapi.non_release_channels,
                 ['Foo', 'Bar']
             )
             self.assertEqual(


### PR DESCRIPTION
Let's try that one more time. 

@selenamarie, r? on the postgres parts? Mainly on the `util.py` file, that is where the slow SQL is.
