### PR TITLE
Bug 1051839 - Introduced elasticsearch-py, used it for all bulk indexing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,11 @@ pgxnclient==1.2.1
 pika==0.9.8
 # sha256: SLcCp8pHnhvCwae4GHWgfUdCmBMmBZk-LLl59eCCd9c
 psycopg2==2.4.5
+# sha256: Y_uAldsYamwLussgySl75CXfqd5MMws1NGD2NYIHxqo
+# sha256: 3-5BXIBkzjYnPzDY-eJ7bA4P8qQ9Uv1-1Gcurbry6DM
+elasticsearch==0.4.5
+# sha256: TkALLi9TZS3Q2AYspezEJbavbpaYm40x9d2HUYaqJHs
+urllib3==1.9
 # sha256: 2upIE6eJSfnxlBvixW1aviyZqFgjUMrwWYBPtleIrKU
 pyelasticsearch==0.6.1
 # sha256: cHay6ATFKumO3svU3B-8qBMYb-f1_dYlR4OgClWntEI

--- a/scripts/elasticsearch_backfill_app.py
+++ b/scripts/elasticsearch_backfill_app.py
@@ -82,6 +82,12 @@ class ElasticsearchBackfillApp(generic_app.App):
             self.config.secondary_storage
         )
 
+        self.connection_context = (
+            self.config.elasticsearch.elasticsearch_class(
+                self.config.elasticsearch
+            )
+        )
+
         now = datetimeutil.utc_now()
         current_date = self.config.end_date
 
@@ -114,7 +120,7 @@ class ElasticsearchBackfillApp(generic_app.App):
                 continue
 
             # First create the new index.
-            self.es_storage.create_index(es_new_index)
+            self.es_storage.create_socorro_index(es_new_index)
 
             # Get all the reports in elasticsearch, but only a few at a time.
             for es_from in range(
@@ -211,7 +217,7 @@ class ElasticsearchBackfillApp(generic_app.App):
         return index_format
 
     def index_crashes(self, es_index, crashes_to_index):
-        self.es_storage.es.bulk_index(
+        self.connection_context.bulk_index(
             es_index,
             self.config.elasticsearch.elasticsearch_doctype,
             crashes_to_index,

--- a/scripts/setup_supersearch_app.py
+++ b/scripts/setup_supersearch_app.py
@@ -62,8 +62,10 @@ class SetupSuperSearchApp(generic_app.App):
         all_fields = json.loads(data_file.read())
 
         # Index the data.
-        es_connection = index_creator.es
-        es_connection.bulk_index(
+        connection_context = self.config.elasticsearch.elasticsearch_class(
+            self.config.elasticsearch
+        )
+        connection_context.bulk_index(
             index='socorro',
             doc_type='supersearch_fields',
             docs=all_fields.values(),
@@ -71,6 +73,7 @@ class SetupSuperSearchApp(generic_app.App):
         )
 
         # Verify data was correctly inserted.
+        es_connection = index_creator.es
         es_connection.refresh()
         total_indexed = es_connection.count(
             '*',

--- a/socorro/external/elasticsearch/connection_context.py
+++ b/socorro/external/elasticsearch/connection_context.py
@@ -2,11 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import elasticsearch
+from elasticsearch.helpers import bulk
+
 from configman import Namespace, RequiredConfig
 from configman.converters import list_converter
 
 
 class ConnectionContext(RequiredConfig):
+    """Abstraction layer for Elasticsearch interactions.
+
+    This is used to create connections to Elasticsearch, and contains some
+    utility functions to interact with it.
+    """
 
     required_config = Namespace()
     required_config.add_option(
@@ -42,3 +50,48 @@ class ConnectionContext(RequiredConfig):
         doc='the default doctype to use in elasticsearch',
         reference_value_from='resource.elasticsearch',
     )
+
+    def __init__(self, config):
+        self.config = config
+        super(self.__class__, self).__init__()
+
+    def get_connection(self):
+        """Return a connection to Elasticsearch.
+
+        Returns an instance of elasticsearch-py's Elasticsearch class.
+        Documentation: http://elasticsearch-py.readthedocs.org
+        """
+        return elasticsearch.Elasticsearch(
+            hosts=self.config.elasticsearch_urls,
+            timeout=self.config.elasticsearch_timeout,
+        )
+
+    def bulk_index(
+        self,
+        index,
+        doc_type,
+        docs,
+        id_field,
+        refresh=False,
+        connection=None
+    ):
+        """Index a list of documents into Elasticsearch all at once.
+
+        This is a utility function primarily created as an abstraction of
+        the pyelasticsearch library's bulk_index function, with the goal of
+        simplifying the transition to the elasticsearch-py library.
+        See bug 1051839 for context.
+        """
+        if connection is None:
+            connection = self.get_connection()
+
+        actions = []
+        for doc in docs:
+            actions.append({
+                '_index': index,
+                '_type': doc_type,
+                '_id': doc.get(id_field),
+                '_source': doc,
+            })
+
+        return bulk(connection, actions, refresh=refresh)

--- a/socorro/unittest/external/elasticsearch/test_settings.py
+++ b/socorro/unittest/external/elasticsearch/test_settings.py
@@ -49,8 +49,12 @@ class IntegrationTestSettings(ElasticSearchTestCase):
         es_index = self.storage.get_index_for_crash(self.now)
         self.storage.create_socorro_index(es_index)
 
+        connection_context = config.elasticsearch_class(
+            config
+        )
+
         # Create the supersearch fields.
-        self.storage.es.bulk_index(
+        connection_context.bulk_index(
             index=config.webapi.elasticsearch_default_index,
             doc_type='supersearch_fields',
             docs=SUPERSEARCH_FIELDS.values(),

--- a/socorro/unittest/external/elasticsearch/test_supersearch.py
+++ b/socorro/unittest/external/elasticsearch/test_supersearch.py
@@ -639,9 +639,12 @@ class TestSuperSearch(ElasticSearchTestCase):
     def test_get_indexes(self):
         config = self.get_config_context()
         storage = crashstorage.ElasticSearchCrashStorage(config)
+        connection_context = config.resource.elasticsearch.elasticsearch_class(
+            config.resource.elasticsearch
+        )
 
         # Create the supersearch fields.
-        storage.es.bulk_index(
+        connection_context.bulk_index(
             index=config.webapi.elasticsearch_default_index,
             doc_type='supersearch_fields',
             docs=SUPERSEARCH_FIELDS.values(),
@@ -885,8 +888,12 @@ class IntegrationTestSuperSearch(ElasticSearchTestCase):
             dict(default_crash_report, uuid=21, address='0xa2e4509ca0')
         )
 
+        connection_context = config.resource.elasticsearch.elasticsearch_class(
+            config.resource.elasticsearch
+        )
+
         # Create the supersearch fields.
-        self.storage.es.bulk_index(
+        connection_context.bulk_index(
             index=config.webapi.elasticsearch_default_index,
             doc_type='supersearch_fields',
             docs=SUPERSEARCH_FIELDS.values(),


### PR DESCRIPTION
@phrawzty How is that as a very small first step? It only touches tests and scripts, nothing that Socorro actually runs, so it's pretty safe. 

Maybe we can work iteratively from there. Also, I'd like us to start using `ConnectionContext.get_connection` systematically to get a new connection to Elasticsearch from now on. I believe it will make things a bit cleaner and easier to maintain. 
