### PR TITLE
fix RST anchor reference

### DIFF
--- a/docs/vagrant.rst
+++ b/docs/vagrant.rst
@@ -1,3 +1,7 @@
+.. index:: vagrant
+
+.. _vagrant-chapter:
+
 Set up a services VM with Vagrant
 =================================
 


### PR DESCRIPTION
My previous commit to the documentation removed the RST link anchor references from the Vagrant install docs. Oops. :rooster: This fixes that.
