### PR TITLE
fixes Bug 959876 - make sure legacy processing flag is an integer

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -87,6 +87,8 @@ class BreakpadCollector(RequiredConfig):
             raw_crash.legacy_processing, raw_crash.throttle_rate = (
                 self.throttler.throttle(raw_crash)
             )
+        else:
+            raw_crash.legacy_processing = int(raw_crash.legacy_processing)
         if raw_crash.legacy_processing == DISCARD:
             self.logger.info('%s discarded', crash_id)
             return "Discarded=1\n"

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -221,7 +221,7 @@ class TestCollectorApp(unittest.TestCase):
         rawform.some_field = '23'
         rawform.some_other_field = ObjectWithValue('XYZ')
         rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
-        rawform.legacy_processing = DEFER
+        rawform.legacy_processing = str(DEFER)
         rawform.throttle_rate = 100
 
         form = DotDict(rawform)


### PR DESCRIPTION
stage will be receiving crashes from prod directly in the future.  a recent change allows the collector to honor the legacy processing flag that it received from an existing crash.  Unfortunately, its type changed from int to unicode.  The collector must convert it back to int before saving it.
