### PR TITLE
Fixes Bug1063599 - neglected rules in the configmanization of rules

### DIFF
--- a/socorro/processor/processed_transform_rules.py
+++ b/socorro/processor/processed_transform_rules.py
@@ -8,135 +8,13 @@ these are the rules that transform a raw crash into a processed crash
 
 from socorro.lib.ver_tools import normalize
 from socorro.lib.util import DotDict
+from socorro.lib.transform_rules import Rule
 
 from sys import maxint
 
 
 #==============================================================================
-class ProcessedTransformRule(object):
-    """the base class for Support Rules.  It provides the framework for the
-    rules 'predicate', 'action', and 'version' as well as utilites to help
-    rules do their jobs."""
-
-    #--------------------------------------------------------------------------
-    def predicate(self, raw_crash, processed_crash, processor):
-        """the default predicate for processed_transform invokes any derivied
-        _predicate function, trapping any exceptions raised in the process.  We
-        are obligated to catch these exceptions to give subsequent rules the
-        opportunity act.  An error during the predicate application is a
-        failure of the rule, not a failure of the classification system itself
-        """
-        try:
-            return self._predicate(raw_crash, processed_crash, processor)
-        except Exception, x:
-            processor.config.logger.debug(
-                'processed_transform: %s predicate rejection - consideration '
-                'of %s failed because of "%s"',
-                self.__class__,
-                raw_crash.get('uuid', 'unknown uuid'),
-                x,
-                exc_info=True
-            )
-            return False
-
-    #--------------------------------------------------------------------------
-    def _predicate(self, raw_crash, processed_crash, processor):
-        """"The default processed_transform predicate just returns True.  We
-        want all the processed_transform rules to run.
-
-        parameters:
-            raw_crash - a mapping representing the raw crash data originally
-                        submitted by the client
-            processed_crash - the ultimate result of the processor, this is the
-                              analyzed version of a crash.  It contains the
-                              output of the MDSW program for each of the dumps
-                              within the crash.
-            processor - a reference to the processor object that is assigned
-                        to working on the current crash. This object contains
-                        resources that might be useful to a classifier rule.
-                        'processor.config' is the configuration for the
-                        processor in which database connection paramaters can
-                        be found.  'processor.config.logger' is useful for any
-                        logging of debug information.
-                        'processor.c_signature_tool' or
-                        'processor.java_signature_tool' contain utilities that
-                        might be useful during classification.
-
-        returns:
-            True - this rule should be applied
-            False - this rule should not be applied
-        """
-        return True
-
-    #--------------------------------------------------------------------------
-    def action(self, raw_crash, processed_crash, processor):
-        """the default action for processed_transform  invokes any derivied
-        _action function, trapping any exceptions raised in the process.  We
-        are obligated to catch these exceptions to give subsequent rules the
-        opportunity act and perhaps (mitigate the error).  An error during the
-        action application is a failure of the rule, not a failure of the
-        classification system itself."""
-        try:
-            return self._action(raw_crash, processed_crash, processor)
-        except KeyError, x:
-            processor.config.logger.debug(
-                'processed_transform: %s action failure - %s failed because of '
-                '"%s"',
-                self.__class__,
-                raw_crash.get('uuid', 'unknown uuid'),
-                x,
-            )
-        except Exception, x:
-            processor.config.logger.debug(
-                'processed_transform: %s action failure - %s failed because of '
-                '"%s"',
-                self.__class__,
-                raw_crash.get('uuid', 'unknown uuid'),
-                x,
-                exc_info=True
-            )
-        return False
-
-    #--------------------------------------------------------------------------
-    def _action(self, raw_crash, processed_crash, processor):
-        """Rules derived from this base class ought to override this method
-        with an actual classification rule.  Successful application of this
-        method should include a call to '_add_classification'.
-
-        parameters:
-            raw_crash - a mapping representing the raw crash data originally
-                        submitted by the client
-            processed_crash - the ultimate result of the processor, this is the
-                              analized version of a crash.  It contains the
-                              output of the MDSW program for each of the dumps
-                              within the crash.
-            processor - a reference to the processor object that is assigned
-                        to working on the current crash. This object contains
-                        resources that might be useful to a classifier rule.
-                        'processor.config' is the configuration for the
-                        processor in which database connection paramaters can
-                        be found.  'processor.config.logger' is useful for any
-                        logging of debug information.
-                        'processor.c_signature_tool' or
-                        'processor.java_signature_tool' contain utilities that
-                        might be useful during classification.
-
-        returns:
-            True - this rule was applied successfully and no further rules
-                   should be applied
-            False - this rule did not succeed and further rules should be
-                    tried
-        """
-        return True
-
-    #--------------------------------------------------------------------------
-    def version(self):
-        """This method should be overridden in a base class."""
-        return '0.0'
-
-
-#==============================================================================
-class OOMSignature(ProcessedTransformRule):
+class OOMSignature(Rule):
     """To satisfy Bug 1007530, this rule will modify the signature to
     tag OOM (out of memory) crashes"""
 
@@ -151,7 +29,7 @@ class OOMSignature(ProcessedTransformRule):
         return '1.0'
 
     #--------------------------------------------------------------------------
-    def _predicate(self, raw_crash, processed_crash, processor):
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, processor):
         if 'OOMAllocationSize' in raw_crash:
             return True
         signature = processed_crash.signature
@@ -161,7 +39,7 @@ class OOMSignature(ProcessedTransformRule):
         return False
 
     #--------------------------------------------------------------------------
-    def _action(self, raw_crash, processed_crash, processor):
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor):
         processed_crash.original_signature = processed_crash.signature
         try:
             size = int(raw_crash.OOMAllocationSize)
@@ -181,7 +59,7 @@ class OOMSignature(ProcessedTransformRule):
 
 
 #==============================================================================
-class SigTrunc(ProcessedTransformRule):
+class SigTrunc(Rule):
     """ensure that the signature is never longer than 255 characters"""
 
     #--------------------------------------------------------------------------
@@ -189,11 +67,11 @@ class SigTrunc(ProcessedTransformRule):
         return '1.0'
 
     #--------------------------------------------------------------------------
-    def _predicate(self, raw_crash, processed_crash, processor):
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, processor):
         return len(processed_crash.signature) > 255
 
     #--------------------------------------------------------------------------
-    def _action(self, raw_crash, processed_crash, processor):
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor):
         processed_crash.signature = "%s..." % processed_crash.signature[:252]
         return True
 

--- a/socorro/unittest/processor/test_processed_transform_rules.py
+++ b/socorro/unittest/processor/test_processed_transform_rules.py
@@ -4,9 +4,8 @@
 
 from nose.tools import eq_, ok_
 
-from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.util import DotDict, SilentFakeLogger, FakeLogger
 from socorro.processor.processed_transform_rules import (
-    ProcessedTransformRule,
     OOMSignature,
     SigTrunc,
 )
@@ -27,32 +26,9 @@ def create_basic_fake_processor():
     fake_processor.c_signature_tool = c_signature_tool
     fake_processor.config = DotDict()
     # need help figuring out failures? switch to FakeLogger and read stdout
-    fake_processor.config.logger = SilentFakeLogger()
-    #fake_processor.config.logger = FakeLogger()
+    #fake_processor.config.logger = SilentFakeLogger()
+    fake_processor.config.logger = FakeLogger()
     return fake_processor
-
-
-class TestProcessedTransformRule(TestCase):
-
-    def test_predicate(self):
-        rc = DotDict()
-        pc = DotDict()
-        processor = None
-
-        rule = ProcessedTransformRule()
-        ok_(rule.predicate(rc, pc, processor))
-
-    def test_action(self):
-        rc = DotDict()
-        pc = DotDict()
-        processor = None
-
-        support_rule = ProcessedTransformRule()
-        ok_(support_rule.action(rc, pc, processor))
-
-    def test_version(self):
-        support_rule = ProcessedTransformRule()
-        eq_(support_rule.version(), '0.0')
 
 
 class TestOOMSignature(TestCase):
@@ -61,46 +37,51 @@ class TestOOMSignature(TestCase):
         pc = DotDict()
         pc.signature = 'hello'
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = OOMSignature()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(not predicate_result)
 
     def test_OOMAllocationSize_predicate(self):
         pc = DotDict()
         pc.signature = 'hello'
+        rd = {}
         rc = DotDict()
         rc.OOMAllocationSize = 17
         fake_processor = create_basic_fake_processor()
-        rule = OOMSignature()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(predicate_result)
 
     def test_OOMAllocationSize_predicate_signature_fragment_1(self):
         pc = DotDict()
         pc.signature = 'this | is | a | NS_ABORT_OOM | signature'
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = OOMSignature()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(predicate_result)
 
     def test_OOMAllocationSize_predicate_signature_fragment_2(self):
         pc = DotDict()
         pc.signature = 'mozalloc_handle_oom | this | is | bad'
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = OOMSignature()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(predicate_result)
 
     def test_OOMAllocationSize_predicate_signature_fragment_3(self):
         pc = DotDict()
         pc.signature = 'CrashAtUnhandlableOOM'
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = OOMSignature()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(predicate_result)
 
     def test_OOMAllocationSize_action_success(self):
@@ -110,9 +91,10 @@ class TestOOMSignature(TestCase):
         fake_processor = create_basic_fake_processor()
 
         rc = DotDict()
+        rd = {}
 
-        rule = OOMSignature()
-        action_result = rule.action(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_(pc.original_signature, 'hello')
@@ -126,9 +108,10 @@ class TestOOMSignature(TestCase):
 
         rc = DotDict()
         rc.OOMAllocationSize = 17
+        rd = {}
 
-        rule = OOMSignature()
-        action_result = rule.action(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_(pc.original_signature, 'hello')
@@ -142,9 +125,10 @@ class TestOOMSignature(TestCase):
 
         rc = DotDict()
         rc.OOMAllocationSize = 17000000
+        rd = {}
 
-        rule = OOMSignature()
-        action_result = rule.action(rc, pc, fake_processor)
+        rule = OOMSignature(fake_processor.config)
+        action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
         ok_(pc.original_signature, 'hello')
@@ -154,27 +138,30 @@ class TestOOMSignature(TestCase):
         pc = DotDict()
         pc.signature = '0' * 100
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = SigTrunc()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = SigTrunc(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(not predicate_result)
 
     def test_SigTrunc_predicate(self):
         pc = DotDict()
         pc.signature = '9' * 256
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = SigTrunc()
-        predicate_result = rule.predicate(rc, pc, fake_processor)
+        rule = SigTrunc(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
         ok_(predicate_result)
 
     def test_SigTrunc_action_success(self):
         pc = DotDict()
         pc.signature = '9' * 256
         rc = DotDict()
+        rd = {}
         fake_processor = create_basic_fake_processor()
-        rule = SigTrunc()
-        predicate_result = rule.action(rc, pc, fake_processor)
+        rule = SigTrunc(fake_processor.config)
+        predicate_result = rule.action(rc, rd, pc, fake_processor)
         ok_(predicate_result)
         eq_(len(pc.signature), 255)
         ok_(pc.signature.endswith('9...'))


### PR DESCRIPTION
In the configmanization of the TransformRule, the ProcessedTransform Rules were neglected and were not updated.  That means that they fail when given a configuration that they weren't expecting.  

This was not caught because the ProcessedTransformRules are added at run time rather than config time based on lists of transforms in the database.  Those rules likely don't exist in the test database, so were never loaded.  Since they're getting moved to configuration, it is not likely worth changing the test to ensure they get loaded - that loading method is about to go away...
