### PR TITLE
fixes bug 908469 - more Metadata tab fixes

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
@@ -6,7 +6,13 @@
   <link media="screen" href="{{ static('crashstats/css/flora/flora.css') }}" type="text/css" rel="stylesheet">
   <link media="screen" href="{{ static('crashstats/css/flora/flora.tabs.css') }}" type="text/css" rel="stylesheet">
   <link media="screen" href="{{ static('crashstats/css/flora/flora.tablesorter.css') }}" type="text/css" rel="stylesheet">
+  <style type="text/css">
+  #details th, #metadata th {
+      width: 15%;
+  }
+  </style>
   {% endcompress %}
+
 {% endblock %}
 
 {% block page_title %}


### PR DESCRIPTION
@ossreleasefeed or @AdrianGaudebert r?

I can't think of a better way to make the columns look identical across the two tabs "Details" and "Metadata"

see https://bugzilla.mozilla.org/show_bug.cgi?id=908469#c17
