### PR TITLE
disable the symbols unpack crontabber app

### DIFF
--- a/socorro/cron/crontabber.py
+++ b/socorro/cron/crontabber.py
@@ -96,7 +96,7 @@ DEFAULT_JOBS = '''
   socorro.cron.jobs.matviews.SignatureSummaryGraphicsCronApp|1d|10:00
   #socorro.cron.jobs.modulelist.ModulelistCronApp|1d
   socorro.cron.jobs.matviews.GCCrashes|1d|10:00
-  socorro.cron.jobs.symbolsunpack.SymbolsUnpackCronApp|1h
+  #socorro.cron.jobs.symbolsunpack.SymbolsUnpackCronApp|1h
 '''
 
 


### PR DESCRIPTION
because the necessary hardware work isn't ready for the symbols unpack app yet we will disable it for now
