### PR TITLE
fixes bug 1047649 - Expose 'ongoing' in the crontabber_state middleware

### DIFF
--- a/socorro/external/postgresql/crontabber_state.py
+++ b/socorro/external/postgresql/crontabber_state.py
@@ -27,7 +27,8 @@ class CrontabberState(PostgreSQLBase):
                 last_success,
                 error_count,
                 depends_on,
-                last_error
+                last_error,
+                ongoing
             FROM crontabber
             ORDER BY app_name
         """
@@ -46,9 +47,17 @@ class CrontabberState(PostgreSQLBase):
                 'last_success',
                 'error_count',
                 'depends_on',
-                'last_error'
+                'last_error',
+                'ongoing'
             ), row[1:]))
-            for key in ('next_run', 'first_run', 'last_run', 'last_success'):
+            possible_datetimes = (
+                'next_run',
+                'first_run',
+                'last_run',
+                'last_success',
+                'ongoing'
+            )
+            for key in possible_datetimes:
                 value = state[app_name][key]
                 if value is None:
                     continue

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1470,6 +1470,7 @@ class Crontabber(DeclarativeBase):
     error_count = Column(u'error_count', INTEGER(), server_default=text('0'))
     depends_on = Column(u'depends_on', ARRAY(TEXT()))
     last_error = Column(u'last_error', JSON())
+    ongoing = Column(u'ongoing', TIMESTAMP(timezone=True))
 
     __table_args__ = (
         Index('crontabber_app_name_idx', app_name, unique=True),


### PR DESCRIPTION
@rhelmer r?

I've tested this locally against my locally running middleware that reads the stage db. It works. But I've not been able to actually see a real value for the `ongoing` field. The few jobs that happen regularly (as opposed to the big slow ones at night) are too quick for me to be able record something. 
