### PR TITLE
FIxes Bug 937801 - fixed up rabbitmq priority job service in the middleware

### DIFF
--- a/config/middleware.ini-dist
+++ b/config/middleware.ini-dist
@@ -134,6 +134,53 @@ application='MiddlewareApp'
     # converter: configman.converters.class_converter
     transaction_executor_class='socorro.database.transaction_executor.TransactionExecutor'
 
+[rabbitmq]
+
+    # name: host
+    # doc: the hostname of the RabbitMQ server
+    # converter: str
+    host='localhost'
+
+    # name: port
+    # doc: the port for the RabbitMQ server
+    # converter: int
+    port='5672'
+
+    # name: priority_queue_name
+    # doc: the name of priority crash queue name within RabbitMQ
+    # converter: str
+    priority_queue_name='socorro.priority'
+
+    # name: rabbitmq_class
+    # doc: None
+    # converter: configman.converters.class_converter
+    rabbitmq_class='socorro.external.rabbitmq.connection_context.ConnectionContext'
+
+    # name: rabbitmq_connection_wrapper_class
+    # doc: a classname for the type of wrapper for RabbitMQ connections
+    # converter: configman.converters.class_converter
+    rabbitmq_connection_wrapper_class='socorro.external.rabbitmq.connection_context.Connection'
+
+    # name: rabbitmq_password
+    # doc: the user's RabbitMQ password
+    # converter: str
+    rabbitmq_password='guest'
+
+    # name: rabbitmq_user
+    # doc: the name of the user within the RabbitMQ instance
+    # converter: str
+    rabbitmq_user='guest'
+
+    # name: standard_queue_name
+    # doc: the name of standard crash queue name within RabbitMQ
+    # converter: str
+    standard_queue_name='socorro.normal'
+
+    # name: virtual_host
+    # doc: the name of the RabbitMQ virtual host
+    # converter: str
+    virtual_host='/'
+
 [http]
 
     [[correlations]]

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -23,7 +23,6 @@ from socorro.external import (
 from socorro.webapi.webapiService import JsonWebServiceBase, Timeout
 from socorro.external.filesystem.crashstorage import FileSystemCrashStorage
 from socorro.external.hbase.crashstorage import HBaseCrashStorage
-from socorro.external.postgresql.connection_context import ConnectionContext
 
 import raven
 from configman import Namespace
@@ -152,7 +151,8 @@ class MiddlewareApp(App):
     required_config.namespace('database')
     required_config.database.add_option(
         'database_class',
-        default=ConnectionContext,
+        default=
+            'socorro.external.postgresql.connection_context.ConnectionContext',
         from_string_converter=class_converter
     )
 
@@ -175,6 +175,18 @@ class MiddlewareApp(App):
     required_config.filesystem.add_option(
         'filesystem_class',
         default=FileSystemCrashStorage,
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    # rabbitmq namespace
+    #     the namespace is for external implementations of the services
+    #-------------------------------------------------------------------------
+    required_config.namespace('rabbitmq')
+    required_config.rabbitmq.add_option(
+        'rabbitmq_class',
+        default=
+            'socorro.external.rabbitmq.connection_context.ConnectionContext',
         from_string_converter=class_converter
     )
 

--- a/socorro/unittest/external/rabbitmq/test_priorityjobs.py
+++ b/socorro/unittest/external/rabbitmq/test_priorityjobs.py
@@ -4,13 +4,12 @@
 
 import unittest
 
-from mock import Mock
+from mock import Mock, MagicMock, patch
 from nose.plugins.attrib import attr
 
 from socorro.external.rabbitmq import priorityjobs
-from socorro.lib import ConfigurationManager
-from socorro.unittest.config import commonconfig
 
+from configman.dotdict import DotDictWithAcquisition
 
 #==============================================================================
 @attr(integration='rabbitmq')  # for nosetests
@@ -19,17 +18,44 @@ class IntegrationTestPriorityjobs(unittest.TestCase):
 
     def setUp(self):
         """Create a configuration context."""
-        self.config = ConfigurationManager.newConfiguration(
-            configurationModule=commonconfig,
-            applicationName="RabbitMQ Tests"
-        )
+        old_config = DotDictWithAcquisition()
+        old_config.rabbitMQUsername = 'guest'
+        old_config.rabbitMQPassword = 'guest'
+        old_config.rabbitMQHost = 'localhost'
+        old_config.rabbitMQPort = 5672
+        old_config.rabbitMQVirtualhost = '/'
+        old_config.rabbitMQStandardQueue = 'socorro.normal'
+        old_config.rabbitMQPriorityQueue = 'socorro.priority'
+        old_config.logger = Mock()
+        self.old_config = old_config
+
+        rabbitmq = DotDictWithAcquisition()
+        rabbitmq.host='localhost'
+        rabbitmq.port=5672
+        rabbitmq.priority_queue_name='socorro.priority'
+        rabbitmq.rabbitmq_class=Mock()
+        rabbitmq.rabbitmq_password='guest'
+        rabbitmq.rabbitmq_user='guest'
+        rabbitmq.standard_queue_name='socorro.normal'
+        rabbitmq.virtual_host='/'
+        self.new_config = DotDictWithAcquisition()
+        self.new_config.logger = Mock()
+        self.new_config.rabbitmq = rabbitmq
 
     #--------------------------------------------------------------------------
     def test_get(self):
         """Test the get method raises an exception, since RabbitMQ doesn't
         implement a way to examine what's in a queue."""
 
-        jobs = priorityjobs.Priorityjobs(config=self.config)
+        # test with old style config
+        jobs = priorityjobs.Priorityjobs(config=self.old_config)
+        self.assertRaises(
+            NotImplementedError,
+            jobs.get
+        )
+
+        # test with new style config
+        jobs = priorityjobs.Priorityjobs(config=self.new_config)
         self.assertRaises(
             NotImplementedError,
             jobs.get
@@ -40,11 +66,53 @@ class IntegrationTestPriorityjobs(unittest.TestCase):
         """Test that the create() method properly creates the job, and errors
         when not given the proper arguments."""
 
-        jobs = priorityjobs.Priorityjobs(config=self.config)
-        jobs.context = Mock()
+        # with old config
+        with patch(
+            'socorro.external.rabbitmq.priorityjobs.ConnectionContext'
+        ) as mocked_connection:
+            mocked_connection.return_value = MagicMock
+            jobs = priorityjobs.Priorityjobs(config=self.old_config)
+            self.assertEqual(mocked_connection.call_count, 1)
+            self.assertEqual(jobs.config.host, 'localhost')
+            self.assertEqual(jobs.config.port, 5672)
+            self.assertEqual(jobs.config.virtual_host, '/')
+            self.assertEqual(jobs.config.rabbitmq_user, 'guest')
+            self.assertEqual(jobs.config.rabbitmq_password, 'guest')
+            self.assertEqual(jobs.config.standard_queue_name, 'socorro.normal')
+            self.assertEqual(
+                jobs.config.priority_queue_name,
+                'socorro.priority'
+            )
+            self.assertEqual(jobs.create(uuid='b1'), True)
 
-        self.assertEqual(jobs.create(uuid='b1'), True)
+        # with new config
+        with patch(
+            'socorro.external.rabbitmq.priorityjobs.pika') as mocked_pika:
+            jobs = priorityjobs.Priorityjobs(config=self.new_config)
+            mocked_connection =  self.new_config.rabbitmq.rabbitmq_class
+            mocked_connection.return_value.return_value = MagicMock()
+            self.assertEqual(mocked_connection.call_count, 1)
+            self.assertEqual(jobs.config.host, 'localhost')
+            self.assertEqual(jobs.config.port, 5672)
+            self.assertEqual(jobs.config.virtual_host, '/')
+            self.assertEqual(jobs.config.rabbitmq_user, 'guest')
+            self.assertEqual(jobs.config.rabbitmq_password, 'guest')
+            self.assertEqual(jobs.config.standard_queue_name, 'socorro.normal')
+            self.assertEqual(
+                jobs.config.priority_queue_name,
+                'socorro.priority'
+            )
+            self.assertEqual(jobs.create(uuid='b1'), True)
 
-        #......................................................................
-        self.assertRaises(priorityjobs.MissingArgumentError,
-                          jobs.create)
+            #..................................................................
+            self.assertRaises(priorityjobs.MissingArgumentError,
+                              jobs.create)
+            self.assertTrue(
+                mocked_connection.return_value.channel. \
+                    basic_publish.called_once_with(
+                        '',
+                        'socorro.priority',
+                        'b1',
+                        mocked_pika.BasicProperties.return_value
+                    )
+            )


### PR DESCRIPTION
the rabbitmq priority job service in the middleware only used old style configuration - so it failed under the new middleware.  This PR corrects that to make the service run in both old and new systems.
