### PR TITLE
(nobug) remove trailing space on the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -351,4 +351,3 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       This Source Code Form is “Incompatible
       With Secondary Licenses”, as defined by
       the Mozilla Public License, v. 2.0.
-


### PR DESCRIPTION
this should trigger a travis build for the PR, but not when it lands
