### PR TITLE
fixes bug 794548 - display "exploitability" rating in UI to logged-in users

### DIFF
--- a/webapp-django/crashstats/api/templates/api/documentation.html
+++ b/webapp-django/crashstats/api/templates/api/documentation.html
@@ -46,9 +46,14 @@
     {% for endpoint in endpoints %}
     <div class="panel" id="{{ endpoint.name }}">
         <div class="title">
-        {% if endpoint.required_permission %}
+        {% if endpoint.required_permissions %}
           <p class="required-permission">
-            Only available if used with an <b>API Token</b> associated with <b>{{ endpoint.required_permission }}</b> permission.
+            Only available if used with an <b>API Token</b> associated with
+            {% for permission in endpoint.required_permissions %}
+              <b>{{ permission }}</b>
+              {% if not loop.last %} and {% endif %}
+            {% endfor %}
+            permission.
           </p>
         {% endif %}
         <h2><a href="#{{ endpoint.name }}">{{ endpoint.name }}</a></h2>

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -264,7 +264,7 @@ class SocorroMiddleware(SocorroCommon):
     default_datetime_format = '%Y-%m-%dT%H:%M:%S'
 
     # by default, no particular permission is needed to use a model
-    API_REQUIRED_PERMISSION = None
+    API_REQUIRED_PERMISSIONS = None
 
 #    def fetch(self, url, *args, **kwargs):
 #        url = self._complete_url(url)
@@ -872,6 +872,28 @@ class ProcessedCrash(SocorroMiddleware):
     )
 
 
+class UnredactedCrash(ProcessedCrash):
+    URL_PREFIX = '/crash_data/datatype/unredacted/'
+
+    API_REQUIRED_PERMISSIONS = (
+        'crashstats.view_exploitability',
+        'crashstats.view_pii'
+    )
+
+    # Why no `API_WHITELIST` here?
+    #
+    # Basically, the intention is this; the `UnredactedCrash` model should
+    # only be usable if you have those two permissions. And if you have
+    # `view_pii` it doesn't matter what `API_WHITELIST` does at all
+    # because of this. Basically, it doesn't even get to the
+    # `API_WHITELIST checking stuff.
+    #
+    # The assumption is that "unredacted = processed + sensitive stuff". So,
+    # if you don't have `view_pii` you won't get anything here you don't
+    # already get from `ProcessedCrash`. And if you have `view_pii`
+    # there's no point writing down a whitelist.
+
+
 class RawCrash(SocorroMiddleware):
 
     URL_PREFIX = '/crash_data/'
@@ -1078,7 +1100,9 @@ class CrashesByExploitability(SocorroMiddleware):
         'page': 1
     }
 
-    API_REQUIRED_PERMISSION = 'crashstats.view_exploitability'
+    API_REQUIRED_PERMISSIONS = (
+        'crashstats.view_exploitability',
+    )
 
     API_WHITELIST = None
 

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
@@ -173,6 +173,16 @@
 	      </td>
 	    </tr>
 	    {% endif %}
+            {% if request.user.has_perm('crashstats.view_exploitability') %}
+	    <tr>
+	      <th scope="row">Exploitability</th>
+	      <td>
+	        {% if report.exploitability %}
+		  {{ report.exploitability }}
+		{% endif %}
+	      </td>
+	    </tr>
+            {% endif %}
             <tr>
               <th scope="row">User Comments</th>
               <td>

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -717,7 +717,7 @@ class TestModels(TestCase):
         ok_(r['total'])
 
     @mock.patch('requests.get')
-    def test_report_index(self, rget):
+    def test_processed_crash(self, rget):
         model = models.ProcessedCrash
         api = model()
 
@@ -751,6 +751,44 @@ class TestModels(TestCase):
         rget.side_effect = mocked_get
         r = api.get(crash_id='7c44ade2-fdeb-4d6c-830a-07d302120525')
         ok_(r['product'])
+
+    @mock.patch('requests.get')
+    def test_unredacted_crash(self, rget):
+        model = models.UnredactedCrash
+        api = model()
+
+        def mocked_get(url, **options):
+            assert '/crash_data/' in url
+            ok_('/datatype/unredacted/' in url)
+            return Response("""
+            {
+              "product": "WaterWolf",
+              "uuid": "7c44ade2-fdeb-4d6c-830a-07d302120525",
+              "version": "13.0",
+              "build": "20120501201020",
+              "ReleaseChannel": "beta",
+              "os_name": "Windows NT",
+              "date_processed": "2012-05-25 11:35:57",
+              "success": true,
+              "signature": "CLocalEndpointEnumerator::OnMediaNotific",
+              "exploitability": "Sensitive stuff",
+              "addons": [
+                [
+                  "testpilot@labs.mozilla.com",
+                  "1.2.1"
+                ],
+                [
+                  "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+                  "13.0"
+                ]
+              ]
+            }
+            """)
+
+        rget.side_effect = mocked_get
+        r = api.get(crash_id='7c44ade2-fdeb-4d6c-830a-07d302120525')
+        ok_(r['product'])
+        ok_(r['exploitability'])
 
     @mock.patch('requests.get')
     def test_search(self, rget):

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -3051,7 +3051,7 @@ class TestViews(BaseTestViews):
                   "URL": "%s"
                 }
                 """ % (email0, url0))
-            if '/crash_data/' in url and '/datatype/processed' in url:
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
                 return Response("""
                 {
                   "client_crash_date": "2012-06-11T06:08:45",
@@ -3080,7 +3080,8 @@ class TestViews(BaseTestViews):
                   "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
                   "address": "0x8",
                   "completeddatetime": "2012-06-11T06:08:57",
-                  "success": true
+                  "success": true,
+                  "exploitability": "Unknown Exploitability"
                 }
                 """ % (dump, comment0))
 
@@ -3158,7 +3159,7 @@ class TestViews(BaseTestViews):
     @mock.patch('requests.get')
     def test_report_pending_today(self, rget, rpost):
         def mocked_get(url, **options):
-            if '/crash_data/' in url and '/datatype/processed' in url:
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
                 raise models.BadStatusCodeError(404)
 
         rget.side_effect = mocked_get
@@ -3240,7 +3241,7 @@ class TestViews(BaseTestViews):
                 }
                 """)
 
-            if '/crash_data/' in url and '/datatype/processed' in url:
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
                 return Response("""
                 {
                   "client_crash_date": "2012-06-11T06:08:45",
@@ -3269,7 +3270,8 @@ class TestViews(BaseTestViews):
                   "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
                   "address": "0x8",
                   "completeddatetime": "2012-06-11T06:08:57",
-                  "success": true
+                  "success": true,
+                  "exploitability": "Unknown Exploitability"
                 }
                 """ % dump)
 
@@ -3350,7 +3352,7 @@ class TestViews(BaseTestViews):
                 }
                 """)
 
-            if '/crash_data/' in url and '/datatype/processed' in url:
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
                 return Response("""
                 {
                   "client_crash_date": "2012-06-11T06:08:45",
@@ -3379,7 +3381,8 @@ class TestViews(BaseTestViews):
                   "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
                   "address": "0x8",
                   "completeddatetime": "2012-06-11T06:08:57",
-                  "success": true
+                  "success": true,
+                  "exploitability": "Unknown Exploitability"
                 }
                 """ % dump)
 
@@ -3401,12 +3404,132 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         ok_('<th>Install Time</th>' not in response.content)
 
+    @mock.patch('requests.post')
+    @mock.patch('requests.get')
+    def test_report_index_with_crash_exploitability(self, rget, rpost):
+        dump = "OS|Mac OS X|10.6.8 10K549\\nCPU|amd64|family 6 mod"
+        comment0 = "This is a comment"
+        email0 = "some@emailaddress.com"
+        url0 = "someaddress.com"
+        email1 = "some@otheremailaddress.com"
+
+        crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
+
+        def mocked_get(url, **options):
+            if '/crash_data/' in url and '/datatype/meta/' in url:
+                return Response("""
+                {
+                  "InstallTime": "Not a number",
+                  "FramePoisonSize": "4096",
+                  "Theme": "classic/1.0",
+                  "Version": "5.0a1",
+                  "Email": "%s",
+                  "Vendor": "Mozilla",
+                  "URL": "%s",
+                  "HangID": "123456789"
+                }
+                """ % (email0, url0))
+            if '/crashes/paireduuid/' in url:
+                return Response("""
+                {
+                  "hits": [{
+                      "uuid": "e8820616-1462-49b6-9784-e99a32120201"
+                  }],
+                  "total": 1
+                }
+                """)
+            if 'crashes/comments' in url:
+                return Response("""
+                {
+                  "hits": [
+                   {
+                     "user_comments": "%s",
+                     "date_processed": "2012-08-21T11:17:28-07:00",
+                     "email": "%s",
+                     "uuid": "469bde48-0e8f-3586-d486-b98810120830"
+                    }
+                  ],
+                  "total": 1
+                }
+              """ % (comment0, email1))
+            if 'correlations/signatures' in url:
+                return Response("""
+                {
+                    "hits": [
+                        "FakeSignature1",
+                        "FakeSignature2"
+                    ],
+                    "total": 2
+                }
+                """)
+
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
+                return Response("""
+                {
+                  "client_crash_date": "2012-06-11T06:08:45",
+                  "dump": "%s",
+                  "signature": "FakeSignature1",
+                  "user_comments": null,
+                  "uptime": 14693,
+                  "release_channel": "nightly",
+                  "uuid": "11cb72f5-eb28-41e1-a8e4-849982120611",
+                  "flash_version": "[blank]",
+                  "hangid": null,
+                  "distributor_version": null,
+                  "truncated": true,
+                  "process_type": null,
+                  "id": 383569625,
+                  "os_version": "10.6.8 10K549",
+                  "version": "5.0a1",
+                  "build": "20120609030536",
+                  "ReleaseChannel": "nightly",
+                  "addons_checked": null,
+                  "product": "WaterWolf",
+                  "os_name": "Mac OS X",
+                  "last_crash": 371342,
+                  "date_processed": "2012-06-11T06:08:44",
+                  "cpu_name": "amd64",
+                  "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
+                  "address": "0x8",
+                  "completeddatetime": "2012-06-11T06:08:57",
+                  "success": true,
+                  "exploitability": "Unknown Exploitability"
+                }
+                """ % dump)
+
+            raise NotImplementedError(url)
+        rget.side_effect = mocked_get
+
+        def mocked_post(url, **options):
+            if '/bugs/' in url:
+                return Response("""
+                   {"hits": [{"id": "123456789",
+                              "signature": "Something"}]}
+                """)
+            raise NotImplementedError(url)
+
+        rpost.side_effect = mocked_post
+
+        url = reverse('crashstats.report_index', args=[crash_id])
+
+        response = self.client.get(url)
+        ok_('Exploitability</th>' not in response.content)
+
+        # you must be signed in to see exploitability
+        user = self._login()
+        group = self._create_group_with_permission('view_exploitability')
+        user.groups.add(group)
+
+        response = self.client.get(url)
+        ok_('Exploitability</th>' in response.content)
+        ok_('Unknown Exploitability' in response.content)
+
     @mock.patch('requests.get')
     def test_report_index_not_found(self, rget):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_get(url, **options):
-            if '/datatype/processed/' in url:
+            if '/datatype/unredacted/' in url:
                 raise models.BadStatusCodeError(404)
 
             raise NotImplementedError(url)
@@ -3424,7 +3547,7 @@ class TestViews(BaseTestViews):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_get(url, **options):
-            if '/datatype/processed/' in url:
+            if '/datatype/unredacted/' in url:
                 raise models.BadStatusCodeError(408)
 
             raise NotImplementedError(url)
@@ -3442,7 +3565,7 @@ class TestViews(BaseTestViews):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_get(url, **options):
-            if '/datatype/processed/' in url:
+            if '/datatype/unredacted/' in url:
                 raise models.BadStatusCodeError(410)
 
             raise NotImplementedError(url)
@@ -3460,7 +3583,7 @@ class TestViews(BaseTestViews):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_get(url, **options):
-            if '/datatype/processed/' in url:
+            if '/datatype/unredacted/' in url:
                 return Response('Scary Error', status_code=500)
 
             raise NotImplementedError(url)
@@ -3479,10 +3602,12 @@ class TestViews(BaseTestViews):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_get(url, **options):
-            if '/datatype/processed/' in url:
+            if '/datatype/unredacted/' in url:
                 raise models.BadStatusCodeError(408)
 
             raise NotImplementedError(url)
+
+        rget.side_effect = mocked_get
 
         url = reverse('crashstats.report_pending',
                       args=[crash_id])
@@ -4524,7 +4649,7 @@ class TestViews(BaseTestViews):
                 }
               """ % (comment0, email1))
 
-            if '/crash_data/' in url and '/datatype/processed' in url:
+            if '/crash_data/' in url and '/datatype/unredacted' in url:
                 return Response("""
                 {
                   "client_crash_date": "2012-06-11T06:08:45",
@@ -4553,7 +4678,8 @@ class TestViews(BaseTestViews):
                   "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
                   "address": "0x8",
                   "completeddatetime": "2012-06-11T06:08:57",
-                  "success": true
+                  "success": true,
+                  "exploitability": "Unknown Exploitability"
                 }
                 """ % dump)
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1020,7 +1020,7 @@ def report_index(request, crash_id, default_context=None):
     context = default_context or {}
     context['crash_id'] = crash_id
 
-    api = models.ProcessedCrash()
+    api = models.UnredactedCrash()
 
     try:
         context['report'] = api.get(crash_id=crash_id)
@@ -1139,6 +1139,7 @@ def report_index(request, crash_id, default_context=None):
                 total_correlations += 1
 
     context['total_correlations'] = total_correlations
+
     return render(request, 'crashstats/report_index.html', context)
 
 
@@ -1151,7 +1152,7 @@ def report_pending(request, crash_id):
 
     url = reverse('crashstats.report_index', kwargs=dict(crash_id=crash_id))
 
-    api = models.ProcessedCrash()
+    api = models.UnredactedCrash()
 
     try:
         data['report'] = api.get(crash_id=crash_id)


### PR DESCRIPTION
@rhelmer r?

(cc @AdrianGaudebert, @twobraids)

Instead of making `processed` vs. `unredacted` a parameter on the `ProcessedCrash` model I introduced another model. I think they are too different to try to "merge" into one thing. Also, the unredacted one shouldn't even go near the public API due to it's sensitive nature. 

I still don't think I understand why the middleware does a bunch of business logic decisions about what data you deserve to get when that general source of that decision is done in Django. @twobraids?
