### PR TITLE
fixes bug 992410 - Remove stale content for "crash_type" in reports tab on report list

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/partials/reports.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/partials/reports.html
@@ -26,12 +26,6 @@
                     <a href="{{ url('crashstats:report_index', crash.duplicate_of) }}">dup</a></td>
                   {% endif %}
                 </td>
-              {% elif column.key == 'crash_type' %}
-                <td>
-                  <div class="signature-icons">
-                    <input type="hidden" name="url0" value="/report/hang_pairs/99ba73dd-34b6-48da-ab53-71b992120511" class="ajax_endpoint" />
-                  </div>
-                </td>
               {% elif column.key == 'os_and_version' %}
                 <td>{{ crash.os_name }} {{ crash.os_version }}</td>
               {% elif column.key == 'comments' or column.key == 'Comments' %}


### PR DESCRIPTION
@rhelmer r?
[There's no column called "crash_type"](https://github.com/peterbe/socorro/blob/31e777e7b6e667eacef97647254174b3bd427b79/webapp-django/crashstats/crashstats/views.py#L1277-L1292)
