### PR TITLE
Fixes bug 874520 - Added string operators to user_comments and address f...

### DIFF
--- a/webapp-django/crashstats/supersearch/forms.py
+++ b/webapp-django/crashstats/supersearch/forms.py
@@ -12,7 +12,7 @@ ADMIN_RESTRICTED_FIELDS = {
 class SearchForm(forms.Form):
     '''Handle the data populating the search form. '''
 
-    address = form_fields.MultipleValueField(required=False)
+    address = form_fields.StringField(required=False)
     app_notes = form_fields.MultipleValueField(required=False)
     build_id = form_fields.IntegerField(required=False)
     cpu_info = form_fields.StringField(required=False)
@@ -38,7 +38,7 @@ class SearchForm(forms.Form):
     signature = form_fields.StringField(required=False)
     topmost_filenames = form_fields.MultipleValueField(required=False)
     uptime = form_fields.IntegerField(required=False)
-    user_comments = form_fields.MultipleValueField(required=False)
+    user_comments = form_fields.StringField(required=False)
     version = form_fields.MultipleValueField(required=False)
     winsock_lsp = form_fields.MultipleValueField(required=False)
 


### PR DESCRIPTION
...ields.

@peterbe r?

The operators available to a field are determined using the type of that field. Using the `MultipleValueField` allows users to use the default operators (`has terms` and its negation), and using `StringField` enables string-related operators like `contains` or `exists`. Hence this very simple change. 
