### PR TITLE
Fixes Bug 1040955 - added 'save_raw_and_processed' to ceph crashstorage

### DIFF
--- a/socorro/external/ceph/crashstorage.py
+++ b/socorro/external/ceph/crashstorage.py
@@ -156,6 +156,19 @@ class BotoS3CrashStorage(CrashStorageBase):
         self.transaction(self._do_save_processed, processed_crash)
 
     #--------------------------------------------------------------------------
+    def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
+        """ bug 866973 - do not put raw_crash back into permanent storage again
+            We are doing this in lieu of a queuing solution that could allow
+            us to operate an independent crashmover. When the queuing system
+            is implemented, we could remove this, and have the raw crash
+            saved by a crashmover that's consuming crash_ids the same way
+            that the processor consumes them.
+
+            See further comments in the ProcesorApp class.
+        """
+        self.save_processed(processed_crash)
+
+    #--------------------------------------------------------------------------
     @staticmethod
     def do_get_raw_crash(boto_s3_store, crash_id):
         try:


### PR DESCRIPTION
If Ceph is to be a proper drop in replacement for HBase, then it must repsond exactly our HBase code does.  When the processor uses the the `save_raw_and_processed` method call, HBase ignores the 'save_raw' part.  The raw crash is already in HBase and saving a second time would only waste storage.  That call to save raw and processed is for PG benefit and even that is a rather degenerate case as PG ignores the dumps.  The processor knows that PG will ignore the dumps, so it doesn't send them.  

Any crashstore bound to the PG crashstore for this call must take into account that the raw crash is missing the dumps.  HBase does it by ignore the save raw crash part - it can afford to do this because the raw crash is already there.  

This PR makes the Ceph crashstore behave in the same manner as the HBase crashstore.  
