### PR TITLE
fixes bug 962264 - Switch to native bugzilla API instead of BzAPI Proxy

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -261,7 +261,7 @@ ENGAGE_ROBOTS = False
 
 
 # Base URL for when we use the Bugzilla API
-BZAPI_BASE_URL = 'https://api-dev.bugzilla.mozilla.org/1.3'
+BZAPI_BASE_URL = 'https://bugzilla.mozilla.org/rest'
 
 # Specify the middleware implementation to use in the middleware
 # Leave empty to use the default

--- a/webapp-django/settings_test.py
+++ b/webapp-django/settings_test.py
@@ -9,7 +9,9 @@ os.environ['FORCE_DB'] = 'true'
 
 DEFAULT_PRODUCT = 'WaterWolf'
 
-BZAPI_BASE_URL = 'https://api-dev.bugzilla.muzilla.org/1.3'
+# here we deliberately "destroy" the BZAPI URL so running tests that are
+# badly mocked never accidentally actually use a real working network address
+BZAPI_BASE_URL = 'https://bugzilla.testrunner/rest'
 
 # by scrubbing this to something unreal, we can be certain the tests never
 # actually go out on the internet when `request.get` should always be mocked


### PR DESCRIPTION
This was almost embarrassingly simple once I realized how little needs to change. However, it took me some time to get it tested and it took some time to realize that the bugzilla cron app can't use the new REST API because of it taking some 15-20 times longer due to [1035804](https://bugzilla.mozilla.org/show_bug.cgi?id=1035804).

@rhelmer r?
