### PR TITLE
ignore E265 pep8 errors

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [pep8]
 # regarding E125, see https://github.com/jcrocholl/pep8/issues/126
-ignore=E125
+ignore=E125,E265


### PR DESCRIPTION
@twobraids @selenamarie @lonnen r?

We have so much code that looks like this:

``` python
#=================(79 chars)========
class SomeClass

    #--------------------------(75 chars---------------
    def some_method():

```

Instead of rewriting all of that or getting TONNES of pep8 errors every time I move that we ignore this rule for socorro. 
