### PR TITLE
FIxes Bug 940499 - add support classifier system

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -187,7 +187,6 @@ class HybridCrashProcessor(RequiredConfig):
         from_string_converter=class_converter
     )
 
-
     #--------------------------------------------------------------------------
     def __init__(self, config, quit_check_callback=None):
         super(HybridCrashProcessor, self).__init__()
@@ -217,7 +216,7 @@ class HybridCrashProcessor(RequiredConfig):
                 'falling back to default skunk_classifier rules'
             )
             from socorro.processor.skunk_classifiers import \
-                 default_classifier_rules
+                default_classifier_rules
             self.rule_system.skunk_classifier.load_rules(
                 default_classifier_rules
             )
@@ -230,7 +229,7 @@ class HybridCrashProcessor(RequiredConfig):
                 'falling back to default support_classifier rules'
             )
             from socorro.processor.support_classifiers import \
-                 default_support_classifier_rules
+                default_support_classifier_rules
             self.rule_system.support_classifier.load_rules(
                 default_support_classifier_rules
             )
@@ -267,7 +266,6 @@ class HybridCrashProcessor(RequiredConfig):
             "processor." + self.config.processor_name
         )
         self._statistics.incr('restarts')
-
 
     #--------------------------------------------------------------------------
     def reject_raw_crash(self, crash_id, reason):
@@ -349,11 +347,12 @@ class HybridCrashProcessor(RequiredConfig):
                 )
 
             try:
-                self.rule_system.support_classifier.apply_all_rules(
-                    raw_crash,
-                    processed_crash,
-                    self
-                )
+                self.rule_system.support_classifier \
+                    .apply_until_action_succeeds(
+                        raw_crash,
+                        processed_crash,
+                        self
+                    )
             except Exception, x:
                 # let's catch any unexpected error here and not let them
                 # derail the rest of the processing.
@@ -362,8 +361,6 @@ class HybridCrashProcessor(RequiredConfig):
                     str(x),
                     exc_info=True
                 )
-
-
 
         except Exception, x:
             self.config.logger.warning(
@@ -535,7 +532,7 @@ class HybridCrashProcessor(RequiredConfig):
         try:
             timestampTime = int(
                 raw_crash.get('timestamp', submitted_timestamp_as_epoch)
-                )  # the old name for crash time
+            )  # the old name for crash time
         except ValueError:
             timestampTime = 0
             processor_notes.append('non-integer value of "timestamp"')
@@ -771,7 +768,7 @@ class HybridCrashProcessor(RequiredConfig):
         java_stack_trace,
         submitted_timestamp,
         processor_notes
-        ):
+    ):
         with closing(dump_analysis_line_iterator) as mdsw_iter:
             processed_crash_update = self._analyze_header(
                 crash_id,
@@ -822,7 +819,7 @@ class HybridCrashProcessor(RequiredConfig):
             try:
                 processed_crash_update.exploitability = (
                     processed_crash_update.json_dump
-                        ['sensitive']['exploitability']
+                    ['sensitive']['exploitability']
                 )
             except KeyError:
                 processed_crash_update.exploitability = 'unknown'
@@ -831,7 +828,7 @@ class HybridCrashProcessor(RequiredConfig):
             try:
                 processed_crash_update.truncated = (
                     processed_crash_update.json_dump
-                        ['crashing_thread']['frames_truncated']
+                    ['crashing_thread']['frames_truncated']
                 )
             except KeyError:
                 processed_crash_update.truncated = False
@@ -842,8 +839,10 @@ class HybridCrashProcessor(RequiredConfig):
             )
 
         return_code = mdsw_subprocess_handle.wait()
-        if ((return_code is not None and return_code != 0) or
-              mdsw_error_string != 'OK'):
+        if (
+            (return_code is not None and return_code != 0) or
+            mdsw_error_string != 'OK'
+        ):
             self._statistics.incr('mdsw_failures')
             processor_notes.append(
                 "MDSW failed: %s" % mdsw_error_string
@@ -1244,7 +1243,6 @@ class HybridCrashProcessor(RequiredConfig):
         for row in product_mappings:
             self._product_id_map[row[1]] = {'product_name': row[0],
                                             'rewrite': row[2]}
-
 
 
 #==============================================================================

--- a/socorro/processor/support_classifiers.py
+++ b/socorro/processor/support_classifiers.py
@@ -11,7 +11,7 @@ the support classifcation rules live here.
         'support': {
             'classification': 'some classification',
             'classification_data': 'extra information saved by rule',
-            'classificaiton_version': '0.0',
+            'classification_version': '0.0',
         }
     }
 
@@ -156,14 +156,12 @@ class SupportClassificationRule(object):
         """
         if 'classifications' not in processed_crash:
             processed_crash['classifications'] = DotDict()
-        if 'support' not in processed_crash['classifications']:
-            processed_crash['classifications']['support'] = []
-        processed_crash['classifications']['support'].append(DotDict({
+        processed_crash['classifications']['support'] = DotDict({
             'classification': classification,
             'classification_data': classification_data,
             'classification_version': self.version()
-        }))
-        if logger and "not classified" not in classification:
+        })
+        if logger:
             logger.debug(
                 'Support classification: %s',
                 classification
@@ -171,7 +169,7 @@ class SupportClassificationRule(object):
 
 
 #==============================================================================
-class BitguardClassfier(SupportClassificationRule):
+class BitguardClassifier(SupportClassificationRule):
     """To satisfy Bug 931907, this rule will detect 'bitguard.dll' in the
     modules list.  If present, it will add the classification,
     classifications.support.classification.bitguard to the processed crash"""
@@ -195,6 +193,17 @@ class BitguardClassfier(SupportClassificationRule):
 
 
 #------------------------------------------------------------------------------
+# the following tuple of tuples is a structure for loading rules into the
+# TransformRules system. The tuples take the form:
+#   predicate_function, predicate_args, predicate_kwargs,
+#   action_function, action_args, action_kwargs.
+#
+# The args and kwargs components are additional information that a predicate
+# or an action might need to have to do its job.  Providing values for args
+# or kwargs essentially acts in a manner similar to functools.partial.
+# When the predicate or action functions are invoked, these args and kwags
+# values will be passed into the function along with the raw_crash,
+# processed_crash and processor objects.
 default_support_classifier_rules = (
-    (BitguardClassfier, (), {}, BitguardClassfier, (), {}),
+    (BitguardClassifier, (), {}, BitguardClassifier, (), {}),
 )

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -311,12 +311,12 @@ class TestHybridProcessor(unittest.TestCase):
                 self.assertEqual(1, leg_proc._log_job_start.call_count)
                 leg_proc._log_job_start.assert_called_with(raw_crash.uuid)
 
-                self.assertEqual(2, m_transform.apply_all_rules.call_count)
+                self.assertEqual(1, m_transform.apply_all_rules.call_count)
                 m_transform.apply_all_rules.has_calls(
                     mock.call(raw_crash, leg_proc),
                 )
                 self.assertEqual(
-                    1,
+                    2,
                     m_transform.apply_until_action_succeeds.call_count
                 )
                 m_transform.apply_all_rules.has_calls(

--- a/socorro/unittest/processor/test_support_classifiers.py
+++ b/socorro/unittest/processor/test_support_classifiers.py
@@ -8,7 +8,7 @@ import copy
 from socorro.lib.util import DotDict, SilentFakeLogger
 from socorro.processor.support_classifiers import (
     SupportClassificationRule,
-    BitguardClassfier,
+    BitguardClassifier,
 )
 
 from socorro.processor.signature_utilities import CSignatureTool
@@ -71,18 +71,18 @@ class TestSupportClassificationRule(unittest.TestCase):
             'extra stuff'
         )
         self.assertTrue('classifications' in pc)
-        self.assertTrue('support' in pc['classifications'])
+        self.assertTrue('support' in pc.classifications)
         self.assertEqual(
             'stupid',
-            pc['classifications']['support'][0].classification
+            pc.classifications.support.classification
         )
         self.assertEqual(
             'extra stuff',
-            pc['classifications']['support'][0].classification_data
+            pc.classifications.support.classification_data
         )
         self.assertEqual(
             '0.0',
-            pc['classifications']['support'][0].classification_version
+            pc.classifications.support.classification_version
         )
 
 
@@ -98,46 +98,16 @@ class TestBitguardClassfier(unittest.TestCase):
 
         rc = DotDict()
 
-        rule = BitguardClassfier()
+        rule = BitguardClassifier()
         action_result = rule.action(rc, pc, fake_processor)
 
         self.assertTrue(action_result)
         self.assertTrue('classifications' in pc)
-        self.assertTrue('support' in pc['classifications'])
+        self.assertTrue('support' in pc.classifications)
         self.assertEqual(
             'bitguard',
-            pc['classifications']['support'][0]['classification']
+            pc.classifications.support.classification
         )
-
-    def test_action_success_multiple(self):
-        jd = copy.deepcopy(cannonical_json_dump)
-        jd['modules'].append({'filename': 'bitguard.dll'})
-        pc = DotDict()
-        pc['classifications'] = {}
-        pc['classifications']['support'] = [
-            DotDict({
-                "classification": 'silly',
-                "classification_data": None,
-                "classification_version": 98.6,
-            })
-        ]
-        pc.json_dump = jd
-
-        fake_processor = create_basic_fake_processor()
-
-        rc = DotDict()
-
-        rule = BitguardClassfier()
-        action_result = rule.action(rc, pc, fake_processor)
-
-        self.assertTrue(action_result)
-        self.assertTrue('classifications' in pc)
-        self.assertTrue('support' in pc['classifications'])
-        self.assertEqual(
-            'bitguard',
-            pc['classifications']['support'][1]['classification']
-        )
-
 
     def test_action_fail(self):
         jd = copy.deepcopy(cannonical_json_dump)
@@ -148,38 +118,9 @@ class TestBitguardClassfier(unittest.TestCase):
 
         rc = DotDict()
 
-        rule = BitguardClassfier()
+        rule = BitguardClassifier()
         action_result = rule.action(rc, pc, fake_processor)
 
         self.assertFalse(action_result)
         self.assertTrue('classifications' not in pc)
 
-    def test_action_fail_multiple(self):
-        jd = copy.deepcopy(cannonical_json_dump)
-        pc = DotDict()
-        pc['classifications'] = {}
-        pc['classifications']['support'] = [
-            DotDict({
-                "classification": 'silly',
-                "classification_data": None,
-                "classification_version": 98.6,
-            })
-        ]
-        pc.json_dump = jd
-
-        fake_processor = create_basic_fake_processor()
-
-        rc = DotDict()
-
-        rule = BitguardClassfier()
-        action_result = rule.action(rc, pc, fake_processor)
-
-        self.assertFalse(action_result)
-        self.assertEqual(
-            len(pc['classifications']['support']),
-            1
-        )
-        self.assertEqual(
-            pc['classifications']['support'][0].classification,
-            "silly"
-        )


### PR DESCRIPTION
Targeting Socorro 66

This PR extends the processor's classification system to have a 'support' category.  Basically a copy of the infrastructure of the skunk classifiers, this system allows multiple classifications.  Support classification rules follow the  same form as the previously implemented transform rules and skunk classifier rules. The classifications are found in the processed crash like this:

```
{
    "classfications": {
        "skunk_works": ...
        "support": [
            { "classification": "bitguard", "classification_data": None, "classification_version": 1.0},
            ...
        ]
    }
}
```
