### PR TITLE
package socorro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,55 @@
+import codecs
+import os
+from setuptools import setup, find_packages
+
+
+# Prevent spurious errors during `python setup.py test`, a la
+# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
+try:
+    import multiprocessing
+except ImportError:
+    pass
+
+
+def read(fname):
+    fpath = os.path.join(os.path.dirname(__file__), fname)
+    with codecs.open(fpath, 'r', 'utf8') as f:
+        return f.read().strip()
+
+
+def find_install_requires():
+    return [x.strip() for x in
+            read('requirements.txt').splitlines()
+            if x.strip() and not x.startswith('#')]
+
+
+setup(
+    name='socorro',
+    version='88',
+    description=('Socorro is a server to accept and process Breakpad'
+                 ' crash reports.'),
+    long_description=open('README.md').read(),
+    author='Mozilla',
+    author_email='socorro-dev@mozilla.com',
+    license='MPL',
+    url='https://github.com/mozilla/socorro',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: MPL License',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
+        ],
+    keywords=['socorro', 'breakpad', 'crash', 'reporting', 'minidump',
+              'stacktrace'],
+    packages=find_packages(),
+    install_requires=find_install_requires(),
+    entry_points={
+        'console_scripts': [
+            'socorro-setupdb = socorro.external.postgresql.setupdb_app:main'
+            ],
+        },
+    test_suite='nose.collector',
+    zip_safe=False,
+),

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.schema import CreateTable
 
-from socorro.app.generic_app import App, main
+from socorro.app.generic_app import App, main as configman_main
 from socorro.external.postgresql import fakedata
 from socorro.external.postgresql.models import *
 
@@ -618,5 +618,8 @@ class SocorroDB(App):
 
         return 0
 
+def main():
+    return configman_main(SocorroDB)
+
 if __name__ == "__main__":
-    sys.exit(main(SocorroDB))
+    sys.exit(main())


### PR DESCRIPTION
Why not have a setup.py for Socorro?

This installs into your virtualenv (or wherever) and puts a working "socorro-setupdb" on your $PATH.
