### PR TITLE
fixes bug 960204 - TCBS middleware endpoint allows for >28 days range

### DIFF
--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -516,6 +516,11 @@ class Crashes(PostgreSQLBase):
         params = external_common.parse_arguments(filters, kwargs)
         params.logger = logger
 
+        # what the twoPeriodTopCrasherComparison() function does is that it
+        # makes a start date from taking the to_date - duration
+        if params.duration > datetime.timedelta(30):
+            raise BadArgumentError('Duration too long. Max 30 days.')
+
         with self.get_connection() as connection:
             return tcbs.twoPeriodTopCrasherComparison(connection, params)
 

--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -109,6 +109,25 @@ class TestCrashes(unittest.TestCase):
         self.assertTrue("plugin_terms" in params)
         self.assertEqual(params["plugin_terms"], "%some plugin%")
 
+    def test_get_signatures_with_too_big_date_range(self):
+        # This can all be some fake crap because we're testing that
+        # the implementation class throws out the request before
+        # it gets to doing any queries.
+        config = {
+            'database_hostname': None,
+            'database_name': None,
+            'database_username': None,
+            'database_password': None,
+        }
+        crashes = Crashes(config=config)
+        params = {}
+        params['duration'] = 31 * 24  # 31 days
+        self.assertRaises(
+            BadArgumentError,
+            crashes.get_signatures,
+            **params
+        )
+
 
 #==============================================================================
 @attr(integration='postgres')  # for nosetests


### PR DESCRIPTION
@rhelmer r?

Anything larger than 30 days will now raise  "400 Bad Request" in the middleware. 
