### PR TITLE
fix bug 1071397 - download and cache breakpad.tar.gz, unless on non-Linu...

### DIFF
--- a/docs/installation/install-src-dev.rst
+++ b/docs/installation/install-src-dev.rst
@@ -39,16 +39,6 @@ From inside the Socorro checkout
   make test database_username=test database_password=aPassword
 
 
-Install stackwalker
--------------------
-
-This is the binary which processes breakpad crash dumps into stack traces.
-You must build it with GCC 4.6 or above.
-
-Compile breakpad and the stackwalker binary:
-::
-  make breakpad stackwalker
-
 Populate PostgreSQL Database
 ----------------------------
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,10 +17,16 @@ source "$VIRTUAL_ENV/bin/activate"
 ${VIRTUAL_ENV}/bin/pip install tools/peep-1.2.tar.gz
 ${VIRTUAL_ENV}/bin/peep install --download-cache=./pip-cache -r requirements.txt
 
-# pull pre-built, known version of breakpad
-wget --quiet 'https://ci.mozilla.org/job/breakpad/lastSuccessfulBuild/artifact/breakpad.tar.gz'
-tar -zxf breakpad.tar.gz && rm breakpad.tar.gz
-mv breakpad stackwalk
+if [ "`uname -sm`" == "Linux x86_64" ]; then
+  # pull pre-built, known version of breakpad
+  wget -N --quiet 'https://ci.mozilla.org/job/breakpad/lastSuccessfulBuild/artifact/breakpad.tar.gz'
+  tar -zxf breakpad.tar.gz
+  rm -rf stackwalk
+  mv breakpad stackwalk
+else
+  # build breakpad from source
+  make breakpad
+fi
 # Build JSON stackwalker
 pushd minidump-stackwalk
 make

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 find ./ -type f -name "*.pyc" -exec rm {} \;
-rm -rf ./google-breakpad/ ./build/ ./breakpad/ ./stackwalk
+rm -rf ./google-breakpad/ ./build/ ./breakpad/ ./stackwalk breakpad.tar.gz
 
 pushd minidump-stackwalk
 make clean


### PR DESCRIPTION
...x x86_64 in which case build breakpad
