### PR TITLE
Move middleware services note in documentation

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -5,6 +5,10 @@
 Middleware API
 ==============
 
+
+If you would like to add a new middleware service,
+:ref:`addaservice-chapter` provides an introduction on how to do that.
+
 API map
 -------
 
@@ -2865,10 +2869,3 @@ For example, if you want to force search to be executed with ElasticSearch,
 you can add to the middleware call `force\_api\_impl/elasticsearch/`. If
 `socorro.external.elasticsearch` exists and contains a `search` module, it
 will get loaded and used.
-
-
-Adding new Middleware Services
-==============================
-
-See :ref:`addaservice-chapter` for an introduction to
-how to add a new middleware service.


### PR DESCRIPTION
As the middleware services document is immediately next in the series, there is
little need to have a note at the end directing the user forward. This
also removes the same level header from the Middleware API document so
that it does not show up in the Sphinx sidebar.
