### PR TITLE
fixes bug 975179 - Expired API tokens are clearly shown as expires

### DIFF
--- a/webapp-django/crashstats/tokens/models.py
+++ b/webapp-django/crashstats/tokens/models.py
@@ -38,3 +38,7 @@ class Token(models.Model):
 
     def __repr__(self):
         return '<%s: %s...>' % (self.__class__.__name__, self.key[:12])
+
+    @property
+    def is_expired(self):
+        return self.expires < get_now()

--- a/webapp-django/crashstats/tokens/static/tokens/css/home.css
+++ b/webapp-django/crashstats/tokens/static/tokens/css/home.css
@@ -40,3 +40,9 @@ table.meta-data td {
     padding: 2px 6px;
     border: 0;
 }
+.is-expired {
+    color: red;
+    font-weight: bold;
+    font-size: 110%;
+    margin: 5px;
+}

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -48,6 +48,11 @@
             <code>{{ token.key[:12] }}<span class="rest-hidden">{{ token.key[12:] }}</span><span class="rest-cover">...</span></code>
             <button type="button" data-toggle="Hide again">Show the whole token</button>
           </p>
+
+          {% if token.is_expired %}
+          <p class="is-expired">Token has expired and will not work any more.</p>
+          {% endif %}
+
           <table class="meta-data">
             <tr>
               <th>Permissions:</th>
@@ -59,6 +64,15 @@
                 </ul>
               </td>
             </tr>
+            {% if token.is_expired %}
+            <tr>
+              <th>Expired:</th>
+              <td>
+                {{ token.expires.strftime('%Y-%m-%d %H:%M:%S%Z') }}
+                (<time class="ago" data-date="{{ token.expires.isoformat() }}">{{ token.expires.isoformat() }}</time>)
+              </td>
+            </tr>
+            {% else %}
             <tr>
               <th>Expires:</th>
               <td>
@@ -66,6 +80,7 @@
                 (<time class="in" data-date="{{ token.expires.isoformat() }}">{{ token.expires.isoformat() }}</time> from now)
               </td>
             </tr>
+            {% endif %}
             <tr>
               <th>Notes:</th>
               <td>

--- a/webapp-django/crashstats/tokens/tests/test_models.py
+++ b/webapp-django/crashstats/tokens/tests/test_models.py
@@ -47,3 +47,16 @@ class TestModels(TestCase):
         )
         eq_(models.Token.objects.all().count(), 2)
         eq_(models.Token.objects.active().count(), 1)
+
+    def test_is_expired(self):
+        bob = User.objects.create(username='bob')
+        token = models.Token.objects.create(
+            user=bob,
+            notes='Some notes'
+        )
+        ok_(not token.is_expired)
+        now = datetime.datetime.utcnow().replace(tzinfo=utc)
+        yesterday = now - datetime.timedelta(days=1)
+        token.expires = yesterday
+        token.save()
+        ok_(token.is_expired)


### PR DESCRIPTION
@rhelmer r?

Trivial. Looks like this:
![screenshot 2014-02-20 16 01 41](https://f.cloud.github.com/assets/26739/2225335/ddb00246-9a8b-11e3-9a0a-1d87e9dd2e01.png)

I think it's important to not automatically delete these or _not_ show them. If you have a script that has stopped working, it should be clear to see why. 
