### PR TITLE
Bug 982136 - Update forced versions for correlations for Firefox cycle starting 2014-03-18

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="28.0 29.0a2 30.0a1"
+MANUAL_VERSION_OVERRIDE="29.0 30.0a2 31.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 982136 - it should go to production the week of March 17 (not before!).
