### PR TITLE
bug 1033584 - add old correlations so middleware will not break before

### DIFF
--- a/socorro/external/http/correlations.py
+++ b/socorro/external/http/correlations.py
@@ -1,0 +1,207 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import os
+import re
+import stat
+import tempfile
+import time
+
+import requests
+
+from socorro.lib import external_common
+
+
+class DownloadError(Exception):
+    pass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+def file_age(f):
+    return int(time.time() - os.stat(f)[stat.ST_MTIME])
+
+
+COUNT_REGEX = re.compile('\((\d+) crashes\)')
+SIGNATURE_LINE_START_REGEX = re.compile('\s{2}\w')
+
+
+class Correlations(object):
+
+    def __init__(self, *args, **kwargs):
+        self.config = kwargs.get('config')
+
+    def get(self, **kwargs):
+        filters = [
+            ('report_type', None, 'str'),
+            ('product', None, 'str'),
+            ('version', None, 'str'),
+            ('platform', None, 'str'),
+            ('signature', None, 'str'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+
+        try:
+            content = self._get_content(params)
+        except NotFoundError, msg:
+            self.config.logger.info('Failed to download %s' % msg)
+            return
+
+        data = self._parse_content(
+            content,
+            params['platform'],
+            params['signature']
+        )
+        reason, count, load = data
+        return {
+            'reason': reason,
+            'count': count,
+            'load': '\n'.join(load),
+        }
+
+    def _get_content(self, params):
+        if 'http' in self.config and 'correlations' in self.config.http:
+            # new middleware!
+            base_url = self.config.http.correlations.base_url
+            save_download = self.config.http.correlations.save_download
+            save_seconds = int(self.config.http.correlations.save_seconds)
+            save_root = self.config.http.correlations.save_root
+        else:
+            # old middleware where nesting (aka namespace) was not possible
+            base_url = self.config.correlations_base_url
+            save_download = self.config.correlations_save_download
+            save_seconds = int(self.config.correlations_save_seconds)
+            save_root = self.config.correlations_save_root
+
+        date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        url_start = base_url + (
+            '%(date)s/%(date)s_%(product)s_%(version)s-%(report_type)s'
+            % dict(params, date=date.strftime('%Y%m%d'))
+        )
+        if not save_root:
+            save_root = tempfile.gettempdir()
+        save_dir = os.path.join(save_root, date.strftime('%Y%m%d'))
+        if not os.path.isdir(save_dir):
+            os.mkdir(save_dir)
+
+        tmp_filepath = os.path.join(
+            save_dir,
+            '%s.txt' % url_start.split('/')[-1]
+        )
+
+        if (
+            save_download and
+            os.path.isfile(tmp_filepath) and
+            file_age(tmp_filepath) < save_seconds
+        ):
+            content = open(tmp_filepath).read()
+        else:
+            content = self._download(url_start)
+            if save_download:
+                with open(tmp_filepath, 'w') as f:
+                    f.write(content)
+        return content
+
+    @staticmethod
+    def _download(url_start):
+        response = requests.get(url_start + '.txt', verify=False)
+        if response.status_code == 200:
+            return response.content
+        else:
+            response = requests.get(url_start + '.txt.gz', verify=False)
+            if response.status_code == 200:
+                return response.content
+            elif response.status_code == 404:
+                raise NotFoundError(url_start + '(.txt|.txt.gz)')
+            else:
+                raise DownloadError(url_start + '(.txt|.txt.gz)')
+
+    @staticmethod
+    def _parse_content(content, platform, signature):
+
+        on = False
+        reason = count = None
+        signature_found = False
+        load = []
+        this_platform = None
+        for line in content.splitlines():
+            if line and not line.startswith(' '):
+                # change of platform
+                this_platform = line
+                if this_platform == platform:
+                    on = True
+                elif on:
+                    # was on
+                    break
+            elif on:
+                try:
+                    this_signature = line.split('|')[-2].strip()
+                    if this_signature == signature:
+                        if signature_found:
+                            break
+                        signature_found = True
+                        rest = line.split('|')[-1]
+                        reason = rest.split('(')[0].strip()
+                        count = int(COUNT_REGEX.findall(rest)[0])
+                        continue
+                except IndexError:
+                    pass
+                if signature_found:
+                    if not line.strip():
+                        break
+                    else:
+                        load.append(line.strip())
+
+        return reason, count, load
+
+
+class CorrelationsSignatures(Correlations):
+
+    def __init__(self, *args, **kwargs):
+        self.config = kwargs.get('config')
+
+    def get(self, **kwargs):
+        filters = [
+            ('report_type', None, 'str'),
+            ('product', None, 'str'),
+            ('version', None, 'str'),
+            ('platforms', None, 'list'),
+        ]
+
+        params = external_common.parse_arguments(filters, kwargs)
+        try:
+            content = self._get_content(params)
+        except NotFoundError, msg:
+            self.config.logger.info('Failed to download %s' % msg)
+            return
+        signatures = self._parse_signatures(content, params['platforms'])
+
+        return {
+            'hits': signatures,
+            'total': len(signatures),
+        }
+
+    @staticmethod
+    def _parse_signatures(content, platforms):
+        """return a list of signatures that these platforms mention"""
+        signatures = []
+
+        on = False
+        for line in content.splitlines():
+            if line and not line.startswith(' '):
+                # change of platform
+                if line in platforms:
+                    on = True
+                else:
+                    on = False
+            elif on:
+                # if starts with exactly two spaces it contains the signature
+                if SIGNATURE_LINE_START_REGEX.match(line):
+                    this_signature = line.split('|')[-2].strip()
+                    signatures.append(this_signature)
+
+        return signatures

--- a/socorro/unittest/external/http/sample-core-counts.txt
+++ b/socorro/unittest/external/http/sample-core-counts.txt
@@ -1,0 +1,480 @@
+
+None
+  EMPTY: no crashing thread identified; corrupt dump (109 crashes)
+
+
+
+Linux
+  js::types::IdToTypeId(long)|SIGSEGV (11 crashes)
+      0% (0/11) vs.   4% (2/48) amd64 with 1 cores
+     73% (8/11) vs.  40% (19/48) amd64 with 2 cores
+      0% (0/11) vs.   2% (1/48) amd64 with 3 cores
+     27% (3/11) vs.  25% (12/48) amd64 with 4 cores
+      0% (0/11) vs.  13% (6/48) amd64 with 8 cores
+      0% (0/11) vs.   4% (2/48) x86 with 1 cores
+      0% (0/11) vs.  10% (5/48) x86 with 2 cores
+      0% (0/11) vs.   2% (1/48) x86 with 4 cores
+
+  js::CloneScript(JSContext*, JS::Handle<JSObject*>, JS::Handle<JSFunction*>, JS::Handle<JSScript*>, js::NewObjectKind)|SIGSEGV (10 crashes)
+      0% (0/10) vs.   4% (2/48) amd64 with 1 cores
+     70% (7/10) vs.  40% (19/48) amd64 with 2 cores
+      0% (0/10) vs.   2% (1/48) amd64 with 3 cores
+     10% (1/10) vs.  25% (12/48) amd64 with 4 cores
+     10% (1/10) vs.  13% (6/48) amd64 with 8 cores
+      0% (0/10) vs.   4% (2/48) x86 with 1 cores
+     10% (1/10) vs.  10% (5/48) x86 with 2 cores
+      0% (0/10) vs.   2% (1/48) x86 with 4 cores
+
+
+
+Mac OS X
+  js::CloneScript(JSContext*, JS::Handle<JSObject*>, JS::Handle<JSFunction*>, JS::Handle<JSScript*>, js::NewObjectKind)|EXC_BAD_ACCESS / 0x0000000d (45 crashes)
+     31% (14/45) vs.  26% (47/180) amd64 with 2 cores
+     29% (13/45) vs.  31% (55/180) amd64 with 4 cores
+     40% (18/45) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/45) vs.   2% (4/180) x86 with 4 cores
+      0% (0/45) vs.   1% (2/180) x86 with 8 cores
+
+  js::types::AddTypePropertyId(JSContext*, JSObject*, long, JS::Value const&)|EXC_BAD_ACCESS / KERN_INVALID_ADDRESS (34 crashes)
+     35% (12/34) vs.  26% (47/180) amd64 with 2 cores
+     29% (10/34) vs.  31% (55/180) amd64 with 4 cores
+     35% (12/34) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/34) vs.   2% (4/180) x86 with 4 cores
+      0% (0/34) vs.   1% (2/180) x86 with 8 cores
+
+  js::types::AddTypePropertyId(JSContext*, JSObject*, long, JS::Value const&)|EXC_BAD_ACCESS / 0x0000000d (20 crashes)
+     25% (5/20) vs.  26% (47/180) amd64 with 2 cores
+     45% (9/20) vs.  31% (55/180) amd64 with 4 cores
+     30% (6/20) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/20) vs.   2% (4/180) x86 with 4 cores
+      0% (0/20) vs.   1% (2/180) x86 with 8 cores
+
+  nsNativeTheme::IsDarkBackground(nsIFrame*)|EXC_BAD_ACCESS / KERN_INVALID_ADDRESS (14 crashes)
+     43% (6/14) vs.  26% (47/180) amd64 with 2 cores
+      0% (0/14) vs.  31% (55/180) amd64 with 4 cores
+     57% (8/14) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/14) vs.   2% (4/180) x86 with 4 cores
+      0% (0/14) vs.   1% (2/180) x86 with 8 cores
+
+  nsNativeThemeCocoa::GetMinimumWidgetSize(nsRenderingContext*, nsIFrame*, unsigned char, nsIntSize*, bool*)|EXC_BAD_ACCESS / KERN_INVALID_ADDRESS (12 crashes)
+     25% (3/12) vs.  26% (47/180) amd64 with 2 cores
+     50% (6/12) vs.  31% (55/180) amd64 with 4 cores
+     25% (3/12) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/12) vs.   2% (4/180) x86 with 4 cores
+      0% (0/12) vs.   1% (2/180) x86 with 8 cores
+
+  js::CompartmentChecker::fail(JSCompartment*, JSCompartment*)|EXC_BAD_ACCESS / KERN_INVALID_ADDRESS (11 crashes)
+     36% (4/11) vs.  26% (47/180) amd64 with 2 cores
+     18% (2/11) vs.  31% (55/180) amd64 with 4 cores
+     45% (5/11) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/11) vs.   2% (4/180) x86 with 4 cores
+      0% (0/11) vs.   1% (2/180) x86 with 8 cores
+
+  JS_HasPropertyById(JSContext*, JSObject*, long, int*)|EXC_BAD_ACCESS / 0x0000000d (10 crashes)
+     10% (1/10) vs.  26% (47/180) amd64 with 2 cores
+     60% (6/10) vs.  31% (55/180) amd64 with 4 cores
+     30% (3/10) vs.  40% (72/180) amd64 with 8 cores
+      0% (0/10) vs.   2% (4/180) x86 with 4 cores
+      0% (0/10) vs.   1% (2/180) x86 with 8 cores
+
+
+
+Windows NT
+  js::types::IdToTypeId(int)|EXCEPTION_ACCESS_VIOLATION_READ (2551 crashes)
+      0% (0/2551) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/2551) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/2551) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/2551) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/2551) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/2551) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/2551) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/2551) vs.   0% (6/5930) amd64 with 16 cores
+      9% (220/2551) vs.   5% (270/5930) x86 with 1 cores
+     46% (1168/2551) vs.  26% (1562/5930) x86 with 2 cores
+      1% (27/2551) vs.   1% (35/5930) x86 with 3 cores
+     36% (926/2551) vs.  22% (1329/5930) x86 with 4 cores
+      1% (27/2551) vs.   1% (44/5930) x86 with 6 cores
+      7% (180/2551) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/2551) vs.   0% (7/5930) x86 with 12 cores
+      0% (2/2551) vs.   0% (2/5930) x86 with 16 cores
+      0% (1/2551) vs.   0% (1/5930) x86 with 24 cores
+
+  js::CloneScript(JSContext*, JS::Handle<JSObject*>, JS::Handle<JSFunction*>, JS::Handle<JSScript*>, js::NewObjectKind)|EXCEPTION_ACCESS_VIOLATION_READ (1742 crashes)
+      1% (24/1742) vs.   1% (32/5930) amd64 with 1 cores
+     25% (431/1742) vs.  11% (629/5930) amd64 with 2 cores
+      1% (9/1742) vs.   0% (11/5930) amd64 with 3 cores
+     48% (832/1742) vs.  20% (1160/5930) amd64 with 4 cores
+      2% (29/1742) vs.   1% (58/5930) amd64 with 6 cores
+     19% (330/1742) vs.   7% (442/5930) amd64 with 8 cores
+      1% (17/1742) vs.   0% (22/5930) amd64 with 12 cores
+      0% (5/1742) vs.   0% (6/5930) amd64 with 16 cores
+      0% (1/1742) vs.   5% (270/5930) x86 with 1 cores
+      1% (26/1742) vs.  26% (1562/5930) x86 with 2 cores
+      0% (1/1742) vs.   1% (35/5930) x86 with 3 cores
+      1% (25/1742) vs.  22% (1329/5930) x86 with 4 cores
+      0% (1/1742) vs.   1% (44/5930) x86 with 6 cores
+      1% (11/1742) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/1742) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/1742) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/1742) vs.   0% (1/5930) x86 with 24 cores
+
+  gfxSVGGlyphs::~gfxSVGGlyphs()|EXCEPTION_ACCESS_VIOLATION_READ (149 crashes)
+      3% (4/149) vs.   1% (32/5930) amd64 with 1 cores
+     21% (31/149) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/149) vs.   0% (11/5930) amd64 with 3 cores
+     44% (65/149) vs.  20% (1160/5930) amd64 with 4 cores
+      3% (5/149) vs.   1% (58/5930) amd64 with 6 cores
+     22% (33/149) vs.   7% (442/5930) amd64 with 8 cores
+      1% (1/149) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/149) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/149) vs.   5% (270/5930) x86 with 1 cores
+      3% (5/149) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/149) vs.   1% (35/5930) x86 with 3 cores
+      3% (5/149) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/149) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/149) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/149) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/149) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/149) vs.   0% (1/5930) x86 with 24 cores
+
+  nsLocalFile::CopySingleFile(nsIFile*, nsIFile*, nsAString_internal const&, bool, bool, bool)|EXCEPTION_ACCESS_VIOLATION_EXEC (104 crashes)
+      0% (0/104) vs.   1% (32/5930) amd64 with 1 cores
+     44% (46/104) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/104) vs.   0% (11/5930) amd64 with 3 cores
+     38% (39/104) vs.  20% (1160/5930) amd64 with 4 cores
+      8% (8/104) vs.   1% (58/5930) amd64 with 6 cores
+     11% (11/104) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/104) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/104) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/104) vs.   5% (270/5930) x86 with 1 cores
+      0% (0/104) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/104) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/104) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/104) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/104) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/104) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/104) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/104) vs.   0% (1/5930) x86 with 24 cores
+
+  JS_HasPropertyById(JSContext*, JSObject*, int, int*)|EXCEPTION_ACCESS_VIOLATION_READ (88 crashes)
+      0% (0/88) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/88) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/88) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/88) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/88) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/88) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/88) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/88) vs.   0% (6/5930) amd64 with 16 cores
+      5% (4/88) vs.   5% (270/5930) x86 with 1 cores
+     34% (30/88) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/88) vs.   1% (35/5930) x86 with 3 cores
+     55% (48/88) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/88) vs.   1% (44/5930) x86 with 6 cores
+      7% (6/88) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/88) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/88) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/88) vs.   0% (1/5930) x86 with 24 cores
+
+  js::CompartmentChecker::fail(JSCompartment*, JSCompartment*)|EXCEPTION_BREAKPOINT (81 crashes)
+      0% (0/81) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/81) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/81) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/81) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/81) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/81) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/81) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/81) vs.   0% (6/5930) amd64 with 16 cores
+      1% (1/81) vs.   5% (270/5930) x86 with 1 cores
+     41% (33/81) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/81) vs.   1% (35/5930) x86 with 3 cores
+     49% (40/81) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/81) vs.   1% (44/5930) x86 with 6 cores
+      7% (6/81) vs.   5% (320/5930) x86 with 8 cores
+      1% (1/81) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/81) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/81) vs.   0% (1/5930) x86 with 24 cores
+
+  gfxContext::PushClipsToDT(mozilla::gfx::DrawTarget*)|EXCEPTION_ACCESS_VIOLATION_READ (75 crashes)
+      0% (0/75) vs.   1% (32/5930) amd64 with 1 cores
+      9% (7/75) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/75) vs.   0% (11/5930) amd64 with 3 cores
+     29% (22/75) vs.  20% (1160/5930) amd64 with 4 cores
+      1% (1/75) vs.   1% (58/5930) amd64 with 6 cores
+      7% (5/75) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/75) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/75) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/75) vs.   5% (270/5930) x86 with 1 cores
+      7% (5/75) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/75) vs.   1% (35/5930) x86 with 3 cores
+     27% (20/75) vs.  22% (1329/5930) x86 with 4 cores
+      1% (1/75) vs.   1% (44/5930) x86 with 6 cores
+     16% (12/75) vs.   5% (320/5930) x86 with 8 cores
+      3% (2/75) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/75) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/75) vs.   0% (1/5930) x86 with 24 cores
+
+  rlnx.dll@0x61f4|EXCEPTION_ACCESS_VIOLATION_READ (62 crashes)
+      0% (0/62) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/62) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/62) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/62) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/62) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/62) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/62) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/62) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/62) vs.   5% (270/5930) x86 with 1 cores
+     37% (23/62) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/62) vs.   1% (35/5930) x86 with 3 cores
+     50% (31/62) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/62) vs.   1% (44/5930) x86 with 6 cores
+      8% (5/62) vs.   5% (320/5930) x86 with 8 cores
+      5% (3/62) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/62) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/62) vs.   0% (1/5930) x86 with 24 cores
+
+  F1398665248_____________________________|EXCEPTION_BREAKPOINT (60 crashes)
+      0% (0/60) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/60) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/60) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/60) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/60) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/60) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/60) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/60) vs.   0% (6/5930) amd64 with 16 cores
+      2% (1/60) vs.   5% (270/5930) x86 with 1 cores
+     38% (23/60) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/60) vs.   1% (35/5930) x86 with 3 cores
+     50% (30/60) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/60) vs.   1% (44/5930) x86 with 6 cores
+     10% (6/60) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/60) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/60) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/60) vs.   0% (1/5930) x86 with 24 cores
+
+  gfxFontEntry::DisconnectSVG()|EXCEPTION_ACCESS_VIOLATION_READ (22 crashes)
+      0% (0/22) vs.   1% (32/5930) amd64 with 1 cores
+     14% (3/22) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/22) vs.   0% (11/5930) amd64 with 3 cores
+     59% (13/22) vs.  20% (1160/5930) amd64 with 4 cores
+      9% (2/22) vs.   1% (58/5930) amd64 with 6 cores
+      9% (2/22) vs.   7% (442/5930) amd64 with 8 cores
+      5% (1/22) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/22) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/22) vs.   5% (270/5930) x86 with 1 cores
+      5% (1/22) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/22) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/22) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/22) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/22) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/22) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/22) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/22) vs.   0% (1/5930) x86 with 24 cores
+
+  JSScript::getName(unsigned char*)|EXCEPTION_ACCESS_VIOLATION_READ (19 crashes)
+      0% (0/19) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/19) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/19) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/19) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/19) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/19) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/19) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/19) vs.   0% (6/5930) amd64 with 16 cores
+     11% (2/19) vs.   5% (270/5930) x86 with 1 cores
+     37% (7/19) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/19) vs.   1% (35/5930) x86 with 3 cores
+     42% (8/19) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/19) vs.   1% (44/5930) x86 with 6 cores
+     11% (2/19) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/19) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/19) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/19) vs.   0% (1/5930) x86 with 24 cores
+
+  js::GCMarker::processMarkStackTop(js::SliceBudget&)|EXCEPTION_ACCESS_VIOLATION_READ (17 crashes)
+      0% (0/17) vs.   1% (32/5930) amd64 with 1 cores
+      6% (1/17) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/17) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/17) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/17) vs.   1% (58/5930) amd64 with 6 cores
+      6% (1/17) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/17) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/17) vs.   0% (6/5930) amd64 with 16 cores
+      6% (1/17) vs.   5% (270/5930) x86 with 1 cores
+     47% (8/17) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/17) vs.   1% (35/5930) x86 with 3 cores
+     18% (3/17) vs.  22% (1329/5930) x86 with 4 cores
+     12% (2/17) vs.   1% (44/5930) x86 with 6 cores
+      6% (1/17) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/17) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/17) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/17) vs.   0% (1/5930) x86 with 24 cores
+
+  F561011053________________|EXCEPTION_ACCESS_VIOLATION_READ (16 crashes)
+      0% (0/16) vs.   1% (32/5930) amd64 with 1 cores
+     13% (2/16) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/16) vs.   0% (11/5930) amd64 with 3 cores
+     50% (8/16) vs.  20% (1160/5930) amd64 with 4 cores
+      6% (1/16) vs.   1% (58/5930) amd64 with 6 cores
+     31% (5/16) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/16) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/16) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/16) vs.   5% (270/5930) x86 with 1 cores
+      0% (0/16) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/16) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/16) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/16) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/16) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/16) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/16) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/16) vs.   0% (1/5930) x86 with 24 cores
+
+  __RtlUserThreadStart | _RtlUserThreadStart|EXCEPTION_ACCESS_VIOLATION_WRITE (12 crashes)
+      0% (0/12) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/12) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/12) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/12) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/12) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/12) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/12) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/12) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/12) vs.   5% (270/5930) x86 with 1 cores
+      0% (0/12) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/12) vs.   1% (35/5930) x86 with 3 cores
+     67% (8/12) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/12) vs.   1% (44/5930) x86 with 6 cores
+     33% (4/12) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/12) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/12) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/12) vs.   0% (1/5930) x86 with 24 cores
+
+  hb_blob_destroy|EXCEPTION_ACCESS_VIOLATION_READ (12 crashes)
+      0% (0/12) vs.   1% (32/5930) amd64 with 1 cores
+     25% (3/12) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/12) vs.   0% (11/5930) amd64 with 3 cores
+     42% (5/12) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/12) vs.   1% (58/5930) amd64 with 6 cores
+     25% (3/12) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/12) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/12) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/12) vs.   5% (270/5930) x86 with 1 cores
+      8% (1/12) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/12) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/12) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/12) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/12) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/12) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/12) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/12) vs.   0% (1/5930) x86 with 24 cores
+
+  pmnx.dll@0x61f4|EXCEPTION_ACCESS_VIOLATION_READ (12 crashes)
+      0% (0/12) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/12) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/12) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/12) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/12) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/12) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/12) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/12) vs.   0% (6/5930) amd64 with 16 cores
+     17% (2/12) vs.   5% (270/5930) x86 with 1 cores
+     33% (4/12) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/12) vs.   1% (35/5930) x86 with 3 cores
+     50% (6/12) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/12) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/12) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/12) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/12) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/12) vs.   0% (1/5930) x86 with 24 cores
+
+  StrChrIA|EXCEPTION_ACCESS_VIOLATION_READ (11 crashes)
+      0% (0/11) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/11) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/11) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/11) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/11) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/11) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/11) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/11) vs.   0% (6/5930) amd64 with 16 cores
+      9% (1/11) vs.   5% (270/5930) x86 with 1 cores
+     45% (5/11) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/11) vs.   1% (35/5930) x86 with 3 cores
+     45% (5/11) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/11) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/11) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/11) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/11) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/11) vs.   0% (1/5930) x86 with 24 cores
+
+  ComputeImmediateDominators|EXCEPTION_ACCESS_VIOLATION_READ (11 crashes)
+      0% (0/11) vs.   1% (32/5930) amd64 with 1 cores
+     27% (3/11) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/11) vs.   0% (11/5930) amd64 with 3 cores
+     36% (4/11) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/11) vs.   1% (58/5930) amd64 with 6 cores
+      9% (1/11) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/11) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/11) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/11) vs.   5% (270/5930) x86 with 1 cores
+     27% (3/11) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/11) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/11) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/11) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/11) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/11) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/11) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/11) vs.   0% (1/5930) x86 with 24 cores
+
+  RtlpAllocateHeap | CContext::RestorePipelineStateImpl<int>(SAPIPipelineState*)|EXCEPTION_ACCESS_VIOLATION_EXEC (10 crashes)
+      0% (0/10) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/10) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/10) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/10) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/10) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/10) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/10) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/10) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/10) vs.   5% (270/5930) x86 with 1 cores
+      0% (0/10) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/10) vs.   1% (35/5930) x86 with 3 cores
+     70% (7/10) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/10) vs.   1% (44/5930) x86 with 6 cores
+     30% (3/10) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/10) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/10) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/10) vs.   0% (1/5930) x86 with 24 cores
+
+  F1814639261_______________________________|EXCEPTION_ACCESS_VIOLATION_READ (10 crashes)
+      0% (0/10) vs.   1% (32/5930) amd64 with 1 cores
+      0% (0/10) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/10) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/10) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/10) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/10) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/10) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/10) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/10) vs.   5% (270/5930) x86 with 1 cores
+     60% (6/10) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/10) vs.   1% (35/5930) x86 with 3 cores
+     10% (1/10) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/10) vs.   1% (44/5930) x86 with 6 cores
+     30% (3/10) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/10) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/10) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/10) vs.   0% (1/5930) x86 with 24 cores
+
+  PR_CreateIOLayerStub | PR_NewPollableEvent | arena_malloc | je_malloc | NS_IsMainThread()|EXCEPTION_ACCESS_VIOLATION_WRITE (10 crashes)
+      0% (0/10) vs.   1% (32/5930) amd64 with 1 cores
+    100% (10/10) vs.  11% (629/5930) amd64 with 2 cores
+      0% (0/10) vs.   0% (11/5930) amd64 with 3 cores
+      0% (0/10) vs.  20% (1160/5930) amd64 with 4 cores
+      0% (0/10) vs.   1% (58/5930) amd64 with 6 cores
+      0% (0/10) vs.   7% (442/5930) amd64 with 8 cores
+      0% (0/10) vs.   0% (22/5930) amd64 with 12 cores
+      0% (0/10) vs.   0% (6/5930) amd64 with 16 cores
+      0% (0/10) vs.   5% (270/5930) x86 with 1 cores
+      0% (0/10) vs.  26% (1562/5930) x86 with 2 cores
+      0% (0/10) vs.   1% (35/5930) x86 with 3 cores
+      0% (0/10) vs.  22% (1329/5930) x86 with 4 cores
+      0% (0/10) vs.   1% (44/5930) x86 with 6 cores
+      0% (0/10) vs.   5% (320/5930) x86 with 8 cores
+      0% (0/10) vs.   0% (7/5930) x86 with 12 cores
+      0% (0/10) vs.   0% (2/5930) x86 with 16 cores
+      0% (0/10) vs.   0% (1/5930) x86 with 24 cores

--- a/socorro/unittest/external/http/test_correlations.py
+++ b/socorro/unittest/external/http/test_correlations.py
@@ -1,0 +1,428 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import shutil
+import os
+import tempfile
+
+import mock
+from nose.tools import eq_, ok_, assert_raises
+
+from socorro.external.http import correlations
+from socorro.lib.util import DotDict
+from socorro.unittest.testbase import TestCase
+
+SAMPLE_CORE_COUNTS = open(
+    os.path.join(os.path.dirname(__file__),
+                 'sample-core-counts.txt')
+).read()
+
+
+class Response(object):
+    def __init__(self, content=None, status_code=200):
+        self.content = content
+        self.status_code = status_code
+
+
+class TestCorrelations(TestCase):
+
+    def setUp(self):
+        super(TestCorrelations, self).setUp()
+        self.temp_dirs = []
+
+    def tearDown(self):
+        super(TestCorrelations, self).tearDown()
+        for temp_dir in self.temp_dirs:
+            shutil.rmtree(temp_dir)
+
+    def _get_model(self, overrides):
+        new_temp_dir = tempfile.mkdtemp()
+        self.temp_dirs.append(new_temp_dir)
+        config_values = {
+            'base_url': 'http://crashanalysis.com',
+            'save_root': new_temp_dir,
+            'save_download': True,
+            'save_seconds': 1000,
+        }
+        config_values.update(overrides)
+        cls = correlations.Correlations
+        config = DotDict()
+        config.logger = mock.Mock()
+        config.http = DotDict()
+        config.http.correlations = DotDict(config_values)
+        return cls(config=config)
+
+    @mock.patch('requests.get')
+    def test_simple_download(self, rget):
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': False,
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+        signature = 'js::types::IdToTypeId(int)'
+        result = model.get(**dict(base_params, signature=signature))
+
+        # See sample-core-counts.txt why I chose these tests
+        eq_(result['count'], 2551)
+        eq_(result['reason'], 'EXCEPTION_ACCESS_VIOLATION_READ')
+        eq_(len(result['load'].splitlines()), 17)
+
+    @mock.patch('requests.get')
+    def test_failing_download_no_error(self, rget):
+
+        def mocked_get(url, **kwargs):
+            return Response('', 404)
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a2',
+        }
+        signature = 'js::types::IdToTypeId(int)'
+        result = model.get(**dict(base_params, signature=signature))
+        eq_(result, None)
+
+    @mock.patch('requests.get')
+    def test_failing_download_should_not_cached(self, rget):
+
+        calls = []
+
+        def mocked_get(url, **kwargs):
+            calls.append(url)
+            # the first two calls should fail
+            # (it's two because of the .txt and the .txt.gz attempt)
+            if len(calls) < 3:
+                return Response('', 404)
+            else:
+                return Response(SAMPLE_CORE_COUNTS)
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': True,
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+        signature = 'js::types::IdToTypeId(int)'
+        result = model.get(**dict(base_params, signature=signature))
+        eq_(result, None)
+        # let's pretend we wait a while and try again, then it shouldn't
+        # have cached the second time
+        result = model.get(**dict(base_params, signature=signature))
+        # See sample-core-counts.txt why I chose these tests
+        eq_(result['count'], 2551)
+
+    @mock.patch('requests.get')
+    def test_failing_download_raised_error(self, rget):
+
+        def mocked_get(url, **kwargs):
+            return Response('Crap!', 500)
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a4',
+        }
+        signature = 'js::types::IdToTypeId(int)'
+        params = dict(base_params, signature=signature)
+        assert_raises(correlations.DownloadError, model.get, **params)
+
+    @mock.patch('requests.get')
+    def test_download_signature_last_in_platform(self, rget):
+        """look for a signature that is last under that platform"""
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': False,
+        })
+
+        base_params = {
+            'platform': 'Mac OS X',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+
+        result = model.get(**dict(
+            base_params,
+            signature='JS_HasPropertyById(JSContext*, JSObject*, long, int*)',
+        ))
+        eq_(result['count'], 10)
+        eq_(result['reason'], 'EXC_BAD_ACCESS / 0x0000000d')
+        eq_(len(result['load'].splitlines()), 5)
+
+    @mock.patch('requests.get')
+    def test_download_signature_middle_in_platform(self, rget):
+        """look for a signature that is last under that platform"""
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': False,
+        })
+
+        base_params = {
+            'platform': 'Mac OS X',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+
+        result = model.get(**dict(
+            base_params,
+            signature='js::CompartmentChecker::fail(JSCompartment*, '
+                      'JSCompartment*)',
+        ))
+        eq_(result['count'], 11)
+        eq_(
+            result['reason'],
+            'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS'
+        )
+        eq_(len(result['load'].splitlines()), 5)
+
+    @mock.patch('requests.get')
+    def test_download_with_unrecognized_signature(self, rget):
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': False,
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+
+        result = model.get(**dict(base_params, signature='OTHER'))
+        ok_(not result['reason'])
+        ok_(not result['count'])
+        ok_(not result['load'])
+
+    @mock.patch('requests.get')
+    def test_valid_signature_but_wrong_platform(self, rget):
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model({
+            'base_url': 'http://doesntmatter/',
+            'save_download': False,
+        })
+
+        base_params = {
+            'platform': 'Windows NT',
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+
+        # try a "valid" signature that is under a different platform
+        result = model.get(**dict(
+            base_params,
+            signature='JS_HasPropertyById(JSContext*, JSObject*, long, int*)',
+        ))
+        ok_(not result['reason'])
+        ok_(not result['count'])
+        ok_(not result['load'])
+
+    @mock.patch('requests.get')
+    def test_save_download(self, rget):
+
+        calls = []
+
+        def mocked_get(url, **kwargs):
+            calls.append(url)
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        tmp_directory = tempfile.mkdtemp()
+
+        try:
+            model = self._get_model({
+                'base_url': 'http://doesntmatter/',
+                'save_download': True,
+                'save_root': tmp_directory,
+            })
+
+            params = {
+                'platform': 'Windows NT',
+                'product': 'Firefox',
+                'report_type': 'core-counts',
+                'version': '24.0a1',
+                'signature': 'js::types::IdToTypeId(int)',
+            }
+            result = model.get(**params)
+            assert len(calls) == 1
+            eq_(result['count'], 2551)
+
+            now = datetime.datetime.utcnow()
+            yesterday = now - datetime.timedelta(days=1)
+            yesterday_str = yesterday.strftime('%Y%m%d')
+            save_directory = os.path.join(tmp_directory, yesterday_str)
+            assert os.path.isdir(save_directory)
+            filename, = os.listdir(save_directory)
+            assert filename.endswith('.txt')
+
+            content = open(os.path.join(save_directory, filename)).read()
+            content = content.replace('2551', '3662')
+            open(os.path.join(save_directory, filename), 'w').write(content)
+
+            result = model.get(**params)
+            assert len(calls) == 1
+            eq_(result['count'], 3662)
+
+        finally:
+            shutil.rmtree(tmp_directory)
+
+
+class TestCorrelationsSignatures(TestCase):
+
+    @staticmethod
+    def _get_model(overrides=None):
+        config_values = {
+            'base_url': 'http://crashanalysis.com',
+            'save_root': '',
+            'save_download': False,
+            'save_seconds': 1000,
+        }
+        if overrides:
+            config_values.update(overrides)
+        cls = correlations.CorrelationsSignatures
+        config = DotDict()
+        config.logger = mock.Mock()
+        config.http = DotDict()
+        config.http.correlations = DotDict(config_values)
+        return cls(config=config)
+
+    @mock.patch('requests.get')
+    def test_simple_download(self, rget):
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model()
+
+        params = {
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+        result = model.get(**dict(params, platforms=['Mac OS X', 'Linux']))
+        assert result['total']
+        eq_(result['total'], 9)
+        # belongs to Mac OS X
+        ok_(
+            'JS_HasPropertyById(JSContext*, JSObject*, long, int*)'
+            in result['hits']
+        )
+        # belongs to Linux
+        ok_('js::types::IdToTypeId(long)' in result['hits'])
+        # belongs to Windows NT
+        ok_('js::types::IdToTypeId(int)' not in result['hits'])
+
+    @mock.patch('requests.get')
+    def test_no_signatures(self, rget):
+
+        def mocked_get(url, **kwargs):
+            if 'core-counts' in url:
+                return Response(SAMPLE_CORE_COUNTS)
+            raise NotImplementedError
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model()
+
+        params = {
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a3',
+        }
+        result = model.get(**dict(params, platforms=['OS/2']))
+        eq_(result['total'], 0)
+
+    @mock.patch('requests.get')
+    def test_failing_download_no_error(self, rget):
+
+        def mocked_get(url, **kwargs):
+            return Response('', 404)
+
+        rget.side_effect = mocked_get
+
+        model = self._get_model()
+
+        params = {
+            'product': 'Firefox',
+            'report_type': 'core-counts',
+            'version': '24.0a1',
+        }
+        result = model.get(**dict(params, platforms=['Mac OS X', 'Linux']))
+        eq_(result, None)


### PR DESCRIPTION
config change
