### PR TITLE
fix bug 1047020 - Add Wheel Hashes to Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -107,8 +107,10 @@ https://github.com/jbalogh/check/archive/9c314d7c16408f876ee89f06a62e40dea4c98a0
 # sha256: l2sTklJ8dzg-uCfef9RNrK8Sl6Y6oN9Sb0evMC9HnVQ
 path.py==5.1
 # sha256: FbQhMbJfN2Fl0ZX-ThewooMRGCqvkzDV61dbvtpaaYk
-pep8>=1.4.5
+# sha256: Yuh_1UU1-5MrSk2Uho21IyV6EDHIvGvTWMIBVDPmRts
+pep8==1.5.7
 # sha256: P6gKELNtUWhr93RPXcmWIs1cmM6O1kAi5imGiq_Bd2k
+# sha256: rEVxaVwQzhU2vNuhopS58tPmzJ0OoXG2fVCghkzj4EI
 pyflakes==0.8.1
 # sha256: LvU9cTRTDj8ZMnNSIRpz3us9QQa1uFewOwMfonIteEU
 https://github.com/BradRuderman/pyhs2/archive/48d22aff9d23db1221ad913670aaad90a73bcbc7.zip#egg=pyhs2


### PR DESCRIPTION
Pins pep8 at 1.5.7 (The current tarball hash), and adds hashes for pep8 and pyflakes wheels.

Fixes bug 1047020
