### PR TITLE
fixes bug 960093 - report list graph & table unchanged by date range

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1337,8 +1337,8 @@ class CrashesFrequency(SocorroMiddleware):
 
     possible_params = (
         ('products', list),
-        ('from', datetime.datetime),
-        ('to', datetime.datetime),
+        ('from', datetime.date),
+        ('to', datetime.date),
         ('versions', list),
         ('os', list),
         ('reasons', list),

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -4153,6 +4153,15 @@ class TestViews(BaseTestViews):
     def test_report_list_partial_graph(self, rget):
 
         def mocked_get(url, **options):
+            today = datetime.datetime.utcnow().date()
+            # because when calling the .get() we use
+            # ?range_value=3&range_unit=days
+            # we expect /from/<3 days ago>
+            # and /to/<today>
+            # both in the URL
+            then = today - datetime.timedelta(days=3)
+            ok_('/from/%s/' % then.strftime('%Y-%m-%d'))
+            ok_('/to/%s/' % today.strftime('%Y-%m-%d'))
             if '/crashes/frequency' in url:
                 # these fixtures make sure we stress the possibility that
                 # the build_date might be invalid or simply just null.
@@ -4207,7 +4216,8 @@ class TestViews(BaseTestViews):
         url = reverse('crashstats.report_list_partial', args=('graph',))
         response = self.client.get(url, {
             'signature': 'sig',
-            'range_value': 3
+            'range_value': 3,
+            'range_unit': 'days'
         })
         eq_(response.status_code, 200)
         expect_xaxis_ticks = [

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1409,11 +1409,14 @@ def report_list(request, partial=None, default_context=None):
                 'XAXIS_TICKS': [],
             }
         crashes_frequency_api = models.CrashesFrequency()
-        builds = crashes_frequency_api.get(
-            signature=context['signature'],
-            products=[context['product']],
-            versions=versions
-        )['hits']
+        params = {
+            'signature': context['signature'],
+            'products': [context['product']],
+            'versions': versions,
+            'from': start_date.date(),
+            'to': end_date.date(),
+        }
+        builds = crashes_frequency_api.get(**params)['hits']
 
         for i, build in enumerate(builds):
             try:


### PR DESCRIPTION
@rhelmer r?

The key ingredient in this patch is that it now passed the `start_date` and `end_date` to the middleware at all. 
Also, when doing so it makes sure it sends it as a `datetime.date`. 
Internally in `socorro/external/postgresq/crashes.py` it converts that to a `datetime.datetime` but that's fine because it becomes `00:00:00+00`. 
