### PR TITLE
Fixed Bug 997981 - corrected the namespace for rabbitmq in the reprocessing job

### DIFF
--- a/socorro/cron/jobs/reprocessingjobs.py
+++ b/socorro/cron/jobs/reprocessingjobs.py
@@ -18,7 +18,7 @@ _reprocessing_sql = """ DELETE FROM reprocessing_jobs RETURNING crash_id """
 @with_single_postgres_transaction()
 @with_transactional_resource(
     'socorro.external.rabbitmq.crashstorage.ReprocessingRabbitMQCrashStore',
-    'queue'
+    'queuing'
 )
 class ReprocessingJobsApp(BaseCronApp):
     app_name = 'reprocessing-jobs'
@@ -31,7 +31,7 @@ class ReprocessingJobsApp(BaseCronApp):
     def run(self, connection):
 
         for crash_id in execute_query_iter(connection, _reprocessing_sql):
-            self.queue_connection.save_raw_crash(
+            self.queuing_connection.save_raw_crash(
                 {'legacy_processing': True},
                 [],
                 crash_id

--- a/socorro/unittest/cron/jobs/test_reprocessingjobs.py
+++ b/socorro/unittest/cron/jobs/test_reprocessingjobs.py
@@ -48,7 +48,7 @@ class IntegrationTestReprocessingJobs(IntegrationTestCaseBase):
 
         return _super(
             'socorro.cron.jobs.reprocessingjobs.ReprocessingJobsApp|5m',
-            extra_value_source={'queue_class': self.rabbit_queue_mocked}
+            extra_value_source={'queuing_class': self.rabbit_queue_mocked}
         )
 
     def test_reprocessing(self):
@@ -73,6 +73,7 @@ class IntegrationTestReprocessingJobs(IntegrationTestCaseBase):
             tab = crontabber.CronTabber(config)
             tab.run_all()
 
+        cursor = self.conn.cursor()
         cursor.execute('select count(*) from reprocessing_jobs')
 
         res_expected = 0


### PR DESCRIPTION
the ReprocessingJobsApp crontabber job used the wrong namespace for rabbitmq. seems to be a benign problem, but consistency is important if we want to do overrides later...
