### PR TITLE
Bug 1000159 - Update forced versions for correlations for Firefox cycle starting 2014-04-29

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="29.0 30.0a2 31.0a1"
+MANUAL_VERSION_OVERRIDE="30.0 31.0a2 32.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 1000159 - it should go to production the week of April 28 (not before!).

(I hope this is correct now. /me eyes git awkwardly)
