### PR TITLE
fixes Bug 956706  (v74) - threadless task manager

### DIFF
--- a/config/processor.ini-dist
+++ b/config/processor.ini-dist
@@ -371,12 +371,12 @@ application='ProcessorApp'
     # name: maximum_queue_size
     # doc: the maximum size of the internal queue
     # converter: int
-    maximum_queue_size='8'
+    #maximum_queue_size='8'
 
     # name: number_of_threads
     # doc: the number of threads
     # converter: int
-    number_of_threads='4'
+    #number_of_threads='4'
 
     # name: producer_consumer_class
     # doc: the class implements a threaded producer consumer queue

--- a/scripts/rabbitmq-integration-test.sh
+++ b/scripts/rabbitmq-integration-test.sh
@@ -128,7 +128,7 @@ done
 echo " Done."
 
 echo -n "INFO: starting up collector, processor and middleware..."
-python socorro/collector/collector_app.py --admin.conf=./config/collector.ini --storage.storage1.host=$RABBITMQ_HOST --storage.storage1.rabbitmq_user=$RABBITMQ_USERNAME --storage.storage1.rabbitmq_password=$RABBITMQ_PASSWORD --storage.storage1.virtual_host=$RABBITMQ_VHOST > collector.log 2>&1 &
+python socorro/collector/collector_app.py --admin.conf=./config/collector.ini --storage.storage1.host=$RABBITMQ_HOST --storage.storage1.rabbitmq_user=$RABBITMQ_USERNAME --storage.storage1.rabbitmq_password=$RABBITMQ_PASSWORD --storage.storage1.virtual_host=$RABBITMQ_VHOST --storage.storage1.transaction_executor_class=socorro.database.transaction_executor.TransactionExecutor > collector.log 2>&1 &
 python socorro/processor/processor_app.py --admin.conf=./config/processor.ini --processor.database_hostname=$DB_HOST --new_crash_source.host=$RABBITMQ_HOST --new_crash_source.rabbitmq_user=$RABBITMQ_USERNAME --new_crash_source.rabbitmq_password=$RABBITMQ_PASSWORD --new_crash_source.virtual_host=$RABBITMQ_VHOST --destination.storage1.database_hostname=$DB_HOST --registrar.database_hostname=$DB_HOST > processor.log 2>&1 &
 sleep 1
 python socorro/middleware/middleware_app.py --admin.conf=./config/middleware.ini --database.database_hostname=$DB_HOST --database.database_username=$DB_USER --database.database_password=$DB_PASSWORD --rabbitmq.host=$RABBITMQ_HOST --rabbitmq.rabbitmq_user=$RABBITMQ_USERNAME --rabbitmq.rabbitmq_password=$RABBITMQ_PASSWORD --rabbitmq.virtual_host=$RABBITMQ_VHOST > middleware.log 2>&1 &

--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -32,7 +32,7 @@ from functools import partial
 from configman import Namespace
 from configman.converters import class_converter
 
-from socorro.lib.threaded_task_manager import respond_to_SIGTERM
+from socorro.lib.task_manager import respond_to_SIGTERM
 from socorro.app.generic_app import App, main  # main not used here, but
                                                # is imported from generic_app
                                                # into this scope to offer to
@@ -202,6 +202,7 @@ class FetchTransformSaveApp(App):
               job_source_iterator=self.source_iterator,
               task_func=self.transform
             )
+        self.config.executor_identity = self.task_manager.executor_identity
 
     #--------------------------------------------------------------------------
     def _cleanup(self):

--- a/socorro/external/hb/connection_context.py
+++ b/socorro/external/hb/connection_context.py
@@ -153,7 +153,7 @@ class HBasePooledConnectionContext(HBaseConnectionContext):
             name - a name as a string
         """
         if not name:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
         if name in self.pool:
             return self.pool[name]
         self.pool[name] = \
@@ -201,6 +201,7 @@ class HBasePooledConnectionContext(HBaseConnectionContext):
         authority.  You are responsible for actually closing the connection or
         not, if it is really hosed."""
         if name is None:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
+            self.config.logger.debug('identity: %s', name)
         if name in self.pool:
             del self.pool[name]

--- a/socorro/external/hbase/connection_context.py
+++ b/socorro/external/hbase/connection_context.py
@@ -180,7 +180,7 @@ class HBaseConnectionContextPooled(HBaseSingleConnectionContext):
             name - a name as a string
         """
         if not name:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
         if name in self.pool:
             #self.config.logger.debug('connection: %s', name)
             return self.pool[name]

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -182,7 +182,7 @@ class ConnectionContextPooled(ConnectionContext):  # pragma: no cover
             name - a name as a string
         """
         if not name:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
         if name in self.pool:
             #self.config.logger.debug('connection: %s', name)
             return self.pool[name]
@@ -207,9 +207,6 @@ class ConnectionContextPooled(ConnectionContext):  # pragma: no cover
             del self.pool[name]
         else:
             pass
-            #self.config.logger.debug('PostgresPooled - refusing to '
-                                     #'close connection %s',
-                                     #threading.currentThread().getName())
 
     #--------------------------------------------------------------------------
     def close(self):
@@ -223,6 +220,6 @@ class ConnectionContextPooled(ConnectionContext):  # pragma: no cover
 
     #--------------------------------------------------------------------------
     def force_reconnect(self):
-        name = threading.currentThread().getName()
+        name = self.config.executor_identity()
         if name in self.pool:
             del self.pool[name]

--- a/socorro/external/rabbitmq/connection_context.py
+++ b/socorro/external/rabbitmq/connection_context.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import threading
 import socket
 import contextlib
 import pika
@@ -284,7 +283,7 @@ class ConnectionContextPooled(ConnectionContext):
             name - a name as a string
         """
         if not name:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
         if name in self.pool:
             #self.config.logger.debug('fetching RMQ connection: %s', name)
             return self.pool[name]
@@ -331,7 +330,7 @@ class ConnectionContextPooled(ConnectionContext):
         authority.  You are responsible for actually closing the connection or
         not, if it is really hosed."""
         if name is None:
-            name = threading.currentThread().getName()
+            name = self.config.executor_identity()
         if name in self.pool:
             del self.pool[name]
 

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -199,6 +199,13 @@ class RabbitMQCrashStorage(CrashStorageBase):
                         crash_id_to_be_acknowledged,
                         exc_info=True
                     )
+                except Exception as x:
+                    self.config.logger.error(
+                        'RabbitMQCrashStorage unexpected failure on %s',
+                        crash_id_to_be_acknowledged,
+                        exc_info=True
+                    )
+
         except Empty:
             pass  # nothing to do with an empty queue
 

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -1,0 +1,182 @@
+import time
+import threading
+import os
+
+from configman import RequiredConfig, Namespace
+from configman.converters import class_converter
+
+#------------------------------------------------------------------------------
+def default_task_func(a_param):
+    """This default consumer function just doesn't do anything.  It is a
+    placeholder just to demonstrate the api and not really for any other
+    purpose"""
+    pass
+
+
+#------------------------------------------------------------------------------
+def default_iterator():
+    """This default producer's iterator yields the integers 0 through 9 and
+    then yields none forever thereafter.  It is a placeholder to demonstrate
+    the  api and not used for anything in a real system."""
+    for x in range(10):
+        yield ((x,), {})
+    while True:
+        yield None
+
+#------------------------------------------------------------------------------
+def respond_to_SIGTERM(signal_number, frame, logger=None):
+    """ these classes are instrumented to respond to a KeyboardInterrupt by
+    cleanly shutting down.  This function, when given as a handler to for
+    a SIGTERM event, will make the program respond to a SIGTERM as neatly
+    as it responds to ^C.
+
+    This function is used in registering a signal handler from the signal
+    module.  It should be registered for any signal for which the desired
+    behavior is to kill the application:
+        signal.signal(signal.SIGTERM, respondToSIGTERM)
+        signal.signal(signal.SIGHUP, respondToSIGTERM)
+
+    parameters:
+        signal_number - unused in this function but required by the api.
+        frame - unused in this function but required by the api.
+    """
+    if logger:
+        logger.info('detected SIGTERM')
+    raise KeyboardInterrupt
+
+
+#==============================================================================
+class TaskManager(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+      'idle_delay',
+      default=7,
+      doc='the delay in seconds if no job is found'
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config,
+                 job_source_iterator=default_iterator,
+                 task_func=default_task_func):
+        """
+        parameters:
+            job_source_iterator - an iterator to serve as the source of data.
+                                  it can be of the form of a generator or
+                                  iterator; a function that returns an
+                                  iterator; a instance of an iterable object;
+                                  or a class that when instantiated with a
+                                  config object can be iterated.  The iterator
+                                  must yield a tuple consisting of a
+                                  function's tuple of args and, optionally, a
+                                  mapping of kwargs.
+                                  Ex:  (('a', 17), {'x': 23})
+            task_func - a function that will accept the args and kwargs yielded
+                        by the job_source_iterator"""
+        super(TaskManager, self).__init__()
+        self.config = config
+        self._pid = os.getpid()
+        self.logger = config.logger
+        self.job_param_source_iter = job_source_iterator
+        self.task_func = task_func
+        self.quit = False
+        self.logger.debug('TaskManager finished init')
+
+    #--------------------------------------------------------------------------
+    def quit_check(self):
+        """this is the polling function that the threads periodically look at.
+        If they detect that the quit flag is True, then a KeyboardInterrupt
+        is raised which will result in the threads dying peacefully"""
+        if self.quit:
+            raise KeyboardInterrupt
+
+    #--------------------------------------------------------------------------
+    def _get_iterator(self):
+        """The iterator passed in can take several forms: a class that can be
+        instantiated and then iterated over; a function that when called
+        returns an iterator; an actual iterator/generator or an iterable
+        collection.  This function sorts all that out and returns an iterator
+        that can be used"""
+        try:
+            return self.job_param_source_iter(self.config)
+        except TypeError:
+            try:
+                return self.job_param_source_iter()
+            except TypeError:
+                return self.job_param_source_iter
+
+    #--------------------------------------------------------------------------
+    def _responsive_sleep(self, seconds, wait_log_interval=0, wait_reason=''):
+        """When there is litte work to do, the queuing thread sleeps a lot.
+        It can't sleep for too long without checking for the quit flag and/or
+        logging about why it is sleeping.
+
+        parameters:
+            seconds - the number of seconds to sleep
+            wait_log_interval - while sleeping, it is helpful if the thread
+                                periodically announces itself so that we
+                                know that it is still alive.  This number is
+                                the time in seconds between log entries.
+            wait_reason - the is for the explaination of why the thread is
+                          sleeping.  This is likely to be a message like:
+                          'there is no work to do'.
+
+        This was also partially motivated by old versions' of Python inability
+        to KeyboardInterrupt out of a long sleep()."""
+
+        for x in xrange(int(seconds)):
+            self.quit_check()
+            if wait_log_interval and not x % wait_log_interval:
+                self.logger.info('%s: %dsec of %dsec',
+                                 wait_reason,
+                                 x,
+                                 seconds)
+                self.quit_check()
+            time.sleep(1.0)
+
+    #--------------------------------------------------------------------------
+    def blocking_start(self, waiting_func=None):
+        """this function starts the task manager running to do tasks.  The
+        waiting_func is normally used to do something while other threads
+        are running, but here we don't have other threads.  So the waiting
+        func will never get called.  I can see wanting this function to be
+        called at least once after the end of the task loop."""
+        self.logger.debug('threadless start')
+        try:
+            while True:
+                for job_params in self._get_iterator():  # may never raise
+                                                         # StopIteration
+                    self.quit_check()
+                    if job_params is None:
+                        self.logger.info("there is nothing to do.  Sleeping "
+                                         "for %d seconds" %
+                                         self.config.idle_delay)
+                        self._responsive_sleep(self.config.idle_delay)
+                        continue
+                    self.quit_check()
+                    try:
+                        args, kwargs = job_params
+                    except ValueError:
+                        args = arguments
+                        kwargs = {}
+                    try:
+                        self.task_func(*args, **kwargs)
+                    except Exception:
+                        self.config.logger.error("Error in processing a job",
+                                                 exc_info=True)
+        except KeyboardInterrupt:
+            self.logger.debug('queuingThread gets quit request')
+        finally:
+            self.quit = True
+            self.logger.debug("ThreadlessTaskManager dies quietly")
+
+    #--------------------------------------------------------------------------
+    def executor_identity(self):
+        """this function is likely to be called via the configuration parameter
+        'executor_identity' at the root of the self.config attribute of the
+        application.  It is most frequently used in the Pooled
+        ConnectionContext classes to ensure that connections aren't shared
+        between threads, greenlets, or whatever the unit of execution is.
+        This is useful for maintaining transactional integrity on a resource
+        connection."""
+        return "%s-%s" % (self._pid, threading.currentThread().getName())
+

--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -839,6 +839,7 @@ class HybridCrashProcessor(RequiredConfig):
         processor_notes
     ):
         with closing(dump_analysis_line_iterator) as mdsw_iter:
+            self.quit_check()
             processed_crash_update = self._analyze_header(
                 crash_id,
                 mdsw_iter,
@@ -851,6 +852,7 @@ class HybridCrashProcessor(RequiredConfig):
                     processed_crash_update.os_name in ('Windows NT')
             except (KeyError, TypeError):
                 make_modules_lowercase = True
+            self.quit_check()
             processed_crash_from_frames = self._analyze_frames(
                 is_hang,
                 java_stack_trace,
@@ -862,6 +864,7 @@ class HybridCrashProcessor(RequiredConfig):
             )
             processed_crash_update.update(processed_crash_from_frames)
 
+            self.quit_check()
             try:
                 mdsw_iter.cache.remove("====PIPE DUMP ENDS===")
             except ValueError:
@@ -911,6 +914,7 @@ class HybridCrashProcessor(RequiredConfig):
                 'unknown error'
             )
 
+        self.quit_check()
         return_code = mdsw_subprocess_handle.wait()
         if (
             (return_code is not None and return_code != 0) or

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -110,7 +110,11 @@ class ProcessorApp(FetchTransformSaveApp):
         self.task_manager.quit_check()
 
     #--------------------------------------------------------------------------
-    def transform(self, crash_id, finished_func=lambda: None):
+    def transform(
+        self,
+        crash_id,
+        finished_func=(lambda: None),
+    ):
         """this implementation is the framework on how a raw crash is
         converted into a processed crash.  The 'crash_id' passed in is used as
         a key to fetch the raw crash from the 'source', the conversion funtion
@@ -165,7 +169,14 @@ class ProcessorApp(FetchTransformSaveApp):
             # no matter what causes this method to end, we need to make sure
             # that the finished_func gets called. If the new crash source is
             # RabbitMQ, this is what removes the job from the queue.
-            finished_func()
+            try:
+                finished_func()
+            except Exception:
+                # when run in a thread, a failure here is not a problem, but if
+                # we're running all in the same thread, a failure here could
+                # derail the the whole processor. Best just log the problem
+                # so that we can continue.
+                self.config.logger.error('Error completing job', exc_info=True)
 
     #--------------------------------------------------------------------------
     def _setup_source_and_destination(self):

--- a/socorro/unittest/app/test_generic_app.py
+++ b/socorro/unittest/app/test_generic_app.py
@@ -71,7 +71,7 @@ class TestGenericAppConfigPathLoading(unittest.TestCase):
         exit_code = main(MyApp, values_source_list=vsl)
         self.assertEqual(exit_code, 0)
 
-        logging.getLogger().error.assert_called_with('colour')
+        logging.getLogger().error.assert_called_with(' - MainThread - colour')
 
         _ini_file = os.path.join(self.tempdir, 'myapp.ini')
         with open(_ini_file, 'w') as f:
@@ -80,7 +80,7 @@ class TestGenericAppConfigPathLoading(unittest.TestCase):
         exit_code = main(MyApp, values_source_list=vsl)
         self.assertEqual(exit_code, 0)
 
-        logging.getLogger().error.assert_called_with('color')
+        logging.getLogger().error.assert_called_with(' - MainThread - color')
 
     @mock.patch('socorro.app.generic_app.logging')
     def test_exit_codes(self, logging):

--- a/socorro/unittest/external/hb/test_connection_context.py
+++ b/socorro/unittest/external/hb/test_connection_context.py
@@ -41,6 +41,7 @@ class TestConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection(local_config)
         with mock.patch.object(connection_context, 'HBaseConnection',
@@ -84,6 +85,7 @@ class TestConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection(local_config)
         with mock.patch.object(connection_context, 'HBaseConnection',
@@ -140,6 +142,7 @@ class TestHBasePooledConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection(local_config)
         with mock.patch.object(connection_context, 'HBaseConnection',
@@ -183,6 +186,7 @@ class TestHBasePooledConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection(local_config)
         with mock.patch.object(connection_context, 'HBaseConnection',
@@ -214,6 +218,8 @@ class TestHBasePooledConnectionContext(unittest.TestCase):
                 raise KeyError('fred')
 
             self.assertRaises(KeyError, transaction, bad_deal, 'hello')
+            # at this point, the underlying connection has been deleted from
+            # the pool, because it was considered to be a bad connection.
             self.assertEqual(
                 a_fake_hbase_connection.close_counter,
                 0
@@ -224,6 +230,8 @@ class TestHBasePooledConnectionContext(unittest.TestCase):
             )
 
             hb_context.close()
+            # because the connection was previously deleted from the pool,
+            # no connection gets closed at this point.
             self.assertEqual(
                 a_fake_hbase_connection.close_counter,
                 0

--- a/socorro/unittest/external/hbase/test_connection_context.py
+++ b/socorro/unittest/external/hbase/test_connection_context.py
@@ -48,6 +48,7 @@ class TestConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection()
         mocked_hbcl.HBaseConnectionForCrashReports = \
@@ -124,6 +125,7 @@ class TestConnectionContext(unittest.TestCase):
           'hbase_timeout': 9000,
           'number_of_retries': 2,
           'logger': SilentFakeLogger(),
+          'executor_identity': lambda: 'dwight'  # bogus thread id
         })
         a_fake_hbase_connection = FakeHB_Connection()
         mocked_hbcl.HBaseConnectionForCrashReports = \

--- a/socorro/unittest/external/hbase/test_crashstorage.py
+++ b/socorro/unittest/external/hbase/test_crashstorage.py
@@ -182,6 +182,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
         )
 
         with config_manager.context() as config:
+            config.executor_identity = lambda: 'dwight'  # bogus thread id
 
             hbaseclient_ = 'socorro.external.hbase.crashstorage.hbase_client'
             with mock.patch(hbaseclient_) as hclient:
@@ -238,6 +239,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
               'redactor_class': Redactor,
               'forbidden_keys':
                   Redactor.required_config.forbidden_keys.default,
+               'executor_identity': lambda: 'dwight'  # bogus thread id
             })
             crashstorage = HBaseCrashStorage(config)
             raw = ('{"name":"Peter", '
@@ -289,6 +291,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
               'redactor_class': Redactor,
               'forbidden_keys':
                   Redactor.required_config.forbidden_keys.default,
+              'executor_identity': lambda: 'dwight'  # bogus thread id
             })
             crashstorage = HBaseCrashStorage(config)
             raw = ('{"name":"Peter", '
@@ -319,6 +322,7 @@ class TestHBaseCrashStorage(unittest.TestCase):
         )
 
         with config_manager.context() as config:
+            config.executor_identity = lambda: 'dwight'  # bogus thread id
 
             hbaseclient_ = 'socorro.external.hbase.crashstorage.hbase_client'
             with mock.patch(hbaseclient_) as hclient:

--- a/socorro/unittest/external/rabbitmq/test_connection_context.py
+++ b/socorro/unittest/external/rabbitmq/test_connection_context.py
@@ -79,6 +79,8 @@ class TestConnectionContext(unittest.TestCase):
         config.priority_queue_name = 'wilma'
         config.reprocessing_queue_name = 'betty'
         config.rabbitmq_connection_wrapper_class = Connection
+        
+        config.executor_identity = lambda: 'MainThread'
 
         return config
 
@@ -154,6 +156,8 @@ class TestConnectionContextPooled(unittest.TestCase):
         config.rabbitmq_connection_wrapper_class = Connection
         config.logger = Mock()
 
+        config.executor_identity = lambda: 'MainThread'
+        
         return config
 
     #--------------------------------------------------------------------------

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -1,0 +1,116 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+import unittest
+
+from mock import Mock
+
+from  socorro.lib.task_manager import TaskManager, default_task_func
+from socorro.lib.util import DotDict, SilentFakeLogger
+
+
+class TestTaskManager(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = SilentFakeLogger()
+
+    def tearDown(self):
+        pass
+
+    def test_constuctor1(self):
+        config = DotDict()
+        config.logger = self.logger
+        tm = TaskManager(config)
+        self.assertTrue(tm.config == config)
+        self.assertTrue(tm.logger == self.logger)
+        self.assertTrue(tm.task_func == default_task_func)
+        self.assertTrue(tm.quit == False)
+
+    def test_executor_identity(self):
+        config = DotDict()
+        config.logger = self.logger
+        tm = TaskManager(
+            config,
+            job_source_iterator=range(1),
+
+        )
+        tm._pid = 666
+        self.assertEqual(tm.executor_identity(), '666-MainThread')
+
+    def test_get_iterator(self):
+        config = DotDict()
+        config.logger = self.logger
+        tm = TaskManager(
+            config,
+            job_source_iterator=range(1),
+        )
+        self.assertEqual(tm._get_iterator(), [0])
+
+        def an_iter(self):
+            for i in range(5):
+                yield i
+
+        tm = TaskManager(
+            config,
+            job_source_iterator=an_iter,
+        )
+        self.assertEqual(
+            [x for x in tm._get_iterator()],
+            [0, 1, 2, 3, 4]
+        )
+
+        class X(object):
+            def __init__(self, config):
+                self.config = config
+
+            def __iter__(self):
+                for key in self.config:
+                    yield key
+
+        tm = TaskManager(
+            config,
+            job_source_iterator=X(config)
+        )
+        self.assertEqual(
+            [x for x in tm._get_iterator()],
+            [y for y in config.keys()]
+        )
+
+    def test_blocking_start(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.idle_delay = 1
+
+        class MyTaskManager(TaskManager):
+            def _responsive_sleep(
+                self,
+                seconds,
+                wait_log_interval=0,
+                wait_reason=''
+            ):
+                try:
+                    if self.count >= 2:
+                        self.quit = True
+                    self.count += 1
+                except AttributeError:
+                    self.count = 0
+
+        tm = MyTaskManager(
+            config,
+            task_func=Mock()
+        )
+
+        waiting_func = Mock()
+
+        tm.blocking_start(waiting_func=waiting_func)
+
+        self.assertEqual(
+            tm.task_func.call_count,
+            10
+        )
+        self.assertEqual(waiting_func.call_count, 0)
+
+
+


### PR DESCRIPTION
this is the groundwork for making different task managers that will allow FTS based apps to run with threads, single threaded, processes, greenlets or whatever processing model one could come up with.  In this first iteration, the ThreadedTaskManager is shunted off to a derived class of a single threaded TaskManager.  

To use the processor as a single threaded app, just change the configured consumer_producer class to TaskManager instead of ThreadedTaskManager.  A far as the processor is concerned, it cannot tell anything has changed.

In the future, if the TaskManager is to use some cooperative multitasking scheme like Greenlets, the polling infrastructure for termination testing (all those self.quit_check() calls scattered throughout the code) becomes instead the yield statements required by cooperative multitasking.  This makes the change transparent to the processor.  

To accomplish all this, logging had to be changed to allow easier identification of what unit of execution (thread or greenlet) is doing the logging.  That's the LoggerWrapper that encapsulates the logging objects and calls the underlying logger methods with the identifier for the unit of execution.  

In at least one place, exception handling had to be enhanced to prevent an exception from derailing the single threaded execution.
