### PR TITLE
Make stackwalker exit(0) instead of returning

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -1057,5 +1057,5 @@ int main(int argc, char** argv)
   printf("%s\n", writer->write(root).c_str());
 
   delete writer;
-  return 0;
+  exit(0);
 }


### PR DESCRIPTION
I noticed that some crashes were failing to process in my Vagrant VM. I ran the stackwalker locally and it was taking  over 30 seconds to process, but it actually produced the output in much less time than that. It spent most of its time shutting down! I'm sure this is some quirk of the VM setup (maybe not enough memory or something), but changing stackwalker to exit(0) and skip all the on-stack destructors makes it take a lot less time in this environment (8 seconds vs. 35 in local testing). None of the destructors are actually doing anything useful, they're just closing files and freeing memory, so skipping them is safe since we're about to exit anyway.
