### PR TITLE
fixes bug 1067548 - API testdrive binary data and failure after success

### DIFF
--- a/webapp-django/crashstats/api/static/api/css/documentation.css
+++ b/webapp-django/crashstats/api/static/api/css/documentation.css
@@ -20,23 +20,21 @@ a.collapse-list, a.expand-list {
 input.error {
     border: 2px solid red;
 }
-div.test-drive {
-    display: none;
-}
-button.close {
+/* things that are hidden by default */
+div.test-drive,
+button.close,
+.status-error,
+img.loading-ajax,
+.binary-response-warning {
     display: none;
 }
 .status-error {
-    display: none;
     color: red;
     font-weight: bold;
 }
 pre.docstring {
     background-color: rgb(225,225,225);
     padding: 6px;
-}
-img.loading-ajax {
-    display: none;
 }
 .title h2 a {
     text-decoration: none;

--- a/webapp-django/crashstats/api/static/api/js/lib/filesize.min.js
+++ b/webapp-django/crashstats/api/static/api/js/lib/filesize.min.js
@@ -1,0 +1,10 @@
+/*
+ 2014 Jason Mulligan
+ @license BSD-3 <https://raw.github.com/avoidwork/filesize.js/master/LICENSE>
+ @link http://filesizejs.com
+ @module filesize
+ @version 2.0.3
+*/
+(function(p){function f(f,c){var b="",a,g,l,m,e,n,d,h,k;if(isNaN(f))throw Error("Invalid arguments");c=c||{};g=!0===c.bits;d=!0===c.unix;b=void 0!==c.base?c.base:d?2:10;n=void 0!==c.round?c.round:d?1:2;h=void 0!==c.spacer?c.spacer:d?"":" ";k=void 0!==c.suffixes?c.suffixes:{};e=Number(f);m=0>e;l=2<b?1E3:1024;m&&(e=-e);0===e?d?b="0":(a="B",b="0"+h+(k[a]||a)):(a=Math.floor(Math.log(e)/Math.log(1E3)),8<a&&(a=8),b=2===b?e/Math.pow(2,10*a):e/Math.pow(1E3,a),g&&(b*=8,b>l&&(b/=l,a++)),b=b.toFixed(0<a?n:0),
+a=q[g?"bits":"bytes"][a],d?(g&&r.test(a)&&(a=a.toLowerCase()),a=a.charAt(0),d=b.replace(s,""),"B"===a?a="":g||"k"!==a||(a="K"),t.test(d)&&(b=parseInt(b,u)),b+=h+(k[a]||a)):d||(b+=h+(k[a]||a)));m&&(b="-"+b);return b}var r=/b$/,u=10,s=/.*\./,t=/^0$/,q={bits:"B kb Mb Gb Tb Pb Eb Zb Yb".split(" "),bytes:"B kB MB GB TB PB EB ZB YB".split(" ")};"undefined"!==typeof exports?module.exports=f:"function"===typeof define?define(function(){return f}):p.filesize=f})(this);
+//@ sourceMappingURL=filesize.map

--- a/webapp-django/crashstats/api/static/api/js/testdrive.js
+++ b/webapp-django/crashstats/api/static/api/js/testdrive.js
@@ -97,9 +97,19 @@
                var container = $('.test-drive', form);
                $('.used-url code', container).text(url);
                $('.used-url a', container).attr('href', url);
+               if (jqXHR.getResponseHeader('Content-Type') === 'application/octet-stream') {
+                    $('pre', container).hide();
+                    $('.binary-response-warning', container).show();
+               } else {
+                    // in case it was binary *before* this run, reset it
+                    $('pre', container).show();
+                    $('.binary-response-warning', container).hide();
+               }
                $('pre', container).text(response);
                $('.status code', container).hide();
                $('.status-error', container).hide();
+               $('.response-size code', container).text(filesize(response.length));
+               $('.response-size').show();
                container.show();
                setTimeout(function() {
                    // add a slight delay so it feels smoother for endpoints
@@ -111,9 +121,15 @@
            },
            error: function(jqXHR, textStatus, errorThrown) {
                var container = $('.test-drive', form);
+               $('.used-url code', container).text(url);
+               $('.used-url a', container).attr('href', url);
                $('pre', container).text(jqXHR.responseText);
                $('.status code', container).text(jqXHR.status).show();
                $('.status-error', container).show();
+               $('.response-size').hide();
+               // in case it was binary before this run
+               $('pre', container).show();
+               $('.binary-response-warning', container).hide();
                container.show();
                setTimeout(function() {
                    // add a slight delay so it feels smoother for endpoints
@@ -166,10 +182,25 @@
             $(this).removeClass('error');
         });
 
-        $('button.close').click(function(event) {
+        $('button.close').on('click', function(event) {
             event.preventDefault();
             $('.test-drive', $(this).parents('form')).hide();
             $(this).hide();
+        });
+
+        $('.binary-response-warning').on('click', 'a.show', function(event) {
+            event.preventDefault();
+            var parent = $(this).closest('.test-drive');
+            $('pre', parent).show();
+            $(this).hide();
+        });
+
+        $('.binary-response-warning').on('click', 'a.open', function(event) {
+            event.preventDefault();
+            var parent = $(this).closest('.test-drive');
+            var url = $('.used-url a', parent).attr('href');
+            location.href = url;
+            // window.open(url);
         });
 
     });

--- a/webapp-django/crashstats/api/templates/api/documentation.html
+++ b/webapp-django/crashstats/api/templates/api/documentation.html
@@ -14,6 +14,7 @@
 
 {% block site_js %}
     {{ super() }}
+    <script type="text/javascript" src="{{ static('api/js/lib/filesize.min.js') }}"></script>
     {% compress js %}
     <script type="text/javascript" src="{{ static('api/js/testdrive.js') }}"></script>
     {% endcompress %}
@@ -127,6 +128,15 @@
           </p>
           <p><strong>Output:</strong></p>
           <pre></pre>
+          <span class="binary-response-warning">
+            Looks like this is binary output!
+            <a href="#" class="show">See it anyway?</a>
+            <a href="#" class="open">Download the content?</a>
+          </span>
+          <p class="response-size">
+            <strong>Size:</strong>
+            <code></code>
+          </p>
 
           </div>
         </form>


### PR DESCRIPTION
@rhelmer r?

Now it looks like this instead:
![screenshot 2014-09-15 14 49 39](https://cloud.githubusercontent.com/assets/26739/4279520/3e85e70a-3d22-11e4-9d36-99e5800473e8.png)

I was cheeky and extended the functionality slightly by adding the "Size: XXX.X Kb" output too. I think this helps to be able to tell what was returned. 
