### PR TITLE
fix bug 928051 - get b2g into reports_clean

### DIFF
--- a/alembic/versions/74d6fd90b59_bug_928051_add_b2g_to_reports_clean.py
+++ b/alembic/versions/74d6fd90b59_bug_928051_add_b2g_to_reports_clean.py
@@ -1,0 +1,44 @@
+"""bug 928051 - add b2g to reports_clean
+
+Revision ID: 74d6fd90b59
+Revises: c1ac31c8fea
+Create Date: 2014-02-18 12:53:41.577292
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '74d6fd90b59'
+down_revision = 'c1ac31c8fea'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+
+
+
+def upgrade():
+    load_stored_proc(op, ['001_update_reports_clean.sql', 'update_product_versions.sql'])
+    op.alter_column(u'update_channel_map', u'update_channel', type_=sa.CITEXT())
+    op.alter_column(u'raw_update_channels', u'update_channel',
+                    type_=sa.CITEXT())
+    op.execute("""
+        INSERT INTO product_release_channels VALUES ('B2G', 'Release', 1)
+        WHERE NOT EXISTS (
+            SELECT product_name, release_channel FROM product_release_channels
+            WHERE product_name = 'B2G'
+            AND release_channel = 'Release'
+        )
+    """)
+    op.execute(""" COMMIT """)
+
+
+def downgrade():
+    load_stored_proc(op, ['001_update_reports_clean.sql', 'update_product_versions.sql'])
+    op.alter_column(u'update_channel_map', u'update_channel', type_=sa.TEXT())
+    op.alter_column(u'raw_update_channels', u'update_channel', type_=sa.TEXT())

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1478,7 +1478,7 @@ class RawUpdateChannel(DeclarativeBase):
     """ Scraped information from reports table for release_channel/update_channel """
     __tablename__ = 'raw_update_channels'
 
-    update_channel = Column(u'update_channel', TEXT(), nullable=False, primary_key=True)
+    update_channel = Column(u'update_channel', CITEXT(), nullable=False, primary_key=True)
     product_name = Column(u'product_name', TEXT(), nullable=False, primary_key=True)
     version = Column(u'version', TEXT(), nullable=False, primary_key=True)
     build = Column(u'build', NUMERIC(), nullable=False, primary_key=True)
@@ -1489,7 +1489,7 @@ class UpdateChannelMap(DeclarativeBase):
     """ Human-defined mapping from raw_update_channel to new update_channel name for reports_clean """
     __tablename__ = 'update_channel_map'
 
-    update_channel = Column(u'update_channel', TEXT(), nullable=False, primary_key=True)
+    update_channel = Column(u'update_channel', CITEXT(), nullable=False, primary_key=True)
     productid = Column(u'productid', TEXT(), nullable=False, primary_key=True)
     version_field = Column(u'version_field', TEXT(), nullable=False, primary_key=True)
     rewrite = Column(u'rewrite', JSON(), nullable=False)


### PR DESCRIPTION
Putting this up for discussion - it does the bare minimum to get b2g reports into `product_versions` and also `reports_clean`. I have only been able to test this locally using fakedata, you must modify the rewrite JSON in `update_channel_map` like so (this is a `copy from update_channel_map with csv`):

```
nightly,{3c2e2abc-06d4-11e1-ac3b-374f68613e61},B2G_OS_Version,"{""Android_Manufacturer"": ""ZTE"",
           ""Android_Model"": ""roamer2"",
           ""Android_Version"": ""15(REL)"",
           ""B2G_OS_Version"": ""1.0.1.0-prerelease"",
           ""BuildID"":
                [""20140216000020"", ""20130621152332"",
                 ""20130531232151"", ""20130617105829"",
                 ""20130724040538""],
            ""ProductName"": ""B2G"",
            ""ReleaseChannel"": ""nightly"",
            ""Version"": ""18.0"",
            ""rewrite_update_channel_to"": ""release-zte"",
            ""rewrite_build_type_to"": ""release""}"
```

Note that the `BuildID` array has at least one entry that matches my local fakedata (which changes depending on the day it is generated).

When I have the above entry and backfill, I see B2G data in `reports_clean` (and also `product_versions` which is currently a prereq).

@selenamarie - we discussed also having an `update_channel` in `product_versions`, which would be set to `release-zte` in this case. What else is this patch missing ? :) I _think_ if we took it as-is, we'd at least be able to start getting crashes for shipped phones into `reports_clean` and all the dependent reports like topcrashers, assuming that `update_channel_map` is filled out correctly. 
