### PR TITLE
bug 915373 - filter out unranked crashes, and increment 0-based ranking

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher_ranks_bybug.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher_ranks_bybug.html
@@ -45,20 +45,20 @@ Top Crashing Signatures {% if bug_number %}For Bug {{ bug_number }} {% endif %}
                     {% for signature in top_crashes_by_signature %}
                       {% for product in top_crashes_by_signature[signature] %}
                         {% for version in top_crashes_by_signature[signature][product] %}
+                          {% if top_crashes_by_signature[signature][product][version] %}
                         <tr>
-                            <td>{{ top_crashes_by_signature[signature][product][version][0]['currentRank'] }}</td>
+                            <td>{{ top_crashes_by_signature[signature][product][version][0]['currentRank']|int + 1}}</td>
                             <td>{{ product }}</td>
                             <td>{{ version }}</td>
                             <td>
-                                {% if top_crashes_by_signature[signature][product][version][0]['plugin_count'] == 'null' %}
-                                (unknown)
-                                {% elif top_crashes_by_signature[signature][product][version][0]['plugin_count'] == 0 %}
+                                {% if top_crashes_by_signature[signature][product][version][0]['plugin_count'] == 0 %}
                                 Browser
                                 {% else %}
                                 Plugin
                                 {% endif %}
                             </td>
                         </tr>
+                          {% endif %}
                         {% endfor %}
                       {% endfor %}
                     {% endfor %}

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -346,11 +346,6 @@ def topcrasher_ranks_bybug(request, bug_number=None, days=None,
                 top_crashes_by_signature[signame][product][version] += \
                     [x for x in tcbs if x['signature'] == signame]
 
-                if not top_crashes_by_signature[signame][product][version]:
-                    crash = [{'currentRank': '', 'plugin_count': 'null'}]
-                    top_crashes_by_signature[signame][product][version] += \
-                        crash
-
         context['top_crashes_by_signature'] = top_crashes_by_signature
 
     return render(request, 'crashstats/topcrasher_ranks_bybug.html', context)


### PR DESCRIPTION
This is a trivial followup to testing in https://bugzilla.mozilla.org/show_bug.cgi?id=915373#c16
