### PR TITLE
no bug; gitignore stackwalker binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,9 @@ pip-log.txt
 build
 .DS_Store
 webapp-django/media/
+minidump-stackwalk/*.o
+minidump-stackwalk/stackwalker
 
 # exclude filesystem storage directories
 primaryCrashStore/
 processedCrashStore/
-minidump-stackwalk/*.o


### PR DESCRIPTION
The `stackwalker` binary is a build artefact and should be ignored by git.
