### PR TITLE
fixes bug 958158 - Exploitability matview should not limit itself to topcrashes, but include all crashes

### DIFF
--- a/socorro/external/postgresql/raw_sql/procs/update_exploitability.sql
+++ b/socorro/external/postgresql/raw_sql/procs/update_exploitability.sql
@@ -3,8 +3,8 @@ CREATE OR REPLACE FUNCTION update_exploitability(updateday date, checkdata boole
     SET client_min_messages TO 'ERROR'
     AS $$
 BEGIN
--- Populate a daily matview which reports on the exploitability of Top Crashers each day
--- depends on tcbs and signatures
+-- Populate a daily matview which reports on the exploitability of crash signatures each day
+-- depends on signatures
 
 -- check if we've been run
 IF checkdata THEN
@@ -68,8 +68,7 @@ select s.signature_id,
 FROM
     signatures s JOIN reports_clean r ON r.signature_id = s.signature_id
 JOIN product_versions pv ON pv.product_version_id = r.product_version_id
-WHERE s.signature_id IN (select signature_id from tcbs where utc_day_is(tcbs.report_date, updateday))
-    AND utc_day_is(r.date_processed, updateday)
+WHERE utc_day_is(r.date_processed, updateday)
 GROUP BY s.signature_id, s.signature, r.date_processed::date, pv.product_version_id;
 
 RETURN TRUE;


### PR DESCRIPTION
r@selenamarie
