### PR TITLE
Bug 967555 add authentication for public api

### DIFF
--- a/webapp-django/crashstats/api/helpers.py
+++ b/webapp-django/crashstats/api/helpers.py
@@ -50,3 +50,10 @@ def make_test_input(parameter, defaults):
     template += '>'
     html = template % data
     return jinja2.Markup(html)
+
+
+@register.filter
+def pluralize(count, multiple='s', single=''):
+    if count == 1:
+        return single
+    return multiple

--- a/webapp-django/crashstats/api/static/api/css/documentation.css
+++ b/webapp-django/crashstats/api/static/api/css/documentation.css
@@ -41,3 +41,14 @@ img.loading-ajax {
 .title h2 a {
     text-decoration: none;
 }
+p.required-permission {
+    float: right;
+    margin: 0;
+}
+p.tokens-callout {
+    float: right;
+    font-size: 120%;
+}
+p.tokens-callout a {
+    font-weight: bold;
+}

--- a/webapp-django/crashstats/api/templates/api/documentation.html
+++ b/webapp-django/crashstats/api/templates/api/documentation.html
@@ -28,20 +28,29 @@
 
     <div class="panel">
       <div class="body notitle">
-      <p>
-      These API endpoints are publicly available. The parameters to some endpoints
-      are non-trivial as some might require deeper understanding of the Soccoro backend.
-      </p>
-      <p>
-        <b>Note:</b> All Personal Identifiable Information
-        will be <b>removed or scrubbed</b> from all responses.
-      </p>
+        <p class="tokens-callout">
+	  You current have <a href="{{ url('tokens:home') }}">{{ count_tokens }} active API Token{{ count_tokens|pluralize }}</a>.
+	</p>
+        <p>
+        These API endpoints are publicly available. The parameters to some endpoints
+        are non-trivial as some might require deeper understanding of the Soccoro backend.
+        </p>
+        <p>
+          <b>Note:</b> The API does depend on <a href="{{ url('crashstats.permissions') }}">your permissions</a>
+          and if you include an <a href="{{ url('tokens:home') }}">API Token</a> with your requests.<br>
+          Some endpoints' accessibility depend entirely on your permissions and use of API Tokens.
+        </p>
       </div>
     </div>
 
     {% for endpoint in endpoints %}
     <div class="panel" id="{{ endpoint.name }}">
         <div class="title">
+        {% if endpoint.required_permission %}
+          <p class="required-permission">
+            Only available if used with an <b>API Token</b> associated with <b>{{ endpoint.required_permission }}</b> permission.
+          </p>
+        {% endif %}
         <h2><a href="#{{ endpoint.name }}">{{ endpoint.name }}</a></h2>
         </div>
         <div class="body">

--- a/webapp-django/crashstats/api/tests/test_helpers.py
+++ b/webapp-django/crashstats/api/tests/test_helpers.py
@@ -1,0 +1,18 @@
+from nose.tools import eq_
+from django.test import TestCase
+
+
+from crashstats.api.helpers import (
+    pluralize
+)
+
+
+class TestPluralize(TestCase):
+
+    def test_basics(self):
+        eq_(pluralize(0), 's')
+        eq_(pluralize(1), '')
+        eq_(pluralize(59), 's')
+
+    def test_overide_s(self):
+        eq_(pluralize(59, 'ies'), 'ies')

--- a/webapp-django/crashstats/base/templates/crashstats_base.html
+++ b/webapp-django/crashstats/base/templates/crashstats_base.html
@@ -141,6 +141,7 @@
             <ul>
                 <li><a href="{{ url('crashstats.status') }}">Server Status</a></li>
                 <li><a href="{{ url('api:documentation') }}">API Documentation</a></li>
+                <li><a href="{{ url('tokens:home') }}">API Tokens</a></li>
                 <li><a href="http://socorro.readthedocs.org/">Project Info</a></li>
                 <li><a href="https://github.com/mozilla/socorro">Source Code</a></li>
                 <li><a href="http://wiki.mozilla.org/Breakpad">Breakpad Wiki</a></li>

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -263,6 +263,9 @@ class SocorroMiddleware(SocorroCommon):
     default_date_format = '%Y-%m-%d'
     default_datetime_format = '%Y-%m-%dT%H:%M:%S'
 
+    # by default, no particular permission is needed to use a model
+    API_REQUIRED_PERMISSION = None
+
 #    def fetch(self, url, *args, **kwargs):
 #        url = self._complete_url(url)
 #        return super(SocorroMiddleware, self).fetch(url, *args, **kwargs)
@@ -1070,6 +1073,14 @@ class CrashesByExploitability(SocorroMiddleware):
         'product',
         'version',
     )
+
+    defaults = {
+        'page': 1
+    }
+
+    API_REQUIRED_PERMISSION = 'crashstats.view_exploitability'
+
+    API_WHITELIST = None
 
 
 class Search(SocorroMiddleware):

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -35,6 +35,8 @@ from crashstats.crashstats.management import PERMISSIONS
 
 class Response(object):
     def __init__(self, content=None, status_code=200):
+        if not isinstance(content, basestring):
+            content = json.dumps(content)
         self.content = content
         self.status_code = status_code
 
@@ -199,6 +201,10 @@ class BaseTestViews(TestCase):
 
     def _logout(self):
         self.client.logout()
+
+    def _add_permission(self, user, codename, group_name='Hackers'):
+        group = self._create_group_with_permission(codename)
+        user.groups.add(group)
 
     def _create_group_with_permission(self, codename, group_name='Group'):
         appname = 'crashstats'

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -51,6 +51,7 @@ MIDDLEWARE_CLASSES = tuple(MIDDLEWARE_CLASSES) + (
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    '%s.tokens.middleware.APIAuthenticationMiddleware' % PROJECT_MODULE,
 )
 
 

--- a/webapp-django/crashstats/tokens/middleware.py
+++ b/webapp-django/crashstats/tokens/middleware.py
@@ -1,0 +1,56 @@
+import json
+from functools import partial
+
+from django.contrib import auth
+from django.core.exceptions import ImproperlyConfigured
+from django import http
+
+from . import models
+
+
+def json_forbidden_response(msg):
+    body = json.dumps({'error': msg})
+    return http.HttpResponseForbidden(
+        body + '\n',
+        mimetype='application/json; charset=UTF-8'
+    )
+
+
+def has_perm(all, codename):
+    codename = codename.split('.', 1)[1]
+    return all.filter(codename=codename).count()
+
+
+class APIAuthenticationMiddleware(object):
+
+    def process_request(self, request):
+        # AuthenticationMiddleware is required so that request.user exists.
+        if not hasattr(request, 'user'):
+            raise ImproperlyConfigured(
+                "The API Authenication middleware requires the"
+                " authentication middleware to be installed. Edit your"
+                " MIDDLEWARE_CLASSES setting to insert"
+                " 'django.contrib.auth.middleware.AuthenticationMiddleware'"
+                " before the RemoteUserMiddleware class.")
+
+        key = request.META.get('HTTP_AUTH_TOKEN')
+        if not key:
+            return
+        try:
+            token = models.Token.objects.select_related('user').get(key=key)
+            if token.is_expired:
+                return json_forbidden_response(
+                    'API Token found but expired'
+                )
+        except models.Token.DoesNotExist:
+            return json_forbidden_response('API Token not matched')
+
+        user = token.user
+        # it actually doesn't matter so much which backend
+        # we use as long as it's something
+        user.backend = 'django.contrib.auth.backends.ModelBackend'
+        user.has_perm = partial(has_perm, token.permissions.all())
+        # User is valid. Set request.user and persist user in the session
+        # by logging the user in.
+        request.user = user
+        auth.login(request, user)

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -131,11 +131,11 @@
         <p>When using the <a href="{{ url('api:documentation') }}">API</a> you must supply these tokens as a header called <code>Token</code>.</p>
         <p>Here's an example:</p>
         <p class="example">
-          <code>curl -H "Token: 58af2acef8a74dbca9580e2bb8ba9c9a" {{ absolute_base_url }}{{ url('api:model_wrapper', 'GCCrashes') }}</code>
+          <code>curl -H "Auth-Token: 58af2acef8a74dbca9580e2bb8ba9c9a" {{ absolute_base_url }}{{ url('api:model_wrapper', 'GCCrashes') }}</code>
         </p>
         <p>Or, if you prefer Python:</p>
         <pre class="example">import requests
-headers = {'Token': '58af2acef8a74dbca9580e2bb8ba9c9x'}
+headers = {'Auth-Token': '58af2acef8a74dbca9580e2bb8ba9c9x'}
 url = '{{ absolute_base_url }}{{ url('api:model_wrapper', 'GCCrashes') }}'
 response = requests.get(url, headers=headers)</pre>
       </div>

--- a/webapp-django/crashstats/tokens/tests/test_middleware.py
+++ b/webapp-django/crashstats/tokens/tests/test_middleware.py
@@ -1,0 +1,106 @@
+import datetime
+import json
+
+from nose.tools import eq_, ok_
+
+from django.contrib.auth.models import User, Permission
+from django.conf import settings
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.exceptions import ImproperlyConfigured
+from django.contrib.contenttypes.models import ContentType
+
+from crashstats.tokens import models
+from crashstats.tokens.middleware import APIAuthenticationMiddleware
+
+
+class TestMiddleware(TestCase):
+
+    django_session_middleware = SessionMiddleware()
+    django_auth_middleware = AuthenticationMiddleware()
+    middleware = APIAuthenticationMiddleware()
+
+    def test_impropertly_configured(self):
+        request = RequestFactory().get('/')
+        self.assertRaises(
+            ImproperlyConfigured,
+            self.middleware.process_request,
+            request
+        )
+
+    def _get_request(self, **headers):
+        # boilerplate stuff
+        request = RequestFactory(**headers).get('/')
+        self.django_session_middleware.process_request(request)
+        self.django_auth_middleware.process_request(request)
+        assert request.user
+        return request
+
+    def test_no_token_key(self):
+        request = self._get_request()
+        eq_(self.middleware.process_request(request), None)
+
+    def test_non_existant_token_key(self):
+        request = self._get_request(HTTP_AUTH_TOKEN='xxx')
+
+        response = self.middleware.process_request(request)
+        eq_(response.status_code, 403)
+        # the response content will be JSON
+        result = json.loads(response.content)
+        eq_(result['error'], 'API Token not matched')
+
+    def test_expired_token(self):
+        user = User.objects.create(username='peterbe')
+        token = models.Token.objects.create(
+            user=user,
+        )
+        token.expires -= datetime.timedelta(
+            days=settings.TOKENS_DEFAULT_EXPIRATION_DAYS
+        )
+        token.save()
+        request = self._get_request(HTTP_AUTH_TOKEN=token.key)
+
+        response = self.middleware.process_request(request)
+        eq_(response.status_code, 403)
+        result = json.loads(response.content)
+        eq_(result['error'], 'API Token found but expired')
+
+    def test_token_valid(self):
+        user = User.objects.create(username='peterbe')
+        token = models.Token.objects.create(
+            user=user,
+        )
+        request = self._get_request(HTTP_AUTH_TOKEN=token.key)
+
+        response = self.middleware.process_request(request)
+        eq_(response, None)
+        eq_(request.user, user)
+
+    def test_token_permissions(self):
+        user = User.objects.create(username='peterbe')
+        token = models.Token.objects.create(
+            user=user,
+        )
+        ct, __ = ContentType.objects.get_or_create(
+            model='',
+            app_label='crashstats',
+        )
+        permission = Permission.objects.create(
+            codename='play',
+            content_type=ct
+        )
+        token.permissions.add(permission)
+        Permission.objects.create(
+            codename='fire',
+            content_type=ct
+        )
+        # deliberately not adding this second permission
+
+        request = self._get_request(HTTP_AUTH_TOKEN=token.key)
+        # do the magic to the request
+        self.middleware.process_request(request)
+        eq_(request.user, user)
+        ok_(request.user.has_perm('crashstats.play'))
+        ok_(not request.user.has_perm('crashstats.fire'))


### PR DESCRIPTION
@rhelmer r? (cc @lauraxt)

I'll try to explain what parts are worth actually reviewing (apart from the usual trivial stuff). 

What this introduces is the ability to do something like 

```
curl -v -H "Auth-Token:  1a5672a09a4943aa9b1fb680e7838c03 " "http://socorro/api/ReportList/?end_date=2014-02-14&signature=nsContentUtils%3A%3AIsCallerChrome()&start_date=2014-02-01&result_number=3"
```

or

```
curl -v -H "Auth-Token:  1a5672a09a4943aa9b1fb680e7838c03 " "http://socorro/api/CrashesByExploitability/?batch=10&page=1"
```

Firstly, the token acts a bit like a session cookie. EXCEPT the session cookie is used to find a user instance to insert onto the `request`, in this patch the `request.user.has_perm` is overwritten so that the `has_perm` question isn't based on the user but based on the token you generated and used. 
I.e. you can generate a token that only has the "View PII data" permission and if you use this token's key to try to reach `.../api/CrashesByExploitability/...` you get a 403 Forbidden. 
In other words, you (as rhelmer@muzilla.com) might be part of a group (e.g. Hackers) that has certain permissions but depending on how you use your tokens, your permissions on the site don't matter. Does that make sense?

Secondly, the API is now dependent on the `request.user` and `request.user` and does not care how that got set. This means that if you use the API with curl and a token as a header, it's still `request.user.has_perm(...)`. And if you sign in to the site and use the API documentation to do some AJAX sample queries it uses the user you are signed in as. What this means is that if you have the "View PII data" permission on the site, you'll be able to use the API endpoints in AJAX and get all the PII included! This means we can use the API as the source of AJAX in various reports instead of having to do things like `someview_json_data`. 

Thirdly, the model "CrashesByExploitability" used to be blacklisted in the API and not included in the documentation if you view `/api/`. That's no longer the case. I added a new class attribute called `API_REQUIRED_PERMISSION` which I hope is self-explanatory. 
