### PR TITLE
fixes Bug 1066120 - patches to transform system to get rules running again

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -444,14 +444,16 @@ def eq_key_predicate(
 # (is_not_null_predicate, '', 'key="fred",
 # ...)
 #------------------------------------------------------------------------------
-def is_not_null_predicate(source, other, key=''):
+def is_not_null_predicate(raw_crash, dumps, processed_crash, processor, key=''):
     """a predicate that converts the key'd source to boolean.
 
     parameters:
-        source - the mapping containing the value to test
-        other - unused
-        key - the key into the source for the first value"""
+        raw_crash - dict
+        dumps - placeholder in a fat interface - unused
+        processed_crash - placeholder in a fat interface - unused
+        processor - placeholder in a fat interface - unused
+    """
     try:
-        return bool(source[key])
+        return bool(raw_crash[key])
     except KeyError:
         return False

--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -1383,14 +1383,14 @@ class HybridCrashProcessor(RequiredConfig):
         # The rule system was written for an older version of the processor.
         # There is data in the database that refers to the dynamic loading of
         # python modules, but only for the old processor.  This next code block
-        # takes the reference to the old code and replacese them with
+        # takes the reference to the old code and replaces them with
         # references to the equivalent modules in the new code.
         translated_rules = [(x[0].replace('processor.processor',
-                                          'processor.legacy_processor'),
+                                          'processor.hybrid_processor'),
                              x[1],
                              x[2],
                              x[3].replace('processor.processor',
-                                          'processor.legacy_processor'),
+                                          'processor.hybrid_processor'),
                              x[4],
                              x[5])
                             for x in rules]
@@ -1579,3 +1579,8 @@ def json_Product_rewrite_action(raw_crash, raw_dumps, processed_crash, processor
     old_product_name = raw_crash['ProductName']
     new_product_name = processor._product_id_map[product_id]['product_name']
     raw_crash['ProductName'] = new_product_name
+    processor.config.logger.debug('product name changed from %s to %s based '
+                                  'on productID %s',
+                                  old_product_name,
+                                  new_product_name,
+                                  product_id)

--- a/socorro/unittest/lib/test_transform_rules.py
+++ b/socorro/unittest/lib/test_transform_rules.py
@@ -441,22 +441,22 @@ class TestTransformRules(TestCase):
     def test_is_not_null_predicate(self):
         ok_(
             transform_rules.is_not_null_predicate(
-                {'alpha': 'hello'}, None, 'alpha'
+                {'alpha': 'hello'}, None, None, None, 'alpha'
             )
         )
         ok_(not
             transform_rules.is_not_null_predicate(
-                {'alpha': 'hello'}, None, 'beta'
+                {'alpha': 'hello'}, None, None, None, 'beta'
             )
         )
         ok_(not
             transform_rules.is_not_null_predicate(
-                {'alpha': ''}, None, 'alpha'
+                {'alpha': ''}, None, None, None, 'alpha'
             )
         )
         ok_(not
             transform_rules.is_not_null_predicate(
-                {'alpha': None}, None, 'alpha'
+                {'alpha': None}, None, None, None, 'alpha'
             )
         )
 


### PR DESCRIPTION
he processor rewrite rules have been broken since the deploying to 101

it has to do with dependency on legacy processor - switch to rules from the HybridProcessor.
