### PR TITLE
No Bug - removed debug print

### DIFF
--- a/socorro/unittest/app/test_generic_app.py
+++ b/socorro/unittest/app/test_generic_app.py
@@ -19,7 +19,6 @@ from socorro.app.socorro_app import App as SApp
 class TestGenericAppModule(TestCase):
 
     def test_exsistance(self):
-        print App, App.__mro__,
         ok_(issubclass(App, SocorroApp))
         eq_(App, SApp)
         ok_(isinstance(main, FunctionType))


### PR DESCRIPTION
delete a `print` that was left in a unittest file.  This will make for a cleaner looking output when running the unittests
