### PR TITLE
FixesBug 999287 - missing comma stops the reprocessing cron job

### DIFF
--- a/socorro/cron/jobs/reprocessingjobs.py
+++ b/socorro/cron/jobs/reprocessingjobs.py
@@ -30,7 +30,7 @@ class ReprocessingJobsApp(BaseCronApp):
 
     def run(self, connection):
 
-        for crash_id in execute_query_iter(connection, _reprocessing_sql):
+        for crash_id, in execute_query_iter(connection, _reprocessing_sql):
             self.queuing_connection.save_raw_crash(
                 {'legacy_processing': True},
                 [],


### PR DESCRIPTION
It turns out that the ReprocessingJobsApp has a fatal flaw in its use of the query iterator.  Each row is returned as a tuple, but treated as if it were a simple variable. A single missing comma was the culprit.
