### PR TITLE
fixes bug 904558 - Current URL not updated when switching between tabs

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list.js
@@ -21,14 +21,25 @@ var Panels = (function() {
 
 $(document).ready(function () {
 
-    // load the tabs and use a cookie to keep state.
-    // the cookie will live for 1 day
+    var active_tab = 0;  // default
+    if (location.hash.match(/#tab-\w/)) {
+        // preferred tab already in location.hash!
+        var tab = location.hash.replace(/tab-/, '');
+        $('#report-list-nav a').each(function(index, tag) {
+            if ($(tag).attr('href') === tab) {
+                active_tab = index;
+            }
+        });
+    }
     $('#report-list').tabs({
+        active: active_tab,
         cookie: {
             expires: 1
         },
         activate: function(event, ui) {
-            Panels.trigger(ui.newPanel.attr('id'));
+            var id = ui.newPanel.attr('id');
+            location.hash = '#tab-' + id;
+            Panels.trigger(id);
         },
         create: function(event, ui) {
             Panels.trigger($(ui.panel[0]).attr('id'));


### PR DESCRIPTION
@ossreleasefeed r?

Yes, I know the code looks complicated but there's an explanation :)

Basically, with [jquery UI tabs](http://api.jqueryui.com/tabs/) you can't connect the `location.hash` to the active tab. 
When you do something like `<li><a href="mytab">My Tab</a></li>` and click on it, because jquery UI tabs "hijacks" the click it does not change the `location.hash` to say `#mytab`. 
Instead, I hook into the `activate` event. 

Also, the reason why I use `#tab-bugzilla`  and `#tab-reports` is because if you do `location.hash = '#bugzilla'` the browser will scroll to where the `id="bugzilla"` tag is. We can't have that. That's annoying. 
By using the `#tab-....` the page does not scroll when you click around and if you refresh the page at any time it will remember which tab you were on. 
