### PR TITLE
fixes Bug 958120 (v72) - added ability for collector to use submitted crash_id

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -28,7 +28,12 @@ class BreakpadCollector(RequiredConfig):
         doc='the prefix to return to the client in front of the OOID',
         default='bp-'
     )
-
+    required_config.add_option(
+        'accept_submitted_crash_id',
+        doc='a boolean telling the collector to use a crash_id provided in '
+            'the crash submission',
+        default=False
+    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config):
@@ -52,6 +57,8 @@ class BreakpadCollector(RequiredConfig):
                 raw_crash[name] = value
             elif hasattr(value, 'file') and hasattr(value, 'value'):
                 dumps[name] = value.value
+            elif isinstance(value, int):
+                raw_crash[name] = value
             else:
                 raw_crash[name] = value.value
         return raw_crash, dumps
@@ -66,12 +73,20 @@ class BreakpadCollector(RequiredConfig):
         # legacy - ought to be removed someday
         raw_crash.timestamp = time.time()
 
-        crash_id = createNewOoid(current_timestamp)
-        self.logger.info('%s received', crash_id)
+        if (not self.config.collector.accept_submitted_crash_id
+            or 'uuid' not in raw_crash
+        ):
+            crash_id = createNewOoid(current_timestamp)
+            raw_crash.uuid = crash_id
+            self.logger.info('%s received', crash_id)
+        else:
+            crash_id = raw_crash.uuid
+            self.logger.info('%s received with existing crash_id:', crash_id)
 
-        raw_crash.legacy_processing, raw_crash.throttle_rate = (
-            self.throttler.throttle(raw_crash)
-        )
+        if 'legacy_processing' not in raw_crash:
+            raw_crash.legacy_processing, raw_crash.throttle_rate = (
+                self.throttler.throttle(raw_crash)
+            )
         if raw_crash.legacy_processing == DISCARD:
             self.logger.info('%s discarded', crash_id)
             return "Discarded=1\n"

--- a/socorro/unittest/collector/test_collector_app.py
+++ b/socorro/unittest/collector/test_collector_app.py
@@ -21,6 +21,7 @@ class TestCollectorApp(unittest.TestCase):
         config.collector.collector_class = BreakpadCollector
         config.collector.dump_id_prefix = 'bp-'
         config.collector.dump_field = 'dump'
+        config.collector.accept_submitted_crash_id = False
 
         config.throttler = DotDict()
         self.mocked_throttler = mock.MagicMock()

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from configman.dotdict import DotDict
 
 from socorro.collector.wsgi_breakpad_collector import BreakpadCollector
-from socorro.collector.throttler import ACCEPT, IGNORE
+from socorro.collector.throttler import ACCEPT, IGNORE, DEFER
 
 
 class ObjectWithValue(object):
@@ -18,7 +18,7 @@ class ObjectWithValue(object):
         self.value = v
 
 
-class TestProcessorApp(unittest.TestCase):
+class TestCollectorApp(unittest.TestCase):
 
     def get_standard_config(self):
         config = DotDict()
@@ -31,6 +31,7 @@ class TestProcessorApp(unittest.TestCase):
         config.collector.collector_class = BreakpadCollector
         config.collector.dump_id_prefix = 'bp-'
         config.collector.dump_field = 'dump'
+        config.collector.accept_submitted_crash_id = False
 
         config.crash_storage = mock.MagicMock()
 
@@ -104,6 +105,7 @@ class TestProcessorApp(unittest.TestCase):
                         r = c.POST()
                         self.assertTrue(r.startswith('CrashID=bp-'))
                         self.assertTrue(r.endswith('120504\n'))
+                        erc['uuid'] = r[11:-1]
                         c.crash_storage.save_raw_crash.assert_called_with(
                           erc,
                           {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
@@ -154,4 +156,108 @@ class TestProcessorApp(unittest.TestCase):
                         self.assertEqual(r, "Unsupported=1\n")
                         self.assertFalse(
                           c.crash_storage.save_raw_crash.call_count
+                        )
+
+    def test_POST_with_existing_crash_id(self):
+        config = self.get_standard_config()
+        c = BreakpadCollector(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc = dict(erc)
+
+        with mock.patch('socorro.collector.wsgi_breakpad_collector.web') as mocked_web:
+            mocked_web.input.return_value = form
+            with mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi') \
+                    as mocked_webapi:
+                mocked_webapi.rawinput.return_value = rawform
+                with mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now') \
+                        as mocked_utc_now:
+                    mocked_utc_now.return_value = datetime(
+                        2012, 5, 4, 15, 10
+                        )
+                    with mock.patch('socorro.collector.wsgi_breakpad_collector.time') \
+                            as mocked_time:
+                        mocked_time.time.return_value = 3.0
+                        c.throttler.throttle.return_value = (ACCEPT, 100)
+                        r = c.POST()
+                        self.assertTrue(r.startswith('CrashID=bp-'))
+                        self.assertTrue(r.endswith('120504\n'))
+                        erc['uuid'] = r[11:-1]
+                        c.crash_storage.save_raw_crash.assert_called_with(
+                          erc,
+                          {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+                          r[11:-1]
+                        )
+
+    def test_POST_with_existing_crash_id_and_use_it(self):
+        config = self.get_standard_config()
+        config.collector.accept_submitted_crash_id = True
+        c = BreakpadCollector(config)
+
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = DEFER
+        rawform.throttle_rate = 100
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = DEFER
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        erc = dict(erc)
+
+        with mock.patch('socorro.collector.wsgi_breakpad_collector.web') as mocked_web:
+            mocked_web.input.return_value = form
+            with mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi') \
+                    as mocked_webapi:
+                mocked_webapi.rawinput.return_value = rawform
+                with mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now') \
+                        as mocked_utc_now:
+                    mocked_utc_now.return_value = datetime(
+                        2012, 5, 4, 15, 10
+                        )
+                    with mock.patch('socorro.collector.wsgi_breakpad_collector.time') \
+                            as mocked_time:
+                        mocked_time.time.return_value = 3.0
+                        c.throttler.throttle.return_value = (DEFER, 100)
+                        r = c.POST()
+                        self.assertTrue(r.startswith('CrashID=bp-'))
+                        self.assertTrue(r.endswith('140107\n'))
+                        c.crash_storage.save_raw_crash.assert_called_with(
+                          erc,
+                          {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+                          r[11:-1]
                         )


### PR DESCRIPTION
to help synchronize crashes between prod and staging, give the collector the option to accept and use the UUID/crash_id submitted along with the crash.  

The production crashmovers will sumbmit crashes to staging  at the same time that they submit to HBase and RabbitMQ.  Since by the time they get to the crashmover, they've already got a UUID/crash_id assigned to them, that id will be sent to staging, too.  The staging collectors will have the option turned on to accept that crash_id instead of making a new one.

With that in place, crashes in prod and staging will be synchronized.
