### PR TITLE
Fixes bug 843240 - use JSON files in Firefox builds for FTP scraper

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -86,11 +86,8 @@ def getLinks(url, startswith=None, endswith=None):
 
 def parseBuildJsonFile(url, nightly=False):
     content = patient_urlopen(url)
-    if not content:
-        return
-    results = json.loads(content)
-
-    return results
+    if content:
+        return json.loads(content)
 
 
 def parseInfoFile(url, nightly=False):
@@ -309,13 +306,9 @@ class FTPScraperCronApp(PostgresBackfillCronApp):
             buildutil.insert_build(cursor, *args, **kwargs)
 
     def _is_final_beta(self, version):
-        # if this is a XX.0 version in the release channel,
+        # If this is a XX.0 version in the release channel,
         # return True otherwise, False
-        version_parts = version.split('.')
-        if version_parts[1] == '0' and len(version_parts) == 2:
-            return True
-        else:
-            return False
+        return version.endswith('.0')
 
     def scrapeJsonReleases(self, connection, product_name):
         prod_url = urljoin(self.config.base_url, product_name, '')

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -681,7 +681,6 @@ class TestIntegrationFTPScraper(IntegrationTestCaseBase):
             from releases_raw
         """ % ','.join(columns))
         builds = [dict(zip(columns, row)) for row in cursor.fetchall()]
-        print builds
         build_ids = dict((str(x['build_id']), x) for x in builds)
         self.assertTrue('20120516114455' in build_ids)
         self.assertTrue('20120516113045' in build_ids)
@@ -830,7 +829,6 @@ class TestIntegrationFTPScraper(IntegrationTestCaseBase):
 
             information = self._load_structure()
 
-            print information['ftpscraper']['last_error']
             assert information['ftpscraper']
             assert not information['ftpscraper']['last_error']
             assert information['ftpscraper']['last_success']
@@ -995,7 +993,6 @@ class TestIntegrationFTPScraper(IntegrationTestCaseBase):
             tab.run_all()
 
             information = self._load_structure()
-            print information['ftpscraper']['last_error']
             assert information['ftpscraper']
             assert not information['ftpscraper']['last_error']
             assert information['ftpscraper']['last_success']


### PR DESCRIPTION
Adds JSON support for finding Firefox build information.

Changes our test to look at /mobile for buildID-only file.
