### PR TITLE
bug 993786 - use sensible signature name for test

### DIFF
--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -1485,7 +1485,7 @@ class IntegrationTestMiddlewareApp(unittest.TestCase):
                 {
                     'start_date': '2012-03-01',
                     'end_date': '2012-03-15',
-                    'signature': 'Firefox',
+                    'signature': 'FakeSignature1',
                     'channel': 'aurora',
                 }
             )


### PR DESCRIPTION
r? anybody - this test simply makes sure that the service is exposed, it doesn't use the value of `signature` here, but having it set to "Firefox" is just confusing.
