### PR TITLE
fixes bug 785271 - Add admin interface for "add new product"

### DIFF
--- a/socorro/external/postgresql/releases.py
+++ b/socorro/external/postgresql/releases.py
@@ -100,7 +100,7 @@ class Releases(PostgreSQLBase):
 
         return True
 
-    def update_release(self, **kwargs):
+    def create_release(self, **kwargs):
         filters = [
             ('product', None, 'str'),
             ('version', None, 'str'),
@@ -114,7 +114,7 @@ class Releases(PostgreSQLBase):
         params = external_common.parse_arguments(filters, kwargs)
         # all fields are mandatory
         for key in [x[0] for x in filters if x[1] is None]:
-            if not params.get(key):
+            if not params.get(key) and params.get(key) != 0:
                 raise MissingArgumentError(key)
 
         with self.get_connection() as connection:

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -56,7 +56,7 @@ SERVICES_LIST = (
     (r'/products/builds/(.*)', 'products_builds.ProductsBuilds'),
     (r'/products/(.*)', 'products.Products'),
     (r'/query/', 'query.Query'),
-    (r'/releases/(featured)/(.*)', 'releases.Releases'),
+    (r'/releases/(featured|release)/(.*)', 'releases.Releases'),
     (r'/signatureurls/(.*)', 'signature_urls.SignatureURLs'),
     (r'/signaturesummary/(.*)', 'signature_summary.SignatureSummary'),
     (r'/search/(signatures|crashes)/(.*)', 'search.Search'),

--- a/socorro/unittest/external/postgresql/test_releases.py
+++ b/socorro/unittest/external/postgresql/test_releases.py
@@ -379,7 +379,7 @@ class IntegrationTestReleases(PostgreSQLTestCase):
         }
         eq_(res, res_expected)
 
-    def test_update_release(self):
+    def test_create_release(self):
         self._insert_release_channels()
         service = Releases(config=self.config)
 
@@ -396,7 +396,7 @@ class IntegrationTestReleases(PostgreSQLTestCase):
             throttle=1
         )
 
-        res = service.update_release(**params)
+        res = service.create_release(**params)
         ok_(res)
 
     def test_update_release_missingargumenterror(self):
@@ -417,6 +417,6 @@ class IntegrationTestReleases(PostgreSQLTestCase):
         )
         assert_raises(
             MissingArgumentError,
-            service.update_release,
+            service.create_release,
             **params
         )

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -518,6 +518,30 @@ class CurrentProducts(SocorroMiddleware):
         }
     }
 
+    def post(self, **data):
+        # why does this feel so clunky?!
+        return super(CurrentProducts, self).post(self.URL_PREFIX, data)
+
+
+class Releases(SocorroMiddleware):
+
+    URL_PREFIX = '/releases/release/'
+
+    required_params = (
+        'product',
+        'version',
+        'update_channel',
+        'build_id',
+        'platform',
+        ('beta_number', int),
+        'release_channel',
+        ('throttle', int),
+    )
+
+    def post(self, **data):
+        # why does this feel so clunky?!
+        return super(Releases, self).post(self.URL_PREFIX, data)
+
 
 class ReleasesFeatured(SocorroMiddleware):
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -1657,3 +1657,9 @@ table.data-table {
 .ui-tabs-panel {
     border: 1px solid #e0e0e0;
 }
+
+
+/* Django forms in general */
+ul.errorlist li {
+    color: red;
+}

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -1275,6 +1275,29 @@ class TestModels(TestCase):
                        'NightTrain': ['1', '2']})
         eq_(r, True)
 
+    @mock.patch('requests.post')
+    def test_create_release(self, rpost):
+        model = models.Releases
+        api = model()
+
+        def mocked_post(url, **options):
+            assert '/releases/release/' in url
+            return Response(True)
+
+        rpost.side_effect = mocked_post
+        now = datetime.datetime.utcnow()
+        r = api.post(**{
+            'product': 'Firefox',
+            'version': '1.0',
+            'update_channel': 'beta',
+            'build_id': now.strftime('%Y%m%d%H%M'),
+            'platform': 'Windows',
+            'beta_number': '0',
+            'release_channel': 'Beta',
+            'throttle': '1'
+        })
+        eq_(r, True)
+
     @mock.patch('requests.get')
     def test_correlations(self, rget):
         model = models.Correlations

--- a/webapp-django/crashstats/manage/templates/manage/base.html
+++ b/webapp-django/crashstats/manage/templates/manage/base.html
@@ -29,6 +29,10 @@
                  {% if url('manage:symbols_uploads') in request.path_info  %}class="selected"{% endif %}>Symbols Uploads</a></li>
             <li><a href="{{ url('manage:supersearch_fields') }}"
                  {% if url('manage:supersearch_fields') in request.path_info  %}class="selected"{% endif %}>Super Search Fields</a></li>
+            <li><a href="{{ url('manage:products') }}"
+                 {% if url('manage:products') in request.path_info  %}class="selected"{% endif %}>Products</a></li>
+            <li><a href="{{ url('manage:releases') }}"
+                 {% if url('manage:releases') in request.path_info  %}class="selected"{% endif %}>Releases</a></li>
         </ul>
     </div>
     {% block mainbody %}

--- a/webapp-django/crashstats/manage/templates/manage/featured_versions.html
+++ b/webapp-django/crashstats/manage/templates/manage/featured_versions.html
@@ -22,6 +22,10 @@
       /* roughly 100/7 */
       width:14.2%;
   }
+  .add-products-versions-link {
+      float: right;
+      margin-right: 20px;
+  }
   </style>
 {% endblock %}
 
@@ -31,7 +35,14 @@
 
     <div class="panel">
       <div class="body notitle">
-        <p>Go straight to...</p>
+        <div class="add-products-versions-link">
+          <p>
+            If you want to <b>add a new product or release</b> go to<br>
+            <a href="{{ url('manage:products') }}">Products</a> and
+	    <a href="{{ url('manage:releases') }}">Releases</a>.
+          </p>
+        </div>
+        <p><b>Go straight to...</b></p>
         <ul>
           {% for product in products %}
           <li><a href="#{{ product }}">{{ product }}</a></li>

--- a/webapp-django/crashstats/manage/templates/manage/home.html
+++ b/webapp-django/crashstats/manage/templates/manage/home.html
@@ -45,6 +45,12 @@
       <p>
          <a href="{{ url('manage:supersearch_fields') }}">Super Search Fields</a>
       </p>
+      <p>
+         <a href="{{ url('manage:products') }}">Products</a>
+      </p>
+      <p>
+         <a href="{{ url('manage:releases') }}">Releases</a>
+      </p>
 
       </div>
     </div>

--- a/webapp-django/crashstats/manage/templates/manage/products.html
+++ b/webapp-django/crashstats/manage/templates/manage/products.html
@@ -1,0 +1,37 @@
+{% extends "manage/base.html" %}
+
+{% block page_title %}{{ super() }} - {{ page_title }}{% endblock %}
+
+
+{% block site_css %}
+  {{ super() }}
+  <style type="text/css">
+  table.data-table th {
+      width: 250px;
+  }
+  </style>
+{% endblock %}
+
+{% block admin_title %}{{ super() }} - {{ page_title }}{% endblock %}
+
+{% block mainbody %}
+
+  <div class="panel">
+    <div class="body notitle">
+
+      <h3>Add New Product</h3>
+
+      <form action="" method="post">{{ csrf() }}
+        <table class="data-table">
+        {{ form }}
+        <tr>
+          <th>&nbsp;</th>
+          <td><input type="submit" value="Submit"></td>
+        </tr>
+        </table>
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/webapp-django/crashstats/manage/templates/manage/releases.html
+++ b/webapp-django/crashstats/manage/templates/manage/releases.html
@@ -1,0 +1,37 @@
+{% extends "manage/base.html" %}
+
+{% block page_title %}{{ super() }} - {{ page_title }}{% endblock %}
+
+{% block site_css %}
+  {{ super() }}
+  <style type="text/css">
+  table.data-table th {
+      width: 250px;
+  }
+  </style>
+{% endblock %}
+
+
+{% block admin_title %}{{ super() }} - {{ page_title }}{% endblock %}
+
+{% block mainbody %}
+
+  <div class="panel">
+    <div class="body notitle">
+
+      <h3>Add New Product Release</h3>
+
+      <form action="" method="post">{{ csrf() }}
+        <table class="data-table">
+        {{ form }}
+        <tr>
+          <th>&nbsp;</th>
+          <td><input type="submit" value="Submit"></td>
+        </tr>
+        </table>
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/webapp-django/crashstats/manage/urls.py
+++ b/webapp-django/crashstats/manage/urls.py
@@ -77,4 +77,10 @@ urlpatterns = patterns(
     url('^supersearch-field/delete/$',
         views.supersearch_field_delete,
         name='supersearch_field_delete'),
+    url('^products/$',
+        views.products,
+        name='products'),
+    url('^releases/$',
+        views.releases,
+        name='releases'),
 )

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -13,10 +13,12 @@ from django.shortcuts import render, redirect, get_object_or_404
 
 from crashstats.crashstats.models import (
     CurrentProducts,
+    Releases,
     ReleasesFeatured,
     Field,
     SkipList,
-    GraphicsDevices
+    GraphicsDevices,
+    Platforms
 )
 from crashstats.supersearch.models import (
     SuperSearchField,
@@ -520,3 +522,84 @@ def supersearch_fields_missing(request):
     context['missing_fields_count'] = missing_fields['total']
 
     return render(request, 'manage/supersearch_fields_missing.html', context)
+
+
+@superuser_required
+def products(request):
+    context = {}
+    api = CurrentProducts()
+    if request.method == 'POST':
+        form = forms.ProductForm(
+            request.POST,
+            existing_products=dict(
+                (k, [v['version'] for v in vs])
+                for k, vs in api.get()['hits'].items()
+            ),
+            product_must_not_exist=True
+        )
+        if form.is_valid():
+            api = CurrentProducts()
+            api.post(
+                product=form.cleaned_data['product'],
+                version=form.cleaned_data['version']
+            )
+            messages.success(
+                request,
+                'Product %s (%s) added.' % (
+                    form.cleaned_data['product'],
+                    form.cleaned_data['version']
+                )
+            )
+            return redirect('manage:products')
+    else:
+        form = forms.ProductForm()
+    context['form'] = form
+    context['page_title'] = "Products"
+    return render(request, 'manage/products.html', context)
+
+
+@superuser_required
+def releases(request):
+    context = {}
+    products_api = CurrentProducts()
+    platforms_api = Platforms()
+    platform_names = [x['name'] for x in platforms_api.get()]
+
+    if request.method == 'POST':
+        form = forms.ReleaseForm(
+            request.POST,
+            existing_products=dict(
+                (k, [v['version'] for v in vs])
+                for k, vs in products_api.get()['hits'].items()
+            ),
+            product_must_exist=True,
+            platforms=platform_names
+        )
+        if form.is_valid():
+            api = Releases()
+            api.post(
+                product=form.cleaned_data['product'],
+                version=form.cleaned_data['version'],
+                update_channel=form.cleaned_data['update_channel'],
+                build_id=form.cleaned_data['build_id'],
+                platform=form.cleaned_data['platform'],
+                beta_number=form.cleaned_data['beta_number'],
+                release_channel=form.cleaned_data['release_channel'],
+                throttle=form.cleaned_data['throttle'],
+            )
+            messages.success(
+                request,
+                'New release for %s:%s added.' % (
+                    form.cleaned_data['product'],
+                    form.cleaned_data['version']
+                )
+            )
+            return redirect('manage:releases')
+    else:
+        form = forms.ReleaseForm(
+            platforms=platform_names
+        )
+
+    context['form'] = form
+    context['page_title'] = "Releases"
+    return render(request, 'manage/releases.html', context)


### PR DESCRIPTION
@rhelmer r?

The way I tested this (apart from a bunch integration tests) was to edit `products.py` and `releases.py` so that, in the moment before calling the relevant stored procedures, it instead raises an exception and I print what it was about to call the stored procedures with. I did this because my middleware is hooked up to the stage DB and I didn't want to create some random junk in there. 

Also, on the Admin interface for `/admin/products/` and `/admin/releases/` there's good opportunity to either explain some of the fields or to make some necessary links to the documentation. What do you think?
