### PR TITLE
Bug 1080072 - Update forced versions for correlations for Firefox cycle starting 2014-10-14

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="33.0 34.0a2 35.0a1"
+MANUAL_VERSION_OVERRIDE="34.0 35.0a2 36.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
The next version of our usual correlation version bump. Should go into production in the week of 2014-10-13 (not before).
