### PR TITLE
bug 1014799 - work around crontabber unit test fail

### DIFF
--- a/docs/installation/install-src.rst
+++ b/docs/installation/install-src.rst
@@ -40,7 +40,7 @@ Run unit/functional tests
 
 From inside the Socorro checkout
 ::
-  make test test-webapp
+  make test test-webapp database_username=test database_password=aPassword
 
 
 Install stackwalker


### PR DESCRIPTION
I am getting a lot of questions about the unit tests being busted due to bug 1014799 - it's been like this for a few weeks now, if a fix is not imminent then let's provide a workaround in the docs for the time being.
