### PR TITLE
bug 1076270 - Windows 10 already exists, update it during migration

### DIFF
--- a/alembic/versions/17e83fdeb135_bug_1076270_support_windows_10.py
+++ b/alembic/versions/17e83fdeb135_bug_1076270_support_windows_10.py
@@ -22,17 +22,19 @@ from sqlalchemy.sql import table, column
 
 def upgrade():
     op.execute("""
-        INSERT INTO os_versions
-        (major_version, minor_version, os_name, os_version_string)
-        VALUES (6, 4, 'Windows', 'Windows 10')
+        UPDATE os_versions
+        SET os_version_string = 'Windows 10'
+        WHERE major_version = 6
+        AND minor_version = 4
+        AND os_name = 'Windows'
     """)
 
 
 def downgrade():
     op.execute("""
-        DELETE FROM os_versions
+        UPDATE os_versions
+        SET os_version_string = 'Windows Unknown'
         WHERE major_version = 6
         AND minor_version = 4
-        AND os_name = 'Windows'
-        AND os_version_string = 'Windows 10'
+        AND os_name = 'Windows Unknown'
     """)


### PR DESCRIPTION
r? @lonnen / @phrawzty  - prod data was not as expected, we want to update not insert
