### PR TITLE
bug 950710 - put the 1024 frame limit back in place until we fix the root cause of runaway stackwalking in upstream Breakpad

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -683,7 +683,9 @@ int main(int argc, char** argv)
 
   minidump.Read();
   // process minidump
-  Stackwalker::set_max_frames(UINT32_MAX);
+  // bug 950710 - Bad symbol files are causing the stackwalker to
+  // run amok. Disabling this until we get an upstream fix.
+  //Stackwalker::set_max_frames(UINT32_MAX);
   Json::Value root;
   SimpleSymbolSupplier symbol_supplier(symbol_paths);
   BasicSourceLineResolver resolver;


### PR DESCRIPTION
This should be a safe band-aid patch.
