### PR TITLE
Fixes bug 1041263 - stopped the BenchmarkingCrashStore from subverting HBase

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -896,6 +896,23 @@ class BenchmarkingCrashStorage(CrashStorageBase):
         )
 
     #--------------------------------------------------------------------------
+    def save_raw_and_processed(self, raw_crash, dumps, processed_crash,
+                               crash_id):
+        start_time = self.start_timer()
+        self.wrapped_crashstore.save_raw_and_processed(
+            raw_crash,
+            dumps,
+            processed_crash,
+            crash_id
+        )
+        end_time = self.end_timer()
+        self.config.logger.debug(
+            '%s save_raw_and_processed %s',
+            self.tag,
+            end_time - start_time
+        )
+
+    #--------------------------------------------------------------------------
     def get_raw_crash(self, crash_id):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_raw_crash(crash_id)

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -644,6 +644,22 @@ class TestBench(TestCase):
             )
             mock_logging.debug.reset_mock()
 
+            crashstorage.save_raw_and_processed({}, 'payload', {}, 'ooid' )
+            crashstorage.wrapped_crashstore.save_raw_and_processed \
+                .assert_called_with(
+                    {},
+                    'payload',
+                    {},
+                    'ooid'
+                )
+            mock_logging.debug.assert_called_with(
+                '%s save_raw_and_processed %s',
+                'test',
+                1
+            )
+            mock_logging.debug.reset_mock()
+
+
             crashstorage.get_raw_crash('uuid')
             crashstorage.wrapped_crashstore.get_raw_crash.assert_called_with(
                 'uuid'


### PR DESCRIPTION
 added benchmarking 'save_raw_and_processed' to prevent subverting HBase.

The problem is in the benchmarking code in a unfortunate interaction with HBase.  At the end of processing a crash, we call a method called "save_raw_and_processed" rather than just "save_processed".  Most crashstores make do with the base class version of this method which calls the "save_raw" and "save_processed" methods in turn.  HBase, though has it's own "save_raw_and_processed" because the raw crash is already in HBase - we don't want to save it a second time (HBase doesn't really delete, we'd end up with wasted space with two copies of the raw crash in HBase).

The Benchmarking code subverted HBase's self protection, by overriding HBase's "save_raw_and_processed" with the base class "save_raw_and_processed" and causing a second storage attempt at the raw_crash.  
