### PR TITLE
Fix bug 1044072 - Run coverage only on release build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,7 +49,6 @@ export ES_URLS="http://jenkins-es20:9200"
 # RHEL postgres 9 RPM installs pg_config here, psycopg2 needs it
 export PATH=/usr/pgsql-9.2/bin:$PATH
 echo "My path is $PATH"
-
 # run unit tests
 make test database_username=test database_hostname=$DB_HOST database_password=aPassword database_port=5432 database_superusername=test database_superuserpassword=aPassword elasticSearchHostname=$ES_HOST elasticsearch_urls=$ES_URLS rmq_host=$RABBITMQ_HOST rmq_virtual_host=$RABBITMQ_VHOST rmq_user=$RABBITMQ_USERNAME rmq_password=$RABBITMQ_PASSWORD
 


### PR DESCRIPTION
This PR adds the environment variable `RUN_COVERAGE` which when set will generate a test coverage report at the same time tests are run.

The flag is only set when `leeroy` is not passed as the first argument to `scripts/build.sh`.
