### PR TITLE
Fixes bug 1067196 - Added columns choice to the Reports tab of signature report.

### DIFF
--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -48,6 +48,40 @@
     content: url('../../img/3rdparty/silk/arrow_bottom.png');
 }
 
+th.crash-id {
+    width: 235px;
+}
+a.crash-id {
+    font-family: monospace;
+}
+
+.controls {
+    text-align: center;
+    position: relative;
+
+    button {
+        cursor: pointer;
+        padding: 2px 6px;
+        vertical-align: middle;
+    }
+
+    hr {
+        background-color: #ccc;
+        border-color: #ccc;
+        color: #ccc;
+        margin-top: 15px;
+        width: 60%;
+    }
+}
+
+#reports-panel {
+    .controls {
+        input {
+            width: 800px;
+        }
+    }
+}
+
 #aggregations-panel {
     .panel {
         float: left;
@@ -66,9 +100,6 @@
     }
 
     .controls {
-        text-align: center;
-        position: relative;
-
         .loader {
             background-image: url('../../img/ajax-loader16x16.gif');
             display: inline-block;
@@ -81,19 +112,6 @@
 
         .fields-list {
             width: 30%;
-        }
-
-        button {
-            padding: 2px 6px;
-            vertical-align: middle;
-        }
-
-        hr {
-            background-color: #ccc;
-            border-color: #ccc;
-            color: #ccc;
-            margin-top: 15px;
-            width: 60%;
         }
     }
 }

--- a/webapp-django/crashstats/signature/templates/signature/signature_comments.html
+++ b/webapp-django/crashstats/signature/templates/signature/signature_comments.html
@@ -7,14 +7,18 @@
     <table class="tablesorter data-table">
         <thead>
             <tr>
-                <th scope="col">Crash ID</th>
+                <th scope="col" class="crash-id">Crash ID</th>
                 <th scope="col">Comment</th>
             </tr>
         </thead>
         <tbody>
             {% for crash in query.hits %}
             <tr>
-                <td><a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link">{{ crash.uuid }}</a></td>
+                <td>
+                    <a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link crash-id">
+                        {{ crash.uuid }}
+                    </a>
+                </td>
                 <td>
                     {{ crash.user_comments }}
                 </td>

--- a/webapp-django/crashstats/signature/templates/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/templates/signature/signature_report.html
@@ -68,7 +68,14 @@
         </header>
 
         <div class="body">
-            <!-- TODO include a fields list input here -->
+            <div class="controls">
+                <input type="text" name="_columns_fake" value="{{ columns | join(', ') }}">
+                <!-- This second input is required by select2 for sorting. -->
+                <input type="hidden" name="_columns" value="{{ columns | join(', ') }}">
+                <button type="submit">Update</button>
+                <hr>
+            </div>
+
             <div class="content">
                 <div class="loader"></div>
             </div>
@@ -135,6 +142,7 @@ var FIELDS = {{ fields | json_dumps }};
 </script>
 
 {% compress js %}
+<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
 <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
 {% endcompress %}
 

--- a/webapp-django/crashstats/signature/templates/signature/signature_reports.html
+++ b/webapp-django/crashstats/signature/templates/signature/signature_reports.html
@@ -7,7 +7,7 @@
     <table id="reports-list" class="tablesorter data-table">
         <thead>
             <tr>
-                <th scope="col">Crash ID</th>
+                <th scope="col" class="crash-id">Crash ID</th>
                 {% for column in columns %}
                 <th scope="col">{{ column | replace('_', ' ') | capitalize }}</th>
                 {% endfor %}
@@ -16,7 +16,11 @@
         <tbody>
             {% for crash in query.hits %}
             <tr>
-                <td><a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link">{{ crash.uuid }}</a></td>
+                <td>
+                    <a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link crash-id">
+                        {{ crash.uuid }}
+                    </a>
+                </td>
                 {% for column in columns %}
                 <td>
                     {% if crash[column] %}

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -75,6 +75,8 @@ def signature_report(request, default_context=None):
         {'id': field, 'text': field.replace('_', ' ')} for field in fields
     ]
 
+    context['columns'] = request.GET.getlist('_columns') or DEFAULT_COLUMNS
+
     return render(request, 'signature/signature_report.html', context)
 
 


### PR DESCRIPTION
@peterbe r?

What's cool is that the columns were already supported, all I had to do was enable them in the HTML/JS. Hence the fact that there is no unit test added here: they already exist (see https://github.com/mozilla/socorro/blob/master/webapp-django/crashstats/signature/tests/test_views.py#L144 ). 
