### PR TITLE
Fixes Bug 1026059 - differentiate breakpad minidumps from memory_info dumps

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -30,7 +30,8 @@ class Redactor(RequiredConfig):
                 "json_dump.sensitive,"
                 "upload_file_minidump_flash1.json_dump.sensitive,"
                 "upload_file_minidump_flash2.json_dump.sensitive,"
-                "upload_file_minidump_browser.json_dump.sensitive",
+                "upload_file_minidump_browser.json_dump.sensitive,"
+                "memory_info",
         reference_value_from='resource.redactor',
     )
 

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -558,6 +558,7 @@ class TestRedactor(TestCase):
         d['upload_file_minidump_flash2.json_dump.sensitive'] = 44
         d['upload_file_minidump_browser.json_dump.sensitive.exploitable'] = 55
         d['upload_file_minidump_browser.json_dump.sensitive.secret'] = 66
+        d['memory_info'] = {'incriminating_memory': 'call the FBI'}
 
         ok_('json_dump' in d)
 


### PR DESCRIPTION
this PR introduces the concept of different types of dumps.  The breakpad dumps should be handled just as they are now.  The new 'memory_info' dump ought to be detected, unzipped, and loaded into the processed crash "memory_info" key.

the "memory_info" key is also now added to the redaction list as a sensitive key.  
