### PR TITLE
Fixes bug 1013308 - Replace all lists of Super Search fields with one central list

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -52,6 +52,7 @@ Documented services
     * `/signaturesummary/report_type/uptime/ <#uptime-signature-summary-service>`_
 * `/signatureurls <#signature-urls-service>`_
 * `/skiplist/ <#skiplist-service>`_
+* `/supersearch/fields/ <#supersearch-fields-service>`_
 * `/suspicious/ <#suspicious-crash-signatures-service>`_
 
 
@@ -2714,6 +2715,69 @@ Return a list of extensions::
             },
         ]
     }
+
+
+.. ############################################################################
+   Supersearch Fields API
+   ############################################################################
+
+Supersearch Fields service
+--------------------------
+
+Returns the list of all the fields that are known to be in the elasticsearch
+database.
+
+The data returned by this service is used to generate:
+    * the list of parameters the ``/supersearch/`` middleware service accepts ;
+    * the list of parameters the SuperSearch django model accepts ;
+    * the list of fields that can be used in the Super Search page ;
+    * and the mapping of the crashes that are inserted into elasticsearch.
+
+API specifications
+^^^^^^^^^^^^^^^^^^
+
++----------------+----------------------+
+| HTTP method    | GET                  |
++----------------+----------------------+
+| URL            | /supersearch/fields/ |
++----------------+----------------------+
+
+Mandatory parameters
+^^^^^^^^^^^^^^^^^^^^
+
+None.
+
+Optional parameters
+^^^^^^^^^^^^^^^^^^^
+
+None.
+
+Return value
+^^^^^^^^^^^^
+
+Returns a dictionary of ``field_name:field_data``, in this format::
+
+    {
+        "signature": {
+            "data_validation_type": "str",
+            "default_value": null,
+            "form_field_choices": null,
+            "form_field_type": "StringField",
+            "has_full_version": true,
+            "in_database_name": "signature",
+            "is_exposed": true,
+            "is_mandatory": false,
+            "is_returned": true,
+            "name": "signature",
+            "namespace": "processed_crash",
+            "permissions_needed": [],
+            "query_type": "string",
+            "storage_mapping": {
+                "type": "string"
+            }
+        }
+    }
+
 
 
 .. ############################################################################

--- a/socorro/external/elasticsearch/supersearch_fields.json
+++ b/socorro/external/elasticsearch/supersearch_fields.json
@@ -1,0 +1,1934 @@
+{
+    "BuildID": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "BuildID",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "BuildID",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "CrashTime": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "CrashTime",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "CrashTime",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "Hang": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "Hang",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "Hang",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "InstallTime": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "InstallTime",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "InstallTime",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "Notes": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "Notes",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "Notes",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "ProcessType": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "ProcessType",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "ProcessType",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "SecondsSinceLastCrash": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "SecondsSinceLastCrash",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "SecondsSinceLastCrash",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "accessibility": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "Accessibility",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "accessibility",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "adapter_device_id": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "AdapterDeviceID",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "adapter_device_id",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "adapter_vendor_id": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "AdapterVendorID",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "adapter_vendor_id",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "additional_minidumps": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "additional_minidumps",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "additional_minidumps",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "addons": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "addons",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "addons",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "addons_checked": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "addons_checked",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "addons_checked",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "address": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": false,
+        "in_database_name": "address",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "address",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "android_board": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Board",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_board",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_brand": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Brand",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_brand",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_cpu_abi": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_CPU_ABI",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_cpu_abi",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "android_cpu_abi2": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_CPU_ABI2",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_cpu_abi2",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "android_device": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Device",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_device",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "android_display": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Display",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_display",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_fingerprint": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Fingerprint",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_fingerprint",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_hardware": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Hardware",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_hardware",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_manufacturer": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Manufacturer",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_manufacturer",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "android_model": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": true,
+        "in_database_name": "Android_Model",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_model",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "fields": {
+                "Android_Model": {
+                    "type": "string"
+                },
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "android_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Android_Version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "android_version",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "app_notes": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "app_notes",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "app_notes",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "available_page_file": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "AvailablePageFile",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "available_page_file",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "available_physical_memory": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "AvailablePhysicalMemory",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "available_physical_memory",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "available_virtual_memory": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "AvailableVirtualMemory",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "available_virtual_memory",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "b2g_os_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "B2G_OS_Version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "b2g_os_version",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "bios_manufacturer": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "BIOS_Manufacturer",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "bios_manufacturer",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "build_date": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "build_date",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "build_date",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+            "type": "date"
+        }
+    },
+    "build_id": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "build",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "build_id",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "buildid": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "buildid",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "buildid",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "classifications": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "classifications",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "classifications",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "dynamic": "true",
+            "properties": {
+                "skunk_works": {
+                    "dynamic": "true",
+                    "properties": {
+                        "classification": {
+                            "type": "string"
+                        },
+                        "classification_data": {
+                            "type": "string"
+                        },
+                        "classification_version": {
+                            "analyzer": "keyword",
+                            "type": "string"
+                        }
+                    }
+                },
+                "support": {
+                    "dynamic": "true",
+                    "properties": {
+                        "classification": {
+                            "type": "string"
+                        },
+                        "classification_data": {
+                            "type": "string"
+                        },
+                        "classification_version": {
+                            "analyzer": "keyword",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "type": "object"
+        }
+    },
+    "client_crash_date": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "client_crash_date",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "client_crash_date",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+            "type": "date"
+        }
+    },
+    "completeddatetime": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "completeddatetime",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "completeddatetime",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+            "type": "date"
+        }
+    },
+    "cpu_info": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": true,
+        "in_database_name": "cpu_info",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "cpu_info",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "fields": {
+                "cpu_info": {
+                    "analyzer": "standard",
+                    "index": "analyzed",
+                    "type": "string"
+                },
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "cpu_name": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "cpu_name",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "cpu_name",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "cpu_usage_flash_process1": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "CpuUsageFlashProcess1",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "cpu_usage_flash_process1",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "double"
+        }
+    },
+    "cpu_usage_flash_process2": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "CpuUsageFlashProcess2",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "cpu_usage_flash_process2",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "double"
+        }
+    },
+    "crash_time": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "crash_time",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "crash_time",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "crashedThread": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "crashedThread",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "crashedThread",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "date": {
+        "data_validation_type": "datetime",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "DateTimeField",
+        "has_full_version": false,
+        "in_database_name": "date_processed",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "date",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "date",
+        "storage_mapping": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+            "type": "date"
+        }
+    },
+    "distributor": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "distributor",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "distributor",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "distributor_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "distributor_version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "distributor_version",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "dom_ipc_enabled": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "DOMIPCEnabled",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "dom_ipc_enabled",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "null_value": false,
+            "type": "boolean"
+        }
+    },
+    "dump": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": false,
+        "in_database_name": "dump",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "dump",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "index": "not_analyzed",
+            "type": "string"
+        }
+    },
+    "em_check_compatibility": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "EMCheckCompatibility",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "em_check_compatibility",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "email": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": false,
+        "in_database_name": "email",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "email",
+        "namespace": "processed_crash",
+        "permissions_needed": [
+            "crashstats.view_pii"
+        ],
+        "query_type": "string",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "exploitability": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": [
+            "high", "normal", "low", "none", "unknown", "error"
+        ],
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "exploitability",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "exploitability",
+        "namespace": "processed_crash",
+        "permissions_needed": [
+            "crashstats.view_exploitability"
+        ],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "flash_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "flash_version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "flash_version",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "frame_poison_base": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "FramePoisonBase",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "frame_poison_base",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "frame_poison_size": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "FramePoisonSize",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "frame_poison_size",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "hang_type": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": [
+            "any", "crash", "hang", "all"
+        ],
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "hang_type",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "hang_type",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "short"
+        }
+    },
+    "hangid": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "hangid",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "hangid",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "install_age": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "install_age",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "install_age",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "is_garbage_collecting": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "IsGarbageCollecting",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "is_garbage_collecting",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "java_stack_trace": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "java_stack_trace",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "java_stack_trace",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "last_crash": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "last_crash",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "last_crash",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "legacy_processing": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "legacy_processing",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "legacy_processing",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "min_arm_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Min_ARM_Version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "min_arm_version",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "number_of_processors": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "NumberOfProcessors",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "number_of_processors",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "oom_allocation_size": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "OOMAllocationSize",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "oom_allocation_size",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "platform": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": true,
+        "in_database_name": "os_name",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "platform",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "fields": {
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "os_name": {
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "platform_version": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": false,
+        "in_database_name": "os_version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "platform_version",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "plugin_cpu_usage": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "PluginCpuUsage",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_cpu_usage",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "double"
+        }
+    },
+    "plugin_filename": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": true,
+        "in_database_name": "PluginFilename",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_filename",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "fields": {
+                "PluginFilename": {
+                    "index": "analyzed",
+                    "type": "string"
+                },
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "plugin_hang": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "PluginHang",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_hang",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "plugin_hang_ui_duration": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "PluginHangUIDuration",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_hang_ui_duration",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "plugin_name": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": true,
+        "in_database_name": "PluginName",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_name",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "fields": {
+                "PluginName": {
+                    "index": "analyzed",
+                    "type": "string"
+                },
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "plugin_version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": true,
+        "in_database_name": "PluginVersion",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "plugin_version",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "fields": {
+                "PluginVersion": {
+                    "index": "analyzed",
+                    "type": "string"
+                },
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "process_type": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": [
+            "any", "browser", "plugin", "content", "all"
+        ],
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "process_type",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "process_type",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "processor_notes": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "processor_notes",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "processor_notes",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "product": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": true,
+        "in_database_name": "product",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "product",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "fields": {
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "product": {
+                    "index": "analyzed",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "productid": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "productid",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "productid",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "reason": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": true,
+        "in_database_name": "reason",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "reason",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "fields": {
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "reason": {
+                    "analyzer": "standard",
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "release_channel": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "release_channel",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "release_channel",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "signature": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": true,
+        "in_database_name": "signature",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "signature",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "fields": {
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "startedDateTime": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "startedDateTime",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "startedDateTime",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+            "type": "date"
+        }
+    },
+    "startup_time": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "StartupTime",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "startup_time",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "success": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "success",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "success",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "system_memory_use_percentage": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "SystemMemoryUsePercentage",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "system_memory_use_percentage",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "theme": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Theme",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "theme",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "throttle_rate": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "throttle_rate",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "throttle_rate",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "throttleable": {
+        "data_validation_type": "bool",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "BooleanField",
+        "has_full_version": false,
+        "in_database_name": "Throttleable",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "throttleable",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "bool",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "timestamp": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "timestamp",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "timestamp",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "double"
+        }
+    },
+    "topmost_filenames": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "topmost_filenames",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "topmost_filenames",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "total_virtual_memory": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "TotalVirtualMemory",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "total_virtual_memory",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "truncated": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "truncated",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "truncated",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "boolean"
+        }
+    },
+    "uptime": {
+        "data_validation_type": "int",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "IntegerField",
+        "has_full_version": false,
+        "in_database_name": "uptime",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "uptime",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "number",
+        "storage_mapping": {
+            "type": "long"
+        }
+    },
+    "url": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": false,
+        "in_database_name": "url",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "url",
+        "namespace": "processed_crash",
+        "permissions_needed": [
+            "crashstats.view_pii"
+        ],
+        "query_type": "string",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "user_comments": {
+        "data_validation_type": "str",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "StringField",
+        "has_full_version": true,
+        "in_database_name": "user_comments",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "user_comments",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {
+            "fields": {
+                "full": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "user_comments": {
+                    "type": "string"
+                }
+            },
+            "type": "multi_field"
+        }
+    },
+    "useragent_locale": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "useragent_locale",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "useragent_locale",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "uuid": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": null,
+        "has_full_version": false,
+        "in_database_name": "uuid",
+        "is_exposed": false,
+        "is_mandatory": false,
+        "is_returned": false,
+        "name": "uuid",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "index": "not_analyzed",
+            "type": "string"
+        }
+    },
+    "vendor": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Vendor",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "vendor",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    },
+    "version": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "version",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "version",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "analyzer": "keyword",
+            "type": "string"
+        }
+    },
+    "winsock_lsp": {
+        "data_validation_type": "enum",
+        "default_value": null,
+        "form_field_choices": null,
+        "form_field_type": "MultipleValueField",
+        "has_full_version": false,
+        "in_database_name": "Winsock_LSP",
+        "is_exposed": true,
+        "is_mandatory": false,
+        "is_returned": true,
+        "name": "winsock_lsp",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {
+            "type": "string"
+        }
+    }
+}

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -69,86 +69,7 @@ class SearchFilter(object):
 
 
 class SearchBase(object):
-    filters = [
-        # Processed crash keys.
-        SearchFilter('address', data_type='str'),
-        SearchFilter('app_notes'),
-        SearchFilter('build_id', data_type='int'),
-        SearchFilter('cpu_info', data_type='str'),
-        SearchFilter('cpu_name'),
-        SearchFilter('date', data_type='datetime'),
-        SearchFilter('distributor'),
-        SearchFilter('distributor_version'),
-        SearchFilter('dump', data_type='str'),
-        SearchFilter('email', data_type='str'),
-        SearchFilter('exploitability'),
-        SearchFilter('flash_version'),
-        SearchFilter('hang_type'),
-        SearchFilter('install_age', data_type='int'),
-        SearchFilter('java_stack_trace'),
-        SearchFilter('last_crash', data_type='int'),
-        SearchFilter('platform'),
-        SearchFilter('platform_version', data_type='str'),
-        SearchFilter('plugin_filename', data_type='str'),
-        SearchFilter('plugin_name', data_type='str'),
-        SearchFilter('plugin_version'),
-        SearchFilter('processor_notes'),
-        SearchFilter('process_type'),
-        SearchFilter('product'),
-        SearchFilter('productid'),
-        SearchFilter('reason', data_type='str'),
-        SearchFilter('release_channel'),
-        SearchFilter('signature', data_type='str'),
-        SearchFilter('topmost_filenames'),
-        SearchFilter('uptime', data_type='int'),
-        SearchFilter('url', data_type='str'),
-        SearchFilter('user_comments', data_type='str'),
-        SearchFilter('version'),
-        SearchFilter('winsock_lsp'),
-        # Raw crash keys.
-        SearchFilter('accessibility', data_type='bool'),
-        SearchFilter('additional_minidumps'),
-        SearchFilter('adapter_device_id'),
-        SearchFilter('adapter_vendor_id'),
-        SearchFilter('android_board'),
-        SearchFilter('android_brand'),
-        SearchFilter('android_cpu_abi'),
-        SearchFilter('android_cpu_abi2'),
-        SearchFilter('android_device'),
-        SearchFilter('android_display'),
-        SearchFilter('android_fingerprint'),
-        SearchFilter('android_hardware'),
-        SearchFilter('android_manufacturer'),
-        SearchFilter('android_model', data_type='str'),
-        SearchFilter('android_version'),
-        SearchFilter('async_shutdown_timeout'),
-        SearchFilter('available_page_file', data_type='int'),
-        SearchFilter('available_physical_memory', data_type='int'),
-        SearchFilter('available_virtual_memory', data_type='int'),
-        SearchFilter('b2g_os_version'),
-        SearchFilter('bios_manufacturer'),
-        SearchFilter('cpu_usage_flash_process1', data_type='int'),
-        SearchFilter('cpu_usage_flash_process2', data_type='int'),
-        SearchFilter('dom_ipc_enabled', data_type='bool'),
-        SearchFilter('em_check_compatibility', data_type='bool'),
-        SearchFilter('frame_poison_base'),
-        SearchFilter('frame_poison_size', data_type='int'),
-        SearchFilter('is_garbage_collecting', data_type='bool'),
-        SearchFilter('min_arm_version'),
-        SearchFilter('number_of_processors', data_type='int'),
-        SearchFilter('oom_allocation_size', data_type='int'),
-        SearchFilter('plugin_cpu_usage', data_type='int'),
-        SearchFilter('plugin_hang'),
-        SearchFilter('plugin_hang_ui_duration', data_type='int'),
-        SearchFilter('startup_time', data_type='int'),
-        SearchFilter('system_memory_use_percentage', data_type='int'),
-        SearchFilter('theme'),
-        SearchFilter('throttleable', data_type='bool'),
-        SearchFilter('throttle_rate', data_type='int'),
-        SearchFilter('total_virtual_memory', data_type='int'),
-        SearchFilter('useragent_locale'),
-        SearchFilter('vendor'),
-        # Meta parameters.
+    meta_filters = [
         SearchFilter('_facets', default='signature'),
         SearchFilter('_results_number', data_type='int', default=100),
         SearchFilter('_results_offset', data_type='int', default=0),
@@ -163,6 +84,23 @@ class SearchBase(object):
             # old middleware
             context = self.context
         self.config = context
+
+        fields = kwargs.get('fields')
+        if fields:
+            self.build_filters(fields)
+
+    def build_filters(self, fields):
+        self.filters = []
+        for field in fields.values():
+            self.filters.append(SearchFilter(
+                field['name'],
+                default=field['default_value'],
+                data_type=field['data_validation_type'],
+                mandatory=field['is_mandatory'],
+            ))
+
+        # Add meta parameters.
+        self.filters.extend(self.meta_filters)
 
     def get_parameters(self, **kwargs):
         parameters = {}

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -56,6 +56,7 @@ SERVICES_LIST = (
     (r'/signatureurls/(.*)', 'signature_urls.SignatureURLs'),
     (r'/signaturesummary/(.*)', 'signature_summary.SignatureSummary'),
     (r'/search/(signatures|crashes)/(.*)', 'search.Search'),
+    (r'/supersearch/(field|fields)/(.*)', 'supersearch.SuperSearch'),
     (r'/supersearch/(.*)', 'supersearch.SuperSearch'),
     (r'/server_status/(.*)', 'server_status.ServerStatus'),
     (r'/report/(list)/(.*)', 'report.Report'),

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -15,6 +15,90 @@ from socorro.lib.search_common import (
 from socorro.unittest.testbase import TestCase
 
 
+SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
+    'signature': {
+        'name': 'signature',
+        'data_validation_type': 'str',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'product': {
+        'name': 'product',
+        'data_validation_type': 'enum',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'version': {
+        'name': 'version',
+        'data_validation_type': 'enum',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'date': {
+        'name': 'date',
+        'data_validation_type': 'datetime',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'build_id': {
+        'name': 'build_id',
+        'data_validation_type': 'int',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'process_type': {
+        'name': 'process_type',
+        'data_validation_type': 'enum',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'hang_type': {
+        'name': 'hang_type',
+        'data_validation_type': 'enum',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'user_comments': {
+        'name': 'user_comments',
+        'data_validation_type': 'str',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+}
+
+
 def _get_config_manager():
     required_config = Namespace()
 
@@ -39,7 +123,10 @@ class TestSearchBase(TestCase):
 
     def test_get_parameters(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         args = {
             'signature': 'mysig',
@@ -89,7 +176,10 @@ class TestSearchBase(TestCase):
 
     def test_get_parameters_with_not(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         args = {
             'signature': '!~mysig',
@@ -113,7 +203,10 @@ class TestSearchBase(TestCase):
 
     def test_get_parameters_date_defaults(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         now = datetimeutil.utc_now()
 
@@ -168,7 +261,10 @@ class TestSearchBase(TestCase):
 
     def test_get_parameters_date_max_range(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         assert_raises(
             BadArgumentError,
@@ -178,7 +274,10 @@ class TestSearchBase(TestCase):
 
     def test_process_type_parameter_correction(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         args = {
             'process_type': 'browser'
@@ -192,7 +291,10 @@ class TestSearchBase(TestCase):
 
     def test_hang_type_parameter_correction(self):
         with _get_config_manager().context() as config:
-            search = SearchBase(config=config)
+            search = SearchBase(
+                config=config,
+                fields=SUPERSEARCH_FIELDS_MOCKED_RESULTS,
+            )
 
         args = {
             'hang_type': 'hang'
@@ -281,8 +383,12 @@ class TestSearchCommon(TestCase):
             if i in ("from_date", "to_date", "build_from", "build_to"):
                 ok_(typei is datetime.datetime)
             else:
-                ok_(not params[i] or typei is int or typei is str
-                                or typei is list)
+                ok_(
+                    not params[i] or
+                    typei is int or
+                    typei is str or
+                    typei is list
+                )
 
         # Empty params
         params = get_parameters({
@@ -310,8 +416,12 @@ class TestSearchCommon(TestCase):
             if i in ("from_date", "to_date", "build_from", "build_to"):
                 ok_(typei is datetime.datetime)
             else:
-                ok_(not params[i] or typei is int or typei is str
-                                or typei is list)
+                ok_(
+                    not params[i] or
+                    typei is int or
+                    typei is str or
+                    typei is list
+                )
 
         # Test with encoded slashes in terms and signature
         params = get_parameters({

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -12,7 +12,10 @@ from waffle import Switch
 from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats.tests.test_views import (
     BaseTestViews,
-    Response
+    Response,
+)
+from crashstats.supersearch.tests.test_views import (
+    SUPERSEARCH_FIELDS_MOCKED_RESULTS
 )
 from crashstats.tokens.models import Token
 
@@ -46,7 +49,14 @@ class TestDocumentationViews(BaseTestViews):
     def tearDownClass():
         TestDocumentationViews.switch.delete()
 
-    def test_documentation_home_page(self):
+    @mock.patch('requests.get')
+    def test_documentation_home_page(self, rget):
+        def mocked_get(url, params, **options):
+            if '/supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+        rget.side_effect = mocked_get
+
         url = reverse('api:documentation')
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -1862,6 +1872,9 @@ class TestViews(BaseTestViews):
     def test_SuperSearch(self, rget):
 
         def mocked_get(url, params, **options):
+            if '/supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
             if '/supersearch' in url:
                 ok_('exploitability' not in params)
                 return Response({
@@ -1910,6 +1923,9 @@ class TestViews(BaseTestViews):
     def test_SuperSearchUnredacted(self, rget):
 
         def mocked_get(url, params, **options):
+            if '/supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
             if '/supersearch' in url:
                 ok_('exploitability' in params)
                 return Response({

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -365,7 +365,7 @@ class SocorroMiddleware(SocorroCommon):
         """
         params = {}
 
-        for param in self.__class__.get_annotated_params():
+        for param in self.get_annotated_params():
             name = param['name']
             if param['required'] and not kwargs.get(name):
                 raise RequiredParameterError(name)
@@ -404,8 +404,7 @@ class SocorroMiddleware(SocorroCommon):
             params[name] = value
         return params
 
-    @classmethod
-    def get_annotated_params(cls):
+    def get_annotated_params(self):
         """return an iterator. One dict for each parameter that the
         class takes.
         Each dict must have the following keys:
@@ -413,8 +412,8 @@ class SocorroMiddleware(SocorroCommon):
             * type
             * required
         """
-        for required, items in ((True, getattr(cls, 'required_params', [])),
-                                (False, getattr(cls, 'possible_params', []))):
+        for required, items in ((True, getattr(self, 'required_params', [])),
+                                (False, getattr(self, 'possible_params', []))):
             for item in items:
                 if isinstance(item, basestring):
                     type_ = basestring

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -230,16 +230,6 @@ PLUGIN_FIELDS = (
     'name',
 )
 
-# exploitability values to allow in queries
-EXPLOITABILITY_VALUES = (
-    'high',
-    'normal',
-    'low',
-    'none',
-    'unknown',
-    'error',
-)
-
 # the number of result filter on tcbs
 TCBS_RESULT_COUNTS = (
     '50',

--- a/webapp-django/crashstats/supersearch/tests/test_forms.py
+++ b/webapp-django/crashstats/supersearch/tests/test_forms.py
@@ -2,12 +2,15 @@ from nose.tools import ok_
 
 from crashstats.base.tests.testbase import TestCase
 from crashstats.supersearch import forms
+from crashstats.supersearch.tests.test_views import (
+    SUPERSEARCH_FIELDS_MOCKED_RESULTS
+)
 
 
 class TestForms(TestCase):
 
     def setUp(self):
-        # Mocking models needed for form validation
+        # Mocking models needed for form validation.
         self.current_products = {
             'WaterWolf': [],
             'NightTrain': [],
@@ -49,16 +52,25 @@ class TestForms(TestCase):
                 'name': 'Linux'
             }
         ]
+        self.all_fields = SUPERSEARCH_FIELDS_MOCKED_RESULTS
 
     def test_search_form(self):
 
         def get_new_form(data):
+
+            class User(object):
+                def has_perm(self, permission):
+                    return {
+                        'crashstats.view_pii': False,
+                        'crashstats.view_exploitability': False,
+                    }.get(permission, False)
+
             return forms.SearchForm(
+                self.all_fields,
                 self.current_products,
                 self.current_versions,
                 self.current_platforms,
-                False,
-                False,
+                User(),
                 data
             )
 
@@ -96,12 +108,20 @@ class TestForms(TestCase):
     def test_search_form_with_admin_mode(self):
 
         def get_new_form(data):
+
+            class User(object):
+                def has_perm(self, permission):
+                    return {
+                        'crashstats.view_pii': True,
+                        'crashstats.view_exploitability': True,
+                    }.get(permission, False)
+
             return forms.SearchForm(
+                self.all_fields,
                 self.current_products,
                 self.current_versions,
                 self.current_platforms,
-                True,
-                True,
+                User(),
                 data
             )
 

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -13,6 +13,180 @@ from crashstats.crashstats.tests.test_views import BaseTestViews, Response
 from crashstats.supersearch.views import get_report_list_parameters
 
 
+SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
+    'signature': {
+        'name': 'signature',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'StringField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'product': {
+        'name': 'product',
+        'query_type': 'enum',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'version': {
+        'name': 'version',
+        'query_type': 'enum',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'platform': {
+        'name': 'platform',
+        'query_type': 'enum',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'dump': {
+        'name': 'dump',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': False,
+        'is_mandatory': False,
+    },
+    'release_channel': {
+        'name': 'release_channel',
+        'query_type': 'enum',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'date': {
+        'name': 'date',
+        'query_type': 'datetime',
+        'namespace': 'processed_crash',
+        'form_field_type': 'DateTimeField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'address': {
+        'name': 'address',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'StringField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'build_id': {
+        'name': 'build_id',
+        'query_type': 'int',
+        'namespace': 'processed_crash',
+        'form_field_type': 'IntegerField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'reason': {
+        'name': 'reason',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'StringField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'java_stack_trace': {
+        'name': 'java_stack_trace',
+        'query_type': 'enum',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': None,
+        'permissions_needed': [],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'email': {
+        'name': 'email',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'StringField',
+        'form_field_choices': None,
+        'permissions_needed': ['crashstats.view_pii'],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'url': {
+        'name': 'url',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'StringField',
+        'form_field_choices': None,
+        'permissions_needed': ['crashstats.view_pii'],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+    'exploitability': {
+        'name': 'exploitability',
+        'query_type': 'str',
+        'namespace': 'processed_crash',
+        'form_field_type': 'MultipleValueField',
+        'form_field_choices': [
+            'high', 'normal', 'low', 'none', 'unknown', 'error'
+        ],
+        'permissions_needed': ['crashstats.view_exploitability'],
+        'default_value': None,
+        'is_exposed': True,
+        'is_returned': True,
+        'is_mandatory': False,
+    },
+}
+
+
 class TestViews(BaseTestViews):
 
     @staticmethod
@@ -73,6 +247,15 @@ class TestViews(BaseTestViews):
 
     @mock.patch('requests.get')
     def test_search(self, rget):
+
+        def mocked_get(url, params, **options):
+            assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+        rget.side_effect = mocked_get
+
         self._login()
         url = reverse('supersearch.search')
         response = self.client.get(url)
@@ -81,6 +264,15 @@ class TestViews(BaseTestViews):
 
     @mock.patch('requests.get')
     def test_search_fields(self, rget):
+
+        def mocked_get(url, params, **options):
+            assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+        rget.side_effect = mocked_get
+
         self._login()
         url = reverse('supersearch.search_fields')
         response = self.client.get(url)
@@ -93,8 +285,8 @@ class TestViews(BaseTestViews):
     @mock.patch('requests.post')
     @mock.patch('requests.get')
     def test_search_results(self, rget, rpost):
-        def mocked_post(**options):
-            assert 'bugs' in options['url'], options['url']
+        def mocked_post(url, **options):
+            assert 'bugs' in url, url
             return Response({
                 "hits": [
                     {
@@ -107,6 +299,9 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, params, **options):
             assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
 
             if 'product' in params and 'WaterWolf' in params['product']:
                 return Response({
@@ -318,6 +513,10 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, params, **options):
             assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
             if '_facets' in params and 'url' in params['_facets']:
                 facets = {
                     "platform": [
@@ -462,6 +661,9 @@ class TestViews(BaseTestViews):
         def mocked_get(url, params, **options):
             assert 'supersearch' in url
 
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
             # Verify that all expected parameters are in the URL.
             ok_('product' in params)
             ok_('WaterWolf' in params['product'])
@@ -512,6 +714,9 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, params, **options):
             assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
 
             # Make sure a negative page does not lead to negative offset value.
             # But instead it is considered as the page 1 and thus is not added.
@@ -610,6 +815,17 @@ class TestViews(BaseTestViews):
 
     @mock.patch('requests.get')
     def test_search_custom_permission(self, rget):
+
+        def mocked_get(url, params, **options):
+            assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+            return Response()
+
+        rget.side_effect = mocked_get
+
         url = reverse('supersearch.search_custom')
 
         response = self.client.get(url)
@@ -623,6 +839,17 @@ class TestViews(BaseTestViews):
 
     @mock.patch('requests.get')
     def test_search_custom(self, rget):
+
+        def mocked_get(url, params, **options):
+            assert 'supersearch' in url
+
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+            return Response()
+
+        rget.side_effect = mocked_get
+
         self.create_custom_query_perm()
 
         url = reverse('supersearch.search_custom')
@@ -635,6 +862,9 @@ class TestViews(BaseTestViews):
         self.create_custom_query_perm()
 
         def mocked_get(url, params, **options):
+            if '/supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
             if '/supersearch' in url:
                 ok_('_return_query' in params)
                 ok_('signature' in params)
@@ -657,9 +887,16 @@ class TestViews(BaseTestViews):
         ok_('socorro200000' in response.content)
         ok_('socorro200001' in response.content)
 
+    @mock.patch('requests.get')
     @mock.patch('requests.post')
-    def test_search_query(self, rpost):
+    def test_search_query(self, rget, rpost):
         self.create_custom_query_perm()
+
+        def mocked_get(url, params, **options):
+            if 'supersearch/fields' in url:
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
+
+            return Response('{"hits": []}')
 
         def mocked_post(url, data, **options):
             ok_('/query' in url)
@@ -668,6 +905,7 @@ class TestViews(BaseTestViews):
 
             return Response({"hits": []})
 
+        rget.side_effect = mocked_get
         rpost.side_effect = mocked_post
 
         url = reverse('supersearch.search_query')


### PR DESCRIPTION
@peterbe r?

Here is the code I used to generate the JSON list of fields: https://gist.github.com/AdrianGaudebert/e640d570d7965d2f1a28 -- I edited a few things afterwards, permissions and choices. I don't think you need to bother reading it. 

This is only the first step, see the tracker bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1013306

There are a few things I am concerned about in this PR: 
- caching of the `/supersearch/fields/` service, as it should not change much. However, I would like to be able to clear the cache, because in the near future superusers will be able to modify that list at any time ;
- our models assumed that `possible_params` and `required_params` were static, which I changed because I need to generate those lists dynamically for the SuperSearch model. I'd like you to pay special attention to this change ;
- I am unsure about performances while adding that many calls to the middleware, just to create the SuperSearch model. 
