### PR TITLE
Fix bug 1042278 - Remove playdoh-lib submodules from gitmodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,3 @@
 [submodule "akela"]
 	path = akela
 	url = git://github.com/mozilla-metrics/akela.git
-[submodule "bixie/vendor"]
-	path = bixie/vendor
-	url = git://github.com/mozilla/playdoh-lib.git
-[submodule "webapp-django/vendor"]
-    path = webapp-django/vendor
-    url = git://github.com/mozilla/playdoh-lib.git


### PR DESCRIPTION
Though these directories have been removed, the submodule entries have
persisted.

Fixes bug 1042278
