### PR TITLE
fixes bug 946429 - Dedicated permission to see exploitability for Flash ...

### DIFF
--- a/webapp-django/crashstats/crashstats/management/__init__.py
+++ b/webapp-django/crashstats/crashstats/management/__init__.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import Permission, Group
+from django.contrib.auth.models import Permission
 from django.db.models.signals import post_syncdb
 from django.contrib.contenttypes.models import ContentType
 from django.dispatch import receiver
@@ -15,11 +15,9 @@ PERMISSIONS = {
     'view_pii': 'View Personal Identifyable Information',
     'view_rawdump': 'View Raw Dumps',
     'view_exploitability': 'View Exploitability Results',
+    'view_flash_exploitability': 'View Flash Exploitability Results',
 }
 
-GROUPS = (
-    ('Hackers', ('view_pii', 'view_rawdump', 'view_exploitability')),
-)
 
 # internal use to know when all interesting models have been synced
 _senders_left = [
@@ -61,20 +59,3 @@ def setup_custom_permissions_and_groups(sender, **kwargs):
                 codename=codename,
                 content_type=ct
             )
-
-        for name, permissions in GROUPS:
-            g, __ = Group.objects.get_or_create(
-                name=name
-            )
-            for permission in permissions:
-                # The add has a built-in for checking it isn't created
-                # repeatedly.
-                g.permissions.add(
-                    Permission.objects.get(codename=permission)
-                )
-
-
-# double check that all groups are set up properly
-for name, perms in GROUPS:
-    for perm in perms:
-        assert perm in PERMISSIONS, "%s not a known permission" % perm

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_signature_summary.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_signature_summary.js
@@ -61,7 +61,18 @@ var SignatureSummary = (function() {
                    distinctInstallHtml = Mustache.to_html(Templates.distinctInstall, data);
                    devicesHtml = Mustache.to_html(Templates.deviceTmpl, data);
                    graphicsHtml = Mustache.to_html(Templates.graphicsTmpl, data);
-                   exploitabilityScoreHtml = Mustache.to_html(Templates.exploitabilityScore, data);
+
+                   /*
+                    * The exploitability one is a bit special.
+                    * Basically, if you don't have permission to see any exploitability
+                    * ratings, the section should not only be empty, it should never even
+                    * be visible.
+                    */
+                   if (data.canViewExploitability) {
+                       exploitabilityScoreHtml = Mustache.to_html(Templates.exploitabilityScore, data);
+                   } else {
+                       $("#exploitabilityScore").remove();
+                   }
 
                    $(percentageByOsHtml).appendTo("#percentageByOsBody");
                    $(uptimeRangeHtml).appendTo("#uptimeRangeBody");
@@ -72,7 +83,9 @@ var SignatureSummary = (function() {
                    $(distinctInstallHtml).appendTo("#distinctInstallBody");
                    $(devicesHtml).appendTo("#devices");
                    $(graphicsHtml).appendTo("#graphics");
-                   $(exploitabilityScoreHtml).appendTo("#exploitabilityScoreBody");
+                   if (data.canViewExploitability) {
+                       $(exploitabilityScoreHtml).appendTo("#exploitabilityScore tbody");
+                   }
 
                    $(".sig-dashboard-tbl", $wrapper).show();
 

--- a/webapp-django/crashstats/crashstats/templates/crashstats/signature_summary.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/signature_summary.html
@@ -142,8 +142,7 @@
         </tbody>
     </table>
 
-{% if request.user.has_perm('crashstats.view_exploitability') %}
-    <table class="sig-dashboard-tbl data-table initially-hidden">
+    <table class="sig-dashboard-tbl data-table initially-hidden" id="exploitabilityScore">
         <caption><span class="sigtbl-title">Exploitability: </span>The exploitability of the crash for product(s) and version(s).</caption>
         <thead>
             <tr>
@@ -154,9 +153,8 @@
                 <th scope="col">High Exploitability</th>
             </tr>
         </thead>
-        <tbody id="exploitabilityScoreBody">
+        <tbody>
 
         </tbody>
     </table>
-{% endif %}
 </div>


### PR DESCRIPTION
...related crashes

@brandonsavage @ossreleasefeed or @AdrianGaudebert r?

This is a bit cryptic but I blame @Kairo-At for that :)

So basically, there's a new permission called "View Flash Exploitability Results" which when you have that, (but not the "View Exploitability Results") you can see the "Exploitability:" section on the Signature Summary IF there are Flash versions (in the signature summary) and none of those versions contain the version `[blank]`. 

This patch does exactly that. Sorry for the added complexity but it should satisfy the business requirement of allowing certain Adobe folks access without get access to things that would require Legal to get involved. 
