### PR TITLE
re- fixes Bug1066156 - reverse the legacy_processing_flag logic

### DIFF
--- a/socorro/cron/jobs/reprocessingjobs.py
+++ b/socorro/cron/jobs/reprocessingjobs.py
@@ -33,7 +33,7 @@ class ReprocessingJobsApp(BaseCronApp):
 
         for crash_id, in execute_query_iter(connection, _reprocessing_sql):
             self.queuing_connection_factory.save_raw_crash(
-                DotDict({'legacy_processing': True}),
+                DotDict({'legacy_processing': 0}),
                 [],
                 crash_id
             )

--- a/socorro/unittest/cron/jobs/test_reprocessingjobs.py
+++ b/socorro/unittest/cron/jobs/test_reprocessingjobs.py
@@ -91,7 +91,7 @@ class IntegrationTestReprocessingJobs(IntegrationTestBase):
 
         self.rabbit_queue_mocked.return_value.save_raw_crash \
             .assert_called_once_with(
-                DotDict({'legacy_processing': True}),
+                DotDict({'legacy_processing': 0}),
                 [],
                 '13c4a348-5d04-11e3-8118-d231feb1dc81'
             )


### PR DESCRIPTION
the reprocessing cron job treated the "legacy_processing" flag as if it were a boolean.  In reality, it is an int because, historically, it needed more than 2 states.  Fixed the logic so it actually uses the correct value instead of True. 
