### PR TITLE
fixes bug 962643 - create the LagLog crontabber job

### DIFF
--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -32,6 +32,7 @@ from configman.converters import class_converter, CannotConvertError
 
 
 DEFAULT_JOBS = '''
+  socorro.cron.jobs.laglog.LagLog|5m
   socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
   socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|10:00
   socorro.cron.jobs.matviews.SignaturesCronApp|1d|10:00

--- a/socorro/cron/jobs/laglog.py
+++ b/socorro/cron/jobs/laglog.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""an app to monitor and report on replication lag in PG databases"""
+
+from configman import Namespace
+
+from socorro.cron.base import PostgresTransactionManagedCronApp
+from socorro.external.postgresql.dbapi2_util import (
+    execute_no_results,
+    execute_query_fetchall,
+)
+
+
+#==============================================================================
+class LagLog(PostgresTransactionManagedCronApp):
+
+    app_name = 'LagLog'
+    app_version = '0.1'
+    app_description = __doc__
+
+    #--------------------------------------------------------------------------
+    required_config = Namespace()
+    required_config.add_option(
+        'transaction_executor',
+        default='socorro.database.transaction_executor.TransactionExecutor',
+        doc='the transaction class to use',
+        reference_value_from='resource.postgresql',
+    )
+
+    insert_sql = (
+        "INSERT INTO laglog (replica_name, moment, lag, master) "
+        "VALUES (%s, %s, %s, %s)"
+    )
+    each_server_sql = (
+        "SELECT NOW(), client_addr, sent_location, replay_location "
+        "FROM pg_stat_replication"
+    )
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def xlog_transform(xlog):
+        logid, offset = xlog.split('/')
+        return int('ffffffff', 16) * int(logid, 16) + int(offset, 16)
+
+    #--------------------------------------------------------------------------
+    def run(self, connection_ignored):
+
+        database_transaction = self.config.transaction_executor(
+            self.config,
+            self.config.database
+        )
+
+        each_server = database_transaction(
+            execute_query_fetchall,
+            self.each_server_sql
+        )
+
+        self.config.logger.debug(
+            'replication database servers: %s',
+            each_server
+        )
+        for now, client_addr, sent_location, replay_location in each_server:
+            sent_location = self.xlog_transform(sent_location)
+            replay_location = self.xlog_transform(replay_location)
+            lag = sent_location - replay_location
+            self.config.logger.debug(
+                '%s %s %s %s',
+                client_addr,
+                now,
+                lag,
+                self.config.database.database_name
+            )
+            database_transaction(
+                execute_no_results,
+                self.insert_sql,
+                (client_addr, now, lag, self.config.database.database_name)
+            )

--- a/socorro/unittest/cron/jobs/test_laglog.py
+++ b/socorro/unittest/cron/jobs/test_laglog.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+import mock
+import datetime
+
+from socorro.cron.jobs.laglog import LagLog
+from socorro.lib.util import SilentFakeLogger
+
+from configman.dotdict import DotDict
+
+
+class TestLagLog(unittest.TestCase):
+
+    def _get_mocked_config(self):
+        config = DotDict()
+        config.database = mock.Mock()
+        config.transaction_executor = mock.Mock()
+        config.logger = SilentFakeLogger()
+        self.config = config
+
+    def test_run(self):
+        self._get_mocked_config()
+        database_transaction_return_value = [
+            [
+                (
+                    datetime.datetime(2014, 01, 22, 01, 13, 38),
+                    '192.168.168.140',
+                    '1798/552C598',
+                    '1798/5527C40'
+                ),
+                (
+                    datetime.datetime(2014, 01, 22, 01, 13, 38),
+                    '192.168.168.141',
+                    '1798/552C598',
+                    '1798/5527C40'
+                ),
+                (
+                    datetime.datetime(2014, 01, 22, 01, 13, 38),
+                    '192.168.168.142',
+                    '1798/552C598',
+                    '1798/5527C40'
+                ),
+            ],
+            None,
+            None,
+            None,
+        ]
+        self.config.transaction_executor.return_value.side_effect = \
+            database_transaction_return_value
+        laglog_app = LagLog(self.config, None)
+        laglog_app.run(None)  # totally faked and unused connection
+        trans_executor_calls = [
+            mock.call(
+                self.config.database.return_value,
+                laglog_app.each_server_sql
+            ),
+            mock.call(
+                self.config.database.return_value,
+                laglog_app.insert_sql,
+                database_transaction_return_value[0],
+            ),
+            mock.call(
+                self.config.database.return_value,
+                laglog_app.insert_sql,
+                database_transaction_return_value[1],
+            ),
+            mock.call(
+                self.config.database.return_value,
+                laglog_app.insert_sql,
+                database_transaction_return_value[2],
+            ),
+        ]
+        self.config.transaction_executor.has_calls(
+            trans_executor_calls
+        )


### PR DESCRIPTION
@twobraids r?

cc @selenamarie 

I closed https://github.com/mozilla/socorro/pull/1807 and reshuffled the code a slight bit. 
Most important difference is that `socorro.cron.jobs.laglog.LagLog|5m` is added to the list of `DEFAULT_JOBS`. 
