### PR TITLE
Bug 1066344 platforms to read from platforms

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -343,14 +343,14 @@ class TestViews(BaseTestViews):
         ok_('featured' in version)
         ok_('release' in version)
 
-    @mock.patch('requests.get')
-    def test_Platforms(self, rget):
+    def test_Platforms(self):
+        # note: this gets mocked out in the setUp
         url = reverse('api:model_wrapper', args=('Platforms',))
         response = self.client.get(url)
         eq_(response.status_code, 200)
         dump = json.loads(response.content)
-        ok_(dump[0]['code'])
-        ok_(dump[0]['name'])
+        # see the setUp for this fixture
+        eq_(dump[0], {'code': 'win', 'name': 'Windows'})
 
     @mock.patch('requests.get')
     def test_TCBS(self, rget):

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -569,44 +569,22 @@ class ProductsVersions(CurrentVersions):
 
 class Platforms(SocorroMiddleware):
 
+    URL_PREFIX = '/platforms/'
+
     API_WHITELIST = (
         'code',
         'name',
     )
 
     def get(self):
-        # For dev only, this should be moved to a middleware service
-        # using the database as soon as possible.
-        platforms = [
-            {
-                'code': 'win',
-                'name': 'Windows',
-                'display': True,
-            },
-            {
-                'code': 'win32',
-                'name': 'Windows',
-            },
-            {
-                'code': 'win',
-                'name': 'Windows NT',
-            },
-            {
-                'code': 'mac',
-                'name': 'Mac OS X',
-                'display': True,
-            },
-            {
-                'code': 'lin',
-                'name': 'Linux',
-                'display': True,
-            },
-            {
-                'code': 'linux-i686',
-                'name': 'Linux'
-            }
+        # When we first exposed this model it would just return a plain
+        # list. It was hardcoded. To avoid deprecating things for people
+        # we continue this trandition by only returning the hits directly
+        result = super(Platforms, self).get()
+        return [
+            dict(x, display=x['name'] in settings.DISPLAY_OS_NAMES)
+            for x in result['hits']
         ]
-        return platforms
 
 
 class CrashesPerAdu(SocorroMiddleware):

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -1537,6 +1537,34 @@ class TestModels(TestCase):
                     channel='nightly')
         eq_(r['total'], 2)
 
+    @mock.patch('requests.get')
+    def test_platforms(self, rget):
+        api = models.Platforms()
+
+        def mocked_get(url, **options):
+            assert '/platforms/' in url
+            return Response({
+                "hits": [
+                    {
+                        "code": "win",
+                        "name": "Windows"
+                    },
+                    {
+                        "code": "unk",
+                        "name": "Unknown"
+                    }
+                ],
+                "total": 2
+            })
+
+        rget.side_effect = mocked_get
+        r = api.get()
+        eq_(len(r), 2)
+        assert 'Windows' in settings.DISPLAY_OS_NAMES
+        eq_(r[0], {'code': 'win', 'name': 'Windows', 'display': True})
+        assert 'Unknown' not in settings.DISPLAY_OS_NAMES
+        eq_(r[1], {'code': 'unk', 'name': 'Unknown', 'display': False})
+
 
 class TestModelsWithFileCaching(TestCase):
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -275,6 +275,36 @@ class BaseTestViews(DjangoTestCase):
         def mocked_get(url, params, **options):
             now = datetime.datetime.utcnow()
             yesterday = now - datetime.timedelta(days=1)
+            if '/platforms/' in url:
+                return Response({
+                    "hits": [
+                        {
+                            'code': 'win',
+                            'name': 'Windows',
+                        },
+                        {
+                            'code': 'win32',
+                            'name': 'Windows',
+                        },
+                        {
+                            'code': 'win',
+                            'name': 'Windows NT',
+                        },
+                        {
+                            'code': 'mac',
+                            'name': 'Mac OS X',
+                        },
+                        {
+                            'code': 'lin',
+                            'name': 'Linux',
+                        },
+                        {
+                            'code': 'linux-i686',
+                            'name': 'Linux'
+                        }
+                    ],
+                    "total": 6
+                })
             if 'products/' in url:
                 return Response("""
                     {"products": [
@@ -372,9 +402,12 @@ class BaseTestViews(DjangoTestCase):
             raise NotImplementedError(url)
 
         rget.side_effect = mocked_get
-        from crashstats.crashstats.models import CurrentVersions
-        api = CurrentVersions()
-        api.get()
+
+        # call these here so it gets patched for each test because
+        # it gets used so often
+        from crashstats.crashstats.models import CurrentVersions, Platforms
+        CurrentVersions().get()
+        Platforms().get()
 
     def tearDown(self):
         super(BaseTestViews, self).tearDown()
@@ -5613,16 +5646,37 @@ class TestViews(BaseTestViews):
         url = reverse('crashstats:correlations_json')
 
         def mocked_get(url, params, **options):
-            ok_('report_type' in params)
-            eq_(params['report_type'], 'core-counts')
+            if '/platforms/' in url:
+                return Response({
+                    "hits": [
+                        {
+                            "code": "win",
+                            "name": "Windows NT"
+                        },
+                        {
+                            "code": "mac",
+                            "name": "Mac OS X"
+                        },
+                        {
+                            "code": "lin",
+                            "name": "Linux"
+                        },
+                        {
+                            "code": "unk",
+                            "name": "Unknown"
+                        }
+                    ],
+                    "total": 4
+                })
+            elif '/correlations/' in url:
+                ok_('report_type' in params)
+                eq_(params['report_type'], 'core-counts')
 
-            return Response("""
-                {
+                return Response({
                     "reason": "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS",
                     "count": 13,
                     "load": "36% (4/11) vs.  26% (47/180) amd64 with 2 cores"
-                }
-            """)
+                })
 
             raise NotImplementedError(url)
 
@@ -5647,14 +5701,34 @@ class TestViews(BaseTestViews):
         url = reverse('crashstats:correlations_signatures_json')
 
         def mocked_get(url, params, **options):
-            assert '/correlations/signatures' in url
-            return Response("""
-                {
+            if '/platforms/' in url:
+                return Response({
+                    "hits": [
+                        {
+                            "code": "win",
+                            "name": "Windows NT"
+                        },
+                        {
+                            "code": "mac",
+                            "name": "Mac OS X"
+                        },
+                        {
+                            "code": "lin",
+                            "name": "Linux"
+                        },
+                        {
+                            "code": "unk",
+                            "name": "Unknown"
+                        }
+                    ],
+                    "total": 4
+                })
+            elif '/correlations/' in url:
+                return Response({
                     "hits": ["FakeSignature1",
                              "FakeSignature2"],
                     "total": 2
-                }
-            """)
+                })
 
             raise NotImplementedError(url)
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -513,6 +513,9 @@ def topcrasher(request, product=None, versions=None, date_range_type=None,
         # once https://bugzilla.mozilla.org/show_bug.cgi?id=790642 lands.
         os_short_name_binding = {'lin': 'linux'}
         for operating_system in operating_systems:
+            if operating_system['name'] == 'Unknown':
+                # not applicable in this context
+                continue
             os_code = operating_system['code'][0:3].lower()
             key = '%s_count' % os_short_name_binding.get(os_code, os_code)
             crash_counts.append([crash[key], operating_system['name']])

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -337,3 +337,7 @@ DISALLOWED_SYMBOLS_SNIPPETS = (
 
 # Rate limit for when using the Web API for anonymous hits
 API_RATE_LIMIT = '10/m'
+
+# When we pull platforms from the Platforms API we later decide which of
+# these to display at various points in the UI.
+DISPLAY_OS_NAMES = ['Windows', 'Mac OS X', 'Linux']


### PR DESCRIPTION
@rhelmer r?

So, `/plaforms/` doesn't have the `display: True/False` which the hardcoded stuff in `models.Platforms` used to have. 
So, instead of hacking that into the middleware service, I apply it inside the `models.Platforms.get` method. 

`/daily/` and `/query/` now work but perhaps best you try it too yourself. 
