### PR TITLE
fixes bug 976731 - Using a valid API token should change how the rate limiter works

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -141,8 +141,16 @@ BLACKLIST = (
 )
 
 
+def _skip_ratelimit(request):
+    return request.user.is_authenticated()
+
+
 @waffle_switch('app_api_all')
-@ratelimit(method=['GET', 'POST', 'PUT'], rate='1000/m')
+@ratelimit(
+    method=['GET', 'POST', 'PUT'],
+    rate='10/m',
+    skip_if=_skip_ratelimit
+)
 @utils.add_CORS_header  # must be before `utils.json_view`
 @utils.json_view
 def model_wrapper(request, model_name):

--- a/webapp-django/crashstats/tokens/forms.py
+++ b/webapp-django/crashstats/tokens/forms.py
@@ -15,8 +15,9 @@ class GenerateTokenForm(BaseModelForm):
         self.fields['permissions'].choices = [
             (x.pk, x.name) for x in possible_permissions
         ]
+        self.fields['permissions'].required = False
         self.fields['permissions'].help_text = (
-            'Required. '
+            'Optional. '
             'These are the permissions you have been granted. '
             'You can select one or more.'
         )

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -30,8 +30,9 @@
     <div class="panel">
       <div class="body notitle">
         <p>
-        You need API Tokens to be able to connect to the API so that the API
-        knows who you are and thus what permissions you have.
+        You need <b>API Tokens to be able to connect to the API</b> so that the API
+        knows who you are and thus what permissions you have.<br>
+        Using any <b>valid API Token</b> with your API calls means a <b>much higher rate limit</b>.
         </p>
       </div>
     </div>
@@ -60,6 +61,8 @@
                 <ul>
                   {% for permission in token.permissions.all() %}
                     <li><code>{{ permission.name }}</code></li>
+                  {% else %}
+                    <li><em>None</em></li>
                   {% endfor %}
                 </ul>
               </td>
@@ -118,7 +121,7 @@
           </table>
         </form>
         {% else %}
-        <p>You currentl do not have any permissions to generate tokens for.</p>
+        <p>You currently do not have any permissions to generate tokens for.</p>
         {% endif %}
       </div>
     </div>

--- a/webapp-django/crashstats/tokens/views.py
+++ b/webapp-django/crashstats/tokens/views.py
@@ -49,6 +49,14 @@ def home(request):
                 possible_permissions=possible_permissions
             )
         else:
+            # This is surprisingly important!
+            # If you *have* permissions, you can actually create a
+            # token without selecting *any* permissions. The point of
+            # that is to avoid the rate limiter.
+            # If you don't have any permissions attached to your user
+            # account means you haven't been hand curated by any
+            # administrator and if that's the case you shouldn't be able
+            # avoid the rate limiter.
             form = None
 
     context['form'] = form


### PR DESCRIPTION
@AdrianGaudebert r?
(cc @rhelmer)

This puts the default rate limit back to 10/min and from now on you need to use an API Token to bypass that limit. And you can't create a API token (with or without permissions attached to it) unless you have some permissions at all. 
