### PR TITLE
Bug 948533 - All services should accept any number of keyword arguments.

### DIFF
--- a/socorro/external/elasticsearch/supersearch.py
+++ b/socorro/external/elasticsearch/supersearch.py
@@ -202,7 +202,9 @@ class SuperS(S):
 
 class SuperSearch(SearchBase, ElasticSearchBase):
 
-    def __init__(self, config):
+    def __init__(self, *args, **kwargs):
+        config = kwargs.get('config')
+
         # We have multiple inheritance here, explicitly calling superclasses's
         # init is mandatory.
         # See http://freshfoo.com/blog/object__init__takes_no_parameters

--- a/socorro/external/rabbitmq/priorityjobs.py
+++ b/socorro/external/rabbitmq/priorityjobs.py
@@ -2,22 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
-
-from configman.dotdict import DotDictWithAcquisition
 import pika
 from pika.exceptions import ChannelClosed
 
 from socorro.external import MissingArgumentError
-from socorro.external.rabbitmq.connection_context import (Connection,
-                                                          ConnectionContext)
 from socorro.lib import external_common
+
 
 class Priorityjobs(object):
     """Implement the /priorityjobs service with RabbitMQ."""
 
-    def __init__(self, config, all_services=None):
-        self.config = config.rabbitmq
+    def __init__(self, *args, **kwargs):
+        self.config = kwargs.get('config').rabbitmq
         self.context = self.config.rabbitmq_class(self.config)
 
     def get(self, **kwargs):
@@ -55,4 +51,3 @@ class Priorityjobs(object):
                 return False
 
         return True
-

--- a/socorro/unittest/external/elasticsearch/test_settings.py
+++ b/socorro/unittest/external/elasticsearch/test_settings.py
@@ -35,7 +35,7 @@ class IntegrationTestSettings(ElasticSearchTestCase):
 
         config = self.get_config_context()
         self.storage = crashstorage.ElasticSearchCrashStorage(config)
-        self.api = SuperSearch(config)
+        self.api = SuperSearch(config=config)
 
         # clear the indices cache so the index is created on every test
         self.storage.indices_cache = set()

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -25,7 +25,7 @@ class TestSuperSearch(ElasticSearchTestCase):
 
     def test_get_indexes(self):
         config = self.get_config_context()
-        api = SuperSearch(config)
+        api = SuperSearch(config=config)
 
         now = datetime.datetime(2000, 2, 1, 0, 0)
         lastweek = now - datetime.timedelta(weeks=1)
@@ -40,7 +40,7 @@ class TestSuperSearch(ElasticSearchTestCase):
         self.assertEqual(res, ['socorro_integration_test'])
 
         config = self.get_config_context(es_index='socorro_%Y%W')
-        api = SuperSearch(config)
+        api = SuperSearch(config=config)
 
         dates = [
             search_common.SearchParam('date', now, '<'),
@@ -74,7 +74,7 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
         super(IntegrationTestSuperSearch, self).setUp()
 
         config = self.get_config_context()
-        self.api = SuperSearch(config)
+        self.api = SuperSearch(config=config)
         self.storage = crashstorage.ElasticSearchCrashStorage(config)
 
         # clear the indices cache so the index is created on every test


### PR DESCRIPTION
Anyone, r? (small patch)

The commit we landed for bug 948533 broke the supersearch middleware service. I also used the occasion to clean up some PEP8 errors. 
