### PR TITLE
remove unnecessary make dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-socorro: bootstrap
 	$(ENV) $(PG_RESOURCES) $(RMQ_RESOURCES) $(ES_RESOURCES) PYTHONPATH=$(PYTHONPATH) $(COVERAGE) run $(NOSE)
 	$(COVERAGE) xml
 
-test-webapp: bootstrap-webapp
+test-webapp:
 	cd webapp-django; ./bin/jenkins.sh
 
 bootstrap:


### PR DESCRIPTION
Fixes bug 1036713 by removing an unnecessary make dependency between the webapp tests and the webapp bootstrap script. This should keep the bootstrap from running twice, uselessly.
