### PR TITLE
Bug 964837 - Update forced versions for correlations for Firefox cycle starting 2014-02-04

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="27.0 28.0a2 29.0a1"
+MANUAL_VERSION_OVERRIDE="28.0 29.0a2 30.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 964837 - it should go to production the week of Feb 3 (not before!).
