### PR TITLE
Bug 847982 paginate comments on report list

### DIFF
--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -605,6 +605,15 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
 
         res = crashes.get_comments(**params)
         self.assertTrue(res)
+        self.assertEqual(len(res['hits']), 2)
+        self.assertEqual(res['total'], 2)
+
+        # use pagination
+        params['result_number'] = 1
+        params['result_offset'] = 0
+        res = crashes.get_comments(**params)
+        self.assertEqual(len(res['hits']), 1)
+        self.assertEqual(res['total'], 2)
 
     #--------------------------------------------------------------------------
     def test_get_daily(self):

--- a/webapp-django/crashstats/crashstats/templates/crashstats/partials/comments.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/partials/comments.html
@@ -1,5 +1,7 @@
-<div class="wrapper"
-     data-count="{{ comments.total }}">
+{% from "macros/pagination.html" import pagination %}
+<div class="wrapper" data-count="{{ comments.total }}">
+{{ pagination(comments, current_url, current_page, '#tab-comments') }}
+
   <h3>Comments</h3>
   {% for comment in comments.hits %}
     <p class="crash_comments">
@@ -15,4 +17,6 @@
     {% endif %}
     <hr>
   {% endfor %}
+
+{{ pagination(comments, current_url, current_page, '#tab-comments') }}
 </div>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1503,6 +1503,7 @@ def report_list(request, partial=None, default_context=None):
     if partial == 'comments':
         context['comments'] = []
         comments_api = models.CommentsBySignature()
+
         context['comments'] = comments_api.get(
             signature=context['signature'],
             products=form.cleaned_data['product'],
@@ -1521,6 +1522,24 @@ def report_list(request, partial=None, default_context=None):
             result_number=results_per_page,
             result_offset=result_offset
         )
+
+        current_query = request.GET.copy()
+        if 'page' in current_query:
+            del current_query['page']
+        context['current_url'] = '%s?%s' % (reverse('crashstats.report_list'),
+                                            current_query.urlencode())
+
+        if not context['comments']['hits']:
+            return render(
+                request,
+                'crashstats/partials/no_data.html',
+                context
+            )
+
+        context['comments']['total_pages'] = int(math.ceil(
+            context['comments']['total'] / float(results_per_page)))
+
+        context['comments']['total_count'] = context['comments']['total']
 
     if partial == 'bugzilla':
         bugs_api = models.Bugs()


### PR DESCRIPTION
@AdrianGaudebert r?

Now you get pagination on the Comments tab of report list too. 
It's not a brilliant solution because the contents of the Comments tab is loaded with AJAX and ideally, when you click to go to a different page it should just reload that piece of AJAX. However, it gets non-trivial about how to change the main URL (pushState?) and besides, it's rare that people go to page 2 or 3 so this'll do. 
