### PR TITLE
Fixes Bug 1038483: made raw crash return a DotDict instance

### DIFF
--- a/socorro/external/ceph/crashstorage.py
+++ b/socorro/external/ceph/crashstorage.py
@@ -143,7 +143,7 @@ class BotoS3CrashStorage(CrashStorageBase):
                 crash_id,
                 "raw_crash"
             )
-            return json.loads(raw_crash_as_string)
+            return json.loads(raw_crash_as_string, object_hook=DotDict)
         except boto.exception.StorageResponseError, x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)

--- a/socorro/unittest/external/ceph/test_crashstorage.py
+++ b/socorro/unittest/external/ceph/test_crashstorage.py
@@ -283,7 +283,7 @@ class TestCase(socorro.unittest.testbase.TestCase):
             any_order=True,
         )
 
-    def test_get_craw_crash(self):
+    def test_get_raw_crash(self):
         # setup some internal behaviors and fake outs
         boto_s3_store = self.setup_mocked_s3_storage()
         mocked_get_contents_as_string = (
@@ -299,6 +299,8 @@ class TestCase(socorro.unittest.testbase.TestCase):
         result = boto_s3_store.get_raw_crash(
             "936ce666-ff3b-4c7a-9674-367fe2120408"
         )
+
+        self.assertTrue(isinstance(result, DotDict))
 
         # what should have happened internally
         self.assertEqual(boto_s3_store._calling_format.call_count, 1)


### PR DESCRIPTION
the BotoS3 crashstore failed to ensure that the raw_crash was returned in the form of a DotDict rather than a simple dict.  This patch fixes that. 
