### PR TITLE
Make generic_app pass down an empty argv to ConfigManager so running gunicorn with arguments works

### DIFF
--- a/socorro/app/generic_app.py
+++ b/socorro/app/generic_app.py
@@ -274,6 +274,7 @@ def _do_main(
     config_manager = config_manager_cls(
       definitions,
       app_name=app_name,
+      argv_source=[],
       app_version=app_version,
       app_description=app_description,
       values_source_list=values_source_list,


### PR DESCRIPTION
I was trying to launch the middleware using gunicorn (so I could run the django webapp with manage.py runserver and get the reload-without-restarting behavior), but I wanted to force it onto port 5100 so I didn't have to change my configs from the "honcho start" configuration. Unfortunately ConfigManager will use sys.argv if you don't pass argv_source in, so it was choking like:

```
$ gunicorn -b 0.0.0.0:5200 wsgi.middleware
2014-06-27 15:55:33 [29763] [INFO] Starting gunicorn 18.0
2014-06-27 15:55:33 [29763] [INFO] Listening at: http://0.0.0.0:5200 (29763)
2014-06-27 15:55:33 [29763] [INFO] Using worker: sync
2014-06-27 15:55:33 [29768] [INFO] Booting worker with pid: 29768
/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/config_manager.py:732: UserWarning: Invalid options: web_server.ip_address, database.database_user, web_server.port, hbase.hbase_connection_pool_class, webapi.channels, hbase.number_of_retries, database.database_host
  'Invalid options: %s' % ', '.join(unmatched_keys)
2014-06-27 15:55:34 [29768] [ERROR] Exception in worker process:
Traceback (most recent call last):
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/arbiter.py", line 495, in spawn_worker
    worker.init_process()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/workers/base.py", line 106, in init_process
    self.wsgi = self.app.wsgi()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/base.py", line 114, in wsgi
    self.callable = self.load()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 62, in load
    return self.load_wsgiapp()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 49, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/util.py", line 354, in import_app
    __import__(module)
  File "/home/vagrant/src/socorro/wsgi/middleware.py", line 16, in <module>
    config_path=config_path
  File "/home/vagrant/src/socorro/socorro/app/generic_app.py", line 214, in main
    config_manager_cls
  File "/home/vagrant/src/socorro/socorro/app/generic_app.py", line 280, in _do_main
    config_pathname=config_path
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/config_manager.py", line 227, in __init__
    self._check_for_mismatches(known_keys)
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/config_manager.py", line 697, in _check_for_mismatches
    allow_mismatches
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/value_sources/for_getopt.py", line 120, in get_values
    raise NotAnOptionError(str(x))
NotAnOptionError: option -b not recognized
Traceback (most recent call last):
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/arbiter.py", line 495, in spawn_worker
    worker.init_process()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/workers/base.py", line 106, in init_process
    self.wsgi = self.app.wsgi()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/base.py", line 114, in wsgi
    self.callable = self.load()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 62, in load
    return self.load_wsgiapp()
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 49, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/gunicorn/util.py", line 354, in import_app
    __import__(module)
  File "/home/vagrant/src/socorro/wsgi/middleware.py", line 16, in <module>
    config_path=config_path
  File "/home/vagrant/src/socorro/socorro/app/generic_app.py", line 214, in main
    config_manager_cls
  File "/home/vagrant/src/socorro/socorro/app/generic_app.py", line 280, in _do_main
    config_pathname=config_path
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/config_manager.py", line 227, in __init__
    self._check_for_mismatches(known_keys)
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/config_manager.py", line 697, in _check_for_mismatches
    allow_mismatches
  File "/home/vagrant/src/socorro/socorro-virtualenv/lib/python2.6/site-packages/configman/value_sources/for_getopt.py", line 120, in get_values
    raise NotAnOptionError(str(x))
NotAnOptionError: option -b not recognized
2014-06-27 15:55:34 [29768] [INFO] Worker exiting (pid: 29768)
2014-06-27 15:55:34 [29763] [INFO] Shutting down: Master
2014-06-27 15:55:34 [29763] [INFO] Reason: Worker failed to boot.
```
