### PR TITLE
946828 - remove more unix time calls

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -64,8 +64,8 @@ fi
 
 # run socorro integration test
 echo "Running integration test..."
-time ./scripts/rabbitmq-integration-test.sh --destroy
-time ./scripts/elasticsearch-integration-test.sh
+./scripts/rabbitmq-integration-test.sh --destroy
+./scripts/elasticsearch-integration-test.sh
 
 if [ "$1" != "leeroy" ]
 then


### PR DESCRIPTION
this should be the last of 'em. did a quick regex and I don't see any more instances of `time` in *.sh files.
