### PR TITLE
Fixes Bug 946875 - added exception handling to tempfile contextmanager

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -1186,16 +1186,18 @@ class HybridCrashProcessor(RequiredConfig):
         """this contextmanager implements conditionally deleting a pathname
         at the end of a context iff the pathname indicates that it is a temp
         file by having the word 'TEMPORARY' embedded in it."""
-        yield raw_dump_path
-        if 'TEMPORARY' in raw_dump_path:
-            try:
-                os.unlink(raw_dump_path)
-            except OSError:
-                self.config.logger.warning(
-                    'unable to delete %s. manual deletion is required.',
-                    raw_dump_path,
-                    exc_info=True
-                )
+        try:
+            yield raw_dump_path
+        finally:
+            if 'TEMPORARY' in raw_dump_path:
+                try:
+                    os.unlink(raw_dump_path)
+                except OSError:
+                    self.config.logger.warning(
+                        'unable to delete %s. manual deletion is required.',
+                        raw_dump_path,
+                        exc_info=True
+                    )
 
     #--------------------------------------------------------------------------
     def __call__(self, raw_crash, raw_dumps):


### PR DESCRIPTION
when invoking stackwalker, the dump file has been written to disk.  If something goes wrong and an exception is raised from within the context scope of the temp file, the temp file is not removed. 

the solution is to put a `try ... finally` around the yield as recommended in the python docs for context managers.  This will ensure that the delete code is run when an exception happens within the scope of the contextmanager.
