### PR TITLE
Bug 1039648 - Update forced versions for correlations for Firefox cycle starting 2014-07-22

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="31.0 32.0a2 33.0a1"
+MANUAL_VERSION_OVERRIDE="32.0 33.0a2 34.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This commit fixes bug 1039648 - it should go to production the week of July 21 (not before!).
