### PR TITLE
fix bug 1069718 - no longer need devtoolset SCL on RHEL/CentOS

### DIFF
--- a/docs/installation/install-src-dev.rst
+++ b/docs/installation/install-src-dev.rst
@@ -45,12 +45,7 @@ Install stackwalker
 This is the binary which processes breakpad crash dumps into stack traces.
 You must build it with GCC 4.6 or above.
 
-If you are using RHEL/CentOS and installed GCC from the devtoolset repo
-(per the installation instructions), make sure to "activate" it:
-::
-  scl enable devtoolset-1.1 bash
-
-Then compile breakpad and the stackwalker binary:
+Compile breakpad and the stackwalker binary:
 ::
   make breakpad stackwalker
 

--- a/docs/installation/rhel.rst
+++ b/docs/installation/rhel.rst
@@ -32,18 +32,13 @@ Then the repository definition:
   enabled=1
   EOF
 
-Install `Devtools 1.1 repository <http://people.centos.org/tru/devtools-1.1/readme>`_, needed for stackwalker
-::
-  sudo curl http://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -o /etc/yum.repos.d/devtools-1.1.repo
-
 Now you can actually install the packages:
 ::
   sudo yum install postgresql93-server postgresql93-plperl \
     postgresql93-contrib postgresql93-devel subversion make rsync \
     subversion gcc-c++ python-devel python-pip mercurial nodejs-less \
-    git libxml2-devel libxslt-devel java-1.7.0-openjdk \
-    python-virtualenv npm devtoolset-1.1-gcc-c++ rabbitmq-server \
-    elasticsearch httpd mod_wsgi memcached daemonize
+    git libxml2-devel libxslt-devel java-1.7.0-openjdk python-virtualenv npm \
+    rabbitmq-server elasticsearch httpd mod_wsgi memcached daemonize
 
 Enable Apache on startup:
 ::


### PR DESCRIPTION
r? anybody - @luser removed the need for installing a newer GCC a while back, and these instructions only ever worked on CentOS not RHEL anyway (I recently got an email from somebody pointing this out).

3 additions, 13 deletions ftw
