### PR TITLE
fixes Bug 951449 (v71) -  Integration tests within Unittests confuse Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ COVEROPTS = --with-coverage --cover-package=socorro
 COVERAGE = $(VIRTUALENV)/bin/coverage
 PYLINT = $(VIRTUALENV)/bin/pylint
 JENKINS_CONF = jenkins.py.dist
+ENV = env
+
+PG_RESOURCES = $(if $(database_hostname), resource.postgresql.database_hostname=$(database_hostname)) $(if $(database_username), resource.postgresql.database_username=$(database_username)) $(if $(database_password), resource.postgresql.database_password=$(database_password)) $(if $(database_port), resource.postgresql.database_port=$(database_port))
+RMQ_RESOURCES = $(if $(rmq_host), resource.rabbitmq.host=$(rmq_host)) $(if $(rmq_virtual_host), resource.rabbitmq.virtual_host=$(rmq_virtual_host)) $(if $(rmq_user), resource.rabbitmq.rabbitmq_user=$(rmq_user)) $(if $(rmq_password), resource.rabbitmq.rabbitmq_password=$(rmq_password))
+ES_RESOURCES = $(if $(elasticsearch_urls), resource.elasticsearch.elasticsearch_urls=$(elasticsearch_urls))
 
 .PHONY: all test test-socorro test-webapp bootstrap install reinstall install-socorro lint clean breakpad stackwalker analysis json_enhancements_pg_extension webapp-django
 
@@ -30,7 +35,7 @@ test-socorro: bootstrap
 	cd socorro/unittest/config; for file in *.py.dist; do if [ ! -f `basename $$file .dist` ]; then cp $$file `basename $$file .dist`; fi; done
 	# run tests with coverage
 	rm -f coverage.xml
-	PYTHONPATH=$(PYTHONPATH) $(COVERAGE) run $(NOSE)
+	$(ENV) $(PG_RESOURCES) $(RMQ_RESOURCES) $(ES_RESOURCES) PYTHONPATH=$(PYTHONPATH) $(COVERAGE) run $(NOSE)
 	$(COVERAGE) xml
 
 # makes thing semantically consistent (test-{component}) while avoiding

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,7 +50,7 @@ export ES_URLS="http://jenkins-es20:9200"
 export PATH=/usr/pgsql-9.2/bin:$PATH
 echo "My path is $PATH"
 # run unit tests
-make test database_username=test database_hostname=$DB_HOST database_password=aPassword database_port=5432 database_superusername=test database_superuserpassword=aPassword elasticSearchHostname=$ES_HOST elasticsearch_urls=$ES_URLS
+make test database_username=test database_hostname=$DB_HOST database_password=aPassword database_port=5432 database_superusername=test database_superuserpassword=aPassword elasticSearchHostname=$ES_HOST elasticsearch_urls=$ES_URLS rmq_host=$RABBITMQ_HOST rmq_virtual_host=$RABBITMQ_VHOST rmq_user=$RABBITMQ_USERNAME rmq_password=$RABBITMQ_PASSWORD
 
 if [ "$1" != "leeroy" ]
 then


### PR DESCRIPTION
right now we've got a bunch of integration tests in the unittest directory.  When run locally, they happily connect to localhost for the database, rabbit, etc.  However, when they're run in Jenkins, they have no way to know that localhost is not the right place to get access to Postgres, Rabbit, etc.

Devise a way to get the connection parameters appropriate for Jenkins into the Integration tests without spoiling it for running those same tests locally.

The solution: as with all problems, Configman solves everything.  The upcoming changes to Configman 1.1.15 enable an apps configuration to have a "resource branch".  Since the resource branch looks the same for _all_ socorro apps, one standard set of command line arguments or environment variables will work for any socorro app.  For example, if you want to set the postgres host name, "--resource.postgres.hostname=whatever" will work for all socorro apps.  

In build.sh, running the make file is augmented by injecting some variables into the Makefile at run time.  If we expand that to giving all the connection parameters for all the required resources, PG, ES, RMQ, etc, we can exploit those values within the Makefile.  If the connection parameters are invoked with make, the nose tests are invoked with those connection parameters in the environment styled in the manner of the Configman resource branch options.  Configman will grab those values and feed them to the Integration tests that are running under nosetests.  The Integration tests will then connect to the appropriate resources within the Jenkins environment.

If make is run with no externally injected parameters, then the Makefile does not make the environment variables and nosetests runs with the Integration tests running with their defaults.  The Integration tests will connect with the appropriate localhost resources.

This change depends on Configman 1.1.15 which is coming in PR 1737 and PR 1741
