### PR TITLE
fixes Bug 1066156 - fixed raw_crash type in ReprocessingJobs

### DIFF
--- a/socorro/cron/jobs/reprocessingjobs.py
+++ b/socorro/cron/jobs/reprocessingjobs.py
@@ -10,6 +10,7 @@ from crontabber.mixins import (
     with_transactional_resource
 )
 from socorro.external.postgresql.dbapi2_util import execute_query_iter
+from socorro.lib.util import DotDict
 
 _reprocessing_sql = """ DELETE FROM reprocessing_jobs RETURNING crash_id """
 
@@ -30,9 +31,9 @@ class ReprocessingJobsApp(BaseCronApp):
 
     def run(self, connection):
 
-        for crash_id in execute_query_iter(connection, _reprocessing_sql):
+        for crash_id, in execute_query_iter(connection, _reprocessing_sql):
             self.queuing_connection_factory.save_raw_crash(
-                {'legacy_processing': True},
+                DotDict({'legacy_processing': True}),
                 [],
                 crash_id
             )

--- a/socorro/unittest/cron/jobs/test_reprocessingjobs.py
+++ b/socorro/unittest/cron/jobs/test_reprocessingjobs.py
@@ -6,6 +6,8 @@ from mock import Mock
 from nose.plugins.attrib import attr
 from nose.tools import eq_
 
+from socorro.lib.util import DotDict
+
 from crontabber.app import CronTabber
 
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
@@ -86,6 +88,13 @@ class IntegrationTestReprocessingJobs(IntegrationTestBase):
         res_expected = 0
         res, = cursor.fetchone()
         eq_(res, res_expected)
+
+        self.rabbit_queue_mocked.return_value.save_raw_crash \
+            .assert_called_once_with(
+                DotDict({'legacy_processing': True}),
+                [],
+                '13c4a348-5d04-11e3-8118-d231feb1dc81'
+            )
 
     def test_reprocessing_exception(self):
         config_manager = self._setup_config_manager()


### PR DESCRIPTION
the crontabber crash reprocessing job had two bad flaws, I don't know how it ever worked.  
1) DotDict is require as the from a raw crash.  the dummy was just a regular dict - fixed
2) the crash_id is should be in the form of a string, not a tuple containing a string - fixed
