### PR TITLE
Fixes Bug 1037874 - pyhs2 with timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -112,8 +112,8 @@ path.py==5.1
 pep8>=1.4.5
 # sha256: P6gKELNtUWhr93RPXcmWIs1cmM6O1kAi5imGiq_Bd2k
 pyflakes==0.8.1
-# sha256: IBHATOBcLURttngxfeVP4PgNdykbnQ1G-sknzAV8ZXo
-https://github.com/BradRuderman/pyhs2/archive/870d5590a97d53855a4aa6da70be8439ce4d690c.zip#egg=pyhs2
+# sha256: LvU9cTRTDj8ZMnNSIRpz3us9QQa1uFewOwMfonIteEU
+https://github.com/BradRuderman/pyhs2/archive/48d22aff9d23db1221ad913670aaad90a73bcbc7.zip#egg=pyhs2
 # sha256: Tg3rRP5GuOADbGx7MBJV1RikfCQL6zZWn7Ua6aAwDpM
 django-jingo-offline-compressor==0.0.7
 # sha256: TzJCJuHuhaxBUgV5up3nAylAEmAuU2IX_Q50VuFH2IY

--- a/socorro/cron/jobs/fetch_adi_from_hive.py
+++ b/socorro/cron/jobs/fetch_adi_from_hive.py
@@ -140,6 +140,12 @@ class FetchADIFromHiveCronApp(BaseCronApp):
         default='PLAIN',
         doc='Auth mechanism for Hive')
 
+    required_config.add_option(
+        'timeout',
+        default=120,
+        doc='number of seconds to wait before timing out')
+
+
     def run(self, connection, date):
         target_date = (date - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
 
@@ -158,7 +164,8 @@ class FetchADIFromHiveCronApp(BaseCronApp):
                     authMechanism=self.config.hive_auth_mechanism,
                     user=self.config.hive_user,
                     password=self.config.hive_password,
-                    database=self.config.hive_database
+                    database=self.config.hive_database,
+                    timeout=self.config.timeout
                 )
 
                 cur = hive.cursor()

--- a/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
+++ b/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
@@ -116,7 +116,8 @@ class TestFetchADIFromHive(IntegrationTestBase):
             host='localhost',
             user='socorro',
             password='ignored',
-            port=10000
+            port=10000,
+            timeout=120,
         )
 
         pgcursor = self.conn.cursor()


### PR DESCRIPTION
this patch upgrades our use of pyhs2 to a version than implements a timeout.  Then I added the timeout to the configuration and the code that acquires a connection. 
