### PR TITLE
adds a script to tag and create releases on github

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,15 +14,15 @@ cd $(dirname "$0")/..
 dryRun=""
 [[ $1 == "--dry-run" ]] && {
   dryRun="y"
-  echo "dry run! commands will be echod but not run"
+  echo "dry run! commands will be echoed but not run"
 }
 
-
 (git branch | grep '* master') || {
-  echo "Only release from the master branch."
+  echo "only release from the master branch."
   exit 1
 }
 
+echo "fetching tags from github.com/mozilla/socorro"
 git fetch -t git@github.com:mozilla/socorro.git
 
 remote=$(git remote -v | grep "mozilla/socorro.git" | cut -f 1 | head -n 1 | tr -d ' ')
@@ -35,9 +35,9 @@ lastTag=$(git tag | grep '^[0-9]*$' | tail -n 1)
 tag=$(($lastTag + 1))
 
 if [ ! -z "$dryRun" ]; then
-    echo "    git tag \"$tag\" && git push $remote master && git push $remote \"$tag\""
+    echo "    git tag \"$tag\" && git push $remote \"$tag\""
 else
-    git tag "$tag" && git push $remote master && git push $remote "$tag"
+    git tag "$tag" && git push $remote "$tag"
 fi
 
 if [ -f ~/.config/hub ]; then


### PR DESCRIPTION
fixes bug 977484 with a script that will tag your local HEAD and push it to github, then make a release. If you have hub installed it will use your hub API token to create the release for you, otherwise it will open your browser and prompt with the contents for the form fields
