### PR TITLE
fix bug 1062614 - Have Travis-CI only run `pip install` once.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
   - sudo ln -s /usr/local/lib/node_modules/less/bin/lessc /usr/local/bin
   - sed -i 's:jenkins-pg92:localhost:' config/alembic.ini-dist
 
+install: true
+
 before_script:
     - psql -c "create user test with encrypted password 'aPassword' superuser;" -U postgres
     - psql -c 'create database socorro_test;' -U postgres


### PR DESCRIPTION
This will allow peep to do it's thing and cryptographically verify the
repeatability of our python packages.

fix bug 1062614
