### PR TITLE
Fixes Bug 932591 - restore friendly logging during shutdown

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -27,6 +27,7 @@ sending new crash records to Postgres; sending the processed crash to HBase;
 the the submission of the crash_id to Elastic Search."""
 
 import signal
+from functools import partial
 
 from configman import Namespace
 from configman.converters import class_converter
@@ -190,7 +191,11 @@ class FetchTransformSaveApp(App):
         """instantiate the threaded task manager to run the producer/consumer
         queue that is the heart of the processor."""
         self.config.logger.info('installing signal handers')
-        signal.signal(signal.SIGTERM, respond_to_SIGTERM)
+        respond_to_SIGTERM_with_logging = partial(
+            respond_to_SIGTERM,
+            logger=self.config.logger
+        )
+        signal.signal(signal.SIGTERM, respond_to_SIGTERM_with_logging)
         self.task_manager = \
             self.config.producer_consumer.producer_consumer_class(
               self.config.producer_consumer,

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -33,7 +33,7 @@ def default_iterator():
 #------------------------------------------------------------------------------
 # TODO: This may not be necessary anymore; I believe Python has ironed out
 # ctrl-C in multithreaded situations.
-def respond_to_SIGTERM(signal_number, frame):
+def respond_to_SIGTERM(signal_number, frame, logger=None):
     """ these classes are instrumented to respond to a KeyboardInterrupt by
     cleanly shutting down.  This function, when given as a handler to for
     a SIGTERM event, will make the program respond to a SIGTERM as neatly
@@ -49,6 +49,8 @@ def respond_to_SIGTERM(signal_number, frame):
         signal_number - unused in this function but required by the api.
         frame - unused in this function but required by the api.
     """
+    if logger:
+        logger.info('detected SIGTERM')
     raise KeyboardInterrupt
 
 


### PR DESCRIPTION
rework the signal handlers to log when any app receives a signal.  add the 'done.' message to every app that has shut down cleanly.  
