### PR TITLE
fixes bug 948704 - day changing links lack range unit

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_list_base.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_list_base.html
@@ -13,7 +13,7 @@ Crash Reports in {{ signature }}
     <ul class="options">
       {% for day in [3, 7, 14, 28] %}
       <li>
-        <a href="{{ change_query_string(range_value=day) }}" {% if day == current_day %} class="selected" {% endif %}>{{ day }} days</a>
+        <a href="{{ change_query_string(range_value=day, range_unit='days') }}" {% if day == current_day %} class="selected" {% endif %}>{{ day }} days</a>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Anybody r?

The default `range_unit` is weeks so if you **set** (as opposed to _change_) the value you better make sure you include the unit too. 
