### PR TITLE
fixes bug 1036652 - Move 'make analysis'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,15 +93,6 @@ clean:
 breakpad:
 	PREFIX=`pwd`/stackwalk/ SKIP_TAR=1 ./scripts/build-breakpad.sh
 
-analysis: bootstrap
-	git submodule update --init socorro-toolbox akela
-	cd akela && mvn package
-	cd socorro-toolbox && mvn package
-	mkdir -p analysis
-	rsync socorro-toolbox/target/*.jar analysis/
-	rsync akela/target/*.jar analysis/
-	rsync -a socorro-toolbox/src/main/pig/ analysis/
-
 json_enhancements_pg_extension: bootstrap
     # This is only run manually, as it is a one-time operation
     # to be performed at system installation time, rather than

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -71,7 +71,15 @@ if [ "$1" != "leeroy" ]
 then
   # package socorro.tar.gz for distribution
   mkdir builds/
-  make analysis
+  # make the analysis
+  git submodule update --init socorro-toolbox akela
+  cd akela && mvn package
+  cd socorro-toolbox && mvn package
+  mkdir -p analysis
+  rsync socorro-toolbox/target/*.jar analysis/
+  rsync akela/target/*.jar analysis/
+  rsync -a socorro-toolbox/src/main/pig/ analysis/
+  # create the tarball
   make install PREFIX=builds/socorro
   tar -C builds --mode 755 --exclude-vcs --owner 0 --group 0 -zcf socorro.tar.gz socorro/
 fi


### PR DESCRIPTION
'make analysis' is only called from the build script, and since bootstrap is a
make dependency, running the target re-runs bootstrap.
