### PR TITLE
fixes Bug 960073 - allow collector to use submitted legacy_processing

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -34,6 +34,12 @@ class BreakpadCollector(RequiredConfig):
             'the crash submission',
         default=False
     )
+    required_config.add_option(
+        'accept_submitted_legacy_processing',
+        doc='a boolean telling the collector to use a any legacy_processing'
+            'flag submitted with the crash',
+        default=False
+    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config):
@@ -83,12 +89,15 @@ class BreakpadCollector(RequiredConfig):
             crash_id = raw_crash.uuid
             self.logger.info('%s received with existing crash_id:', crash_id)
 
-        if 'legacy_processing' not in raw_crash:
+        if ('legacy_processing' not in raw_crash
+            or not self.config.collector.accept_submitted_legacy_processing
+        ):
             raw_crash.legacy_processing, raw_crash.throttle_rate = (
                 self.throttler.throttle(raw_crash)
             )
         else:
             raw_crash.legacy_processing = int(raw_crash.legacy_processing)
+
         if raw_crash.legacy_processing == DISCARD:
             self.logger.info('%s discarded', crash_id)
             return "Discarded=1\n"

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -32,6 +32,7 @@ class TestCollectorApp(unittest.TestCase):
         config.collector.dump_id_prefix = 'bp-'
         config.collector.dump_field = 'dump'
         config.collector.accept_submitted_crash_id = False
+        config.collector.accept_submitted_legacy_processing = False
 
         config.crash_storage = mock.MagicMock()
 
@@ -211,6 +212,112 @@ class TestCollectorApp(unittest.TestCase):
     def test_POST_with_existing_crash_id_and_use_it(self):
         config = self.get_standard_config()
         config.collector.accept_submitted_crash_id = True
+        c = BreakpadCollector(config)
+
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = str(DEFER)
+        rawform.throttle_rate = 100
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = DEFER
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        erc = dict(erc)
+
+        with mock.patch('socorro.collector.wsgi_breakpad_collector.web') as mocked_web:
+            mocked_web.input.return_value = form
+            with mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi') \
+                    as mocked_webapi:
+                mocked_webapi.rawinput.return_value = rawform
+                with mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now') \
+                        as mocked_utc_now:
+                    mocked_utc_now.return_value = datetime(
+                        2012, 5, 4, 15, 10
+                        )
+                    with mock.patch('socorro.collector.wsgi_breakpad_collector.time') \
+                            as mocked_time:
+                        mocked_time.time.return_value = 3.0
+                        c.throttler.throttle.return_value = (DEFER, 100)
+                        r = c.POST()
+                        self.assertTrue(r.startswith('CrashID=bp-'))
+                        self.assertTrue(r.endswith('140107\n'))
+                        c.crash_storage.save_raw_crash.assert_called_with(
+                          erc,
+                          {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+                          r[11:-1]
+                        )
+
+    def test_POST_with_existing_legacy_processing(self):
+        config = self.get_standard_config()
+        c = BreakpadCollector(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = u'1'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc = dict(erc)
+
+        with mock.patch('socorro.collector.wsgi_breakpad_collector.web') as mocked_web:
+            mocked_web.input.return_value = form
+            with mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi') \
+                    as mocked_webapi:
+                mocked_webapi.rawinput.return_value = rawform
+                with mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now') \
+                        as mocked_utc_now:
+                    mocked_utc_now.return_value = datetime(
+                        2012, 5, 4, 15, 10
+                        )
+                    with mock.patch('socorro.collector.wsgi_breakpad_collector.time') \
+                            as mocked_time:
+                        mocked_time.time.return_value = 3.0
+                        c.throttler.throttle.return_value = (ACCEPT, 100)
+                        r = c.POST()
+                        self.assertTrue(r.startswith('CrashID=bp-'))
+                        self.assertTrue(r.endswith('120504\n'))
+                        erc['uuid'] = r[11:-1]
+                        c.crash_storage.save_raw_crash.assert_called_with(
+                          erc,
+                          {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+                          r[11:-1]
+                        )
+
+    def test_POST_with_existing_legacy_processing_and_use_it(self):
+        config = self.get_standard_config()
+        config.collector.accept_submitted_crash_id = True
+        config.collector.accept_submitted_legacy_processing = True
         c = BreakpadCollector(config)
 
         rawform = DotDict()


### PR DESCRIPTION
the staging collector is soon to start getting all crashes from production.  We already can have it use the same crash_ids as production, it ought to use the same legacy_processing too. 

Change collector to allow for using any legacy_processing flag that is submitted with the crash. Make a configuration parameter to turn off this behavior, defaulting to off.
