### PR TITLE
bug 1037512 - adding 'name' param to /api/RawCrash/

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -878,6 +878,10 @@ class UnredactedCrash(ProcessedCrash):
 
 
 class RawCrash(SocorroMiddleware):
+    """
+    To access any of the raw dumps (e.g. format=raw) you need an API
+    token that carries the "View Raw Dumps" permission.
+    """
 
     URL_PREFIX = '/crash_data/'
 
@@ -886,6 +890,7 @@ class RawCrash(SocorroMiddleware):
     )
     possible_params = (
         'format',
+        'name',
     )
 
     defaults = {


### PR DESCRIPTION
@rhelmer r?

NB: I have not been able to manually test this new code. As we're discussing this in IRC at the time of writing. This code likely won't change since it's quite a superficial change on how to send the parameter. 
