### PR TITLE
fix bug 1078816 - no need to install python 2.6 from homebrew

### DIFF
--- a/docs/installation/mac.rst
+++ b/docs/installation/mac.rst
@@ -8,8 +8,7 @@ Mac OS X
 Install dependencies
 ::
   brew update
-  brew tap homebrew/versions
-  brew install python26 git gpp postgresql subversion rabbitmq memcached npm
+  brew install git gpp postgresql subversion rabbitmq memcached npm
   sudo easy_install virtualenv virtualenvwrapper pip
   sudo pip-2.7 install docutils
   brew install mercurial


### PR DESCRIPTION
r? anybody, looks like we don't need this on Mac? It's not available from homebrew-versions anymore in any case.
