### PR TITLE
followup from bug 1037855 - this introduced an intermittent test

### DIFF
--- a/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
+++ b/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
@@ -192,7 +192,8 @@ class TestFetchADIFromHive(IntegrationTestBase):
             'update_channel',
         )
         pgcursor.execute(
-            """ select %s from raw_adi """ % ','.join(columns)
+            """ select %s from raw_adi
+                order by update_channel desc""" % ','.join(columns)
         )
         adi = [dict(zip(columns, row)) for row in pgcursor.fetchall()]
         eq_(adi, [


### PR DESCRIPTION
failure, specify ORDER BY to make results consistent
