### PR TITLE
Move the supersearch ID column to the far left and actually print the ID

### DIFF
--- a/webapp-django/crashstats/supersearch/templates/supersearch/search_results.html
+++ b/webapp-django/crashstats/supersearch/templates/supersearch/search_results.html
@@ -15,7 +15,7 @@
         <caption>Crash Reports</caption>
         <thead>
             <tr>
-                <th scope="col">UUID</th>
+                <th scope="col">Crash ID</th>
                 {% for column in columns %}
                 <th scope="col">{{ column | replace('_', ' ') | capitalize }}</th>
                 {% endfor %}


### PR DESCRIPTION
r? @AdrianGaudebert This is entirely unbuilt and untested, I just wrote it by inspection. It has been confusing me that the link to actually open the crash report is on the left and you can't see the report ID which is useful to me for copy/paste reasons.
