### PR TITLE
fixes Bug fixed 1027653 - repaired config setup for fetch_adi_from_hive test

### DIFF
--- a/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
+++ b/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
@@ -8,13 +8,16 @@ from nose.plugins.attrib import attr
 from nose.tools import eq_
 
 from crontabber.app import CronTabber
-from crontabber.tests.base import IntegrationTestCaseBase
+from socorro.unittest.cron.jobs.base import IntegrationTestBase
+from socorro.unittest.cron.setup_configman import (
+    get_config_manager_for_crontabber,
+)
 
 from socorro.cron.jobs import fetch_adi_from_hive
 
 
 @attr(integration='postgres')
-class TestFetchADIFromHive(IntegrationTestCaseBase):
+class TestFetchADIFromHive(IntegrationTestBase):
 
     def setUp(self):
         super(TestFetchADIFromHive, self).setUp()
@@ -49,9 +52,9 @@ class TestFetchADIFromHive(IntegrationTestCaseBase):
         super(TestFetchADIFromHive, self).tearDown()
 
     def _setup_config_manager(self):
-        _super = super(TestFetchADIFromHive, self)._setup_config_manager
-        return _super(
-            'socorro.cron.jobs.fetch_adi_from_hive.FetchADIFromHiveCronApp|1d'
+        return get_config_manager_for_crontabber(
+            jobs=
+            'socorro.cron.jobs.fetch_adi_from_hive.FetchADIFromHiveCronApp|1d',
         )
 
     def test_mocked_fetch(self):


### PR DESCRIPTION
It looks like there was a merge conflict and the wrong code was chosen as the winner of the merge. 
The config setup for crontabber tests was changed to unify it for all tests.  This test still had the old style and was therefore not picking up config info correctly.
