### PR TITLE
Fixes bug 872547 - Improved mapping with a list of all fields and better...

### DIFF
--- a/socorro/external/elasticsearch/socorro_index_settings.json
+++ b/socorro/external/elasticsearch/socorro_index_settings.json
@@ -6,123 +6,21 @@
     },
     "mappings": {
         "%s": {
-            "_source": {
-                "compress": true
-            },
             "_all": {
                 "enabled": false
             },
+            "_source": {
+                "compress": true
+            },
             "properties": {
+                "crash_id": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
                 "processed_crash": {
                     "type": "object",
+                    "dynamic": "true",
                     "properties": {
-                        "address": {
-                            "type": "string",
-                            "index": "analyzed",
-                            "analyzer": "standard"
-                        },
-                        "completeddatetime": {
-                            "type": "date",
-                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
-                        },
-                        "date_processed": {
-                            "type": "date",
-                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
-                        },
-                        "client_crash_date": {
-                            "type": "date",
-                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
-                        },
-                        "build_date": {
-                            "type": "date",
-                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
-                        },
-                        "startedDateTime": {
-                            "type": "date",
-                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
-                        },
-                        "signature": {
-                            "type": "multi_field",
-                            "fields": {
-                                "signature": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
-                        "product": {
-                            "type": "multi_field",
-                            "fields": {
-                                "product": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "multi_field",
-                            "fields": {
-                                "email": {
-                                    "type": "string",
-                                    "index": "analyzed",
-                                    "analyzer": "simple"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
-                        "reason": {
-                            "type": "multi_field",
-                            "fields": {
-                                "reason": {
-                                    "type": "string",
-                                    "index": "analyzed",
-                                    "analyzer": "standard"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "multi_field",
-                            "fields": {
-                                "url": {
-                                    "type": "string",
-                                    "index": "analyzed",
-                                    "analyzer": "simple"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
-                        "user_comments": {
-                            "type": "multi_field",
-                            "fields": {
-                                "user_comments": {
-                                    "type": "string",
-                                    "index": "analyzed",
-                                    "analyzer": "standard"
-                                },
-                                "full": {
-                                    "type": "string",
-                                    "index": "not_analyzed"
-                                }
-                            }
-                        },
                         "PluginFilename": {
                             "type": "multi_field",
                             "fields": {
@@ -161,6 +59,420 @@
                                     "index": "not_analyzed"
                                 }
                             }
+                        },
+                        "Winsock_LSP": {
+                            "type": "string"
+                        },
+                        "addons": {
+                            "type": "nested"
+                        },
+                        "addons_checked": {
+                            "type": "boolean"
+                        },
+                        "address": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "app_notes": {
+                            "type": "string"
+                        },
+                        "build": {
+                            "type": "integer"
+                        },
+                        "build_date": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                        },
+                        "classifications": {
+                            "type": "object",
+                            "dynamic": "true",
+                            "properties": {
+                                "skunk_works": {
+                                    "dynamic": "true",
+                                    "properties": {
+                                        "classification": {
+                                            "type": "string"
+                                        },
+                                        "classification_data": {
+                                            "type": "string"
+                                        },
+                                        "classification_version": {
+                                            "type": "string",
+                                            "analyzer": "keyword"
+                                        }
+                                    }
+                                },
+                                "support": {
+                                    "dynamic": "true",
+                                    "properties": {
+                                        "classification": {
+                                            "type": "string"
+                                        },
+                                        "classification_data": {
+                                            "type": "string"
+                                        },
+                                        "classification_version": {
+                                            "type": "string",
+                                            "analyzer": "keyword"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "client_crash_date": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                        },
+                        "completeddatetime": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                        },
+                        "cpu_info": {
+                            "type": "multi_field",
+                            "fields": {
+                                "cpu_info": {
+                                    "type": "string",
+                                    "index": "analyzed",
+                                    "analyzer": "standard"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "cpu_name": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "crash_time": {
+                            "type": "long"
+                        },
+                        "crashedThread": {
+                            "type": "integer"
+                        },
+                        "date_processed": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                        },
+                        "distributor": {
+                            "type": "string"
+                        },
+                        "distributor_version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "dump": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                        "email": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "exploitability": {
+                            "type": "string"
+                        },
+                        "flash_version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "hang_type": {
+                            "type": "integer"
+                        },
+                        "hangid": {
+                            "type": "string"
+                        },
+                        "install_age": {
+                            "type": "long"
+                        },
+                        "java_stack_trace": {
+                            "type": "string"
+                        },
+                        "last_crash": {
+                            "type": "long"
+                        },
+                        "os_name": {
+                            "type": "multi_field",
+                            "fields": {
+                                "os_name": {
+                                    "type": "string"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "os_version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "process_type": {
+                            "type": "string"
+                        },
+                        "processor_notes": {
+                            "type": "string"
+                        },
+                        "product": {
+                            "type": "multi_field",
+                            "fields": {
+                                "product": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "productid": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "reason": {
+                            "type": "multi_field",
+                            "fields": {
+                                "reason": {
+                                    "type": "string",
+                                    "analyzer": "standard"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "release_channel": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "signature": {
+                            "type": "multi_field",
+                            "fields": {
+                                "signature": {
+                                    "type": "string"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "startedDateTime": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                        },
+                        "success": {
+                            "type": "boolean"
+                        },
+                        "topmost_filenames": {
+                            "type": "string"
+                        },
+                        "truncated": {
+                            "type": "boolean"
+                        },
+                        "uptime": {
+                            "type": "long"
+                        },
+                        "url": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "user_comments": {
+                            "type": "multi_field",
+                            "fields": {
+                                "user_comments": {
+                                    "type": "string"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "uuid": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                        "version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        }
+                    }
+                },
+                "raw_crash": {
+                    "type": "object",
+                    "dynamic": "true",
+                    "properties": {
+                        "Accessibility": {
+                            "type": "boolean"
+                        },
+                        "AdapterDeviceID": {
+                            "type": "string"
+                        },
+                        "AdapterVendorID": {
+                            "type": "string"
+                        },
+                        "Android_Board": {
+                            "type": "string"
+                        },
+                        "Android_Brand": {
+                            "type": "string"
+                        },
+                        "Android_CPU_ABI": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "Android_CPU_ABI2": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "Android_Device": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "Android_Display": {
+                            "type": "string"
+                        },
+                        "Android_Fingerprint": {
+                            "type": "string"
+                        },
+                        "Android_Hardware": {
+                            "type": "string"
+                        },
+                        "Android_Manufacturer": {
+                            "type": "string"
+                        },
+                        "Android_Model": {
+                            "type": "multi_field",
+                            "fields": {
+                                "Android_Model": {
+                                    "type": "string"
+                                },
+                                "full": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "Android_Version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "AvailablePageFile": {
+                            "type": "long"
+                        },
+                        "AvailablePhysicalMemory": {
+                            "type": "long"
+                        },
+                        "AvailableVirtualMemory": {
+                            "type": "long"
+                        },
+                        "B2G_OS_Version": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "BIOS_Manufacturer": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "BuildID": {
+                            "type": "integer"
+                        },
+                        "CpuUsageFlashProcess1": {
+                            "type": "double"
+                        },
+                        "CpuUsageFlashProcess2": {
+                            "type": "double"
+                        },
+                        "CrashTime": {
+                            "type": "long"
+                        },
+                        "EMCheckCompatibility": {
+                            "type": "boolean"
+                        },
+                        "FramePoisonBase": {
+                            "type": "string"
+                        },
+                        "FramePoisonSize": {
+                            "type": "long"
+                        },
+                        "Hang": {
+                            "type": "boolean"
+                        },
+                        "InstallTime": {
+                            "type": "long"
+                        },
+                        "IsGarbageCollecting": {
+                            "type": "boolean"
+                        },
+                        "Min_ARM_Version": {
+                            "type": "string"
+                        },
+                        "Notes": {
+                            "type": "string"
+                        },
+                        "NumberOfProcessors": {
+                            "type": "integer"
+                        },
+                        "OOMAllocationSize": {
+                            "type": "long"
+                        },
+                        "PluginCpuUsage": {
+                            "type": "double"
+                        },
+                        "PluginHang": {
+                            "type": "boolean"
+                        },
+                        "PluginHangUIDuration": {
+                            "type": "long"
+                        },
+                        "ProcessType": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "SecondsSinceLastCrash": {
+                            "type": "long"
+                        },
+                        "StartupTime": {
+                            "type": "long"
+                        },
+                        "SystemMemoryUsePercentage": {
+                            "type": "long"
+                        },
+                        "Theme": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        },
+                        "Throttleable": {
+                            "type": "boolean"
+                        },
+                        "TotalVirtualMemory": {
+                            "type": "long"
+                        },
+                        "Vendor": {
+                            "type": "string"
+                        },
+                        "additional_minidumps": {
+                            "type": "string"
+                        },
+                        "buildid": {
+                            "type": "integer"
+                        },
+                        "legacy_processing": {
+                            "type": "boolean"
+                        },
+                        "throttle_rate": {
+                            "type": "integer"
+                        },
+                        "timestamp": {
+                            "type": "double"
+                        },
+                        "useragent_locale": {
+                            "type": "string",
+                            "analyzer": "keyword"
                         }
                     }
                 }

--- a/socorro/external/elasticsearch/supersearch.py
+++ b/socorro/external/elasticsearch/supersearch.py
@@ -81,16 +81,17 @@ FIELD_TO_PARAM_MAPPING = dict(
 )
 
 
-FIELDS_WITH_FULL_VERSION = [
-    'processed_crash.email',
+FIELDS_WITH_FULL_VERSION = (
+    'processed_crash.cpu_info',
+    'processed_crash.os_name',
+    'processed_crash.product',
     'processed_crash.reason',
     'processed_crash.signature',
-    'processed_crash.url',
     'processed_crash.user_comments',
     'processed_crash.PluginFilename',
     'processed_crash.PluginName',
     'processed_crash.PluginVersion',
-]
+)
 
 
 class SuperS(S):
@@ -212,7 +213,7 @@ class SuperSearch(SearchBase, ElasticSearchBase):
                     search = search.query(**args)
                 else:
                     # If we reach this point, that means the operator is
-                    # not supported, and we should raise an error about that
+                    # not supported, and we should raise an error about that.
                     raise NotImplementedError(
                         'Operator %s is not supported' % param.operator
                     )
@@ -230,7 +231,7 @@ class SuperSearch(SearchBase, ElasticSearchBase):
             for value in param.value:
                 filter_ = self.get_filter(value)
                 if not filter_:
-                    # That is not a known field, we can't facet on it
+                    # That is not a known field, we can't facet on it.
                     raise BadArgumentError(
                         'Unknown field "%s", cannot facet on it' % value
                     )
@@ -239,8 +240,8 @@ class SuperSearch(SearchBase, ElasticSearchBase):
                 field_name = self.prefix_field_name(field_name)
 
                 if field_name in FIELDS_WITH_FULL_VERSION:
-                    # If the param is a string, that means what matters is
-                    # the full string, and not its individual terms
+                    # If the param has a full version, that means what matters
+                    # is the full string, and not its individual terms.
                     field_name += '.full'
 
                 args = {

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -391,10 +391,10 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
 
         # Test url
         args = {
-            'url': 'mozilla',
+            'url': 'https://mozilla.org',
         }
         res = api.get(**args)
-        self.assertEqual(res['total'], 20)
+        self.assertEqual(res['total'], 19)
         self.assertEqual(res['hits'][0]['signature'], 'js::break_your_browser')
         self.assertTrue('mozilla.org' in res['hits'][0]['url'])
 
@@ -534,14 +534,12 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
 
         # Test email
         args = {
-            'email': ['gmail', 'hotmail'],
+            'email': 'sauron@mordor.info',
         }
         res = api.get(**args)
-        self.assertEqual(res['total'], 19)
+        self.assertEqual(res['total'], 1)
         self.assertTrue(res['hits'])
-        for report in res['hits']:
-            self.assertTrue('@' in report['email'])
-            self.assertTrue('mail.com' in report['email'])
+        self.assertEqual(res['hits'][0]['email'], 'sauron@mordor.info')
 
         args = {
             'email': '~mail.com',
@@ -564,10 +562,10 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
 
         # Test url
         args = {
-            'url': ['mozilla', 'www'],
+            'url': 'https://mozilla.org',
         }
         res = api.get(**args)
-        self.assertEqual(res['total'], 21)
+        self.assertEqual(res['total'], 19)
 
         args = {
             'url': '~mozilla.org',
@@ -649,9 +647,8 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
 
         self.assertTrue('platform' in res['facets'])
         expected_platforms = [
-            {'term': 'linux', 'count': 20},
-            {'term': 'windows', 'count': 1},
-            {'term': 'nt', 'count': 1},
+            {'term': 'Linux', 'count': 20},
+            {'term': 'Windows NT', 'count': 1},
         ]
         self.assertEqual(res['facets']['platform'], expected_platforms)
 


### PR DESCRIPTION
... analyzers.

@twobraids @erikrose r?

Changes in the unit tests reflect some side effects of changing the mapping. The mapping now includes almost all fields that we know, and all fields that we care about. This will be a step into allowing better behavior in supersearch, and will also serve as a base for making raw crash fields accessible in the UI.

We want to merge this before the big reindex that should happen during the next release of Socorro 67. 
