### PR TITLE
fixes bug 981854 - make reports tab paginate and sort with AJAX

### DIFF
--- a/webapp-django/crashstats/base/helpers.py
+++ b/webapp-django/crashstats/base/helpers.py
@@ -38,7 +38,11 @@ def change_query_string(context, **kwargs):
         <a href=/page>
 
     """
-    base = context['request'].META['PATH_INFO']
+    if kwargs.get('_no_base'):
+        kwargs.pop('_no_base')
+        base = ''
+    else:
+        base = context['request'].META['PATH_INFO']
     qs = cgi.parse_qs(context['request'].META['QUERY_STRING'])
     for key, value in kwargs.items():
         if value is None:

--- a/webapp-django/crashstats/base/tests/test_helpers.py
+++ b/webapp-django/crashstats/base/tests/test_helpers.py
@@ -51,3 +51,9 @@ class TestChangeURL(TestCase):
         context['request'] = RequestFactory().get('/page/?foo=bar&other=thing')
         result = change_query_string(context, foo=None)
         eq_(result, '/page/?other=thing')
+
+    def test_change_query_without_base(self):
+        context = {}
+        context['request'] = RequestFactory().get('/page/?foo=bar')
+        result = change_query_string(context, foo='else', _no_base=True)
+        eq_(result, '?foo=else')

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -692,6 +692,8 @@ class ReportList(SocorroMiddleware):
         'result_number',
         'result_offset',
         'include_raw_crash',
+        'sort',
+        'reverse',
     )
 
     aliases = {

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/report_list.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/report_list.less
@@ -41,3 +41,11 @@
         color: #fff;
     }
 }
+
+#reportsList {
+    thead th a {
+        display: block;
+        color: black;
+        text-decoration: none;
+    }
+}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/partials/reports.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/partials/reports.html
@@ -2,11 +2,13 @@
 <div class="wrapper" data-columns="{{ columns_values_joined }}">
 {{ pagination(report_list, current_url, current_page, '#tab-reports') }}
 
-<table class="tablesorter data-table" id="reportsList">
+<table class="data-table tablesorter " id="reportsList">
     <thead>
         <tr>
             {% for column in columns %}
-            <th scope="col">{{ column.label }}</th>
+            <th scope="col" class="header {% if sort==column.key %}headerSort{% if column.reverse %}Up{% else %}Down{% endif %}{% endif %}">
+                <a href="{{ change_query_string(sort=column.key, reverse=column.reverse, _no_base=True) }}" class="sort-header" data-key="{{ column.key }}">{{ column.label }}</a>
+            </th>
             {% endfor %}
         </tr>
     </thead>

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -4196,6 +4196,102 @@ class TestViews(BaseTestViews):
         ok_('0xdeadbeef' in response.content)
 
     @mock.patch('requests.get')
+    def test_report_list_partial_reports_with_sorting(self, rget):
+
+        mock_calls = []
+
+        def mocked_get(url, params, **options):
+            mock_calls.append(params)
+
+            if 'report/list' in url:
+                return Response("""
+                {
+                  "hits": [
+                    {
+                      "user_comments": null,
+                      "product": "WaterWolf",
+                      "os_name": "Linux",
+                      "uuid": "441017f4-e006-4eea-8451-dc20e0120905",
+                      "cpu_info": "...",
+                      "url": "http://example.com/116",
+                      "last_crash": 1234,
+                      "date_processed": "2012-09-05T21:18:58+00:00",
+                      "cpu_name": "x86",
+                      "uptime": 1234,
+                      "process_type": "browser",
+                      "hangid": null,
+                      "reason": "reason7",
+                      "version": "5.0a1",
+                      "os_version": "1.2.3.4",
+                      "build": "20120901000007",
+                      "install_age": 1234,
+                      "signature": "FakeSignature2",
+                      "install_time": "2012-09-05T20:58:24+00:00",
+                      "address": "0xdeadbeef",
+                      "duplicate_of": null
+                    },
+                    {
+                      "user_comments": null,
+                      "product": "WaterWolf",
+                      "os_name": "Mac OS X",
+                      "uuid": "e491c551-be0d-b0fb-c69e-107380120905",
+                      "cpu_info": "...",
+                      "url": "http://example.com/60053",
+                      "last_crash": 1234,
+                      "date_processed": "2012-09-05T22:19:59+00:00",
+                      "cpu_name": "x86",
+                      "uptime": 1234,
+                      "process_type": "content",
+                      "hangid": null,
+                      "reason": "reason7",
+                      "version": "5.0a1",
+                      "os_version": "1.2.3.4",
+                      "build": "20120822000007",
+                      "install_age": 1234,
+                      "signature": "FakeSignature2",
+                      "install_time": "2012-09-05T20:58:24+00:00",
+                      "address": "0xdeadbeef",
+                      "duplicate_of": null
+                    }
+                    ],
+                    "total": 2
+                    }
+                """)
+            raise NotImplementedError(url)
+
+        rget.side_effect = mocked_get
+
+        url = reverse('crashstats:report_list_partial', args=('reports',))
+        data = {
+            'signature': 'FakeSignature2',
+            'range_value': 3
+        }
+        response = self.client.get(url, data)
+        eq_(response.status_code, 200)
+        assert len(mock_calls) == 1
+        eq_(mock_calls[-1]['sort'], 'date_processed')
+        ok_('reverse' not in mock_calls[-1])
+
+        response = self.client.get(url, dict(
+            data,
+            sort='build'
+        ))
+        eq_(response.status_code, 200)
+        assert len(mock_calls) == 2
+        eq_(mock_calls[-1]['sort'], 'build')
+        ok_('reverse' not in mock_calls[-1])
+
+        response = self.client.get(url, dict(
+            data,
+            sort='build',
+            reverse='True'
+        ))
+        eq_(response.status_code, 200)
+        assert len(mock_calls) == 3
+        eq_(mock_calls[-1]['sort'], 'build')
+        eq_(mock_calls[-1]['reverse'], True)
+
+    @mock.patch('requests.get')
     def test_report_list_partial_reports_columns_override(self, rget):
 
         def mocked_get(url, params, **options):
@@ -4444,7 +4540,9 @@ class TestViews(BaseTestViews):
         })
         eq_(response.status_code, 200)
         # because with page < 1 you get page=1
-        eq_(response_zero.content, response_first.content)
+        tbody_zero = response_zero.content.split('<tbody')[1]
+        tbody_first = response_first.content.split('<tbody')[1]
+        eq_(hash(tbody_zero), hash(tbody_first))
 
         response = self.client.get(url, {
             'signature': 'sig',


### PR DESCRIPTION
@AdrianGaudebert r?
cc @ossreleasefeed

So, what this does is that it hijacks pagination and sort-header links on the reports.html template that gets loaded with AJAX. Those links in there "assume" that you would want to reload the whole. 

For example, you're on `/report/list?signature=Foo#tab-reports`
and the pagination link goes to `/report/list?signature=Foo&page=2#tab-reports`
So far, nothing has changed. 

What my javascript does is that is, on the fly, it rewrites these URLs to use the "partial URL" and then it hijacks the `onclick` and use that to instead reload the partial tab with this URL. It's confusing perhaps but it works fine.

As a kinda nasty hack, I used the tablesorter CSS (and relevant class names) but ditched all things to do with the tablesorter javascript. 
