### PR TITLE
fixes bug 1052727 - Signature summary to support returning multiple reports

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -1280,8 +1280,8 @@ class TestViews(BaseTestViews):
 
         def mocked_get(url, params, **options):
             if 'signaturesummary' in url:
-                ok_('report_type' in params)
-                eq_('uptime', params['report_type'])
+                ok_('report_types' in params)
+                ok_('uptime' in params['report_types'])
 
                 ok_('signature' in params)
                 eq_('one & two', params['signature'])
@@ -1292,24 +1292,26 @@ class TestViews(BaseTestViews):
                 ok_('end_date' in params)
                 eq_('2013-01-01', params['end_date'])
 
-                return Response("""
-                [
-                  {
-                    "version_string": "12.0",
-                    "percentage": "48.440",
-                    "report_count": 52311,
-                    "product_name": "WaterWolf",
-                    "category": "XXX"
-                  },
-                  {
-                    "version_string": "13.0b4",
-                    "percentage": "9.244",
-                    "report_count": 9983,
-                    "product_name": "WaterWolf",
-                    "category": "YYY"
-                  }
-                ]
-                """)
+                return Response({
+                    "reports": {
+                        "uptime": [
+                            {
+                                "version_string": "12.0",
+                                "percentage": "48.440",
+                                "report_count": 52311,
+                                "product_name": "WaterWolf",
+                                "category": "XXX"
+                            },
+                            {
+                                "version_string": "13.0b4",
+                                "percentage": "9.244",
+                                "report_count": 9983,
+                                "product_name": "WaterWolf",
+                                "category": "YYY"
+                            }
+                        ]
+                    }
+                })
 
             raise NotImplementedError(url)
 
@@ -1321,19 +1323,19 @@ class TestViews(BaseTestViews):
         dump = json.loads(response.content)
         ok_(dump['errors']['start_date'])
         ok_(dump['errors']['end_date'])
-        ok_(dump['errors']['report_type'])
+        ok_(dump['errors']['report_types'])
         ok_(dump['errors']['signature'])
 
         response = self.client.get(url, {
-            'report_type': 'uptime',
+            'report_types': ['uptime'],
             'signature': 'one & two',
             'start_date': '2012-1-1',
             'end_date': '2013-1-1',
         })
         eq_(response.status_code, 200)
         dump = json.loads(response.content)
-        ok_(dump)
-        eq_(len(dump), 2)
+        ok_(dump['reports'])
+        eq_(len(dump['reports']['uptime']), 2)
 
     @mock.patch('requests.get')
     def test_Status(self, rget):

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1208,7 +1208,7 @@ class SignatureSummary(SocorroMiddleware):
     URL_PREFIX = '/signaturesummary/'
 
     required_params = (
-        'report_type',
+        ('report_types', list),
         'signature',
         ('start_date', datetime.date),
         ('end_date', datetime.date),
@@ -1216,6 +1216,7 @@ class SignatureSummary(SocorroMiddleware):
 
     possible_params = (
         ('versions', list),
+        'report_type',  # kept for legacy
     )
 
     API_WHITELIST = (
@@ -1223,6 +1224,7 @@ class SignatureSummary(SocorroMiddleware):
         'percentage',
         'product_name',
         'version_string',
+        'reports',
     )
 
 

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -1036,7 +1036,7 @@ class TestModels(TestCase):
         today = datetime.datetime.utcnow()
         yesterday = today - datetime.timedelta(days=10)
         r = api.get(
-            report_type='products',
+            report_types=['products'],
             signature='Pickle::ReadBytes',
             start_date=yesterday,
             end_date=today,
@@ -1044,7 +1044,7 @@ class TestModels(TestCase):
         )
         ok_(r[0]['version_string'])
         r = api.get(
-            report_type='products',
+            report_types=['products'],
             signature='Pickle::ReadBytes',
             start_date=yesterday,
             end_date=today,

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import datetime
 import json
@@ -130,6 +131,92 @@ BUG_STATUS = """ {
               "signature": "Other FakeSignature"}
             ]
 } """
+
+SAMPLE_SIGNATURE_SUMMARY = {
+    "reports": {
+        "products": [
+            {
+                "version_string": "33.0a2",
+                "percentage": "57.542",
+                "report_count": 103,
+                "product_name": "Firefox"
+            },
+        ],
+        "uptime": [
+            {
+                "category": "< 1 min",
+                "percentage": "29.126",
+                "report_count": 30
+            }
+        ],
+        "architecture": [
+            {
+                "category": "x86",
+                "percentage": "100.000",
+                "report_count": 103
+            }
+        ],
+        "flash_version": [
+            {
+                "category": "[blank]",
+                "percentage": "100.000",
+                "report_count": 103
+            }
+        ],
+        "graphics": [
+            {
+                "report_count": 24,
+                "adapter_name": None,
+                "vendor_hex": "0x8086",
+                "percentage": "23.301",
+                "vendor_name": None,
+                "adapter_hex": "0x0166"
+            }
+        ],
+        "distinct_install": [
+            {
+                "crashes": 103,
+                "version_string": "33.0a2",
+                "product_name": "Firefox",
+                "installations": 59
+            }
+        ],
+        "devices": [
+            {
+                "cpu_abi": "XXX",
+                "manufacturer": "YYY",
+                "model": "ZZZ",
+                "version": "1.2.3",
+                "report_count": 52311,
+                "percentage": "48.440",
+            }
+        ],
+        "os": [
+            {
+                "category": "Windows 8.1",
+                "percentage": "55.340",
+                "report_count": 57
+            }
+        ],
+        "process_type": [
+            {
+                "category": "Browser",
+                "percentage": "100.000",
+                "report_count": 103
+            }
+        ],
+        "exploitability": [
+            {
+                "low_count": 0,
+                "high_count": 0,
+                "null_count": 0,
+                "none_count": 4,
+                "report_date": "2014-08-12",
+                "medium_count": 0
+            }
+        ]
+    }
+}
 
 
 class RobotsTestViews(DjangoTestCase):
@@ -1060,77 +1147,30 @@ class TestViews(BaseTestViews):
             """)
 
         def mocked_get(url, params, **options):
+            signature_summary_data = copy.deepcopy(SAMPLE_SIGNATURE_SUMMARY)
             if '/signaturesummary' in url:
-                return Response("""
-                [
-                  {
-                    "version_string": "18.0",
-                    "percentage": "48.440",
-                    "report_count": 52311,
-                    "product_name": "WaterWolf",
-                    "category": "XXX",
-                    "crashes": "1234",
-                    "installations": "5679",
-                    "null_count" : "456",
-                    "low_count": "789",
-                    "medium_count": "123",
-                    "high_count": "1200",
-                    "report_date": "2013-01-01",
-                    "cpu_abi": "XXX",
-                    "manufacturer": "YYY",
-                    "model": "ZZZ",
-                    "version": "1.2.3",
-                    "vendor_hex" : "0x8086",
-                    "adapter_hex": " 0x2972",
-                    "vendor_name": "abc",
-                    "adapter_name" : "def"
-                  },
-                  {
-                    "version_string": "18.0",
-                    "percentage": "48.440",
-                    "report_count": 52311,
-                    "product_name": "NightTrain",
-                    "category": "XXX",
-                    "crashes": "1234",
-                    "installations": "5679",
-                    "null_count" : "456",
-                    "low_count": "789",
-                    "medium_count": "123",
-                    "high_count": "1200",
-                    "report_date": "2013-01-01",
-                    "cpu_abi": "XXX",
-                    "manufacturer": "YYY",
-                    "model": "ZZZ",
-                    "version": "1.2.3",
-                    "vendor_hex" : "0x8086",
-                    "adapter_hex": " 0x2972",
-                    "vendor_name": "abc",
-                    "adapter_name" : "def"
-                  },
-                  {
-                    "version_string": "13.0b4",
-                    "percentage": "9.244",
-                    "report_count": 9983,
-                    "product_name": "WaterWolf",
-                    "category": "YYY",
-                    "crashes": "3210",
-                    "installations": "9876",
-                    "null_count" : "123",
-                    "low_count": "456",
-                    "medium_count": "789",
-                    "high_count": "1100",
-                    "report_date": "2013-01-02",
-                    "cpu_abi": "AAA",
-                    "manufacturer": "BBB",
-                    "model": "CCC",
-                    "version": "4.5.6",
-                    "vendor_hex": "0x10de",
-                    "adapter_hex": "0x9804",
-                    "vendor_name": "",
-                    "adapter_name": ""
-                  }
+                signature_summary_data['reports']['products'] = [
+                    {
+                        "version_string": "18.0",
+                        "percentage": "48.440",
+                        "report_count": 52311,
+                        "product_name": "WaterWolf",
+                    },
+                    {
+                        "version_string": "18.0",
+                        "percentage": "48.440",
+                        "report_count": 52311,
+                        "product_name": "NightTrain",
+                    },
+                    {
+                        "version_string": "13.0b4",
+                        "percentage": "9.244",
+                        "report_count": 9983,
+                        "product_name": "WaterWolf",
+                    }
+
                 ]
-                """)
+                return Response(signature_summary_data)
 
             if '/crashes/signatures' in url:
                 return Response(u"""
@@ -2734,64 +2774,104 @@ class TestViews(BaseTestViews):
     def test_signature_summary(self, rget):
         def mocked_get(url, params, **options):
             if '/signaturesummary' in url:
-                return Response("""
-                [
-                  {
-                    "version_string": "12.0",
-                    "percentage": "48.440",
-                    "report_count": 52311,
-                    "product_name": "WaterWolf",
-                    "category": "XXX",
-                    "crashes": "1234",
-                    "installations": "5679",
-                    "null_count" : "456",
-                    "low_count": "789",
-                    "medium_count": "123",
-                    "high_count": "1200",
-                    "report_date": "2013-01-01",
-                    "cpu_abi": "XXX",
-                    "manufacturer": "YYY",
-                    "model": "ZZZ",
-                    "version": "1.2.3",
-                    "vendor_hex" : "0x8086",
-                    "adapter_hex": " 0x2972",
-                    "vendor_name": "abc",
-                    "adapter_name" : "def"
-                  },
-                  {
-                    "version_string": "13.0b4",
-                    "percentage": "9.244",
-                    "report_count": 9983,
-                    "product_name": "WaterWolf",
-                    "category": "YYY",
-                    "crashes": "3210",
-                    "installations": "9876",
-                    "null_count" : "123",
-                    "low_count": "456",
-                    "medium_count": "789",
-                    "high_count": "1100",
-                    "report_date": "2013-01-02",
-                    "cpu_abi": "AAA",
-                    "manufacturer": "BBB",
-                    "model": "CCC",
-                    "version": "4.5.6",
-                    "vendor_hex": "0x10de",
-                    "adapter_hex": "0x9804",
-                    "vendor_name": "",
-                    "adapter_name": ""
-                  }
-                ]
-                """)
+                assert params['report_types']
+                return Response({
+                    "reports": {
+                        "products": [
+                            {
+                                "version_string": "33.0a2",
+                                "percentage": "57.542",
+                                "report_count": 103,
+                                "product_name": "Firefox"
+                            },
+                        ],
+                        "uptime": [
+                            {
+                                "category": "< 1 min",
+                                "percentage": "29.126",
+                                "report_count": 30
+                            }
+                        ],
+                        "architecture": [
+                            {
+                                "category": "x86",
+                                "percentage": "100.000",
+                                "report_count": 103
+                            }
+                        ],
+                        "flash_version": [
+                            {
+                                "category": "[blank]",
+                                "percentage": "100.000",
+                                "report_count": 103
 
+                            }
+                        ],
+                        "graphics": [
+                            {
+                                "report_count": 24,
+                                "adapter_name": None,
+                                "vendor_hex": "0x8086",
+                                "percentage": "23.301",
+                                "vendor_name": None,
+                                "adapter_hex": "0x0166"
+                            }
+                        ],
+                        "distinct_install": [
+                            {
+                                "crashes": 103,
+                                "version_string": "33.0a2",
+                                "product_name": "Firefox",
+                                "installations": 59
+                            }
+                        ],
+                        "devices": [
+                            {
+                                "cpu_abi": "XXX",
+                                "manufacturer": "YYY",
+                                "model": "ZZZ",
+                                "version": "1.2.3",
+                                "report_count": 52311,
+                                "percentage": "48.440",
+                            }
+                        ],
+                        "os": [
+                            {
+                                "category": "Windows 8.1",
+                                "percentage": "55.340",
+                                "report_count": 57
+                            }
+                        ],
+                        "process_type": [
+                            {
+                                "category": "Browser",
+                                "percentage": "100.000",
+                                "report_count": 103
+                            }
+                        ],
+                        "exploitability": [
+                            {
+                                "low_count": 0,
+                                "high_count": 0,
+                                "null_count": 0,
+                                "none_count": 4,
+                                "report_date": "2014-08-12",
+                                "medium_count": 0
+                            }
+                        ]
+                    }
+                })
             raise NotImplementedError(url)
 
         url = reverse('crashstats:signature_summary')
 
         rget.side_effect = mocked_get
 
-        response = self.client.get(url, {'range_value': '1',
-                                         'signature': 'sig',
-                                         'version': 'WaterWolf:19.0'})
+        response = self.client.get(url, {
+            'range_value': '1',
+            'signature': 'sig',
+            'version': 'WaterWolf:19.0'
+        })
         eq_(response.status_code, 200)
         ok_('application/json' in response['content-type'])
         struct = json.loads(response.content)
@@ -2810,7 +2890,7 @@ class TestViews(BaseTestViews):
         # percentages are turned into string as they're fed straight into
         # a mustache template.
         # for example,
-        eq_(struct['uptimeRange'][0]['percentage'], '48.44')
+        eq_(struct['uptimeRange'][0]['percentage'], '29.13')
 
         user = self._login()
         group = self._create_group_with_permission('view_exploitability')
@@ -2828,101 +2908,46 @@ class TestViews(BaseTestViews):
     @mock.patch('requests.get')
     def test_signature_summary_flash_exploitability(self, rget):
         def mocked_get(url, params, **options):
-            if (
-                'report_type' in params and
-                params['report_type'] == 'flash_version'
-            ):
-                assert 'signature' in params
+            signature_summary_data = copy.deepcopy(SAMPLE_SIGNATURE_SUMMARY)
+            if '/signaturesummary' in url:
                 if 'sig1' in params['signature']:
-                    return Response("""
-                    [
-                      {
-                        "category": "11.9.900.117",
-                        "percentage": "50.794",
-                        "report_count": 320
-                      },
-                      {
-                        "category": "11.9.900.152",
-                        "percentage": "45.397",
-                        "report_count": 286
-                      },
-                      {
-                        "category": "11.7.700.224",
-                        "percentage": "1.429",
-                        "report_count": 9
-                      }
+                    signature_summary_data['reports']['flash_version'] = [
+                        {
+                            "category": "11.9.900.117",
+                            "percentage": "50.794",
+                            "report_count": 320
+                        },
+                        {
+                            "category": "11.9.900.152",
+                            "percentage": "45.397",
+                            "report_count": 286
+                        },
+                        {
+                            "category": "11.7.700.224",
+                            "percentage": "1.429",
+                            "report_count": 9
+                        }
                     ]
-                    """)
                 elif 'sig2' in params['signature']:
-                    return Response("""
-                    [
-                      {
-                        "category": "11.9.900.117",
-                        "percentage": "50.794",
-                        "report_count": 320
-                      },
-                      {
-                        "category": "[blank]",
-                        "percentage": "45.397",
-                        "report_count": 286
-                      },
-                      {
-                        "category": "11.7.700.224",
-                        "percentage": "1.429",
-                        "report_count": 9
-                      }
+                    signature_summary_data['reports']['flash_version'] = [
+                        {
+                            "category": "11.9.900.117",
+                            "percentage": "50.794",
+                            "report_count": 320
+                        },
+                        {
+                            "category": "[blank]",
+                            "percentage": "45.397",
+                            "report_count": 286
+                        },
+                        {
+                            "category": "11.7.700.224",
+                            "percentage": "1.429",
+                            "report_count": 9
+                        }
                     ]
-                    """)
-            elif '/signaturesummary' in url:
-                return Response("""
-                [
-                  {
-                    "version_string": "12.0",
-                    "percentage": "48.440",
-                    "report_count": 52311,
-                    "product_name": "WaterWolf",
-                    "category": "XXX",
-                    "crashes": "1234",
-                    "installations": "5679",
-                    "null_count" : "456",
-                    "low_count": "789",
-                    "medium_count": "123",
-                    "high_count": "1200",
-                    "report_date": "2013-01-01",
-                    "cpu_abi": "XXX",
-                    "manufacturer": "YYY",
-                    "model": "ZZZ",
-                    "version": "1.2.3",
-                    "vendor_hex" : "0x8086",
-                    "adapter_hex": " 0x2972",
-                    "vendor_name": "abc",
-                    "adapter_name" : "def"
-                  },
-                  {
-                    "version_string": "13.0b4",
-                    "percentage": "9.244",
-                    "report_count": 9983,
-                    "product_name": "WaterWolf",
-                    "category": "YYY",
-                    "crashes": "3210",
-                    "installations": "9876",
-                    "null_count" : "123",
-                    "low_count": "456",
-                    "medium_count": "789",
-                    "high_count": "1100",
-                    "report_date": "2013-01-02",
-                    "cpu_abi": "AAA",
-                    "manufacturer": "BBB",
-                    "model": "CCC",
-                    "version": "4.5.6",
-                    "vendor_hex": "0x10de",
-                    "adapter_hex": "0x9804",
-                    "vendor_name": "",
-                    "adapter_name": ""
-                  }
-                ]
-                """)
 
+                return Response(signature_summary_data)
             raise NotImplementedError(url)
 
         url = reverse('crashstats:signature_summary')
@@ -2933,9 +2958,11 @@ class TestViews(BaseTestViews):
         group = self._create_group_with_permission('view_flash_exploitability')
         user.groups.add(group)
 
-        response = self.client.get(url, {'range_value': '1',
-                                         'signature': 'sig1',
-                                         'version': 'WaterWolf:19.0'})
+        response = self.client.get(url, {
+            'range_value': '1',
+            'signature': 'sig1',
+            'version': 'WaterWolf:19.0'
+        })
         eq_(response.status_code, 200)
         ok_('application/json' in response['content-type'])
         struct = json.loads(response.content)


### PR DESCRIPTION
@AdrianGaudebert r?
cc @ossreleasefeed @rhelmer

So I thought this would be a lot easier change but as I dug in I found some really strange flaws and things that weren't testing properly. 

The new change is that you used to do this:

``` python
for report_type in report_types:
    r = SignatureSummary().get(
        report_type=report_type,
        signature=signature,
        start_date=start_date, 
        ...
    )
```

Now that's going away. But is still supported out of legacy. (will file follow-up bug)
The new way of using this API is like this:

``` python
r = SignatureSummary().get(
    report_types=report_types,
    signature=signature,
    start_date=start_date, 
    ...
)
```

Inside the middleware implementation it doesn't try to do anything smart. It simply loops over every `report_type in report_types` and does a SQL select for each just like before. 
The big noticable difference, that matters, in `signature_summary.py` is that it's using **one** connection for each report type and it keeps it open for each and every one. Also, I moved some pieces around but it's just for avoiding too much indentation. 

What was really hard was to fix up all the old tests. It used to be that calling `/signature_summary/` in the middleware it would return a plain list (yuck!). Now it returns something like this:

```
{"reports": {
    "uptime": [...uptime stuff...],
    "graphics": [...graphics stuff...],
    ...
}}
```

It used to just return `[...uptime stuff...]` or `[...graphics stuff...]`. 

And now for the really good news. I collected a bunch of signatures, cleared the cache and loaded the `/signature_summary/json_data` view. For example `'http://socorro/signature_summary/json_data?range_value=7&range_unit=days&signature=StrChrIA&version=Firefox:33.0a2&date=2014-08-13`
I did this before and after making this patch. The results are:

Before: 
https://gist.github.com/peterbe/a952e404086f42cf06fe
After:
https://gist.github.com/peterbe/26cf4d706267e9534412

**That's, on average, 5 times faster to load all the signature summary data per signature!**

Also, had I been logged in when making these, it would make the old way even slower!! because it would require one more request for each signature. 

When you click on various signatures from the "Top Crashers" you can really feel how it loads the "Signature Summary" tab much faster. 
