### PR TITLE
Fixes bug 1069077 - Removed encoding of HTML characters in signature in JS.

### DIFF
--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -6,6 +6,7 @@ $(function () {
     // parameters
     var form = $('#search-form form');
     var fieldsURL = form.data('fields-url');
+    var SIGNATURE = form.data('signature');
     var tabsElt = $('.tabs');
 
     var pageNum = 1;  // the page number as passed in the URL

--- a/webapp-django/crashstats/signature/templates/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/templates/signature/signature_report.html
@@ -25,6 +25,7 @@
 
         <form method="get" action="{{ url('signature:signature_report') }}"
             data-fields-url="{{ url('supersearch.search_fields') }}?exclude=signature"
+            data-signature="{{ signature }}"
         >
             <button type="submit" id="search-button">Search</button>
             <button class="new-line">new line</button>
@@ -130,7 +131,6 @@
 
 <script>
 var BASE_URL = location.protocol + '//' + location.host;
-var SIGNATURE = '{{ signature }}';
 var FIELDS = {{ fields | json_dumps }};
 </script>
 


### PR DESCRIPTION
@peterbe Is this the correct solution? The problem here is that a signature can contain characters such as `&` or `<`, and those get encoded when they are displayed with jinja, leading to the signature becoming, from `fun(a&, b<>)`, something like `fun(a&amp;, b&lt;&gt;)`. That value cannot be understood by the server, of course, so we need to mark the signature as safe. But it's a user-generated value, so it should not be safe!!! Hence the replacement of the quotes inside that variable to make sure it's impossible to execute any code by finishing the string statement. 

Is that safe? Did I forget anything? Is there a much better way of doing this that I am not aware of? 
