### PR TITLE
fix bug 972612 - some buildIDs in reports_clean are too small to parse a...

### DIFF
--- a/socorro/external/postgresql/raw_sql/procs/update_gccrashes.sql
+++ b/socorro/external/postgresql/raw_sql/procs/update_gccrashes.sql
@@ -64,6 +64,7 @@ WHERE utc_day_is(date_processed, updateday)
         AND adu_count > 0
         AND build_date(build) = build_adu.build_date
         AND date_processed - build_date(build) < '7 days'::interval
+        AND length(build::text) >= 10
 GROUP BY build, product_version_id
 ORDER BY build;
 


### PR DESCRIPTION
...s dates
