### PR TITLE
Fixes bug 497731 - Fixed list of possible values, removed all errors-related words.

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -236,12 +236,8 @@ EXPLOITABILITY_VALUES = (
     'normal',
     'low',
     'none',
-    'analyze',
-    'dump',
-    'error',
-    'unable',
     'unknown',
-    'wrong',
+    'error',
 )
 
 # the number of result filter on tcbs


### PR DESCRIPTION
Anyone r?

I realized while testing on stage that some of the default values for the `exploitability` field didn't make sense. I pulled them from elasticsearch and didn't see that they were just explanations of various errors. This removes those values and only keeps the `error` word. If a user wants to search for something more specific, that is still possible but not proposed by the UI. 
