### PR TITLE
Fixes Bug 935546 - silence debugging print statements

### DIFF
--- a/socorro/unittest/collector/test_submitter_app.py
+++ b/socorro/unittest/collector/test_submitter_app.py
@@ -193,7 +193,6 @@ class TestDBSamplingCrashSource(unittest.TestCase):
 
         raw_dumps_as_files = \
             db_sampling._implementation.get_raw_dumps_as_files(crash_id)
-        print raw_dumps_as_files
         self.assertTrue(isinstance(raw_dumps_as_files, dict))
         self.assertEqual(raw_dumps_as_files['upload_file_minidump'],
                          '86b58ff2-9708-487d-bfc4-9dac32121214.' \

--- a/socorro/unittest/external/filesystem/test_dump_storage.py
+++ b/socorro/unittest/external/filesystem/test_dump_storage.py
@@ -377,7 +377,6 @@ class TestDumpStorage:
   def testReadableOrThrow(self):
     d = dumpStorage.DumpStorage
     assert_raises(OSError,d.readableOrThrow,self.testDir)
-    print "lars", self.testDir
     os.mkdir(self.testDir)
     tname = 'someUselessFile_'
     d.readableOrThrow(self.testDir)

--- a/socorro/unittest/external/postgresql/test_setupdb_app.py
+++ b/socorro/unittest/external/postgresql/test_setupdb_app.py
@@ -26,7 +26,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
             'password=%(database_password)s' %
             dict(DSN, database_name=database_name)
         )
-        print 'DEBUG', dsn
+        #print 'DEBUG', dsn
         return psycopg2.connect(dsn)
 
     def _drop_database(self):

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -926,8 +926,7 @@ class TestHybridProcessor(unittest.TestCase):
                   'exploitability': 'unknown',
                   'json_dump': {'status': 'unknown error'},
                 })
-                print dict(processed_crash_update)
-                
+
                 self.assertEqual(e_pcu, processed_crash_update)
                 excess = list(m_iter)
                 self.assertEqual(len(excess), 0)


### PR DESCRIPTION
There's a number of places where stdout debugging has been left in the source code.  Remove this unnecessary chatter.
