### PR TITLE
fixes bug 1065145 - Refactor ftpscraper.py crontabber app so it can use config.logger

### DIFF
--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -41,6 +41,9 @@ class TestFTPScraper(TestCaseBase):
         self.urllib2 = self.urllib2_patcher.start()
 
         self.scrapers = ftpscraper.ScrapersMixin()
+        self.scrapers.config = DotDict({
+            'logger': mock.Mock()
+        })
 
     def tearDown(self):
         super(TestFTPScraper, self).tearDown()


### PR DESCRIPTION
@rhelmer r?

Sorry, this patch looks much bigger than it is. That's because of a lot of moving things around and indenting them.

I basically took all the `getSomethingxxx()` function and put them into a class called `ScrapersMixin` and then I added a bunch of `self` signatures where appropriate. 
