### PR TITLE
Fixes Bug 929533 -  code to identify the processor class in use in processor_notes

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -268,7 +268,7 @@ class HybridCrashProcessor(RequiredConfig):
             input parameters:
         """
         self._statistics.incr('jobs')
-        processor_notes = [self.config.processor_name]
+        processor_notes = [self.config.processor_name, self.__class__.__name__]
         try:
             self.quit_check()
             crash_id = raw_crash.uuid

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -292,7 +292,7 @@ class LegacyCrashProcessor(RequiredConfig):
             input parameters:
         """
         self._statistics.incr('jobs')
-        processor_notes = [self.config.processor_name]
+        processor_notes = [self.config.processor_name, self.__class__.__name__]
         try:
             self.quit_check()
             crash_id = raw_crash.uuid
@@ -317,6 +317,7 @@ class LegacyCrashProcessor(RequiredConfig):
                 started_timestamp,
                 processor_notes
             )
+
             processed_crash.uuid = raw_crash.uuid
 
             processed_crash.additional_minidumps = []

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -334,6 +334,7 @@ class TestHybridProcessor(unittest.TestCase):
                   started_timestamp,
                   [
                       'testing_processor:2012',
+                      'HybridCrashProcessor'
                   ]
                 )
 
@@ -349,6 +350,7 @@ class TestHybridProcessor(unittest.TestCase):
                    0, None, datetime(2012, 5, 4, 15, 33, 33, tzinfo=UTC),
                    [
                       'testing_processor:2012',
+                      'HybridCrashProcessor'
                    ]),)
                 )
                 self.assertEqual(
@@ -358,6 +360,7 @@ class TestHybridProcessor(unittest.TestCase):
                    0, None, datetime(2012, 5, 4, 15, 33, 33, tzinfo=UTC),
                    [
                       'testing_processor:2012',
+                      'HybridCrashProcessor'
                    ]),)
                 )
 
@@ -371,7 +374,8 @@ class TestHybridProcessor(unittest.TestCase):
                 epc = DotDict()
                 epc.uuid = raw_crash.uuid
                 epc.topmost_filenames = ''
-                epc.processor_notes = "testing_processor:2012"
+                epc.processor_notes = \
+                    "testing_processor:2012; HybridCrashProcessor"
 
                 epc.success = True
                 epc.completeddatetime = datetime(2012, 5, 4, 15, 11,
@@ -456,7 +460,8 @@ class TestHybridProcessor(unittest.TestCase):
 
                 e = {
                   'processor_notes':
-                      'testing_processor:2012; unrecoverable processor error: '
+                      'testing_processor:2012; HybridCrashProcessor; '
+                      'unrecoverable processor error: '
                       'nobody expects the spanish inquisition',
                   'completeddatetime': datetime(2012, 5, 4, 15, 11,
                                                 tzinfo=UTC),

--- a/socorro/unittest/processor/test_legacy_processor.py
+++ b/socorro/unittest/processor/test_legacy_processor.py
@@ -334,6 +334,7 @@ class TestLegacyProcessor(unittest.TestCase):
                   started_timestamp,
                   [
                       'testing_processor:2012',
+                      'LegacyCrashProcessor',
                       "Pipe dump missing from 'upload_file_minidump'",
                       "Pipe dump missing from 'aux_dump_001'"
                   ]
@@ -351,6 +352,7 @@ class TestLegacyProcessor(unittest.TestCase):
                    0, None, datetime(2012, 5, 4, 15, 33, 33, tzinfo=UTC),
                    [
                       'testing_processor:2012',
+                      'LegacyCrashProcessor',
                       "Pipe dump missing from 'upload_file_minidump'",
                       "Pipe dump missing from 'aux_dump_001'"
                    ]),)
@@ -362,6 +364,7 @@ class TestLegacyProcessor(unittest.TestCase):
                    0, None, datetime(2012, 5, 4, 15, 33, 33, tzinfo=UTC),
                    [
                       'testing_processor:2012',
+                      'LegacyCrashProcessor',
                       "Pipe dump missing from 'upload_file_minidump'",
                       "Pipe dump missing from 'aux_dump_001'"
                    ]),)
@@ -378,7 +381,8 @@ class TestLegacyProcessor(unittest.TestCase):
                 epc.uuid = raw_crash.uuid
                 epc.topmost_filenames = ''
                 epc.processor_notes = \
-                    "testing_processor:2012; Pipe dump missing from " \
+                    "testing_processor:2012; LegacyCrashProcessor; " \
+                    "Pipe dump missing from " \
                     "'upload_file_minidump'; Pipe dump missing from " \
                     "'aux_dump_001'"
 
@@ -465,7 +469,8 @@ class TestLegacyProcessor(unittest.TestCase):
 
                 e = {
                   'processor_notes':
-                      'testing_processor:2012; unrecoverable processor error: '
+                      'testing_processor:2012; LegacyCrashProcessor; '
+                      'unrecoverable processor error: '
                       'nobody expects the spanish inquisition',
                   'completeddatetime': datetime(2012, 5, 4, 15, 11,
                                                 tzinfo=UTC),


### PR DESCRIPTION
Now that we've got multiple processor algorithms (legacy_processor, hybrid_processor, and soon processor2014), they ought to identify themselves in the processor notes.
