### PR TITLE
Bug 946944 - Update forced versions for correlations for Firefox cycle starting 2013-12-10

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="26.0 27.0a2 28.0a1"
+MANUAL_VERSION_OVERRIDE="27.0 28.0a2 29.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 946944 - it should go to production the week of Dec 9 (not before!).
