### PR TITLE
fix bug 1035457 - Remove multiple 'make bootstrap' calls

### DIFF
--- a/scripts/elasticsearch-integration-test.sh
+++ b/scripts/elasticsearch-integration-test.sh
@@ -8,11 +8,6 @@ then
 fi
 
 echo -n "INFO: setting up environment..."
-make bootstrap > setup.log 2>&1
-if [ $? != 0 ]
-then
-  fatal 1 "could not set up virtualenv"
-fi
 . socorro-virtualenv/bin/activate >> setup.log 2>&1
 if [ $? != 0 ]
 then

--- a/scripts/rabbitmq-integration-test.sh
+++ b/scripts/rabbitmq-integration-test.sh
@@ -94,11 +94,6 @@ function fatal() {
 }
 
 echo -n "INFO: setting up environment..."
-make bootstrap > setup.log 2>&1
-if [ $? != 0 ]
-then
-  fatal 1 "could not set up virtualenv"
-fi
 . socorro-virtualenv/bin/activate >> setup.log 2>&1
 if [ $? != 0 ]
 then


### PR DESCRIPTION
`build.sh` sets up the build environment (which includes running `make
bootstrap`) and runs elasticsearch and rabbitmq integration tests, which in
turn run `make bootstrap` again.
