### PR TITLE
bug 1069359; init virtualenv on login

### DIFF
--- a/puppet/modules/socorro/files/home/bashrc
+++ b/puppet/modules/socorro/files/home/bashrc
@@ -1,0 +1,13 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi
+
+# User specific aliases and functions
+VENV="${HOME}/socorro/socorro-virtualenv/bin/activate"
+if [ -f $VENV ] && [ -r $VENV ]; then
+    . $VENV
+    export PYTHONPATH=.
+fi

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -182,6 +182,12 @@ class socorro::vagrant {
       source => 'puppet:///modules/socorro/etc_profile.d/pgsql.sh',
       owner  => 'root',
       ensure => file;
+
+    '.bashrc':
+      path   => '/home/vagrant/.bashrc',
+      source => 'puppet:///modules/socorro/home/bashrc',
+      owner  => 'vagrant',
+      ensure => file;
   }
 
 }


### PR DESCRIPTION
Pretty straightforward.  I expect that this will be (eventually) replaced by something more programmatic down the line, but imho, this is a convenient addition with little incurred technical debt. :money_with_wings:

@rhelmer @bramwelt `r?`
