### PR TITLE
Bug 969062 return more descriptive 4xx errors in json

### DIFF
--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -450,7 +450,13 @@ class Crashes(PostgreSQLBase):
         if not params.uuid:
             raise MissingArgumentError('uuid')
 
-        crash_date = datetimeutil.uuid_to_date(params.uuid)
+        try:
+            crash_date = datetimeutil.uuid_to_date(params.uuid)
+        except ValueError:
+            raise BadArgumentError(
+                'uuid',
+                'Date could not be converted extract from %s' % (params.uuid,)
+            )
 
         sql = """
             /* socorro.external.postgresql.crashes.Crashes.get_paireduuid */

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -323,16 +323,47 @@ class ImplementationWrapperTestCase(unittest.TestCase):
         # Test a Not Found error
         response = testapp.get('/aux/notfound', expect_errors=True)
         self.assertEqual(response.status, 404)
+        self.assertEqual(
+            response.header('content-type'),
+            'application/json; charset=UTF-8'
+        )
+        body = json.loads(response.body)
+        self.assertEqual(body['error']['message'], 'not here')
 
         # Test a Timeout error
         response = testapp.get('/aux/unavailable', expect_errors=True)
         self.assertEqual(response.status, 408)
+        self.assertEqual(
+            response.header('content-type'),
+            'application/json; charset=UTF-8'
+        )
+        body = json.loads(response.body)
+        self.assertEqual(body['error']['message'], 'unavailable')
 
         # Test BadRequest errors
         response = testapp.get('/aux/missing', expect_errors=True)
         self.assertEqual(response.status, 400)
+        self.assertEqual(
+            response.header('content-type'),
+            'application/json; charset=UTF-8'
+        )
+        body = json.loads(response.body)
+        self.assertEqual(
+            body['error']['message'],
+            "Mandatory parameter(s) 'missing arg' is missing or empty."
+        )
+
         response = testapp.get('/aux/bad', expect_errors=True)
         self.assertEqual(response.status, 400)
+        self.assertEqual(
+            response.header('content-type'),
+            'application/json; charset=UTF-8'
+        )
+        body = json.loads(response.body)
+        self.assertEqual(
+            body['error']['message'],
+            "Bad value for parameter(s) 'bad arg'"
+        )
 
     @mock.patch('raven.Client')
     @mock.patch('logging.info')

--- a/socorro/webapi/webapiService.py
+++ b/socorro/webapi/webapiService.py
@@ -9,8 +9,12 @@ import web
 import socorro.lib.util as util
 import socorro.database.database as db
 import socorro.storage.crashstorage as cs
-from socorro.external import DatabaseError, InsertionError, \
-                             MissingArgumentError, BadArgumentError
+from socorro.external import (
+    DatabaseError,
+    InsertionError,
+    MissingArgumentError,
+    BadArgumentError
+)
 
 
 logger = logging.getLogger("webapi")
@@ -30,24 +34,39 @@ class BadRequest(web.webapi.HTTPError):
     """
     def __init__(self, message="bad request"):
         status = "400 Bad Request"
-        headers = {'Content-Type': 'text/html'}
-        # can't use super() because it's an old-style class base
-        web.webapi.HTTPError.__init__(self, status, headers, message)
+        if message and isinstance(message, dict):
+            headers = {'Content-Type': 'application/json; charset=UTF-8'}
+            message = json.dumps(message)
+        else:
+            headers = {'Content-Type': 'text/html'}
+        super(BadRequest, self).__init__(status, headers, message)
 
 
 class Timeout(web.webapi.HTTPError):
-
     """
     '408 Request Timeout' Error
 
     """
-
-    message = "item currently unavailable"
-
-    def __init__(self):
+    def __init__(self, message="item currently unavailable"):
         status = "408 Request Timeout"
-        headers = {'Content-Type': 'text/html'}
-        super(Timeout, self).__init__(status, headers, self.message)
+        if message and isinstance(message, dict):
+            headers = {'Content-Type': 'application/json; charset=UTF-8'}
+            message = json.dumps(message)
+        else:
+            headers = {'Content-Type': 'text/html'}
+        super(Timeout, self).__init__(status, headers, message)
+
+
+class NotFound(web.webapi.HTTPError):
+    """Return a HTTPError with status code 404 and a description in JSON"""
+    def __init__(self, message="Not found"):
+        if isinstance(message, dict):
+            message = json.dumps(message)
+            headers = {'Content-Type': 'application/json; charset=UTF-8'}
+        else:
+            headers = {'Content-Type': 'text/html'}
+        status = '404 Not Found'
+        super(NotFound, self).__init__(status, headers, message)
 
 
 class JsonWebServiceBase(object):

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -120,7 +120,7 @@ class TestViews(BaseTestViews):
             # note! no 'product'
             'versions': ['10.0', '11.1'],
         })
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['product'])
         ok_('versions' not in dump['errors'])
@@ -257,7 +257,7 @@ class TestViews(BaseTestViews):
             'versions': ['10.0', '11.1'],
             'from_date': '2012-01-xx',  # invalid format
         })
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['from_date'])
 
@@ -266,7 +266,7 @@ class TestViews(BaseTestViews):
             'versions': ['10.0', '11.1'],
             'from_date': '2012-02-32',  # invalid numbers
         })
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['from_date'])
 
@@ -431,7 +431,7 @@ class TestViews(BaseTestViews):
             'os': 'OSX',
         }
         response = self.client.get(url, data)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['limit'])
         ok_(dump['errors']['duration'])
@@ -449,7 +449,7 @@ class TestViews(BaseTestViews):
     def test_ReportList(self, rget):
         url = reverse('api:model_wrapper', args=('ReportList',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['signature'])
 
@@ -479,7 +479,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(url, {
             'signature': 'one & two',
         })
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['start_date'])
         ok_(dump['errors']['end_date'])
@@ -501,7 +501,7 @@ class TestViews(BaseTestViews):
     def test_ReportList_with_optional_parameters(self, rget):
         url = reverse('api:model_wrapper', args=('ReportList',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['signature'])
 
@@ -555,7 +555,7 @@ class TestViews(BaseTestViews):
     def test_ProcessedCrash(self, rget):
         url = reverse('api:model_wrapper', args=('ProcessedCrash',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['crash_id'])
 
@@ -657,7 +657,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('RawCrash',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['crash_id'])
 
@@ -700,7 +700,7 @@ class TestViews(BaseTestViews):
     def test_CommentsBySignature(self, rget):
         url = reverse('api:model_wrapper', args=('CommentsBySignature',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['signature'])
 
@@ -735,7 +735,7 @@ class TestViews(BaseTestViews):
     def test_CrashPairsByCrashId(self, rget):
         url = reverse('api:model_wrapper', args=('CrashPairsByCrashId',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['uuid'])
         ok_(dump['errors']['hang_id'])
@@ -862,7 +862,7 @@ class TestViews(BaseTestViews):
     def test_Bugs(self, rpost):
         url = reverse('api:model_wrapper', args=('Bugs',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['signatures'])
 
@@ -885,7 +885,7 @@ class TestViews(BaseTestViews):
     def test_SignaturesForBugs(self, rpost):
         url = reverse('api:model_wrapper', args=('SignaturesByBugs',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['bug_ids'])
 
@@ -934,7 +934,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('SignatureTrend',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['product'])
         ok_(dump['errors']['version'])
@@ -988,7 +988,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('SignatureSummary',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['start_date'])
         ok_(dump['errors']['end_date'])
@@ -1118,7 +1118,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('DailyBuilds',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['product'])
 
@@ -1158,7 +1158,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('CrashTrends',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['product'])
         ok_(dump['errors']['version'])
@@ -1198,7 +1198,7 @@ class TestViews(BaseTestViews):
 
         url = reverse('api:model_wrapper', args=('SignatureURLs',))
         response = self.client.get(url)
-        eq_(response.status_code, 200)
+        eq_(response.status_code, 400)
         dump = json.loads(response.content)
         ok_(dump['errors']['products'])
         ok_(dump['errors']['signature'])
@@ -1226,29 +1226,59 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, **options):
             attempts.append(url)
+
+            # The middleware will return JSON encoded errors.
+            # These will be carried through to the end user here
+
+            def wrap_error(msg):
+                return json.dumps({'error': {'message': msg}})
+
             if len(attempts) == 1:
-                return Response('Not found Stuff', status_code=400)
+                return Response(
+                    wrap_error('Not found Stuff'),
+                    status_code=400
+                )
             if len(attempts) == 2:
-                return Response('Forbidden Stuff', status_code=403)
+                return Response(
+                    wrap_error('Forbidden Stuff'),
+                    status_code=403
+                )
             if len(attempts) == 3:
-                return Response('Bad Stuff', status_code=500)
+                return Response(
+                    wrap_error('Bad Stuff'),
+                    status_code=500
+                )
             if len(attempts) == 4:
-                return Response('Someone elses Bad Stuff', status_code=502)
+                return Response(
+                    wrap_error('Someone elses Bad Stuff'),
+                    status_code=502
+                )
 
         rget.side_effect = mocked_get
 
         url = reverse('api:model_wrapper', args=('CrontabberState',))
         response = self.client.get(url)
         eq_(response.status_code, 400)
+        eq_(response['content-type'], 'application/json; charset=UTF-8')
+        error = json.loads(response.content)['error']
+        eq_(error['message'], 'Not found Stuff')
+
         # second attempt
         response = self.client.get(url)
         eq_(response.status_code, 403)
+        eq_(response['content-type'], 'application/json; charset=UTF-8')
+        error = json.loads(response.content)['error']
+        eq_(error['message'], 'Forbidden Stuff')
+
         # third attempt
         response = self.client.get(url)
         eq_(response.status_code, 424)
+        eq_(response['content-type'], 'text/plain')
+
         # forth attempt
         response = self.client.get(url)
         eq_(response.status_code, 424)
+        eq_(response['content-type'], 'text/plain')
 
     @mock.patch('requests.get')
     def test_Correlations(self, rget):

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -27,8 +27,10 @@ from crashstats.api.cleaner import Cleaner
 logger = logging.getLogger('crashstats_models')
 
 
-class BadStatusCodeError(Exception):  # XXX poor name
-    pass
+class BadStatusCodeError(Exception):
+    def __init__(self, status, message="Bad status code"):
+        self.status = status
+        self.message = message
 
 
 class RequiredParameterError(Exception):
@@ -222,12 +224,10 @@ class SocorroCommon(object):
                 retries=retries - 1
             )
 
-        if resp.status_code == 400:
-            raise BadStatusCodeError(
-                '%s: %s' % (resp.status_code, resp.content)
-            )
+        if resp.status_code >= 400 and resp.status_code < 500:
+            raise BadStatusCodeError(resp.status_code, resp.content)
         elif not resp.status_code == 200:
-            raise BadStatusCodeError('%s: on: %s' % (resp.status_code, url))
+            raise BadStatusCodeError(resp.status_code, url)
 
         result = resp.content
         if expect_json:

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -57,12 +57,17 @@ def json_view(f):
             indent = 0
             if request.REQUEST.get('pretty') == 'print':
                 indent = 2
+            if isinstance(response, tuple) and isinstance(response[1], int):
+                response, status = response
+            else:
+                status = 200
             return http.HttpResponse(
                 _json_clean(json.dumps(
                     response,
                     cls=DateTimeEncoder,
                     indent=indent
                 )),
+                status=status,
                 content_type='application/json; charset=UTF-8'
             )
     return wrapper

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -982,7 +982,8 @@ def report_index(request, crash_id, default_context=None):
     try:
         context['report'] = api.get(crash_id=crash_id)
     except models.BadStatusCodeError as e:
-        if str(e).startswith('404'):
+        error_code = e.status
+        if error_code == 404:
             # if crash was submitted today, send to pending screen
             crash_date = datetime.datetime.strptime(crash_id[-6:], '%y%m%d')
             crash_age = datetime.datetime.utcnow() - crash_date
@@ -991,10 +992,10 @@ def report_index(request, crash_id, default_context=None):
             else:
                 tmpl = 'crashstats/report_index_not_found.html'
             return render(request, tmpl, context)
-        elif str(e).startswith('408'):
+        elif error_code == 408:
             return render(request,
                           'crashstats/report_index_pending.html', context)
-        elif str(e).startswith('410'):
+        elif error_code == 410:
             return render(request,
                           'crashstats/report_index_too_old.html', context)
         else:


### PR DESCRIPTION
@AdrianGaudebert r?

cc @rhelmer @twobraids

First of all, the middleware now returns errors in JSON. This is best described this way:

```
$ curl -v "http://localhost:8883/crashes/paireduuid/uuid/xxx/hang_id/xxx/" | json_print
* Adding handle: conn: 0x7f9a1a802000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7f9a1a802000) send_pipe: 1, recv_pipe: 0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to localhost port 8883 (#0)
*   Trying ::1...
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8883 (#0)
> GET /crashes/paireduuid/uuid/xxx/hang_id/xxx/ HTTP/1.1
> User-Agent: curl/7.30.0
> Host: localhost:8883
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Content-Type: application/json; charset=UTF-8
< Transfer-Encoding: chunked
< Date: Thu, 06 Feb 2014 22:54:05 GMT
* Server localhost is not blacklisted
< Server: localhost
<
{ [data not shown]
100    99    0    99    0     0  30564      0 --:--:-- --:--:-- --:--:-- 33000
* Connection #0 to host localhost left intact
{
  "error": {
    "message": "Bad value for parameter(s) 'Date could not be converted extract from xxx'"
  }
}
```

See, it returns a proper `400` code. And it returns it as `application/json; charset=UTF-8`. 
And the response body is a valid piece of JSON. 

With that in place, if you use the public API and cause the same error the error message is "carried" there too. See:

```
$ curl -v "http://socorro/api/CrashPairsByCrashId/?hang_id=xxx&uuid=xxx" | json_print
* Adding handle: conn: 0x7ff023804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7ff023804000) send_pipe: 1, recv_pipe: 0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to socorro port 80 (#0)
*   Trying 127.0.0.1...
* Connected to socorro (127.0.0.1) port 80 (#0)
> GET /api/CrashPairsByCrashId/?hang_id=xxx&uuid=xxx HTTP/1.1
> User-Agent: curl/7.30.0
> Host: socorro
> Accept: */*
>
< HTTP/1.1 400 BAD REQUEST
* Server nginx/1.4.1 is not blacklisted
< Server: nginx/1.4.1
< Date: Thu, 06 Feb 2014 22:56:18 GMT
< Content-Type: application/json; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Vary: X-Mobile, User-Agent, Cookie
< Access-Control-Allow-Origin: *
< X-Frame-Options: DENY
< Set-Cookie: anoncsrf=X6tRCd1xwTJpEmptkEUxgh4zuQpfJEfR; expires=Fri, 07-Feb-2014 00:56:18 GMT; httponly; Max-Age=7200; Path=/
<
{ [data not shown]
100    99    0    99    0     0    244      0 --:--:-- --:--:-- --:--:--   244
* Connection #0 to host socorro left intact
{
  "error": {
    "message": "Bad value for parameter(s) 'Date could not be converted extract from xxx'"
  }
}
```

This is only applicable to any of the 4xx errors. If you get any 500 error you get it back in `text/plain` and any response body given by the middleware is discarded as the error is re-represented in the webapp. 
