### PR TITLE
fixes bug 1076908 - ought to call the method rather than refer to the method

### DIFF
--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -282,7 +282,7 @@ class PostgreSQLAlchemyManager(object):
     # compare the actual server version number to a required server version number
     # version required should be an integer, in the format 90300 for 9.3
     def min_ver_check(self, version_required):
-        return self.version_number >= version_required
+        return self.version_number() >= version_required
 
     def create_roles(self, config):
         """


### PR DESCRIPTION
coding error where an integer is being compared to method rather than a call of the method.  This PR add the missing  `()`
