### PR TITLE
bug 1066058; add Support Reason API crashstorage type

### DIFF
--- a/socorro/external/ceph/crashstorage.py
+++ b/socorro/external/ceph/crashstorage.py
@@ -487,8 +487,7 @@ class SupportReasonAPIStorage(BotoS3CrashStorage):
             # Set up the data chunk to be passed to S3.
             reason = processed_crash['classifications']['support']['classification']
             content = {
-                # Unfortunate mixing of uuid and crash_id terminology. :(
-                'uuid': crash_id,
+                'crash_id': crash_id,
                 'reasons': [reason]
             }
         except KeyError:

--- a/socorro/unittest/external/ceph/test_crashstorage.py
+++ b/socorro/unittest/external/ceph/test_crashstorage.py
@@ -415,7 +415,7 @@ class TestCase(socorro.unittest.testbase.TestCase):
             [
                 mock.call(
                     '{"reasons": ["SIGSEGV"],'
-                    ' "uuid": "3c61f81e-ea2b-4d24-a3ce-6bb9d2140915"}'
+                    ' "crash_id": "3c61f81e-ea2b-4d24-a3ce-6bb9d2140915"}'
                 ),
             ],
             any_order=True,


### PR DESCRIPTION
_Preamble: This PR is primarily submitted for discussion purposes (I expect more work to be necessary)._

This adds the `SupportReasonAPIStorage` class which is a sub-class of `BotoS3CrashStorage`; functionally speaking, the former is basically a _highly lossy_ implementation of the latter.

cc @twobraids 
