### PR TITLE
remove .pyc from the webapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ lint:
 	$(PYLINT) -f parseable --rcfile=pylintrc socorro > pylint.txt
 
 clean:
-	find ./socorro/ ./alembic/versions -type f -name "*.pyc" -exec rm {} \;
+	find ./socorro/ ./alembic/versions ./webapp-django -type f -name "*.pyc" -exec rm {} \;
 	rm -rf ./google-breakpad/ ./builds/ ./breakpad/ ./stackwalk ./pip-cache
 	rm -rf ./breakpad.tar.gz
 	cd minidump-stackwalk; make clean


### PR DESCRIPTION
removes .pyc files from the webapp which is safer and will help us avoid and debug future dependency change issues
