### PR TITLE
Bug 1059871 api whitelist to leverage its lists from super search fields

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -729,7 +729,7 @@ class TestViews(BaseTestViews):
         ok_(dump['errors']['crash_id'])
 
         def mocked_get(url, params, **options):
-            assert '/crash_data' in url
+            assert '/crash_data' in url, url
 
             if 'datatype' in params and params['datatype'] == 'processed':
                 return Response("""
@@ -778,6 +778,7 @@ class TestViews(BaseTestViews):
         dump = json.loads(response.content)
         eq_(dump['uuid'], u'11cb72f5-eb28-41e1-a8e4-849982120611')
         ok_('upload_file_minidump_flash2' in dump)
+        ok_('url' not in dump)
 
     @mock.patch('requests.get')
     def test_UnredactedCrash(self, rget):

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -322,6 +322,10 @@ def model_wrapper(request, model_name):
 
         elif not request.user.has_perm('crashstats.view_pii'):
             clean_scrub = getattr(model, 'API_CLEAN_SCRUB', None)
+
+            if isinstance(model.API_WHITELIST, models.Lazy):
+                model.API_WHITELIST = model.API_WHITELIST.materialize()
+
             if result and model.API_WHITELIST:
                 cleaner = Cleaner(
                     model.API_WHITELIST,

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -1257,6 +1257,7 @@ class TestModels(TestCase):
         rget.side_effect = mocked_get
         r = api.get(crash_id='some-crash-id')
         eq_(r['Vendor'], 'Mozilla')
+        ok_('Email' in r)  # no filtering at this level
 
     @mock.patch('requests.get')
     def test_raw_crash_raw_data(self, rget):

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -387,6 +387,11 @@ class BaseTestViews(DjangoTestCase):
                  }
                       """ % {'end_date': now.strftime('%Y-%m-%d'),
                              'yesterday': yesterday.strftime('%Y-%m-%d')})
+            if '/supersearch/fields/' in url:
+                from crashstats.supersearch.tests.test_views import (
+                    SUPERSEARCH_FIELDS_MOCKED_RESULTS
+                )
+                return Response(SUPERSEARCH_FIELDS_MOCKED_RESULTS)
             raise NotImplementedError(url)
 
         rget.side_effect = mocked_get
@@ -396,6 +401,8 @@ class BaseTestViews(DjangoTestCase):
         from crashstats.crashstats.models import CurrentVersions, Platforms
         CurrentVersions().get()
         Platforms().get()
+        from crashstats.supersearch.models import SuperSearchFields
+        SuperSearchFields().get()
 
     def tearDown(self):
         super(BaseTestViews, self).tearDown()

--- a/webapp-django/crashstats/manage/static/manage/css/supersearch_fields.less
+++ b/webapp-django/crashstats/manage/static/manage/css/supersearch_fields.less
@@ -46,3 +46,9 @@ td.boolean {
     vertical-align: middle;
     width: 16px;
 }
+
+.api-exposure-warning {
+    text-align: center;
+    font-size: 110%;
+    margin: 30px;
+}

--- a/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
+++ b/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
@@ -33,6 +33,15 @@ var ALL_PERMISSIONS = {{ all_permissions | json_dumps }};
   <div class="panel">
     <div class="body notitle">
 
+        <p class="api-exposure-warning">
+          <b>A Word of Warning!</b><br>
+          By default, adding a field to the <code>raw_crash</code> or
+          <code>processed_crash</code> namespaces will expose that field in the
+          public <a href="{{ url('api:documentation') }}">Web API</a>. Make
+          sure you have set appropriate permissions to fields containing
+          private or sensitive data before submitting.
+        </p>
+
         <form
             id="supersearch-field"
             method="post"

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -476,6 +476,10 @@ def supersearch_field_create(request):
     # Refresh the cache for the fields service.
     SuperSearchFields().get(refresh_cache=True)
 
+    # The API is using cache to get all fields by a specific namespace
+    # for the whitelist lookup, clear that cache too.
+    cache.delete('api_supersearch_fields_%s' % field_data['namespace'])
+
     return redirect(reverse('manage:supersearch_fields'))
 
 

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -24,6 +24,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'signature',
     },
     'product': {
         'name': 'product',
@@ -35,6 +36,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'product',
     },
     'version': {
         'name': 'version',
@@ -46,6 +48,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'version',
     },
     'platform': {
         'name': 'platform',
@@ -57,6 +60,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'platform',
     },
     'dump': {
         'name': 'dump',
@@ -68,6 +72,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': False,
         'is_mandatory': False,
+        'in_database_name': 'dump',
     },
     'release_channel': {
         'name': 'release_channel',
@@ -79,6 +84,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'release_channel',
     },
     'date': {
         'name': 'date',
@@ -90,6 +96,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'date_processed',
     },
     'address': {
         'name': 'address',
@@ -101,6 +108,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'address',
     },
     'build_id': {
         'name': 'build_id',
@@ -112,6 +120,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'build',
     },
     'reason': {
         'name': 'reason',
@@ -123,6 +132,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'reason',
     },
     'java_stack_trace': {
         'name': 'java_stack_trace',
@@ -134,6 +144,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'java_stack_trace',
     },
     'email': {
         'name': 'email',
@@ -145,6 +156,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'email',
     },
     'url': {
         'name': 'url',
@@ -156,6 +168,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'url',
     },
     'exploitability': {
         'name': 'exploitability',
@@ -169,6 +182,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'exploitability',
     },
     'user_comments': {
         'name': 'user_comments',
@@ -180,6 +194,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_exposed': True,
         'is_returned': True,
         'is_mandatory': False,
+        'in_database_name': 'user_comments',
     },
 }
 


### PR DESCRIPTION
@AdrianGaudebert r?

Even though it seems tests are working and manually testing it seems to work too. However, it feels like it was too easy. :)

Things to note:
- To keep things small, I did not try to solve it for Super Search's API exposure in this round. That's why the commit message doesn't say "fixed bug 1059871"
- I'm not in love about the `Lazy` class and the `materialize()` method. It does so little. Perhaps it can become something else instead. I looked at the `SimpleLazyObject` which looks good but that's more for doing things like attributes. 
- I'm really not in love making the `API_WHITELIST` be a combination of stuff from Super Search and an existing list. Ideally, we should type ALL of those in on the admin pages and just have one monster list. What do you think?
