### PR TITLE
Fix 1038956 - Wait for pg_hba to be updated before creating Postgres test user

### DIFF
--- a/puppet/manifests/socorro.pp
+++ b/puppet/manifests/socorro.pp
@@ -112,6 +112,8 @@ class webapp::socorro {
       require => [
         Package['postgresql93-server'],
         Exec['postgres-initdb'],
+        File['pg_hba.conf'],
+        Service['postgresql-9.3']
       ];
   }
 


### PR DESCRIPTION
Puppet tries to create the postgres test user after postgres has been
initialized, but before pg_hba.conf has been updated and the service
restarted.

This fixes the `socorro-vagrant` build.
