### PR TITLE
fixes bug 963297 - enforce annotated types in crashstats model

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -1254,7 +1254,8 @@ class TestViews(BaseTestViews):
     def test_Correlations(self, rget):
 
         def mocked_get(url, **options):
-            assert 'correlations/report_type' in url
+            assert 'correlations/' in url
+            assert 'report_type/core-counts' in url
             return Response("""
                 {
                     "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
@@ -1329,7 +1330,8 @@ class TestViews(BaseTestViews):
     def test_Correlations_returning_nothing(self, rget):
 
         def mocked_get(url, **options):
-            assert 'correlations/report_type' in url
+            assert 'correlations/' in url
+            assert 'report_type/core-counts' in url
             # 'null' is a perfectly valid JSON response
             return Response('null')
 

--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -293,41 +293,6 @@ class CrashTrendsForm(BaseForm):
         return value
 
 
-class GCCrashesForm(BaseForm):
-
-    product = forms.ChoiceField(required=True)
-    version = forms.ChoiceField(required=True)
-
-    def __init__(self, nightly_versions,
-                 *args, **kwargs):
-        super(GCCrashesForm, self).__init__(*args, **kwargs)
-        self.versions = collections.defaultdict(list)
-        for each in nightly_versions:
-            self.versions[each['product']].append(each['version'])
-
-        self.fields['product'].choices = [
-            (x, x) for x in self.versions
-        ]
-
-        self.fields['version'].choices = [
-            (x, x) for sublist in self.versions.values() for x in sublist
-        ] + [('', 'blank')]
-
-    def clean_version(self):
-        if 'product' not in self.cleaned_data:
-            # don't bother, the product didn't pass validation
-            return
-        value = self.cleaned_data['version']
-        allowed_versions = self.versions[self.cleaned_data['product']]
-
-        if value not in allowed_versions:
-            raise forms.ValidationError(
-                "Unrecognized version for product: %s" % value
-            )
-
-        return value
-
-
 class FrontpageJSONForm(forms.Form):
     product = forms.ChoiceField(required=False)
     versions = forms.MultipleChoiceField(required=False)
@@ -434,3 +399,16 @@ class CorrelationsSignaturesJSONForm(CorrelationsJSONFormBase):
             raise forms.ValidationError('Invalid platform(s)')
         else:
             return '+'.join(value)
+
+
+class GCCrashesForm(BaseForm):
+
+    start_date = forms.DateField(required=True)
+    end_date = forms.DateField(required=True)
+
+    def clean(self):
+        cleaned_data = super(GCCrashesForm, self).clean()
+        if 'start_date' in cleaned_data and 'end_date' in cleaned_data:
+            if cleaned_data['start_date'] > cleaned_data['end_date']:
+                raise forms.ValidationError('start_date > end_date')
+        return cleaned_data

--- a/webapp-django/crashstats/crashstats/tests/test_forms.py
+++ b/webapp-django/crashstats/crashstats/tests/test_forms.py
@@ -427,3 +427,35 @@ class TestForms(TestCase):
         ok_(form.is_valid())
         eq_(form.cleaned_data['bug_ids'], ['123', '345', '100'])
         eq_(form.cleaned_data['include_fields'], ['foo_1', 'bar_2'])
+
+    def test_gcrashes_form(self):
+
+        def get_new_form(data):
+            return forms.GCCrashesForm(data)
+
+        form = get_new_form({})
+        ok_(not form.is_valid())  # missing both
+
+        form = get_new_form({
+            'start_date': '2013-02-33',
+            'end_date': '2013-01-02'
+        })
+        ok_(not form.is_valid())  # not a valid date
+
+        form = get_new_form({
+            'start_date': '2013-02-13',
+            'end_date': '2013-01-44'
+        })
+        ok_(not form.is_valid())  # not a valid date
+
+        form = get_new_form({
+            'start_date': '2013-02-02',
+            'end_date': '2013-01-01'
+        })
+        ok_(not form.is_valid())  # start_date > end_date
+
+        form = get_new_form({
+            'start_date': '2013-01-01',
+            'end_date': '2013-01-02'
+        })
+        ok_(form.is_valid())  # should be fine

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -196,8 +196,7 @@ urlpatterns = patterns(
     url(r'^gccrashes' + products + versions + '$',
         views.gccrashes,
         name='crashstats.gccrashes'),
-    url(r'^gccrashes/json_data' + products + versions + start_date +
-        end_date + '$',
+    url(r'^gccrashes/json_data' + products + versions + '$',
         views.gccrashes_json,
         name='crashstats.gccrashes_json'),
     url(r'^login/$',


### PR DESCRIPTION
@rhelmer r?

I know this is a very large patch and some details could sort of have been dealt with in some follow-up bugs but any of those few changes are very minor or were actually blocking the tests from working. For example, the use of `settings.TCBS_RESULT_COUNTS`.

I'll try to point out some areas that are important and really need review. 
