### PR TITLE
fixes Bug 1062272 - configmanize transform rules

### DIFF
--- a/socorro/lib/converters.py
+++ b/socorro/lib/converters.py
@@ -1,0 +1,103 @@
+from configman import RequiredConfig, Namespace, class_converter
+
+
+#------------------------------------------------------------------------------
+def _default_list_splitter(class_list_str):
+    return [x.strip() for x in class_list_str.split(',')]
+
+
+#------------------------------------------------------------------------------
+def _default_class_extractor(list_element):
+    return list_element
+
+
+#------------------------------------------------------------------------------
+def str_to_classes_in_namespaces_converter(
+        template_for_namespace="%(name)s",
+        list_splitter_fn=_default_list_splitter,
+        class_extractor=_default_class_extractor,
+):
+    """
+    parameters:
+        template_for_namespace - a template for the names of the namespaces
+                                 that will contain the classes and their
+                                 associated required config options.  There are
+                                 two template variables available: %(name)s -
+                                 the name of the class to be contained in the
+                                 namespace; %(index)d - the sequential index
+                                 number of the namespace.
+        list_converter - a function that will take the string list of classes
+                         and break it up into a sequence if individual elements
+        class_extractor - a function that will return the string version of
+                          a classname from the result of the list_converter
+    """
+
+    # -------------------------------------------------------------------------
+    def class_list_converter(class_list_str):
+        """This function becomes the actual converter used by configman to
+        take a string and convert it into the nested sequence of Namespaces,
+        one for each class in the list.  It does this by creating a proxy
+        class stuffed with its own 'required_config' that's dynamically
+        generated."""
+        if isinstance(class_list_str, basestring):
+            class_str_list = list_splitter_fn(class_list_str)
+        else:
+            raise TypeError('must be derivative of a basestring')
+
+        # =====================================================================
+        class InnerClassList(RequiredConfig):
+            """This nested class is a proxy list for the classes.  It collects
+            all the config requirements for the listed classes and places them
+            each into their own Namespace.
+            """
+            # we're dynamically creating a class here.  The following block of
+            # code is actually adding class level attributes to this new class
+
+            # 1st requirement for configman
+            required_config = Namespace()
+
+            # to help the programmer know what Namespaces we added
+            subordinate_namespace_names = []
+
+            # save the template for future reference
+            namespace_template = template_for_namespace
+
+            # for display
+            original_input = class_list_str.replace('\n', '\\n')
+
+            # for each class in the class list
+            class_list = []
+            for namespace_index, class_list_element in enumerate(
+                class_str_list
+            ):
+                a_class = class_converter(
+                    class_extractor(class_list_element)
+                )
+
+                class_list.append((a_class.__name__, a_class))
+                # figure out the Namespace name
+                namespace_name_dict = {
+                    'name': a_class.__name__,
+                    'index': namespace_index
+                }
+                namespace_name = template_for_namespace % namespace_name_dict
+                subordinate_namespace_names.append(namespace_name)
+                # create the new Namespace
+                required_config.namespace(namespace_name)
+                a_class_namespace = required_config[namespace_name]
+                # add options for the classes required config
+                try:
+                    for k, v in a_class.get_required_config().iteritems():
+                        a_class_namespace[k] = v
+                except AttributeError:  # a_class has no get_required_config
+                    pass
+
+            @classmethod
+            def to_str(cls):
+                """this method takes this inner class object and turns it back
+                into the original string of classnames.  This is used
+                primarily as for the output of the 'help' option"""
+                return cls.original_input
+
+        return InnerClassList  # result of class_list_converter
+    return class_list_converter  # result of classes_in_namespaces_converter

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -1184,7 +1184,7 @@ class LegacyCrashProcessor(RequiredConfig):
                              x[4],
                              x[5])
                             for x in rules]
-        rule_system = TransformRuleSystem()
+        rule_system = TransformRuleSystem(self.config)
         rule_system.load_rules(translated_rules)
 
         self.config.logger.debug(

--- a/socorro/unittest/lib/test_converters.py
+++ b/socorro/unittest/lib/test_converters.py
@@ -1,0 +1,177 @@
+from configman import ConfigurationManager, RequiredConfig, Namespace
+from configman.converters import to_str
+
+from socorro.lib.converters import str_to_classes_in_namespaces_converter
+from socorro.unittest.testbase import TestCase
+
+#==============================================================================
+# the following two classes are used in test_classes_in_namespaces_converter1
+# and need to be declared at module level scope
+class Foo(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('x', default=17)
+    required_config.add_option('y', default=23)
+
+
+#==============================================================================
+class Bar(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('x', default=227)
+    required_config.add_option('a', default=11)
+
+
+# the following two classes are used in test_classes_in_namespaces_converter2
+# and test_classes_in_namespaces_converter_3.  They need to be declared at
+#module level scope
+#==============================================================================
+class Alpha(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('a', doc='a', default=17)
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.a = config.a
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        return "I am an instance of an Alpha object"
+
+
+#==============================================================================
+class AlphaBad1(Alpha):
+    def __init__(self, config):
+        super(AlphaBad1, self).__init__(config)
+        self.a_type = int
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise AttributeError
+
+
+#==============================================================================
+class AlphaBad2(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise KeyError
+
+
+#==============================================================================
+class AlphaBad3(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise TypeError
+
+
+#==============================================================================
+class Beta(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+        'b',
+        doc='b',
+        default=23
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.b = config.b
+
+
+#==============================================================================
+class TestConverters(TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_1(self):
+        converter_fn = str_to_classes_in_namespaces_converter(
+            'class_%(name)s'
+        )
+        class_list_str = (
+            'socorro.unittest.lib.test_converters.Foo,'
+            'socorro.unittest.lib.test_converters.Bar'
+        )
+        result = converter_fn(class_list_str)
+        self.assertTrue(hasattr(result, 'required_config'))
+        req = result.required_config
+        self.assertEqual(len(req), 2)
+        self.assertTrue('class_Foo' in req)
+        self.assertEqual(len(req.class_Foo), 2)
+        self.assertTrue('class_Bar' in req)
+        self.assertEqual(len(req.class_Bar), 2)
+        self.assertEqual(
+            sorted([x.strip() for x in class_list_str.split(',')]),
+            sorted([
+                x.strip() for x in
+                to_str(result).split(',')
+            ])
+        )
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_2(self):
+        converter_fn = str_to_classes_in_namespaces_converter(
+            'class_%(name)s'
+        )
+        class_sequence = (Foo, Bar)
+        # ought to raise TypeError because 'class_sequence' is not a string
+        self.assertRaises(TypeError, converter_fn, class_sequence)
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_3(self):
+        n = Namespace()
+        n.add_option(
+            'kls_list',
+            default=(
+                'socorro.unittest.lib.test_converters.Foo, '
+                'socorro.unittest.lib.test_converters.Foo, '
+                'socorro.unittest.lib.test_converters.Foo'
+            ),
+            from_string_converter= str_to_classes_in_namespaces_converter(
+                '%(name)s_%(index)02d'
+            )
+        )
+
+        cm = ConfigurationManager(n, argv_source=[])
+        config = cm.get_config()
+
+        self.assertEqual(len(config.kls_list.subordinate_namespace_names), 3)
+        self.assertTrue('Foo_00' in config)
+        self.assertTrue('Foo_01' in config)
+        self.assertTrue('Foo_02' in config)
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_4(self):
+        n = Namespace()
+        n.add_option(
+            'kls_list',
+            default=(
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha'
+            ),
+            from_string_converter=str_to_classes_in_namespaces_converter(
+                '%(name)s_%(index)02d'
+            )
+        )
+
+        cm = ConfigurationManager(
+            n,
+            [{
+                'kls_list': (
+                    'socorro.unittest.lib.test_converters.Alpha, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Alpha'
+                ),
+                'Alpha_00.a': 21,
+                'Beta_01.b': 38,
+            }]
+        )
+        config = cm.get_config()
+
+
+        self.assertEqual(len(config.kls_list.subordinate_namespace_names), 4)
+        for x in config.kls_list.subordinate_namespace_names:
+            self.assertTrue(x in config)
+        self.assertEqual(config.Alpha_00.a, 21)
+        self.assertEqual(config.Beta_01.b, 38)
+

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -330,9 +330,12 @@ class TestHybridProcessor(TestCase):
                   1,
                   leg_proc._create_basic_processed_crash.call_count
                 )
+                minimal_processed_crash = \
+                    leg_proc._create_minimal_processed_crash()
                 leg_proc._create_basic_processed_crash.assert_called_with(
                   raw_crash.uuid,
                   raw_crash,
+                  minimal_processed_crash,
                   datetime(2012, 5, 4, 15, 33, 33, tzinfo=UTC),
                   started_timestamp,
                   [
@@ -513,9 +516,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
 
                 # test 01
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -530,9 +535,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 raw_crash_missing_product = copy.deepcopy(raw_crash)
                 del raw_crash_missing_product['ProductName']
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_missing_product,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -555,6 +562,7 @@ class TestHybridProcessor(TestCase):
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_missing_version,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -575,9 +583,11 @@ class TestHybridProcessor(TestCase):
                 raw_crash_with_hangid = copy.deepcopy(raw_crash)
                 raw_crash_with_hangid.HangID = \
                     '30cb3212-b61d-4d1f-85ae-3bc4bcaa0504'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_with_hangid,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -597,9 +607,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 raw_crash_with_pluginhang = copy.deepcopy(raw_crash)
                 raw_crash_with_pluginhang.PluginHang = '1'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_with_pluginhang,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -619,9 +631,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 raw_crash_with_hang_only = copy.deepcopy(raw_crash)
                 raw_crash_with_hang_only.Hang = 16
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_with_hang_only,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -645,9 +659,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 raw_crash_with_hang_only = copy.deepcopy(raw_crash)
                 raw_crash_with_hang_only.Hang = 'bad value'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   raw_crash_with_hang_only,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -671,9 +687,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 bad_raw_crash = copy.deepcopy(raw_crash)
                 bad_raw_crash['SecondsSinceLastCrash'] = 'badness'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   bad_raw_crash,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -688,9 +706,11 @@ class TestHybridProcessor(TestCase):
                 processor_notes = []
                 bad_raw_crash = copy.deepcopy(raw_crash)
                 bad_raw_crash['CrashTime'] = 'badness'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   bad_raw_crash,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,
@@ -706,9 +726,11 @@ class TestHybridProcessor(TestCase):
                 bad_raw_crash['StartupTime'] = 'badness'
                 bad_raw_crash['InstallTime'] = 'more badness'
                 bad_raw_crash['CrashTime'] = 'even more badness'
+                processed_crash = leg_proc._create_minimal_processed_crash()
                 processed_crash = leg_proc._create_basic_processed_crash(
                   '3bc4bcaa-b61d-4d1f-85ae-30cb32120504',
                   bad_raw_crash,
+                  processed_crash,
                   datetimeFromISOdateString(raw_crash.submitted_timestamp),
                   started_timestamp,
                   processor_notes,

--- a/socorro/unittest/processor/test_skunk_classifiers.py
+++ b/socorro/unittest/processor/test_skunk_classifiers.py
@@ -43,26 +43,28 @@ class TestSkunkClassificationRule(TestCase):
 
     def test_predicate(self):
         rc = DotDict()
+        rd = {}
         pc = DotDict()
         pc.classifications = DotDict()
         processor = None
 
         skunk_rule = SkunkClassificationRule()
-        ok_(skunk_rule.predicate(rc, pc, processor))
+        ok_(skunk_rule.predicate(rc, rd, pc, processor))
 
         pc.classifications.skunk_works = DotDict()
-        ok_(skunk_rule.predicate(rc, pc, processor))
+        ok_(skunk_rule.predicate(rc, rd, pc, processor))
 
         pc.classifications.skunk_works.classification = 'stupid'
-        ok_(not skunk_rule.predicate(rc, pc, processor))
+        ok_(not skunk_rule.predicate(rc, rd, pc, processor))
 
     def test_action(self):
         rc = DotDict()
+        rd = {}
         pc = DotDict()
         processor = None
 
         skunk_rule = SkunkClassificationRule()
-        ok_(skunk_rule.action(rc, pc, processor))
+        ok_(skunk_rule.action(rc, rd, pc, processor))
 
     def test_version(self):
         skunk_rule = SkunkClassificationRule()
@@ -156,8 +158,10 @@ class TestDontConsiderTheseFilter(TestCase):
         # find non-plugin crashes
         test_raw_crash = DotDict()
         test_raw_crash.PluginHang = '0'
+        test_raw_dumps = {}
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -168,6 +172,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.ProductName = "Internet Explorer"
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -178,6 +183,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.ProductName = "Firefox"
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -189,6 +195,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.Version = 'dwight'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -200,6 +207,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.Version = '17.1'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -212,6 +220,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '201307E2'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -224,6 +233,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '201307E2'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -236,6 +246,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '20131458'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -248,6 +259,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '20121015'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -260,6 +272,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '20121015'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -273,6 +286,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_raw_crash.BuildID = '20121015'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             DotDict(),
             fake_processor
         ))
@@ -286,6 +300,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash = DotDict()
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -301,6 +316,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.json_dump = DotDict()
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -318,6 +334,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.json_dump.cpu_arch = 'amd64'
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -336,6 +353,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.success = False
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -361,6 +379,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.c.success = False
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -386,6 +405,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.c.success = False
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -411,6 +431,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.c.success = False
         ok_(filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -436,6 +457,7 @@ class TestDontConsiderTheseFilter(TestCase):
         test_processed_crash.c.success = True
         ok_(not filter_rule.predicate(
             test_raw_crash,
+            test_raw_dumps,
             test_processed_crash,
             fake_processor
         ))
@@ -459,9 +481,9 @@ class TestUpdateWindowAttributes(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = UpdateWindowAttributes()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -483,9 +505,9 @@ class TestUpdateWindowAttributes(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = UpdateWindowAttributes()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_(not 'classifications' in pc)
@@ -509,9 +531,9 @@ class TestSetWindowPos(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SetWindowPos()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -538,9 +560,9 @@ class TestSetWindowPos(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SetWindowPos()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -568,9 +590,9 @@ class TestSetWindowPos(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SetWindowPos()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -596,9 +618,9 @@ class TestSetWindowPos(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SetWindowPos()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -621,9 +643,9 @@ class TestSetWindowPos(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SetWindowPos()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_(not 'classifications' in pc)
@@ -644,9 +666,9 @@ class TestSendWaitReceivePort(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = SendWaitReceivePort()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -663,9 +685,10 @@ class TestSendWaitReceivePort(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
+        rd = {}
 
         rule = SendWaitReceivePort()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_(not 'classifications' in pc)
@@ -687,9 +710,9 @@ class TestBug811804(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = Bug811804()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -709,9 +732,9 @@ class TestBug811804(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = Bug811804()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_(not 'classifications' in pc)
@@ -733,9 +756,9 @@ class TestBug812318(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = Bug812318()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -756,9 +779,9 @@ class TestBug812318(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = Bug812318()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -777,9 +800,9 @@ class TestBug812318(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = Bug812318()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_(not 'classifications' in pc)

--- a/socorro/unittest/processor/test_support_classifiers.py
+++ b/socorro/unittest/processor/test_support_classifiers.py
@@ -43,23 +43,25 @@ class TestSupportClassificationRule(TestCase):
 
     def test_predicate(self):
         rc = DotDict()
+        rd = {}
         pc = DotDict()
         pc.classifications = DotDict()
         processor = None
 
         support_rule = SupportClassificationRule()
-        ok_(support_rule.predicate(rc, pc, processor))
+        ok_(support_rule.predicate(rc, rd, pc, processor))
 
         pc.classifications.support = DotDict()
-        ok_(support_rule.predicate(rc, pc, processor))
+        ok_(support_rule.predicate(rc, rd, pc, processor))
 
     def test_action(self):
         rc = DotDict()
+        rd = {}
         pc = DotDict()
         processor = None
 
         support_rule = SupportClassificationRule()
-        ok_(support_rule.action(rc, pc, processor))
+        ok_(support_rule.action(rc, rd, pc, processor))
 
     def test_version(self):
         support_rule = SupportClassificationRule()
@@ -102,9 +104,9 @@ class TestBitguardClassfier(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = BitguardClassifier()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_('classifications' in pc)
@@ -122,9 +124,9 @@ class TestBitguardClassfier(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
-
+        rd = {}
         rule = BitguardClassifier()
-        action_result = rule.action(rc, pc, fake_processor)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(not action_result)
         ok_('classifications' not in pc)
@@ -139,6 +141,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash = DotDict()
         raw_crash.ProductName = 'Firefox'
         raw_crash.Version = '16'
+        raw_dumps = {}
 
         fake_processor = create_basic_fake_processor()
         fake_processor.config.firefox_out_of_date_version = '17'
@@ -146,6 +149,7 @@ class TestOutOfDateClassifier(TestCase):
         classifier = OutOfDateClassifier()
         ok_(classifier._predicate(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -153,6 +157,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash.Version = '19'
         ok_(not classifier._predicate(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -161,6 +166,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash.ProductName = 'NotFireFox'
         ok_(not classifier._predicate(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -196,6 +202,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash = DotDict()
         raw_crash.ProductName = 'Firefox'
         raw_crash.Version = '16'
+        raw_dumps = {}
 
         fake_processor = create_basic_fake_processor()
 
@@ -206,6 +213,7 @@ class TestOutOfDateClassifier(TestCase):
             '5.1.2600 Service Pack 2'
         ok_(classifier._windows_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -221,6 +229,7 @@ class TestOutOfDateClassifier(TestCase):
             '5.0 Service Pack 23'
         ok_(classifier._windows_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -236,6 +245,7 @@ class TestOutOfDateClassifier(TestCase):
             '5.1.2600 Service Pack 3'
         ok_(classifier._windows_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -269,6 +279,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash = DotDict()
         raw_crash.ProductName = 'Firefox'
         raw_crash.Version = '16'
+        raw_dumps = {}
 
         fake_processor = create_basic_fake_processor()
 
@@ -279,6 +290,7 @@ class TestOutOfDateClassifier(TestCase):
         processed_crash.json_dump['system_info']['cpu_arch'] = 'ppc'
         ok_(classifier._osx_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -294,6 +306,7 @@ class TestOutOfDateClassifier(TestCase):
         processed_crash.json_dump['system_info']['cpu_arch'] = 'ppc'
         ok_(classifier._osx_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -309,6 +322,7 @@ class TestOutOfDateClassifier(TestCase):
         processed_crash.json_dump['system_info']['cpu_arch'] = 'x86'
         ok_(classifier._osx_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -323,6 +337,7 @@ class TestOutOfDateClassifier(TestCase):
         processed_crash.json_dump['system_info']['os_ver'] = '10.99'
         ok_(classifier._osx_action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -338,6 +353,7 @@ class TestOutOfDateClassifier(TestCase):
         raw_crash = DotDict()
         raw_crash.ProductName = 'Firefox'
         raw_crash.Version = '16'
+        raw_dumps = {}
 
         fake_processor = create_basic_fake_processor()
 
@@ -349,6 +365,7 @@ class TestOutOfDateClassifier(TestCase):
         processed_crash.json_dump['system_info']['cpu_arch'] = 'ppc'
         ok_(classifier._action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))
@@ -361,6 +378,7 @@ class TestOutOfDateClassifier(TestCase):
             '5.1.2600 Service Pack 3'
         ok_(classifier._action(
             raw_crash,
+            raw_dumps,
             processed_crash,
             fake_processor
         ))


### PR DESCRIPTION
in preparation for Processor2015, the processor based entirely on transform rules, the existing transform rules had to be modernized.  There were several major changes:

1) a new Rules base class, Configman enabled
2) the TransformRuleSet needed to understand configman in order to load rules from configuration
3) the API for all rules needed to be unified

beware: this PR changes the fundamental from of the TransformRules system.  It was built to be backwards compatible, but there still had to be changes to the existing calling code.  This change cannot be feature-flagged on or off.  That would have required duplicating the functionality of the whole rules system and I deemed that excessive.  
