### PR TITLE
(fixup) README edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Socorro
+-------
+
 A server for collecting, processing, and displaying crash reports from
 clients using the [Breakpad libraries](http://code.google.com/p/google-breakpad/)
 


### PR DESCRIPTION
renames the README so that it is rendered as Markdown, add some formatting to render line 1 as a header.
