### PR TITLE
fix error about duplicate table in update_reports_clean (PL/pgSQL)

### DIFF
--- a/socorro/external/postgresql/raw_sql/procs/001_update_reports_clean.sql
+++ b/socorro/external/postgresql/raw_sql/procs/001_update_reports_clean.sql
@@ -79,6 +79,7 @@ LIMIT 1;
 IF NOT FOUND THEN
     IF checkdata THEN
         RAISE NOTICE 'no report data found for period %',fromtime;
+        DROP TABLE new_reports;
         RETURN FALSE;
     ELSE
         DROP TABLE new_reports;


### PR DESCRIPTION
'relation "new_reports" already exists' (in recursed code path)
