### PR TITLE
fix bug 1071410 - handle all enums in switch

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -165,6 +165,8 @@ string FrameTrust(StackFrame::FrameTrust trust) {
     return "cfi";
   case StackFrame::FRAME_TRUST_CONTEXT:
     return "context";
+  case StackFrame::FRAME_TRUST_PREWALKED:
+    return "prewalked";
   }
 
   return "none";


### PR DESCRIPTION
r? @luser - looks like this is just a description to go in the JSON - the comment for this in stack_frame.h says:

```
Explicitly provided by some external stack walker.
```
