### PR TITLE
fixes Bug 994913 - corrected regular expression for CrashAtUnhandlableOOM

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -267,7 +267,7 @@ class CSignatureTool(CSignatureToolBase):
           'overall signature',
       default="""'|'.join([
           '@0x0',
-          '.*::CrashAtUnhandlableOOM',
+          '.*CrashAtUnhandlableOOM',
           'Abort',
           '.*abort',
           '_alloca_probe.*',


### PR DESCRIPTION
changes as requested by KaiRo:

"""Hrm, I just realized we actually have a pure "CrashAtUnhandlableOOM" as well, so we need to actually make this '.*CrashAtUnhandlableOOM' (no colons). Sorry."""
