### PR TITLE
fix bug 1077108 - crash_id in cache but not rabbitmq should be warn not ...

### DIFF
--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -193,7 +193,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
                         crash_id_to_be_acknowledged
                     ]
                 except KeyError:
-                    self.config.logger.error(
+                    self.config.logger.warning(
                         'RabbitMQCrashStorage tried to acknowledge crash %s'
                         ', which was not in the cache',
                         crash_id_to_be_acknowledged,

--- a/socorro/unittest/external/rabbitmq/test_crashstorage.py
+++ b/socorro/unittest/external/rabbitmq/test_crashstorage.py
@@ -158,7 +158,7 @@ class TestCrashStorage(TestCase):
         crash_store.acknowledgment_queue.put('b2')
         crash_store._consume_acknowledgement_queue()
 
-        config.logger.error.assert_called_once_with(
+        config.logger.warning.assert_called_once_with(
             'RabbitMQCrashStorage tried to acknowledge crash %s'
             ', which was not in the cache',
             'b2',


### PR DESCRIPTION
...fail
