### PR TITLE
Bug 1020397 - Update forced versions for correlations for Firefox cycle starting 2014-06-10

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="30.0 31.0a2 32.0a1"
+MANUAL_VERSION_OVERRIDE="31.0 32.0a2 33.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 1020397 - it should go to production the week of June 9 (not before!).
