### PR TITLE
Fixes Bug 1007530 - OOM signature manipulations

### DIFF
--- a/socorro/processor/processed_transform_rules.py
+++ b/socorro/processor/processed_transform_rules.py
@@ -1,0 +1,198 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+""""
+these are the rules that transform a raw crash into a processed crash
+"""
+
+from socorro.lib.ver_tools import normalize
+from socorro.lib.util import DotDict
+
+from sys import maxint
+
+
+#==============================================================================
+class ProcessedTransformRule(object):
+    """the base class for Support Rules.  It provides the framework for the
+    rules 'predicate', 'action', and 'version' as well as utilites to help
+    rules do their jobs."""
+
+    #--------------------------------------------------------------------------
+    def predicate(self, raw_crash, processed_crash, processor):
+        """the default predicate for processed_transform invokes any derivied
+        _predicate function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity act.  An error during the predicate application is a
+        failure of the rule, not a failure of the classification system itself
+        """
+        try:
+            return self._predicate(raw_crash, processed_crash, processor)
+        except Exception, x:
+            processor.config.logger.debug(
+                'processed_transform: %s predicate rejection - consideration '
+                'of %s failed because of "%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+                exc_info=True
+            )
+            return False
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash, processed_crash, processor):
+        """"The default processed_transform predicate just returns True.  We
+        want all the processed_transform rules to run.
+
+        parameters:
+            raw_crash - a mapping representing the raw crash data originally
+                        submitted by the client
+            processed_crash - the ultimate result of the processor, this is the
+                              analyzed version of a crash.  It contains the
+                              output of the MDSW program for each of the dumps
+                              within the crash.
+            processor - a reference to the processor object that is assigned
+                        to working on the current crash. This object contains
+                        resources that might be useful to a classifier rule.
+                        'processor.config' is the configuration for the
+                        processor in which database connection paramaters can
+                        be found.  'processor.config.logger' is useful for any
+                        logging of debug information.
+                        'processor.c_signature_tool' or
+                        'processor.java_signature_tool' contain utilities that
+                        might be useful during classification.
+
+        returns:
+            True - this rule should be applied
+            False - this rule should not be applied
+        """
+        return True
+
+    #--------------------------------------------------------------------------
+    def action(self, raw_crash, processed_crash, processor):
+        """the default action for processed_transform  invokes any derivied
+        _action function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity act and perhaps (mitigate the error).  An error during the
+        action application is a failure of the rule, not a failure of the
+        classification system itself."""
+        try:
+            return self._action(raw_crash, processed_crash, processor)
+        except KeyError, x:
+            processor.config.logger.debug(
+                'processed_transform: %s action failure - %s failed because of '
+                '"%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+            )
+        except Exception, x:
+            processor.config.logger.debug(
+                'processed_transform: %s action failure - %s failed because of '
+                '"%s"',
+                self.__class__,
+                raw_crash.get('uuid', 'unknown uuid'),
+                x,
+                exc_info=True
+            )
+        return False
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash, processed_crash, processor):
+        """Rules derived from this base class ought to override this method
+        with an actual classification rule.  Successful application of this
+        method should include a call to '_add_classification'.
+
+        parameters:
+            raw_crash - a mapping representing the raw crash data originally
+                        submitted by the client
+            processed_crash - the ultimate result of the processor, this is the
+                              analized version of a crash.  It contains the
+                              output of the MDSW program for each of the dumps
+                              within the crash.
+            processor - a reference to the processor object that is assigned
+                        to working on the current crash. This object contains
+                        resources that might be useful to a classifier rule.
+                        'processor.config' is the configuration for the
+                        processor in which database connection paramaters can
+                        be found.  'processor.config.logger' is useful for any
+                        logging of debug information.
+                        'processor.c_signature_tool' or
+                        'processor.java_signature_tool' contain utilities that
+                        might be useful during classification.
+
+        returns:
+            True - this rule was applied successfully and no further rules
+                   should be applied
+            False - this rule did not succeed and further rules should be
+                    tried
+        """
+        return True
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        """This method should be overridden in a base class."""
+        return '0.0'
+
+
+#==============================================================================
+class OOMSignature(ProcessedTransformRule):
+    """To satisfy Bug 1007530, this rule will modify the signature to
+    tag OOM (out of memory) crashes"""
+
+    signature_fragments = (
+        'NS_ABORT_OOM',
+        'mozalloc_handle_oom',
+        'CrashAtUnhandlableOOM'
+    )
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '1.0'
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash, processed_crash, processor):
+        if 'OOMAllocationSize' in raw_crash:
+            return True
+        signature = processed_crash.signature
+        for a_signature_fragment in self.signature_fragments:
+            if a_signature_fragment in signature:
+                return True
+        return False
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash, processed_crash, processor):
+        processed_crash.original_signature = processed_crash.signature
+        try:
+            size = int(raw_crash.OOMAllocationSize)
+        except (TypeError, AttributeError, KeyError):
+            processed_crash.signature = (
+                "OOM | unknown | " + processed_crash.signature
+            )
+            return True
+
+        if size <= 262144:  # 256K
+            processed_crash.signature = "OOM | small"
+        else:
+            processed_crash.signature = (
+                "OOM | large | " + processed_crash.signature
+            )
+        return True
+
+
+
+#------------------------------------------------------------------------------
+# the following tuple of tuples is a structure for loading rules into the
+# TransformRules system. The tuples take the form:
+#   predicate_function, predicate_args, predicate_kwargs,
+#   action_function, action_args, action_kwargs.
+#
+# The args and kwargs components are additional information that a predicate
+# or an action might need to have to do its job.  Providing values for args
+# or kwargs essentially acts in a manner similar to functools.partial.
+# When the predicate or action functions are invoked, these args and kwags
+# values will be passed into the function along with the raw_crash,
+# processed_crash and processor objects.
+default_support_classifier_rules = (
+    (OOMSignature, (), {}, OOMSignature, (), {}),
+)

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -255,7 +255,7 @@ class TestHybridProcessor(TestCase):
               leg_proc.mdsw_command_line,
               '/bin/mdsw -m DUMPFILEPATHNAME "/a/a" "/b/b" "/c/c" 2>/dev/null'
             )
-            eq_(m_transform.call_count, 3)
+            eq_(m_transform.call_count, 4)
 
     def test_convert_raw_crash_to_processed_crash_basic(self):
         config = setup_config_with_mocks()
@@ -313,7 +313,7 @@ class TestHybridProcessor(TestCase):
                 eq_(1, leg_proc._log_job_start.call_count)
                 leg_proc._log_job_start.assert_called_with(raw_crash.uuid)
 
-                eq_(1, m_transform.apply_all_rules.call_count)
+                eq_(2, m_transform.apply_all_rules.call_count)
                 m_transform.apply_all_rules.has_calls(
                     mock.call(raw_crash, leg_proc),
                 )

--- a/socorro/unittest/processor/test_processed_transform_rules.py
+++ b/socorro/unittest/processor/test_processed_transform_rules.py
@@ -1,0 +1,162 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import copy
+
+from nose.tools import eq_, ok_
+
+from sys import maxint
+
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.processor.processed_transform_rules import (
+    ProcessedTransformRule,
+    OOMSignature
+)
+
+from socorro.processor.signature_utilities import CSignatureTool
+from socorro.unittest.processor.test_breakpad_pipe_to_json import (
+    cannonical_json_dump,
+)
+from socorro.unittest.testbase import TestCase
+
+csig_config = DotDict()
+csig_config.irrelevant_signature_re = ''
+csig_config.prefix_signature_re = ''
+csig_config.signatures_with_line_numbers_re = ''
+csig_config.signature_sentinels = []
+c_signature_tool = CSignatureTool(csig_config)
+
+
+def create_basic_fake_processor():
+    fake_processor = DotDict()
+    fake_processor.c_signature_tool = c_signature_tool
+    fake_processor.config = DotDict()
+    # need help figuring out failures? switch to FakeLogger and read stdout
+    fake_processor.config.logger = SilentFakeLogger()
+    #fake_processor.config.logger = FakeLogger()
+    return fake_processor
+
+
+class TestProcessedTransformRule(TestCase):
+
+    def test_predicate(self):
+        rc = DotDict()
+        pc = DotDict()
+        processor = None
+
+        rule = ProcessedTransformRule()
+        ok_(rule.predicate(rc, pc, processor))
+
+    def test_action(self):
+        rc = DotDict()
+        pc = DotDict()
+        processor = None
+
+        support_rule = ProcessedTransformRule()
+        ok_(support_rule.action(rc, pc, processor))
+
+    def test_version(self):
+        support_rule = ProcessedTransformRule()
+        eq_(support_rule.version(), '0.0')
+
+
+class TestOOMSignature(TestCase):
+
+    def test_predicate_no_match(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+        rc = DotDict()
+        fake_processor = create_basic_fake_processor()
+        rule = OOMSignature()
+        predicate_result = rule.predicate(rc, pc, fake_processor)
+        ok_(not predicate_result)
+
+    def test_predicate_OOMAllocationSize(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+        rc = DotDict()
+        rc.OOMAllocationSize = 17
+        fake_processor = create_basic_fake_processor()
+        rule = OOMSignature()
+        predicate_result = rule.predicate(rc, pc, fake_processor)
+        ok_(predicate_result)
+
+    def test_predicate_signature_fragment_1(self):
+        pc = DotDict()
+        pc.signature = 'this | is | a | NS_ABORT_OOM | signature'
+        rc = DotDict()
+        fake_processor = create_basic_fake_processor()
+        rule = OOMSignature()
+        predicate_result = rule.predicate(rc, pc, fake_processor)
+        ok_(predicate_result)
+
+    def test_predicate_signature_fragment_2(self):
+        pc = DotDict()
+        pc.signature = 'mozalloc_handle_oom | this | is | bad'
+        rc = DotDict()
+        fake_processor = create_basic_fake_processor()
+        rule = OOMSignature()
+        predicate_result = rule.predicate(rc, pc, fake_processor)
+        ok_(predicate_result)
+
+    def test_predicate_signature_fragment_3(self):
+        pc = DotDict()
+        pc.signature = 'CrashAtUnhandlableOOM'
+        rc = DotDict()
+        fake_processor = create_basic_fake_processor()
+        rule = OOMSignature()
+        predicate_result = rule.predicate(rc, pc, fake_processor)
+        ok_(predicate_result)
+
+    def test_action_success(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+
+        rule = OOMSignature()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        ok_(action_result)
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | unknown | hello')
+
+    def test_action_small(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+        rc.OOMAllocationSize = 17
+
+        rule = OOMSignature()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        ok_(action_result)
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | small')
+
+    def test_action_large(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+
+        fake_processor = create_basic_fake_processor()
+
+        rc = DotDict()
+        rc.OOMAllocationSize = 17000000
+
+        rule = OOMSignature()
+        action_result = rule.action(rc, pc, fake_processor)
+
+        ok_(action_result)
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | large | hello')
+
+
+
+
+


### PR DESCRIPTION
added processed crash transform rule (predicate):
- The OOMAllocationSize annotation is present
- The signature contains NS_ABORT_OOM, mozalloc_handle_oom, CrashAtUnhandlableOOM

added processed crash transform rule (action):

```
If the OOMAllocationSize annotation is present:
    If the value is 256k or smaller (262144):
        The signature should be "OOM | Small"
    If the value is larger than 256k:
        The signature should be "OOM | Large | <C++Signature>"
Else:
    The signature should be "OOM | Unknown | <C++Signature>"
```

the original unmodified signature is available as `processed_crash.original_signature` _iff_ the predicate succeeded.
