### PR TITLE
Fixes Bug 935520 - optionally supress stdout in submitter

### DIFF
--- a/socorro/collector/bixie_submitter_utilities.py
+++ b/socorro/collector/bixie_submitter_utilities.py
@@ -26,6 +26,12 @@ class BixieGETDestination(CrashStorageBase):
         doc="The url of the Bixie collector to submit to",
         default="http://127.0.0.1:8882/"
     )
+    required_config.add_option(
+        'echo_response',
+        short_form='e',
+        doc="echo the submission response to stdout",
+        default=False
+    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
@@ -78,4 +84,5 @@ class BixieGETDestination(CrashStorageBase):
             'submission response: %s',
             submission_response
             )
-        print submission_response
+        if self.config.echo_response:
+            print submission_response

--- a/socorro/collector/breakpad_submitter_utilities.py
+++ b/socorro/collector/breakpad_submitter_utilities.py
@@ -22,6 +22,12 @@ class BreakpadPOSTDestination(CrashStorageBase):
         doc="The url of the Socorro collector to submit to",
         default="http://127.0.0.1:8882/submit"
     )
+    required_config.add_option(
+        'echo_response',
+        short_form='e',
+        doc="echo the submission response to stdout",
+        default=False
+    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
@@ -56,7 +62,8 @@ class BreakpadPOSTDestination(CrashStorageBase):
                 'submission response: %s',
                 submission_response
                 )
-            print submission_response
+            if self.config.echo_response:
+                print submission_response
         finally:
             for dump_name, dump_pathname in dumps.iteritems():
                 if "TEMPORARY" in dump_pathname:

--- a/socorro/unittest/collector/test_bixie_submitter_utilities.py
+++ b/socorro/unittest/collector/test_bixie_submitter_utilities.py
@@ -61,6 +61,7 @@ class TestBixieGETDestination(unittest.TestCase):
         config.url = "http://127.0.0.1:8882/"
         config.redactor_class = Redactor
         config.forbidden_keys = Redactor.required_config.forbidden_keys.default
+        config.echo_response = False
         return config
 
     def test_setup(self):


### PR DESCRIPTION
both the Breakpad and Bixie submitters echo the http request response to stdout.  Add a config option to suppress that output. 
