### PR TITLE
Fixes Bug 999060 - mixins inadvertently propagate changes to other classes

### DIFF
--- a/socorro/cron/mixins.py
+++ b/socorro/cron/mixins.py
@@ -58,21 +58,21 @@ def with_transactional_resource(transactional_resource_class, resource_name):
             raise Exception(
                 '%s must have RequiredConfig as a base class' % cls
             )
-        if not hasattr(cls, 'required_config'):
-            cls.requried_config = Namespace()
-        cls.required_config.namespace(resource_name)
-        cls.required_config[resource_name].add_option(
+        new_req = cls.get_required_config()
+        new_req.namespace(resource_name)
+        new_req[resource_name].add_option(
             '%s_class' % resource_name,
             default=transactional_resource_class,
             from_string_converter=class_converter,
         )
-        cls.required_config[resource_name].add_option(
+        new_req[resource_name].add_option(
             '%s_transaction_executor_class' % resource_name,
             default=
             'socorro.database.transaction_executor.TransactionExecutor',
             doc='a class that will execute transactions',
             from_string_converter=class_converter,
         )
+        cls.required_config = new_req
 
         #------------------------------------------------------------------
         def new__init__(self, *args, **kwargs):

--- a/socorro/unittest/cron/test_crontab_mixins.py
+++ b/socorro/unittest/cron/test_crontab_mixins.py
@@ -122,3 +122,22 @@ class TestCrontabMixins(unittest.TestCase):
             def __init__(self, config):
                 self.config = config
         ok_(hasattr(Alpha, '_run_proxy'))
+
+    def test_no_over_propagation(self):
+
+
+        @ctm.with_postgres_transactions()
+        class Alpha(BaseCronApp):
+            required_config = Namespace()
+            required_config.add_option('a', default=0)
+
+
+        @ctm.with_rabbitmq_transactions()
+        class Beta(BaseCronApp):
+            required_config = Namespace()
+            required_config.add_option('a', default=0)
+
+        ok_('database' in Alpha.get_required_config())
+        ok_('queuing' not in Alpha.get_required_config())
+        ok_('database' not in Beta.get_required_config())
+        ok_('queuing' in Beta.get_required_config())


### PR DESCRIPTION
I've discovered that the mixins are overworking.  If we have jobs A, B  and C, at they, repetitively require resources X, Y and Z, the mixins will set it up like this:

A -> X
B -> X, Y
C -> X, Y, Z

when it should be:

A -> X
B -> Y
C -> Z

this happens because the mixin decorators are using the 'required_config' directly rather than calling the 'get_required_config' method.  This is a relatively benign problem as jobs with extra resources just ignore them.  It makes for messy ini files, though.
