### PR TITLE
fixes bug 959601 - Graphics signature summary matview broken

### DIFF
--- a/socorro/cron/jobs/matviews.py
+++ b/socorro/cron/jobs/matviews.py
@@ -263,8 +263,8 @@ class SignatureSummaryDeviceCronApp(_MatViewBackfillBase):
 
 
 class SignatureSummaryGraphicsCronApp(_MatViewBackfillBase):
-    proc_name = 'update_signature_summary_device'
-    app_name = 'signature-summary-uptime-device'
+    proc_name = 'update_signature_summary_graphics'
+    app_name = 'signature-summary-uptime-graphics'
     depends_on = (
         'reports-clean',
         'product-versions-matview'


### PR DESCRIPTION
@selenamarie r?

The culprit was [this commit](https://github.com/mozilla/socorro/commit/0b2a6810c6b4721ae0429ab1d4981138672a468d#diff-b9a3224d80ecf491d8e0e5bbb9612c67R265) .
It wasn't executing the [right stored procedure](https://github.com/mozilla/socorro/blob/master/socorro/external/postgresql/raw_sql/procs/update_signature_summary_graphics.sql)
