### PR TITLE
Fixes Bug 992347 : adds 'mozilla.*FatalError' to prefix list

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -326,6 +326,7 @@ class CSignatureTool(CSignatureToolBase):
           'mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame',
           'mozilla::ipc::RPCChannel::EnteredCxxStack',
           'mozilla::ipc::RPCChannel::Send',
+          'mozilla.*FatalError',
           'moz_xmalloc',
           'moz_xrealloc',
           'NP_Shutdown',


### PR DESCRIPTION
This bug adds 'mozilla.*FatalError' to the processor signature genertor's prefix list.
