### PR TITLE
fixes bug 1066344 - accept Windows NT as a platform

### DIFF
--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -435,7 +435,8 @@ class CorrelationsJSONFormBase(BaseForm):
         products = [(x, x) for x in current_products]
         versions = [(x['version'], x['version']) for x in current_versions]
         self.platforms = [(x['name'], x['name']) for x in current_platforms]
-
+        # add a necessary exception
+        self.platforms.append(('Windows NT', 'Windows NT'))
         self.fields['product'].choices = products
         self.fields['version'].choices = versions
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -283,24 +283,12 @@ class BaseTestViews(DjangoTestCase):
                             'name': 'Windows',
                         },
                         {
-                            'code': 'win32',
-                            'name': 'Windows',
-                        },
-                        {
-                            'code': 'win',
-                            'name': 'Windows NT',
-                        },
-                        {
                             'code': 'mac',
                             'name': 'Mac OS X',
                         },
                         {
                             'code': 'lin',
                             'name': 'Linux',
-                        },
-                        {
-                            'code': 'linux-i686',
-                            'name': 'Linux'
                         }
                     ],
                     "total": 6
@@ -5760,29 +5748,7 @@ class TestViews(BaseTestViews):
         url = reverse('crashstats:correlations_json')
 
         def mocked_get(url, params, **options):
-            if '/platforms/' in url:
-                return Response({
-                    "hits": [
-                        {
-                            "code": "win",
-                            "name": "Windows NT"
-                        },
-                        {
-                            "code": "mac",
-                            "name": "Mac OS X"
-                        },
-                        {
-                            "code": "lin",
-                            "name": "Linux"
-                        },
-                        {
-                            "code": "unk",
-                            "name": "Unknown"
-                        }
-                    ],
-                    "total": 4
-                })
-            elif '/correlations/' in url:
+            if '/correlations/' in url:
                 ok_('report_type' in params)
                 eq_(params['report_type'], 'core-counts')
 
@@ -5815,29 +5781,7 @@ class TestViews(BaseTestViews):
         url = reverse('crashstats:correlations_signatures_json')
 
         def mocked_get(url, params, **options):
-            if '/platforms/' in url:
-                return Response({
-                    "hits": [
-                        {
-                            "code": "win",
-                            "name": "Windows NT"
-                        },
-                        {
-                            "code": "mac",
-                            "name": "Mac OS X"
-                        },
-                        {
-                            "code": "lin",
-                            "name": "Linux"
-                        },
-                        {
-                            "code": "unk",
-                            "name": "Unknown"
-                        }
-                    ],
-                    "total": 4
-                })
-            elif '/correlations/' in url:
+            if '/correlations/' in url:
                 return Response({
                     "hits": ["FakeSignature1",
                              "FakeSignature2"],


### PR DESCRIPTION
@rhelmer r?

To make the test really depend on this change, I fixed it so that the mocked GET on getting `/platforms/` is more like it is in reality. 
