### PR TITLE
Fixes bug 853455 - Allowed android_model field to be queried as expected.

### DIFF
--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -118,7 +118,7 @@ class SearchBase(object):
         SearchFilter('android_fingerprint'),
         SearchFilter('android_hardware'),
         SearchFilter('android_manufacturer'),
-        SearchFilter('android_model'),
+        SearchFilter('android_model', data_type='str'),
         SearchFilter('android_version'),
         SearchFilter('async_shutdown_timeout'),
         SearchFilter('available_page_file', data_type='int'),

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -219,8 +219,11 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
             7
         )
 
-        self.storage.save_processed(
-            dict(default_crash_report, uuid=8, process_type='plugin')
+        self.storage.save_raw_and_processed(
+            dict(default_raw_crash_report, Android_Model='PediaMad 17 Heavy'),
+            None,
+            dict(default_crash_report, uuid=8, process_type='plugin'),
+            8
         )
 
         self.storage.save_processed(
@@ -462,7 +465,7 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
             'accessibility': 'True',
         }
         res = api.get(**args)
-        self.assertEqual(res['total'], 7)
+        self.assertEqual(res['total'], 8)
         self.assertTrue(res['hits'][0]['accessibility'])
 
         # Test b2g_os_version
@@ -557,7 +560,7 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
             'available_virtual_memory': '>=1',
         }
         res = api.get(**args)
-        self.assertEqual(res['total'], 7)
+        self.assertEqual(res['total'], 8)
         for report in res['hits']:
             self.assertTrue(report['available_virtual_memory'] >= 1)
 
@@ -727,6 +730,19 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
         self.assertEqual(res['total'], 21)
         args = {
             'address': '~a2',
+        }
+        res = api.get(**args)
+        self.assertEqual(res['total'], 1)
+
+        # Test android_model
+        args = {
+            'android_model': '~PediaMad',
+        }
+        res = api.get(**args)
+        self.assertEqual(res['total'], 1)
+
+        args = {
+            'android_model': '=PediaMad 17 Heavy',
         }
         res = api.get(**args)
         self.assertEqual(res['total'], 1)

--- a/webapp-django/crashstats/supersearch/forms.py
+++ b/webapp-django/crashstats/supersearch/forms.py
@@ -57,7 +57,7 @@ class SearchForm(forms.Form):
     android_fingerprint = form_fields.MultipleValueField(required=False)
     android_hardware = form_fields.MultipleValueField(required=False)
     android_manufacturer = form_fields.MultipleValueField(required=False)
-    android_model = form_fields.MultipleValueField(required=False)
+    android_model = form_fields.StringField(required=False)
     android_version = form_fields.MultipleValueField(required=False)
     async_shutdown_timeout = form_fields.MultipleValueField(required=False)
     available_page_file = form_fields.IntegerField(required=False)


### PR DESCRIPTION
@lauraxt r?

That was a lot easier to fix than I expected! Luckily I was smart enough to use the correct mapping for this field. I just forgot to make it behave correctly with the string operators. 
