### PR TITLE
Fixes Bug 557234 adds nsACString_internal::... to prefix skiplist

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -329,6 +329,7 @@ class CSignatureTool(CSignatureToolBase):
           'moz_xmalloc',
           'moz_xrealloc',
           'NP_Shutdown',
+          'nsACString_internal::Assign.*',
           'nsCOMPtr.*',
           'NS_DebugBreak.*',
           '[-+]\[NSException raise(:format:(arguments:)?)?\]',


### PR DESCRIPTION
as requested, this PR adds "nsACString_internal::Assign.*" to the prefix skiplist.
