### PR TITLE
fixes bug 983294 - BadStatusCodeError doesn't have an error message

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -28,8 +28,10 @@ logger = logging.getLogger('crashstats_models')
 
 class BadStatusCodeError(Exception):
     def __init__(self, status, message="Bad status code"):
-        self.status = status
         self.message = message
+        self.status = status
+        combined = '%d: %s' % (status, message)
+        super(BadStatusCodeError, self).__init__(combined)
 
 
 class RequiredParameterError(Exception):

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -5,6 +5,8 @@ import tempfile
 import datetime
 import time
 import random
+import unittest
+
 import mock
 import requests
 from nose.tools import eq_, ok_, assert_raises
@@ -20,6 +22,16 @@ class Response(object):
     def __init__(self, content=None, status_code=200):
         self.content = content
         self.status_code = status_code
+
+
+class TestExceptions(unittest.TestCase):
+
+    def test_BadStatusCodeError(self):
+        try:
+            raise models.BadStatusCodeError(500, 'some message')
+        except models.BadStatusCodeError as exp:
+            ok_('500: some message' in str(exp))
+            eq_(exp.status, 500)
 
 
 class TestModels(TestCase):


### PR DESCRIPTION
@rhelmer r?

The traceback used to look like this:

```
...
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/models.py", line 243, in fetch
    raise BadStatusCodeError(resp.status_code, url)
BadStatusCodeError
```

Now it looks like this:

```
...
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/models.py", line 244, in fetch
    raise BadStatusCodeError(resp.status_code, url)
BadStatusCodeError: 500: http://localhost:8883/server_status/duration/12
```
