### PR TITLE
fix bug 1035519 - Stop destroying pip-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ lint:
 
 clean:
 	find ./ -type f -name "*.pyc" -exec rm {} \;
-	rm -rf ./google-breakpad/ ./builds/ ./breakpad/ ./stackwalk ./pip-cache
+	rm -rf ./google-breakpad/ ./builds/ ./breakpad/ ./stackwalk
 	rm -rf ./breakpad.tar.gz
 	cd minidump-stackwalk; make clean
 


### PR DESCRIPTION
Keep the pip-cache around so that peep can do it's job by making sure
packages have not change out from under us. Also reduces build time, as
package no longer have to be re-downloaded.
