### PR TITLE
keep track of the jenkins build #

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,5 +81,6 @@ then
   rsync -a socorro-toolbox/src/main/pig/ analysis/
   # create the tarball
   make install PREFIX=builds/socorro
+  echo "$BUILD_NUMBER" > buids/socorro/JENKINS_BUILD_NUMBER
   tar -C builds --mode 755 --exclude-vcs --owner 0 --group 0 -zcf socorro.tar.gz socorro/
 fi


### PR DESCRIPTION
fixes bug 1043681 by putting the build number into the file JENKINS_BUILD_NUMBER
