### PR TITLE
Fixes 949711 - build analysis before syncing folder to build artifact

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -71,7 +71,7 @@ if [ "$1" != "leeroy" ]
 then
   # package socorro.tar.gz for distribution
   mkdir builds/
-  make install PREFIX=builds/socorro
   make analysis
+  make install PREFIX=builds/socorro
   tar -C builds --mode 755 --exclude-vcs --owner 0 --group 0 -zcf socorro.tar.gz socorro/
 fi


### PR DESCRIPTION
Right now we build the target AFTER we sync its artifact to the payload. We're always getting last builds analysis folder that is lingering around the workspace. This reverses the order so that it builds before it syncs.
