### PR TITLE
fix bug 1054587 - Clean up after fetch adi test

### DIFF
--- a/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
+++ b/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
@@ -49,7 +49,7 @@ class TestFetchADIFromHive(IntegrationTestBase):
 
     def tearDown(self):
         cursor = self.conn.cursor()
-        cursor.execute("TRUNCATE raw_adi_logs, product_productid_map, products CASCADE")
+        cursor.execute("TRUNCATE raw_adi, raw_adi_logs, product_productid_map, products CASCADE")
         super(TestFetchADIFromHive, self).tearDown()
 
     def _setup_config_manager(self):


### PR DESCRIPTION
The raw_adi table did not get cleaned up after the tests were run.

r? @rhelmer

This fixes the problem for me, but I'm not sure if that is because it is the correct solution, or merely hiding it.
