### PR TITLE
fixes bug 997236 - Run check.py on ALL files before exiting

### DIFF
--- a/webapp-django/bin/jenkins-tests.sh
+++ b/webapp-django/bin/jenkins-tests.sh
@@ -29,7 +29,7 @@ fi
 source $VENV/bin/activate
 
 echo "Linting..."
-find crashstats/ | grep '\.py$' | xargs check.py | grep -v "unable to detect undefined names" | grep -v settings/local.py | awk '{ if ($0 ~ /[A-Za-z]/) { print; exit 1 } }'
+git ls-files crashstats | xargs check.py | bin/linting.py
 
 echo "Starting tests..."
 FORCE_DB=true coverage run manage.py test --noinput --with-xunit

--- a/webapp-django/bin/linting.py
+++ b/webapp-django/bin/linting.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+Use like this:
+
+    find somedir | xargs check.py | python linting.py
+
+or:
+
+    check.py somedir | python linting.py
+
+or:
+
+    git ls-files somedir | python linting.py
+
+"""
+
+import os
+import sys
+
+
+# Enter any part of a warning that we deem OK.
+# It can be a pep8 warning error code or any other part of a string.
+#
+# NOTE! Be as specific as you possibly can!
+# Only blanket whole files if you desperately have to
+#
+EXCEPTIONS = (
+    # has a exceptional use of `...import *`
+    'settings/base.py:4:',
+
+    # has a well known `...import *` trick that we like
+    'settings/__init__.py',
+
+    # all downloaded libs to be ignored
+    '/js/lib/',
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=997270
+    '/js/jquery/',
+    '/js/flot',
+    '/js/timeago/',
+    'jquery.tablesorter.min.js',
+    'async-local-storage-with-Promise.min.js',
+    'underscore-min.js',
+    'moment.min.js',
+    'jquery.metadata.js',
+
+)
+
+EXTENSIONS_ONLY = (
+    '.py',
+    # commented out until we clean up our .js files
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=997272
+    # '.js'
+)
+
+
+def main():
+    errors = 0
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        _, ext = os.path.splitext(line.split(':')[0])
+        if ext not in EXTENSIONS_ONLY:
+            continue
+        if [f for f in EXCEPTIONS if f in line]:
+            continue
+        errors += 1
+        sys.stderr.write(line)
+    return errors
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
@lonnen r?

This first comment has some deliberate errors added just to see if the new change to jenkins-test.sh catches it accordingly. 

Once leeroy is happy I'll commit one more to this PR. 

NB: We currently don't have a strict jshint policy on .js files. That's unfortunate. I filed a couple of followup bugs to improve that. Once that's in place, we can some day uncomment the checking of the `.js` extension. 
