### PR TITLE
Fixes bug 991730 - Fixed theming of ACE editor in non-dev environments.

### DIFF
--- a/webapp-django/crashstats/supersearch/templates/supersearch/search_custom.html
+++ b/webapp-django/crashstats/supersearch/templates/supersearch/search_custom.html
@@ -59,6 +59,8 @@ var ELASTICSEARCH_INDICES = {{ elasticsearch_indices | json_dumps }};
     {% compress js %}
 <script src="{{ static('supersearch/js/lib/select2/select2.js') }}"></script>
 <script src="{{ static('supersearch/js/lib/ace/ace.js') }}"></script>
+<script src="{{ static('supersearch/js/lib/ace/theme-monokai.js') }}"></script>
+<script src="{{ static('supersearch/js/lib/ace/mode-json.js') }}"></script>
 <script src="{{ static('supersearch/js/socorro/search_custom.js') }}"></script>
     {% endcompress %}
 


### PR DESCRIPTION
@peterbe r? 

In production-like environments, the `ace.js` file tries to download the theme files (`theme-monokai.js` and `mode-json.js`) but it does so with an incorrect URL. I can't test the production-like set-up locally though, so this is a guess. 
