### PR TITLE
fixes bug 950385 - use psycopg's IN operator serializer

### DIFF
--- a/socorro/external/postgresql/releases.py
+++ b/socorro/external/postgresql/releases.py
@@ -6,7 +6,7 @@ import logging
 import psycopg2
 
 from socorro.external import DatabaseError
-from socorro.external.postgresql.base import PostgreSQLBase, add_param_to_dict
+from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.external.postgresql.products import Products
 from socorro.lib import external_common
 
@@ -35,13 +35,8 @@ class Releases(PostgreSQLBase):
         sql_params = {}
 
         if params.products and params.products[0]:
-            sql_where = []
-            for i in xrange(len(params.products)):
-                sql_where.append("%%(product%s)s" % i)
-
-            sql = "%s AND product_name IN (%s)" % (sql, ", ".join(sql_where))
-            sql_params = add_param_to_dict(sql_params, "product",
-                                           params.products)
+            sql += " AND product_name IN %(product)s"
+            sql_params['product'] = tuple(params.products)
 
         error_message = "Failed to retrieve featured versions from PostgreSQL"
         sql_results = self.query(sql, sql_params, error_message=error_message)

--- a/socorro/external/postgresql/signature_urls.py
+++ b/socorro/external/postgresql/signature_urls.py
@@ -83,13 +83,12 @@ class SignatureURLs(PostgreSQLBase):
         # if this query is for all versions the 'ALL' keyword will be
         # the only item in the versions list.
         elif 'ALL' in params['versions']:
-            sql_products = " product_name IN ('%s') )" % (
-                    "', '".join([product for product in params.products]))
+            sql_products = " product_name IN %(products)s )"
+            sql_params['products'] = tuple(params.products)
 
-            sql_date_range_limit = """AND '%s' BETWEEN
+            sql_date_range_limit = """AND %(end_date)s BETWEEN
                 product_versions.build_date
-                    AND product_versions.sunset_date""" % params.end_date
-
+                    AND product_versions.sunset_date"""
             sql_query = " ".join((sql, sql_products,
                                   sql_date_range_limit, sql_group_order))
         else:


### PR DESCRIPTION
No string variables called something like `sql` should contain ANY parameter data. Hopefully this fixes all the occasions I could find with grep. 

@AdrianGaudebert r? cc @rhelmer
