### PR TITLE
deploy: Ensure that cron file doesn't have +x.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -198,7 +198,12 @@ error $? "could not run crontabber `cat /var/log/socorro/crontabber.log`"
 popd > /dev/null
 
 if [ ! -f /etc/cron.d/socorro ]; then
-    cp /data/socorro/application/config/crontab-dist \
+    # crond doesn't like files with executable bits, and doesn't load
+    # them.
+    chmod 644 /data/socorro/application/config/crontab-dist
+    error $? "could not modify socorro crontab permissions"
+
+    cp -a /data/socorro/application/config/crontab-dist \
         /etc/cron.d/socorro
     error $? "could not copy socorro crontab"
 fi


### PR DESCRIPTION
crond on my CentOS 6 box refuses to load files with the executable bit.
Since chmod-ing does not update the mtime (and cause a crond reload) of
the file, we chmod it before we cp.

Not sure where the +x bit came from - it's not in git - but deploy.sh
installed one with an executable bit on my system.

@rhelmer, r? 
