### PR TITLE
Add webapp-django/media/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pip-cache
 pip-log.txt
 build
 .DS_Store
+webapp-django/media/
 
 # exclude filesystem storage directories
 primaryCrashStore/


### PR DESCRIPTION
Given that `webapp-django/media/` is a build artefact, it is not and should not be tracked by git, therefore we could (should?) add it to `.gitignore`.

([bug 1062913](https://bugzilla.mozilla.org/show_bug.cgi?id=1062913))
