### PR TITLE
fixes Bug 1077234: restore config_path & values_source_list to app framework

### DIFF
--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -45,12 +45,47 @@ class TestSocorroApp(TestCase):
     def test_run(self):
         class SomeOtherApp(SocorroApp):
             @classmethod
-            def _do_run(klass):
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.config_path = config_path
                 return 17
 
         eq_(SomeOtherApp._do_run(), 17)
+        ok_(SomeOtherApp.config_path is None)
         x = SomeOtherApp.run()
         eq_(x, 17)
+
+    #--------------------------------------------------------------------------
+    def test_run_with_alternate_config_path(self):
+        class SomeOtherApp(SocorroApp):
+            @classmethod
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        eq_(SomeOtherApp._do_run('my/path'), 17)
+        eq_(SomeOtherApp.config_path, 'my/path')
+        x = SomeOtherApp.run('my/other/path')
+        eq_(x, 17)
+        eq_(SomeOtherApp.config_path, 'my/other/path')
+
+    #--------------------------------------------------------------------------
+    def test_run_with_alternate_values_source_list(self):
+        class SomeOtherApp(SocorroApp):
+            @classmethod
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        eq_(SomeOtherApp._do_run('my/path', [{}, {}]), 17)
+        eq_(SomeOtherApp.config_path, 'my/path')
+        eq_(SomeOtherApp.values_source_list, [{}, {}])
+        x = SomeOtherApp.run('my/other/path', [])
+        eq_(x, 17)
+        eq_(SomeOtherApp.config_path, 'my/other/path')
+        eq_(SomeOtherApp.values_source_list, [])
+
 
     #--------------------------------------------------------------------------
     def test_do_run(self):
@@ -87,6 +122,85 @@ class TestSocorroApp(TestCase):
                     ApplicationDefaultsProxy
                 ))
                 eq_(result, 17)
+
+    #--------------------------------------------------------------------------
+    def test_do_run_with_alternate_class_path(self):
+        config = DotDict()
+        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
+            cm.return_value.context.return_value = mock.MagicMock()
+            with mock.patch('socorro.app.socorro_app.signal') as s:
+                class SomeOtherApp(SocorroApp):
+                    app_name='SomeOtherApp'
+                    app_verision='1.2.3'
+                    app_description='a silly app'
+                    def main(self):
+                        ok_(
+                            self.config
+                            is cm.return_value.context.return_value.__enter__
+                                 .return_value
+                        )
+                        return 17
+
+                result = main(SomeOtherApp, 'my/other/path')
+
+                args = cm.call_args_list
+                args, kwargs = args[0]
+                ok_(isinstance(args[0], Namespace))
+                ok_(isinstance(kwargs['values_source_list'], list))
+                eq_(kwargs['app_name'], SomeOtherApp.app_name)
+                eq_(kwargs['app_version'], SomeOtherApp.app_version)
+                eq_(kwargs['app_description'], SomeOtherApp.app_description)
+                eq_(kwargs['config_pathname'], 'my/other/path')
+                ok_(kwargs['values_source_list'][-1], command_line)
+                ok_(isinstance(kwargs['values_source_list'][-2], DotDict))
+                ok_(kwargs['values_source_list'][-3] is ConfigFileFutureProxy)
+                ok_(isinstance(
+                    kwargs['values_source_list'][0],
+                    ApplicationDefaultsProxy
+                ))
+                eq_(result, 17)
+
+
+    #--------------------------------------------------------------------------
+    def test_do_run_with_alternate_values_source_list(self):
+        config = DotDict()
+        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
+            cm.return_value.context.return_value = mock.MagicMock()
+            with mock.patch('socorro.app.socorro_app.signal') as s:
+                class SomeOtherApp(SocorroApp):
+                    app_name='SomeOtherApp'
+                    app_verision='1.2.3'
+                    app_description='a silly app'
+                    def main(self):
+                        ok_(
+                            self.config
+                            is cm.return_value.context.return_value.__enter__
+                                 .return_value
+                        )
+                        return 17
+
+                result = main(
+                    SomeOtherApp,
+                    config_path='my/other/path',
+                    values_source_list=[{"a": 1}, {"b": 2}]
+                )
+
+                args = cm.call_args_list
+                args, kwargs = args[0]
+                ok_(isinstance(args[0], Namespace))
+                eq_(kwargs['app_name'], SomeOtherApp.app_name)
+                eq_(kwargs['app_version'], SomeOtherApp.app_version)
+                eq_(kwargs['app_description'], SomeOtherApp.app_description)
+                eq_(kwargs['config_pathname'], 'my/other/path')
+                ok_(isinstance(kwargs['values_source_list'], list))
+                ok_(isinstance(
+                    kwargs['values_source_list'][0],
+                    ApplicationDefaultsProxy
+                ))
+                eq_(kwargs['values_source_list'][1], {"a": 1})
+                eq_(kwargs['values_source_list'][2], {"b": 2})
+                eq_(result, 17)
+
 
 
 #==============================================================================


### PR DESCRIPTION
the older app framework allowed apps to define their own config_path and values_source_list.  None of the apps in the socorro package actually  used the feature.   The new SocorroApp framework removed the feature.  I didn't think to look outside the package to the wsgi directory.   It turns out that the .wsgi files use the 'config_path' and  the .py files used both 'config_path' and 'values_source' list.  It didn't show up in unit or integration tests because they all use the internal CherryPy web servers.

This PR restores both 'config_path' and 'values_source_list' to the app framework.  
