### PR TITLE
initscripts: Fix log & pidfile name.

### DIFF
--- a/scripts/init.d/socorro-crashmover
+++ b/scripts/init.d/socorro-crashmover
@@ -12,7 +12,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-progname=`basename $0|sed 's/^S[0-9]*//'`
+progname=socorro-crashmover
 
 # Source socorro overrides
 config=/etc/socorro/crashmover.ini

--- a/scripts/init.d/socorro-monitor
+++ b/scripts/init.d/socorro-monitor
@@ -12,7 +12,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-progname=`basename $0|sed 's/^S[0-9]*//'`
+progname=socorro-monitor
 
 # Source socorro overrides
 config=/etc/socorro/monitor.ini

--- a/scripts/init.d/socorro-processor
+++ b/scripts/init.d/socorro-processor
@@ -12,7 +12,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-progname=`basename $0|sed 's/^S[0-9]*//'`
+progname=socorro-processor
 
 # Source socorro overrides
 config=/etc/socorro/processor.ini


### PR DESCRIPTION
At startup, these would be S98socorro-_.pid and log, and if you did
'service socorro-foo start' it would just be socorro-_.pid. This unifies
it by stripping S?? prefixes.
