### PR TITLE
Fixes bug 1010353 - Middleware roles

### DIFF
--- a/config/middleware.ini-dist
+++ b/config/middleware.ini-dist
@@ -1,309 +1,513 @@
-# name: application
-# doc: the fully qualified module or class of the application
-# converter: configman.converters.class_converter
-# application='MiddlewareApp'
+# the fully qualified module or class of the application
+#application='MiddlewareApp'
+
+# a list of namespace:class associations for classes that offer  implementations of services
+#service_classes='InnerClassList'
+
+[resource]
+
+    #+include ./common_resource.ini
+
+    [[elasticsearch]]
+
+        #+include ./common_elasticsearch.ini
+
+        # String containing the URI of the Elastic Search instance.
+        #elasticSearchHostname=localhost
+
+        # String containing the port on which calling the Elastic Search instance.
+        #elasticSearchPort=9200
+
+        # the default doctype to use in elasticsearch
+        #elasticsearch_doctype=crash_reports
+
+        # an index format to pull crashes from elasticsearch (use datetime's strftime format to have daily, weekly or monthly indexes)
+        #elasticsearch_index=socorro%Y%W
+
+        # the time in seconds before a query to elasticsearch fails
+        #elasticsearch_timeout=30
+
+        # the time in seconds before a query to elasticsearch fails in restricted sections
+        #elasticsearch_timeout_extended=120
+
+        # the urls to the elasticsearch instances
+        #elasticsearch_urls='http://localhost:9200'
+
+    [[fs]]
+
+        #+include ./common_fs.ini
+
+        # the default dump field
+        #dump_field=upload_file_minidump
+
+        # the suffix used to identify a dump file
+        #dump_file_suffix=.dump
+
+        # a path to a file system
+        #fs_root='./crashes'
+
+        # the suffix used to identify a json file
+        #json_file_suffix=.json
+
+        # the suffix used to identify a gzipped json file
+        #jsonz_file_suffix=.jsonz
+
+        # the directory base name to use for the named radix tree storage
+        #name_branch_base=name
+
+        # umask to use for new files
+        #umask=18
+
+    [[logging]]
+
+        #+include ./common_logging.ini
+
+        # logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+        #stderr_error_logging_level=10
+
+        # python logging system format for logging to stderr
+        #stderr_line_format_string={asctime} {levelname} - {threadName} - {message}
+
+        # logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+        #syslog_error_logging_level=40
+
+        # syslog facility string ("user", "local0", etc)
+        #syslog_facility_string=user
+
+        # syslog hostname
+        #syslog_host=localhost
+
+        # python logging system format for syslog entries
+        #syslog_line_format_string=middleware (pid {process}): {asctime} {levelname} - {threadName} - {message}
+
+        # syslog port
+        #syslog_port=514
+
+    [[postgresql]]
+
+        #+include ./common_postgresql.ini
+
+        # delays in seconds between retries
+        #backoff_delays='10, 30, 60, 120, 300'
+
+        # the class responsible for connecting to Postgres
+        #database_class='socorro.external.postgresql.connection_context.ConnectionContext'
+
+        # the hostname of the database
+        # see "resource.postgresql.database_hostname" for the default or override it here
+        #database_hostname=localhost
+
+        # the name of the database
+        # see "resource.postgresql.database_name" for the default or override it here
+        #database_name=breakpad
+
+        # the user's database password
+        # see "secrets.postgresql.database_password" for the default or override it here
+        #database_password=aPassword
+
+        # the port for the database
+        # see "resource.postgresql.database_port" for the default or override it here
+        #database_port=5432
+
+        # the name of the user within the database
+        # see "secrets.postgresql.database_username" for the default or override it here
+        #database_username=breakpad_rw
+
+        # a class that will manage transactions
+        #transaction_executor_class='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff'
+
+        # seconds between log during retries
+        #wait_log_interval=10
+
+    [[rabbitmq]]
+
+        #+include ./common_rabbitmq.ini
+
+        # delays in seconds between retries
+        #backoff_delays='10, 30, 60, 120, 300'
+
+        # toggle for using or ignoring the throttling flag
+        #filter_on_legacy_processing='False'
+
+        # the hostname of the RabbitMQ server
+        # see "resource.rabbitmq.host" for the default or override it here
+        #host=localhost
+
+        # the port for the RabbitMQ server
+        # see "resource.rabbitmq.port" for the default or override it here
+        #port=5672
+
+        # the name of priority crash queue name within RabbitMQ
+        # see "resource.rabbitmq.priority_queue_name" for the default or override it here
+        #priority_queue_name=socorro.priority
+
+        # the class responsible for connecting to RabbitMQ
+        #rabbitmq_class='socorro.external.rabbitmq.connection_context.ConnectionContextPooled'
+
+        # a classname for the type of wrapper for RabbitMQ connections
+        # see "resource.rabbitmq.rabbitmq_connection_wrapper_class" for the default or override it here
+        #rabbitmq_connection_wrapper_class='socorro.external.rabbitmq.connection_context.Connection'
+
+        # the user's RabbitMQ password
+        # see "secrets.rabbitmq.rabbitmq_password" for the default or override it here
+        #rabbitmq_password=guest
+
+        # the name of the user within the RabbitMQ instance
+        # see "secrets.rabbitmq.rabbitmq_user" for the default or override it here
+        #rabbitmq_user=guest
+
+        # the name of reprocessing crash queue name within RabbitMQ
+        #reprocessing_queue_name=socorro.reprocessing
+
+        # the name of the queue to recieve crashes
+        #routing_key=socorro.reprocessing
+
+        # the name of standard crash queue name within RabbitMQ
+        # see "resource.rabbitmq.standard_queue_name" for the default or override it here
+        #standard_queue_name=socorro.normal
+
+        # a class that will manage transactions
+        #transaction_executor_class='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff'
+
+        # the name of the RabbitMQ virtual host
+        # see "resource.rabbitmq.virtual_host" for the default or override it here
+        #virtual_host=/
+
+        # seconds between log during retries
+        #wait_log_interval=10
+
+    [[redactor]]
+
+        #+include ./common_redactor.ini
+
+        # a list of keys not allowed in a redacted processed crash
+        # see "resource.redactor.forbidden_keys" for the default or override it here
+        #forbidden_keys='url, email, user_id, exploitability,json_dump.sensitive,upload_file_minidump_flash1.json_dump.sensitive,upload_file_minidump_flash2.json_dump.sensitive,upload_file_minidump_browser.json_dump.sensitive'
+
+        # the name of the class that implements a 'redact' method
+        #redactor_class='socorro.external.crashstorage_base.Redactor'
+
+[secrets]
+
+    #+include ./common_secrets.ini
+
+    [[postgresql]]
+
+        #+include ./common_postgresql.ini
+
+        # the user's database password
+        #database_password=aPassword
+
+        # the name of the user within the database
+        #database_username=breakpad_rw
+
+    [[rabbitmq]]
+
+        #+include ./common_rabbitmq.ini
+
+        # the user's RabbitMQ password
+        #rabbitmq_password=guest
+
+        # the name of the user within the RabbitMQ instance
+        #rabbitmq_user=guest
+
+    [[sentry]]
+
+        #+include ./common_sentry.ini
+
+        # DSN for Sentry via raven
+        #dsn=
 
 [database]
 
-    # name: database_class
-    # doc: None
-    # converter: configman.converters.class_converter
-    database_class='socorro.external.postgresql.connection_context.ConnectionContext'
+    # delays in seconds between retries
+    # see "resource.postgresql.backoff_delays" for the default or override it here
+    #backoff_delays='10, 30, 60, 120, 300'
 
-    # name: database_host
-    # doc: the hostname of the database
-    # converter: str
-    database_host='localhost'
+    # the class responsible for connecting to Postgres
+    # see "resource.postgresql.database_class" for the default or override it here
+    #database_class='socorro.external.postgresql.connection_context.ConnectionContext'
 
-    # name: database_name
-    # doc: the name of the database
-    # converter: str
-    database_name='breakpad'
+    # the hostname of the database
+    # see "resource.postgresql.database_hostname" for the default or override it here
+    #database_hostname=localhost
 
-    # name: database_password
-    # doc: the user's database password
-    # converter: str
-    database_password='aPassword'
+    # the name of the database
+    # see "resource.postgresql.database_name" for the default or override it here
+    #database_name=breakpad
 
-    # name: database_port
-    # doc: the port for the database
-    # converter: int
-    database_port='5432'
+    # the user's database password
+    # see "secrets.postgresql.database_password" for the default or override it here
+    #database_password=aPassword
 
-    # name: database_user
-    # doc: the name of the user within the database
-    # converter: str
-    database_user='breakpad_rw'
+    # the port for the database
+    # see "resource.postgresql.database_port" for the default or override it here
+    #database_port=5432
 
-[filesystem]
+    # None
+    #database_source_class='socorro.external.postgresql.crashstorage.PostgreSQLCrashStorage'
 
-    # name: dump_field
-    # doc: the default dump field
-    # converter: str
-    dump_field='upload_file_minidump'
+    # the name of the user within the database
+    # see "secrets.postgresql.database_username" for the default or override it here
+    #database_username=breakpad_rw
 
-    # name: dump_file_suffix
-    # doc: the suffix used to identify a dump file
-    # converter: str
-    dump_file_suffix='.dump'
+    # a list of keys not allowed in a redacted processed crash
+    # see "resource.redactor.forbidden_keys" for the default or override it here
+    #forbidden_keys='url, email, user_id, exploitability,json_dump.sensitive,upload_file_minidump_flash1.json_dump.sensitive,upload_file_minidump_flash2.json_dump.sensitive,upload_file_minidump_browser.json_dump.sensitive'
 
-    # name: filesystem_class
-    # doc: None
-    # converter: configman.converters.class_converter
-    filesystem_class='socorro.external.fs.crashstorage.FSLegacyRadixTreeStorage'
+    # the name of the class that implements a 'redact' method
+    # see "resource.redactor.redactor_class" for the default or override it here
+    #redactor_class='socorro.external.crashstorage_base.Redactor'
 
-    # name: forbidden_keys
-    # doc: a comma delimited list of keys to not allowed in the processed crash
-    # converter: socorro.external.fs.crashstorage.<lambda>
-    forbidden_keys='url, email, user_id, exploitability'
+    # a class that will manage transactions
+    # see "resource.postgresql.transaction_executor_class" for the default or override it here
+    #transaction_executor_class='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff'
 
-    # name: fs_root
-    # doc: a path to a file system
-    # converter: socorro.external.fs.crashstorage.<lambda>
-    fs_root='./crashes'
-
-    # name: json_file_suffix
-    # doc: the suffix used to identify a json file
-    # converter: str
-    json_file_suffix='.json'
-
-    # name: jsonz_file_suffix
-    # doc: the suffix used to identify a gzipped json file
-    # converter: str
-    jsonz_file_suffix='.jsonz'
-
-    # name: name_branch_base
-    # doc: the directory base name to use for the named radix tree storage
-    # converter: str
-    name_branch_base='name'
-
-    # name: umask
-    # doc: umask to use for new files
-    # converter: int
-    umask='18'
-
-[hbase]
-
-    # name: dump_file_suffix
-    # doc: the suffix used to identify a dump file (for use in temp files)
-    # converter: str
-    dump_file_suffix='.dump'
-
-    # name: forbidden_keys
-    # doc: a comma delimited list of keys banned from the processed crash in HBase
-    forbidden_keys='email, url, user_id, exploitability'
-
-    # name: hbase_class
-    # doc: None
-    # converter: configman.converters.class_converter
-    hbase_class='socorro.external.hb.crashstorage.HBaseCrashStorage'
-
-    # name: hbase_connection_pool_class
-    # doc: the class responsible for pooling and giving out HBaseconnections
-    # converter: configman.converters.class_converter
-    hbase_connection_pool_class='socorro.external.hb.connection_context.HBaseConnectionContextPooled'
-
-    # name: hbase_host
-    # doc: Host to HBase server
-    # converter: str
-    hbase_host='localhost'
-
-    # name: hbase_port
-    # doc: Port to HBase server
-    # converter: int
-    hbase_port='9090'
-
-    # name: hbase_timeout
-    # doc: timeout in milliseconds for an HBase connection
-    # converter: int
-    hbase_timeout='5000'
-
-    # name: number_of_retries
-    # doc: Max. number of retries when fetching from hbaseClient
-    # converter: int
-    number_of_retries='0'
-
-    # name: temporary_file_system_storage_path
-    # doc: a local filesystem path where dumps temporarily during processing
-    # converter: str
-    temporary_file_system_storage_path='/home/socorro/temp'
-
-    # name: transaction_executor_class
-    # doc: a class that will execute transactions
-    # converter: configman.converters.class_converter
-    transaction_executor_class='socorro.database.transaction_executor.TransactionExecutor'
-
-[rabbitmq]
-
-    # name: host
-    # doc: the hostname of the RabbitMQ server
-    # converter: str
-    host='localhost'
-
-    # name: port
-    # doc: the port for the RabbitMQ server
-    # converter: int
-    port='5672'
-
-    # name: priority_queue_name
-    # doc: the name of priority crash queue name within RabbitMQ
-    # converter: str
-    priority_queue_name='socorro.priority'
-
-    # name: rabbitmq_class
-    # doc: None
-    # converter: configman.converters.class_converter
-    rabbitmq_class='socorro.external.rabbitmq.connection_context.ConnectionContext'
-
-    # name: rabbitmq_connection_wrapper_class
-    # doc: a classname for the type of wrapper for RabbitMQ connections
-    # converter: configman.converters.class_converter
-    rabbitmq_connection_wrapper_class='socorro.external.rabbitmq.connection_context.Connection'
-
-    # name: rabbitmq_password
-    # doc: the user's RabbitMQ password
-    # converter: str
-    rabbitmq_password='guest'
-
-    # name: rabbitmq_user
-    # doc: the name of the user within the RabbitMQ instance
-    # converter: str
-    rabbitmq_user='guest'
-
-    # name: standard_queue_name
-    # doc: the name of standard crash queue name within RabbitMQ
-    # converter: str
-    standard_queue_name='socorro.normal'
-
-    # name: virtual_host
-    # doc: the name of the RabbitMQ virtual host
-    # converter: str
-    virtual_host='/'
+    # seconds between log during retries
+    # see "resource.postgresql.wait_log_interval" for the default or override it here
+    #wait_log_interval=10
 
 [http]
 
     [[correlations]]
 
-        # name: base_url
-        # doc: Base URL where correlations text files are
-        # converter: str
-        base_url='https://crash-analysis.mozilla.com/crash_analysis/'
+        # Base URL where correlations text files are
+        #base_url=https://crash-analysis.mozilla.com/crash_analysis/
 
-        # name: save_download
-        # doc: Whether files downloaded for correlations should be temporary stored on disk
-        # converter: configman.converters.boolean_converter
-        save_download='True'
+        # Whether files downloaded for correlations should be temporary stored on disk
+        #save_download='True'
 
-        # name: save_root
-        # doc: Directory where the temporary downloads are stored (if left empty will become the systems tmp directory)
-        # converter: str
-        save_root=''
+        # Directory where the temporary downloads are stored (if left empty will become the systems tmp directory)
+        #save_root=
 
-        # name: save_seconds
-        # doc: Number of seconds that the downloaded .txt file is stored in a temporary place
-        # converter: int
-        save_seconds='600'
+        # Number of seconds that the downloaded .txt file is stored in a temporary place
+        #save_seconds=600
 
 [implementations]
 
-    # name: implementation_list
-    # doc: list of packages for service implementations
-    # converter: items_list_converter
-    #implementation_list='psql: socorro.external.postgresql, fs: socorro.external.fs, http:socorro.external.http, es:socorro.external.elasticsearch'
+    # list of packages for service implementations
+    #implementation_list='database: socorro.external.postgresql, webapi: socorro.external.elasticsearch, primary_storage: socorro.external.fs, http: socorro.external.http, queuing: socorro.external.rabbitmq'
 
-    # name: service_overrides
-    # doc: comma separated list of class overrides, e.g `Crashes: hbase`
-    # converter: items_list_converter
-    #service_overrides='CrashData: fs, Correlations: http, CorrelationsSignatures: http, SuperSearch: es, Priorityjobs: rabbitmq'
+    # comma separated list of class overrides, e.g `Crashes: hbase`
+    #service_overrides='CrashData: primary_storage, Correlations: http, CorrelationsSignatures: http, SuperSearch: webapi, Priorityjobs: queuing, Query: webapi'
+
+[laglog]
+
+    # Number of bytes that warrents a critial
+    #max_bytes_critical=33554432
+
+    # Number of bytes that warrents a warning
+    #max_bytes_warning=16777216
 
 [logging]
 
-    # name: stderr_error_logging_level
-    # doc: logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
-    # converter: int
-    stderr_error_logging_level='10'
+    # logging level for the logging to stderr (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # see "resource.logging.stderr_error_logging_level" for the default or override it here
+    #stderr_error_logging_level=10
 
-    # name: stderr_line_format_string
-    # doc: python logging system format for logging to stderr
-    # converter: str
-    stderr_line_format_string='{asctime} {levelname} - {threadName} - {message}'
+    # python logging system format for logging to stderr
+    # see "resource.logging.stderr_line_format_string" for the default or override it here
+    #stderr_line_format_string={asctime} {levelname} - {threadName} - {message}
 
-    # name: syslog_error_logging_level
-    # doc: logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
-    # converter: int
-    syslog_error_logging_level='40'
+    # logging level for the log file (10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)
+    # see "resource.logging.syslog_error_logging_level" for the default or override it here
+    #syslog_error_logging_level=40
 
-    # name: syslog_facility_string
-    # doc: syslog facility string ("user", "local0", etc)
-    # converter: str
-    syslog_facility_string='user'
+    # syslog facility string ("user", "local0", etc)
+    # see "resource.logging.syslog_facility_string" for the default or override it here
+    #syslog_facility_string=user
 
-    # name: syslog_host
-    # doc: syslog hostname
-    # converter: str
-    syslog_host='localhost'
+    # syslog hostname
+    # see "resource.logging.syslog_host" for the default or override it here
+    #syslog_host=localhost
 
-    # name: syslog_line_format_string
-    # doc: python logging system format for syslog entries
-    # converter: str
-    syslog_line_format_string='middleware (pid {process}): {asctime} {levelname} - {threadName} - {message}'
+    # python logging system format for syslog entries
+    # see "resource.logging.syslog_line_format_string" for the default or override it here
+    #syslog_line_format_string=middleware (pid {process}): {asctime} {levelname} - {threadName} - {message}
 
-    # name: syslog_port
-    # doc: syslog port
-    # converter: int
-    syslog_port='514'
+    # syslog port
+    # see "resource.logging.syslog_port" for the default or override it here
+    #syslog_port=514
+
+[primary_storage]
+
+    # the default dump field
+    # see "resource.fs.dump_field" for the default or override it here
+    #dump_field=upload_file_minidump
+
+    # the suffix used to identify a dump file
+    # see "resource.fs.dump_file_suffix" for the default or override it here
+    #dump_file_suffix=.dump
+
+    # a list of keys not allowed in a redacted processed crash
+    # see "resource.redactor.forbidden_keys" for the default or override it here
+    #forbidden_keys='url, email, user_id, exploitability,json_dump.sensitive,upload_file_minidump_flash1.json_dump.sensitive,upload_file_minidump_flash2.json_dump.sensitive,upload_file_minidump_browser.json_dump.sensitive'
+
+    # a path to a file system
+    # see "resource.fs.fs_root" for the default or override it here
+    #fs_root='./crashes'
+
+    # the suffix used to identify a json file
+    # see "resource.fs.json_file_suffix" for the default or override it here
+    #json_file_suffix=.json
+
+    # the suffix used to identify a gzipped json file
+    # see "resource.fs.jsonz_file_suffix" for the default or override it here
+    #jsonz_file_suffix=.jsonz
+
+    # the directory base name to use for the named radix tree storage
+    # see "resource.fs.name_branch_base" for the default or override it here
+    #name_branch_base=name
+
+    # None
+    #primary_storage_source_class='socorro.external.fs.crashstorage.FSLegacyRadixTreeStorage'
+
+    # the name of the class that implements a 'redact' method
+    # see "resource.redactor.redactor_class" for the default or override it here
+    #redactor_class='socorro.external.crashstorage_base.Redactor'
+
+    # umask to use for new files
+    # see "resource.fs.umask" for the default or override it here
+    #umask=18
+
+[queuing]
+
+    # delays in seconds between retries
+    # see "resource.rabbitmq.backoff_delays" for the default or override it here
+    #backoff_delays='10, 30, 60, 120, 300'
+
+    # toggle for using or ignoring the throttling flag
+    # see "resource.rabbitmq.filter_on_legacy_processing" for the default or override it here
+    #filter_on_legacy_processing='False'
+
+    # a list of keys not allowed in a redacted processed crash
+    # see "resource.redactor.forbidden_keys" for the default or override it here
+    #forbidden_keys='url, email, user_id, exploitability,json_dump.sensitive,upload_file_minidump_flash1.json_dump.sensitive,upload_file_minidump_flash2.json_dump.sensitive,upload_file_minidump_browser.json_dump.sensitive'
+
+    # the hostname of the RabbitMQ server
+    # see "resource.rabbitmq.host" for the default or override it here
+    #host=localhost
+
+    # the port for the RabbitMQ server
+    # see "resource.rabbitmq.port" for the default or override it here
+    #port=5672
+
+    # the name of priority crash queue name within RabbitMQ
+    # see "resource.rabbitmq.priority_queue_name" for the default or override it here
+    #priority_queue_name=socorro.priority
+
+    # None
+    #queuing_source_class='socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage'
+
+    # the class responsible for connecting to RabbitMQ
+    # see "resource.rabbitmq.rabbitmq_class" for the default or override it here
+    #rabbitmq_class='socorro.external.rabbitmq.connection_context.ConnectionContextPooled'
+
+    # a classname for the type of wrapper for RabbitMQ connections
+    # see "resource.rabbitmq.rabbitmq_connection_wrapper_class" for the default or override it here
+    #rabbitmq_connection_wrapper_class='socorro.external.rabbitmq.connection_context.Connection'
+
+    # the user's RabbitMQ password
+    # see "secrets.rabbitmq.rabbitmq_password" for the default or override it here
+    #rabbitmq_password=guest
+
+    # the name of the user within the RabbitMQ instance
+    # see "secrets.rabbitmq.rabbitmq_user" for the default or override it here
+    #rabbitmq_user=guest
+
+    # the name of the class that implements a 'redact' method
+    # see "resource.redactor.redactor_class" for the default or override it here
+    #redactor_class='socorro.external.crashstorage_base.Redactor'
+
+    # the name of reprocessing crash queue name within RabbitMQ
+    # see "resource.rabbitmq.reprocessing_queue_name" for the default or override it here
+    #reprocessing_queue_name=socorro.reprocessing
+
+    # the name of the queue to recieve crashes
+    # see "resource.rabbitmq.routing_key" for the default or override it here
+    #routing_key=socorro.reprocessing
+
+    # the name of standard crash queue name within RabbitMQ
+    # see "resource.rabbitmq.standard_queue_name" for the default or override it here
+    #standard_queue_name=socorro.normal
+
+    # a class that will manage transactions
+    # see "resource.rabbitmq.transaction_executor_class" for the default or override it here
+    #transaction_executor_class='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff'
+
+    # the name of the RabbitMQ virtual host
+    # see "resource.rabbitmq.virtual_host" for the default or override it here
+    #virtual_host=/
+
+    # seconds between log during retries
+    # see "resource.rabbitmq.wait_log_interval" for the default or override it here
+    #wait_log_interval=10
+
+[sentry]
+
+    # DSN for Sentry via raven
+    # see "secrets.sentry.dsn" for the default or override it here
+    #dsn=
 
 [web_server]
 
-    # name: ip_address
-    # doc: the IP address from which to accept submissions
-    # converter: str
-    ip_address='127.0.0.1'
+    # the IP address from which to accept submissions
+    #ip_address=127.0.0.1
 
-    # name: port
-    # doc: the port to listen to for submissions
-    # converter: int
-    port='8883'
+    # the port to listen to for submissions
+    #port=8883
 
-    # name: wsgi_server_class
-    # doc: a class implementing a wsgi web server
-    # converter: configman.converters.class_converter
-    wsgi_server_class='socorro.webapi.servers.CherryPy'
+    # a class implementing a wsgi web server
+    #wsgi_server_class='socorro.webapi.servers.CherryPy'
 
 [webapi]
 
-    # name: channels
-    # doc: List of release channels, excluding the `release` one.
-    # converter: string_to_list
-    channels='beta, aurora, nightly'
+    # String containing the URI of the Elastic Search instance.
+    # see "resource.elasticsearch.elasticSearchHostname" for the default or override it here
+    #elasticSearchHostname=localhost
 
-    # name: elasticSearchHostname
-    # doc: String containing the URI of the Elastic Search instance.
-    # converter: str
-    elasticSearchHostname='localhost'
+    # String containing the port on which calling the Elastic Search instance.
+    # see "resource.elasticsearch.elasticSearchPort" for the default or override it here
+    #elasticSearchPort=9200
 
-    # name: elasticSearchPort
-    # doc: String containing the port on which calling the Elastic Search instance.
-    # converter: str
-    elasticSearchPort='9200'
+    # the default doctype to use in elasticsearch
+    # see "resource.elasticsearch.elasticsearch_doctype" for the default or override it here
+    #elasticsearch_doctype=crash_reports
 
-    # name: elasticsearch_index
-    # doc: an index format to pull crashes from elasticsearch (use datetime's strftime format to have daily, weekly or monthly indexes)
-    # converter: str
-    elasticsearch_index='socorro%Y%W'
+    # an index format to pull crashes from elasticsearch (use datetime's strftime format to have daily, weekly or monthly indexes)
+    # see "resource.elasticsearch.elasticsearch_index" for the default or override it here
+    #elasticsearch_index=socorro%Y%W
 
-    # name: platforms
-    # doc: Array associating OS ids to full names.
-    # converter: <lambda>
-    #platforms=''
+    # the time in seconds before a query to elasticsearch fails
+    # see "resource.elasticsearch.elasticsearch_timeout" for the default or override it here
+    #elasticsearch_timeout=30
 
-    # name: restricted_channels
-    # doc: List of release channels to restrict based on build ids.
-    # converter: string_to_list
-    restricted_channels='beta'
+    # the time in seconds before a query to elasticsearch fails in restricted sections
+    # see "resource.elasticsearch.elasticsearch_timeout_extended" for the default or override it here
+    #elasticsearch_timeout_extended=120
 
-    # name: searchMaxNumberOfDistinctSignatures
-    # doc: Integer containing the maximum allowed number of distinct signatures the system should retrieve. Used mainly for performances in ElasticSearch
-    # converter: int
-    searchMaxNumberOfDistinctSignatures='1000'
+    # the urls to the elasticsearch instances
+    # see "resource.elasticsearch.elasticsearch_urls" for the default or override it here
+    #elasticsearch_urls='http://localhost:9200'
+
+    # the maximum number of results a facet will return in search
+    #facets_max_number=50
+
+    # List of channels, excluding the `release` one.
+    #non_release_channels='beta, aurora, nightly'
+
+    # Array associating OS ids to full names.
+    #platforms='{"id": "windows", "name": "Windows NT"}, {"id": "mac", "name": "Mac OS X"}, {"id": "linux", "name": "Linux"}'
+
+    # List of channels to restrict based on build ids.
+    #restricted_channels='beta'
+
+    # Integer containing the maximum allowed number of distinct signatures the system should retrieve. Used mainly for performances in ElasticSearch
+    #searchMaxNumberOfDistinctSignatures=1000
+
+    # the default date range for searches, in days
+    #search_default_date_range=7
+
+    # the maximum date range for searches, in days
+    #search_maximum_date_range=365
 

--- a/scripts/rabbitmq-integration-test.sh
+++ b/scripts/rabbitmq-integration-test.sh
@@ -144,7 +144,8 @@ echo -n "INFO: starting up collector, processor and middleware..."
 python socorro/collector/collector_app.py --admin.conf=./config/collector.ini --storage.storage1.host=$RABBITMQ_HOST --storage.storage1.rabbitmq_user=$RABBITMQ_USERNAME --storage.storage1.rabbitmq_password=$RABBITMQ_PASSWORD --storage.storage1.virtual_host=$RABBITMQ_VHOST --storage.storage1.transaction_executor_class=socorro.database.transaction_executor.TransactionExecutor > collector.log 2>&1 &
 python socorro/processor/processor_app.py --admin.conf=./config/processor.ini --processor.database_hostname=$DB_HOST --new_crash_source.host=$RABBITMQ_HOST --new_crash_source.rabbitmq_user=$RABBITMQ_USERNAME --new_crash_source.rabbitmq_password=$RABBITMQ_PASSWORD --new_crash_source.virtual_host=$RABBITMQ_VHOST --destination.storage1.database_hostname=$DB_HOST --registrar.database_hostname=$DB_HOST > processor.log 2>&1 &
 sleep 1
-python socorro/middleware/middleware_app.py --admin.conf=./config/middleware.ini --database.database_hostname=$DB_HOST --database.database_username=$DB_USER --database.database_password=$DB_PASSWORD --rabbitmq.host=$RABBITMQ_HOST --rabbitmq.rabbitmq_user=$RABBITMQ_USERNAME --rabbitmq.rabbitmq_password=$RABBITMQ_PASSWORD --rabbitmq.virtual_host=$RABBITMQ_VHOST > middleware.log 2>&1 &
+#python socorro/middleware/middleware_app.py --admin.conf=./config/middleware.ini --admin.dump_conf=./config/middleware.auto.ini > middleware.log 2>&1 &
+python socorro/middleware/middleware_app.py --admin.conf=./config/middleware.ini --resource.postgresql.database_hostname=$DB_HOST --secrets.postgresql.database_username=$DB_USER --secrets.postgresql.database_password=$DB_PASSWORD --resource.rabbitmq.host=$RABBITMQ_HOST --secrets.rabbitmq.rabbitmq_user=$RABBITMQ_USERNAME --secrets.rabbitmq.rabbitmq_password=$RABBITMQ_PASSWORD --resource.rabbitmq.virtual_host=$RABBITMQ_VHOST > middleware.log 2>&1 &
 echo " Done."
 
 function retry() {

--- a/socorro/external/crash_data_base.py
+++ b/socorro/external/crash_data_base.py
@@ -22,15 +22,24 @@ class CrashDataBase(object):
     crashstorage class.
     """
 
+    # derived classes must define these two attributes
+    #role = 'unknown'
+    #class_key = 'unknown_class'
+
     def __init__(self, *args, **kwargs):
         super(CrashDataBase, self).__init__()
         self.config = kwargs['config']
         self.all_services = kwargs['all_services']
 
     def get_storage(self):
-        """derived classes must implement this method to return an instance
-        of their own crashstorage class"""
-        raise NotImplementedError
+        try:
+            return self.config[self.role]["crashstorage_class"](
+                self.config[self.role]
+            )
+        except AttributeError, x:
+            raise NotImplementedError(
+                'derived classes are required to have attribute %s' % x
+            )
 
     def get(self, **kwargs):
         """Return JSON data of a crash report, given its uuid. """

--- a/socorro/external/filesystem/crash_data.py
+++ b/socorro/external/filesystem/crash_data.py
@@ -10,6 +10,4 @@ class CrashData(CrashDataBase):
     """
     Implement the /crash_data service with the file system.
     """
-
-    def get_storage(self):
-        return self.config.filesystem.filesystem_class(self.config.filesystem)
+    role = 'filesystem'

--- a/socorro/external/fs/crash_data.py
+++ b/socorro/external/fs/crash_data.py
@@ -10,6 +10,4 @@ class CrashData(CrashDataBase):
     """
     Implement the /crash_data service with the file system.
     """
-
-    def get_storage(self):
-        return self.config.filesystem.filesystem_class(self.config.filesystem)
+    role = 'filesystem'

--- a/socorro/external/happybase/crash_data.py
+++ b/socorro/external/happybase/crash_data.py
@@ -9,6 +9,5 @@ class CrashData(CrashDataBase):
     """
     Implement the /crash_data service with HBase.
     """
-    def get_storage(self):
-        return self.config.hb.hbase_class(self.config.hb)
+    role = 'filesystem'
 

--- a/socorro/external/hb/crash_data.py
+++ b/socorro/external/hb/crash_data.py
@@ -9,6 +9,4 @@ class CrashData(CrashDataBase):
     """
     Implement the /crash_data service with HBase.
     """
-    def get_storage(self):
-        return self.config.hbase.hbase_class(self.config.hbase)
-
+    role = 'hbase'

--- a/socorro/external/hbase/crash_data.py
+++ b/socorro/external/hbase/crash_data.py
@@ -9,5 +9,4 @@ class CrashData(CrashDataBase):
     """
     Implement the /crash_data service with HBase.
     """
-    def get_storage(self):
-        return self.config.hbase.hbase_class(self.config.hbase)
+    role = 'hbase'

--- a/socorro/external/postgresql/dbapi2_util.py
+++ b/socorro/external/postgresql/dbapi2_util.py
@@ -60,3 +60,4 @@ def execute_query_fetchall(connection, sql, parameters=None):
 def execute_no_results(connection, sql, parameters=None):
     a_cursor = connection.cursor()
     a_cursor.execute(sql, parameters)
+    return a_cursor.rowcount

--- a/socorro/external/postgresql/report.py
+++ b/socorro/external/postgresql/report.py
@@ -241,29 +241,25 @@ class Report(PostgreSQLBase):
         )
 
         # Querying the DB
-        with self.get_connection() as connection:
+        total = self.count(
+            sql_count_query,
+            sql_params,
+            error_message="Failed to count crashes from reports.",
+        )
 
-            total = self.count(
-                sql_count_query,
+        # No need to call Postgres if we know there will be no results
+        if total:
+
+            if include_raw_crash:
+                sql_query = wrapped_select % sql_query
+
+            results = self.query(
+                sql_query,
                 sql_params,
-                error_message="Failed to count crashes from reports.",
-                connection=connection
+                error_message="Failed to retrieve crashes from reports",
             )
-
-            # No need to call Postgres if we know there will be no results
-            if total:
-
-                if include_raw_crash:
-                    sql_query = wrapped_select % sql_query
-
-                results = self.query(
-                    sql_query,
-                    sql_params,
-                    error_message="Failed to retrieve crashes from reports",
-                    connection=connection
-                )
-            else:
-                results = []
+        else:
+            results = []
 
         # Transforming the results into what we want
         fields = (

--- a/socorro/external/postgresql/search.py
+++ b/socorro/external/postgresql/search.py
@@ -128,28 +128,24 @@ class Search(PostgreSQLBase):
                 "SELECT count(DISTINCT r.signature)", sql_from, sql_where))
 
         # Querying the database
+        # editorial: why query twice?  use the second query only, and then get
+        #    the length of the relults to determine the value of "total"
         error_message = "Failed to retrieve crashes from PostgreSQL"
-        with self.get_connection() as connection:
-            try:
-                total = self.count(
-                    sql_count_query,
-                    sql_params,
-                    error_message="Failed to count crashes from PostgreSQL.",
-                    connection=connection
-                )
+        total = self.count(
+            sql_count_query,
+            sql_params,
+            error_message="Failed to count crashes from PostgreSQL.",
+        )
 
-                results = []
+        results = []
 
-                # No need to call Postgres if we know there will be no results
-                if total != 0:
-                    results = self.query(
-                        sql_query,
-                        sql_params,
-                        error_message=error_message,
-                        connection=connection
-                    )
-            except psycopg2.Error:
-                raise DatabaseError(error_message)
+        # No need to call Postgres if we know there will be no results
+        if total != 0:
+            results = self.query(
+                sql_query,
+                sql_params,
+                error_message=error_message,
+            )
 
         # Transforming the results into what we want
         crashes = []

--- a/socorro/external/rabbitmq/priorityjobs.py
+++ b/socorro/external/rabbitmq/priorityjobs.py
@@ -11,10 +11,14 @@ from socorro.lib import external_common
 
 class Priorityjobs(object):
     """Implement the /priorityjobs service with RabbitMQ."""
+    role = 'rabbitmq'
 
     def __init__(self, *args, **kwargs):
-        self.config = kwargs.get('config').rabbitmq
-        self.context = self.config.rabbitmq_class(self.config)
+        self.config = kwargs.get('config')
+        self.config = self.config[self.role]
+        self.crash_store = self.config.crashstorage_class(self.config)
+        self.context = self.crash_store.rabbitmq
+        self.transaction = self.crash_store.transaction
 
     def get(self, **kwargs):
         raise NotImplementedError(

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -29,8 +29,127 @@ from socorro.webapi.webapiService import (
 )
 
 import raven
-from configman import Namespace
+from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
+
+
+#------------------------------------------------------------------------------
+def classes_in_namespaces_converter(
+    attr_name_for_resource_class='crashstorage_class',
+    instantiate_classes=False
+):
+    """take a comma delimited  list of namespaces & class names, convert each
+    class name into an actual class as an option within the named namespace.
+    This function creates a closure over a new function.  That new function,
+    in turn creates a class derived from RequiredConfig.  The inner function,
+    'class_list_converter', populates the InnerClassList with a Namespace for
+    each of the classes in the class list.  In addition, it puts the each class
+    itself into the subordinate Namespace.  The requirement discovery mechanism
+    of configman then reads the InnerClassList's requried config, pulling in
+    the namespaces and associated classes within.
+
+    For example, if we have a class list like this: "alf:Alpha, bet:Beta",
+    then this converter will add the following Namespaces and options to the
+    configuration:
+
+        "alf" - the subordinate Namespace for Alpha
+        "alf.alf_class" - the option containing the class Alpha itself
+        "bet" - the subordinate Namespace for Beta
+        "bet.bet_class" - the option containing the class Beta itself
+
+    Optionally, the 'class_list_converter' inner function can embue the
+    InnerClassList's subordinate namespaces with aggregates that will
+    instantiate classes from the class list.  This is a convenience to the
+    programmer who would otherwise have to know ahead of time what the
+    namespace names were so that the classes could be instantiated within the
+    context of the correct namespace.  Remember the user could completely
+    change the list of classes at run time, so prediction could be difficult.
+
+        "alf" - the subordinate Namespace for Alpha
+        "alf.alf_class" - the option containing the class Alpha itself
+        "alf.cls_instance" - an instance of the class Alpha
+        "bet" - the subordinate Namespace for Beta
+        "bet.bet_class" - the option containing the class Beta itself
+        "bet.cls_instance" - an instance of the class Beta
+
+    parameters:
+        class_option_name - the name to be used for the class option within
+                            the nested namespace.  By default, it will choose:
+                            "cls1.cls", "cls2.cls", etc.
+        instantiate_classes - a boolean to determine if there should be an
+                              aggregator added to each namespace that
+                              instantiates each class.  If True, then each
+                              Namespace will contain elements for the class, as
+                              well as an aggregator that will instantiate the
+                              class.
+                              """
+
+    #--------------------------------------------------------------------------
+    def class_list_converter(class_list_str):
+        """This function becomes the actual converter used by configman to
+        take a string and convert it into the nested sequence of Namespaces,
+        one for each class in the list.  It does this by creating a proxy
+        class stuffed with its own 'required_config' that's dynamically
+        generated."""
+        if isinstance(class_list_str, basestring):
+            temp_list = [x.strip() for x in class_list_str.split(',')]
+            if temp_list == ['']:
+                temp_list = []
+            # now we should have a list of ":" delimited namespace/class pairs
+            class_list = []
+            for a_pair in temp_list:
+                if a_pair:
+                    namespace_name, class_name = a_pair.split(':')
+                    namespace_name = namespace_name.strip()
+                    class_name = class_name.strip()
+                    class_list.append((namespace_name, class_name))
+        else:
+            raise TypeError('must be derivative of a basestring')
+
+        #======================================================================
+        class InnerClassList(RequiredConfig):
+            """This nested class is a proxy list for the classes.  It collects
+            all the config requirements for the listed classes and places them
+            each into their own Namespace.
+            """
+            # we're dynamically creating a class here.  The following block of
+            # code is actually adding class level attributes to this new class
+            required_config = Namespace()  # 1st requirement for configman
+            subordinate_namespace_names = []  # to help the programmer know
+                                              # what Namespaces we added
+            # save the class's option name for the future
+            class_option_name = attr_name_for_resource_class
+            original_class_list_str = class_list_str
+            # for each class in the class list
+            for namespace_name, a_class in (class_list):
+                # figure out the Namespace name
+                subordinate_namespace_names.append(namespace_name)
+                # create the new Namespace
+                required_config[namespace_name] = Namespace()
+                # add the option for the class itself
+                required_config[namespace_name].add_option(
+                    attr_name_for_resource_class,
+                    #doc=a_class.__doc__  # not helpful if too verbose
+                    default=a_class,
+                    from_string_converter=class_converter
+                )
+                if instantiate_classes:
+                    # add an aggregator to instantiate the class
+                    required_config[namespace_name].add_aggregation(
+                        "%s_instance" % attr_name_for_resource_class,
+                        lambda c, lc, a: lc[attr_name_for_resource_class](lc)
+                    )
+
+            @classmethod
+            def to_str(cls):
+                """this method takes this inner class object and turns it back
+                into the original string of classnames.  This is used
+                primarily as for the output of the 'help' option"""
+                return cls.original_class_list_str
+
+        return InnerClassList  # result of class_list_converter
+    return class_list_converter  # result of classes_in_namespaces_converter
+
 
 #------------------------------------------------------------------------------
 # Here's the list of URIs mapping to classes and the files they belong to.
@@ -132,12 +251,14 @@ class MiddlewareApp(App):
     required_config.implementations.add_option(
         'implementation_list',
         doc='list of packages for service implementations',
-        default='psql:socorro.external.postgresql, '
-                'hbase:socorro.external.hb, '
-                'es:socorro.external.elasticsearch, '
-                'fs:socorro.external.fs, '
+        default='database:socorro.external.postgresql, '
+                #'primary_storage:socorro.external.hb, '
+                # conisder changing "webapi" to "search"
+                'webapi:socorro.external.elasticsearch, '
+                'primary_storage:socorro.external.fs, '
+                # conisder changing "webapi" to "analysis"
                 'http:socorro.external.http, '
-                'rabbitmq:socorro.external.rabbitmq',
+                'queuing:socorro.external.rabbitmq',
         from_string_converter=items_list_decode,
         to_string_converter=items_list_encode
     )
@@ -145,60 +266,40 @@ class MiddlewareApp(App):
     required_config.implementations.add_option(
         'service_overrides',
         doc='comma separated list of class overrides, e.g `Crashes: hbase`',
-        default='CrashData: fs, '
+        default='CrashData: primary_storage, '
                 'Correlations: http, '
                 'CorrelationsSignatures: http, '
-                'SuperSearch: es, '
-                'Priorityjobs: rabbitmq, '
-                'Query: es',
+                'SuperSearch: webapi, '
+                'Priorityjobs: queuing, '
+                'Query: webapi',
         from_string_converter=items_list_decode,
         to_string_converter=items_list_encode
     )
 
-    #--------------------------------------------------------------------------
-    # database namespace
-    #     the namespace is for external implementations of the services
-    #-------------------------------------------------------------------------
-    required_config.namespace('database')
-    required_config.database.add_option(
-        'database_class',
-        default='socorro.external.postgresql.connection_context.'
-                'ConnectionContext',
-        from_string_converter=class_converter
-    )
-
-    #--------------------------------------------------------------------------
-    # hbase namespace
-    #     the namespace is for external implementations of the services
-    #-------------------------------------------------------------------------
-    required_config.namespace('hbase')
-    required_config.hbase.add_option(
-        'hbase_class',
-        default='socorro.external.hb.crashstorage.HBaseCrashStorage',
-        from_string_converter=class_converter
-    )
-
-    #--------------------------------------------------------------------------
-    # filesystem namespace
-    #     the namespace is for external implementations of the services
-    #-------------------------------------------------------------------------
-    required_config.namespace('filesystem')
-    required_config.filesystem.add_option(
-        'filesystem_class',
-        default='socorro.external.fs.crashstorage.FSLegacyRadixTreeStorage',
-        from_string_converter=class_converter
-    )
-
-    #--------------------------------------------------------------------------
-    # rabbitmq namespace
-    #     the namespace is for external implementations of the services
-    #-------------------------------------------------------------------------
-    required_config.namespace('rabbitmq')
-    required_config.rabbitmq.add_option(
-        'rabbitmq_class',
-        default='socorro.external.rabbitmq.connection_context.'
-                'ConnectionContext',
-        from_string_converter=class_converter
+    required_config.add_option(
+        'service_classes',
+        doc='a list of namespace:class associations for classes that offer '
+            ' implementations of services',
+        # these classes bring the basic resource configuration parameters into
+        # the middleware configuration.  Each resource listed in this section
+        # will have a namespace in the middleware config root correspondng to
+        # key given in the entry here. Each of the web services implemented
+        # by that resource will look to that namespace entry for configuration
+        # info. This entry makes that happen by calling the local
+        # classes_in_namespaces_converter
+        # role: database - for any service that want to access a database with
+        #                  a database connection.  Offering a transaction
+        #                  manager would sure be nice.
+        # role: primary_storage - services in this role always want a crash-
+        #                         storage instance rather than a bare
+        #                         to some resource.
+        # role: queuing - the services in this category want bare connections
+        #                 to their resources
+        default="""
+database: socorro.external.postgresql.crashstorage.PostgreSQLCrashStorage,
+primary_storage: socorro.external.fs.crashstorage.FSLegacyRadixTreeStorage,
+queuing: socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage""",
+        from_string_converter=classes_in_namespaces_converter()
     )
 
     #--------------------------------------------------------------------------
@@ -383,42 +484,53 @@ class MiddlewareApp(App):
     StandAloneServer.required_config.port.set_default(8883, force=True)
 
     #--------------------------------------------------------------------------
+    def lookup(self, file_and_class):
+        #turn these names of classes into real references to classes
+        file_name, class_name = file_and_class.rsplit('.', 1)
+        try:
+            if class_name in self.overrides:
+                target_role = self.overrides[class_name]
+                base_module_path = self.implementations[target_role]
+            else:
+                base_module_path = (
+                    self.config.implementations.implementation_list[0][1]
+                )
+                target_role = (
+                    self.config.implementations.implementation_list[0][0]
+                )
+            try:
+                module = __import__(
+                    '%s.%s' % (base_module_path, file_name),
+                    globals(),
+                    locals(),
+                    [class_name]
+                )
+            except ImportError:
+                raise ImportError(
+                    "Unable to import %s.%s.%s" %
+                    (base_module_path, file_name, class_name)
+                )
+            impl_class = getattr(module, class_name)
+
+            class RoleImbuedImplClass(impl_class):
+                role = target_role
+                class_key = "%s_class" % target_role
+            return RoleImbuedImplClass
+        except (KeyError, IndexError), x:
+            raise ImplementationConfigurationError(file_and_class)
+
+    #--------------------------------------------------------------------------
     def main(self):
         # Apache modwsgi requireds a module level name 'application'
         global application
 
-        # 1 turn these names of classes into real references to classes
-        def lookup(file_and_class):
-            file_name, class_name = file_and_class.rsplit('.', 1)
-            overrides = dict(self.config.implementations.service_overrides)
-            _list = self.config.implementations.implementation_list
-            for prefix, base_module_path in _list:
-                if class_name in overrides:
-                    if prefix != overrides[class_name]:
-                        continue
-                try:
-                    module = __import__(
-                        '%s.%s' % (base_module_path, file_name),
-                        globals(),
-                        locals(),
-                        [class_name]
-                    )
-                except ImportError:
-                    raise ImportError(
-                        "Unable to import %s.%s.%s" %
-                        (base_module_path, file_name, class_name)
-                    )
-                return getattr(module, class_name)
-            raise ImplementationConfigurationError(file_and_class)
-
-        # This list will hold the collection of url/service-implementations.
-        # It is populated in the for loop a few lines lower in this file.
-        # This list is used in the 'wrap' function so that all services have
-        # place to lookup dependent services.
+        self.overrides = dict(self.config.implementations.service_overrides)
+        self.implementations = dict(
+            self.config.implementations.implementation_list
+        )
 
         all_services_mapping = {}
 
-        # 2 wrap each service class with the ImplementationWrapper class
         def wrap(cls, file_and_class):
             return type(
                 cls.__name__,
@@ -435,7 +547,7 @@ class MiddlewareApp(App):
         # populate the 'services_list' with the tuples that will define the
         # urls and services offered by the middleware.
         for url, impl_class in SERVICES_LIST:
-            impl_instance = lookup(impl_class)
+            impl_instance = self.lookup(impl_class)
             wrapped_impl = wrap(impl_instance, impl_class)
             services_list.append((url, wrapped_impl))
             all_services_mapping[impl_instance.__name__] = wrapped_impl

--- a/socorro/unittest/external/filesystem/test_crash_data.py
+++ b/socorro/unittest/external/filesystem/test_crash_data.py
@@ -77,7 +77,7 @@ class IntegrationTestCrashData(TestCase):
         mock_logging = Mock()
         required_config = Namespace()
         required_config.namespace('filesystem')
-        required_config.filesystem.filesystem_class = \
+        required_config.filesystem.crashstorage_class = \
             crashstorage.FileSystemCrashStorage
         required_config.filesystem.add_option('logger', default=mock_logging)
         config_manager = ConfigurationManager(

--- a/socorro/unittest/external/filesystem/test_crashstorage.py
+++ b/socorro/unittest/external/filesystem/test_crashstorage.py
@@ -50,6 +50,7 @@ class TestFileSystemCrashStorage(TestCase):
         return found
 
     def _common_config_setup(self):
+        # MOCKED CONFIG DONE HERE
         mock_logging = Mock()
         required_config = FileSystemCrashStorage.get_required_config()
         required_config.add_option('logger', default=mock_logging)

--- a/socorro/unittest/external/fs/test_crash_data.py
+++ b/socorro/unittest/external/fs/test_crash_data.py
@@ -77,7 +77,7 @@ class IntegrationTestCrashData(TestCase):
         mock_logging = Mock()
         required_config = Namespace()
         required_config.namespace('filesystem')
-        required_config.filesystem.filesystem_class = \
+        required_config.filesystem.crashstorage_class = \
             crashstorage.FSRadixTreeStorage
         required_config.filesystem.add_option('logger', default=mock_logging)
         config_manager = ConfigurationManager(

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -5,10 +5,15 @@
 from nose.plugins.attrib import attr
 from nose.tools import eq_, ok_, assert_raises
 
+from mock import Mock
+
 from socorro.external import DatabaseError
 from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.lib import search_common, util
 from socorro.unittest.testbase import TestCase
+from socorro.external.postgresql.crashstorage import PostgreSQLCrashStorage
+from socorro.external.postgresql.connection_context import ConnectionContext
+from socorro.database.transaction_executor import TransactionExecutor
 
 from .unittestbase import PostgreSQLTestCase
 
@@ -20,13 +25,21 @@ class TestPostgreSQLBase(TestCase):
     #--------------------------------------------------------------------------
     def get_dummy_context(self):
         """Create a dummy config object to use when testing."""
+        # MOCKED CONFIG DONE HERE
         context = util.DotDict()
+        context.logger = util.SilentFakeLogger()
+        context.executor_identity = lambda: ''
         context.database = util.DotDict({
             'database_hostname': 'somewhere',
             'database_port': '8888',
             'database_name': 'somename',
             'database_username': 'someuser',
             'database_password': 'somepasswd',
+            'crashstorage_class': PostgreSQLCrashStorage,
+            'database_class': ConnectionContext,
+            'transaction_executor_class': TransactionExecutor,
+            'redactor_class': Mock(),
+            'logger': util.SilentFakeLogger()
         })
         context.platforms = (
             {

--- a/socorro/unittest/external/postgresql/test_setupdb_app.py
+++ b/socorro/unittest/external/postgresql/test_setupdb_app.py
@@ -27,7 +27,6 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
             'password=%(database_password)s' %
             dict(DSN, database_name=database_name)
         )
-        #print 'DEBUG', dsn
         return psycopg2.connect(dsn)
 
     def _drop_database(self):
@@ -44,6 +43,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
 
     def setUp(self):
         super(IntegrationTestSetupDB, self).setUp()
+        # MOCKED CONFIG DONE HERE
 
         config_manager = self._setup_config_manager({'dropdb': True})
         with config_manager.context() as config:
@@ -68,7 +68,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
             extra_value_source = {}
         mock_logging = mock.Mock()
 
-        required_config = setupdb_app.SocorroDB.required_config
+        required_config = setupdb_app.SocorroDB.get_required_config()
         required_config.add_option('logger', default=mock_logging)
 
         # We manually set the database_name to something deliberately
@@ -77,7 +77,8 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
         # the other tests.
         required_config.database_name = 'soccoro_integration_test_setupdb_only'
 
-        required_config.database_hostname = self.config.database_hostname
+        required_config.database_hostname = \
+            self.config.database.database_hostname
 
         config_manager = ConfigurationManager(
             [required_config,

--- a/socorro/unittest/external/rabbitmq/test_priorityjobs.py
+++ b/socorro/unittest/external/rabbitmq/test_priorityjobs.py
@@ -7,9 +7,13 @@ from nose.plugins.attrib import attr
 from nose.tools import eq_, ok_, assert_raises
 
 from socorro.external.rabbitmq import priorityjobs
+from socorro.external.rabbitmq.crashstorage import RabbitMQCrashStorage
+from socorro.external.rabbitmq.connection_context import ConnectionContext
+from socorro.database.transaction_executor import TransactionExecutor
 from socorro.unittest.testbase import TestCase
 
 from configman.dotdict import DotDictWithAcquisition
+
 
 #==============================================================================
 @attr(integration='rabbitmq')  # for nosetests
@@ -18,8 +22,13 @@ class IntegrationTestPriorityjobs(TestCase):
 
     def setUp(self):
         """Create a configuration context."""
+        # MOCKED CONFIG DONE HERE
         super(IntegrationTestPriorityjobs, self).setUp()
         rabbitmq = DotDictWithAcquisition()
+        rabbitmq.crashstorage_class = RabbitMQCrashStorage
+        rabbitmq.redactor_class = Mock()
+        rabbitmq.rabbitmq_class = ConnectionContext
+        rabbitmq.transaction_executor_class = TransactionExecutor
         rabbitmq.host='localhost'
         rabbitmq.port=5672
         rabbitmq.priority_queue_name='socorro.priority'
@@ -72,7 +81,7 @@ class IntegrationTestPriorityjobs(TestCase):
             assert_raises(priorityjobs.MissingArgumentError,
                               jobs.create)
             ok_(
-                mocked_connection.return_value.channel. \
+                mocked_connection.return_value.channel.
                     basic_publish.called_once_with(
                         '',
                         'socorro.priority',

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -288,8 +288,8 @@ class ImplementationWrapperTestCase(TestCase):
         )
         eq_(response.status, 200)
         eq_(json.loads(response.body),
-                         {'foo': 'bar',
-                          'names': ['peter', 'anders']})
+            {'foo': 'bar',
+             'names': ['peter', 'anders']})
 
         logging_info.assert_called_with('Running AuxImplementation5')
 
@@ -432,6 +432,7 @@ class IntegrationTestMiddlewareApp(TestCase):
         mock_logging = mock.Mock()
         required_config = middleware_app.MiddlewareApp.get_required_config()
         required_config.add_option('logger', default=mock_logging)
+        required_config.add_option('executor_identity', default=mock.Mock())
         config_manager = ConfigurationManager(
             [required_config],
             app_name='middleware',
@@ -474,6 +475,7 @@ class IntegrationTestMiddlewareApp(TestCase):
         mock_logging = mock.Mock()
         required_config = middleware_app.MiddlewareApp.get_required_config()
         required_config.add_option('logger', default=mock_logging)
+        required_config.add_option('executor_identity', default=mock.Mock())
 
         config_manager = ConfigurationManager(
             [required_config,
@@ -1180,8 +1182,8 @@ class IntegrationTestMiddlewareApp(TestCase):
             hits = sorted(response.data['hits'], key=lambda k: k['id'])
             eq_(response.data['total'], 2)
             eq_(hits,
-                             [{u'id': 2, u'signature': u'sign2+'},
-                              {u'id': 3, u'signature': u'si/gn1'}])
+                [{u'id': 2, u'signature': u'sign2+'},
+                 {u'id': 3, u'signature': u'si/gn1'}])
 
             response = self.post(
                 server,
@@ -1489,4 +1491,4 @@ class IntegrationTestMiddlewareApp(TestCase):
                     'channel': 'aurora',
                 }
             )
-            eq_(response.data, {'hits': [], 'total':0})
+            eq_(response.data, {'hits': [], 'total': 0})


### PR DESCRIPTION
this PR refactors the middleware so that the storage classes are not hard coded into the middleware_app itself.  The "prefix" system for associating services with implementations has been replaced with a "role" system instead.  Overrides are done by specifying the namespace in which an alternative implementation resides rather than the name of a implementation
