### PR TITLE
Fixes bug 958558 - fixes to releases_raw and product_version related tables

### DIFF
--- a/socorro/external/postgresql/raw_sql/procs/is_rapid_beta.sql
+++ b/socorro/external/postgresql/raw_sql/procs/is_rapid_beta.sql
@@ -1,7 +1,10 @@
-CREATE OR REPLACE FUNCTION is_rapid_beta(channel citext, repversion text, rbetaversion text) RETURNS boolean
+CREATE OR REPLACE FUNCTION is_rapid_beta(
+    channel text,
+    repversion text,
+    rbetaversion text
+)
+    RETURNS boolean
     LANGUAGE sql
-    AS $_$
+AS $_$
 SELECT $1 = 'beta' AND major_version_sort($2) >= major_version_sort($3);
 $_$;
-
-

--- a/socorro/external/postgresql/raw_sql/procs/sunset_date.sql
+++ b/socorro/external/postgresql/raw_sql/procs/sunset_date.sql
@@ -1,18 +1,20 @@
-CREATE OR REPLACE FUNCTION sunset_date(build_id numeric, build_type citext) RETURNS date
+CREATE OR REPLACE FUNCTION sunset_date(
+    build_id numeric,
+    build_type text
+)
+    RETURNS date
     LANGUAGE sql IMMUTABLE
-    AS $_$
+AS $_$
 -- sets a sunset date for visibility
 -- based on a build number
 -- current spec is 18 weeks for releases
 -- 9 weeks for everything else
 select ( build_date($1) +
-	case when $2 = 'release'
-		then interval '18 weeks'
-	when $2 = 'ESR'
-		then interval '18 weeks'
-	else
-		interval '9 weeks'
-	end ) :: date
+    case when lower($2) = 'release'
+        then interval '18 weeks'
+    when lower($2) = 'esr'
+        then interval '18 weeks'
+    else
+        interval '9 weeks'
+    end ) :: date
 $_$;
-
-


### PR DESCRIPTION
Mostly whitespace changes, with changes to use `update_channel` and `build_type_enum` instead of `build_type` (the old kind) where appropriate.
