### PR TITLE
Fixes Bug 1084182 -  ensure Hybrid & Proc2015 do the same thing

### DIFF
--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -61,10 +61,10 @@ class OSInfoRule(Rule):
         processed_crash.os_name = ''
         processed_crash.os_version = ''
         processed_crash.os_name = (
-            processed_crash.json_dump['system_info']['os']
+            processed_crash.json_dump['system_info']['os'].strip()
         )
         processed_crash.os_version = (
-            processed_crash.json_dump['system_info']['os_ver']
+            processed_crash.json_dump['system_info']['os_ver'].strip()
         )
 
         return True

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -67,11 +67,15 @@ mozilla_processor_rule_sets = [
         "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_until_action_succeeds",
         "socorro.processor.skunk_classifiers.DontConsiderTheseFilter, "
-        "socorro.processor.skunk_classifiers.UpdateWindowAttributes, "
+        # currently not in use, anticipated to be re-enabled in the future
+        #"socorro.processor.skunk_classifiers.UpdateWindowAttributes, "
         "socorro.processor.skunk_classifiers.SetWindowPos, "
-        "socorro.processor.skunk_classifiers.SendWaitReceivePort, "
-        "socorro.processor.skunk_classifiers.Bug811804, "
-        "socorro.processor.skunk_classifiers.Bug812318, "
+        # currently not in use, anticipated to be re-enabled in the future
+        #"socorro.processor.skunk_classifiers.SendWaitReceivePort, "
+        # currently not in use, anticipated to be re-enabled in the future
+        #"socorro.processor.skunk_classifiers.Bug811804, "
+        # currently not in use, anticipated to be re-enabled in the future
+        #"socorro.processor.skunk_classifiers.Bug812318, "
         "socorro.processor.skunk_classifiers.NullClassification"
     ]
 ]

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -92,7 +92,7 @@ canonical_standard_raw_crash = DotDict({
 canonical_processed_crash = DotDict({
     "json_dump" : {
         "system_info" : {
-            "os_ver" : "6.1.7601 Service Pack 1",
+            "os_ver" : "6.1.7601 Service Pack 1 ",
             "cpu_count" : 4,
             "cpu_info" : "GenuineIntel family 6 model 42 stepping 7",
             "cpu_arch" : "x86",

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -218,8 +218,8 @@ class TestProductRule(TestCase):
             processed_crash.productid,
             "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
         )
-        eq_(processed_crash.distributor, "")
-        eq_(processed_crash.distributor_version, "")
+        eq_(processed_crash.distributor, None)
+        eq_(processed_crash.distributor_version, None)
         eq_(processed_crash.release_channel, "")
         eq_(processed_crash.build, "20120420145725")
 
@@ -279,9 +279,9 @@ class TestUserDataRule(TestCase):
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        eq_(processed_crash.url, "")
-        eq_(processed_crash.user_comments, "")
-        eq_(processed_crash.email, "")
+        eq_(processed_crash.url, None)
+        eq_(processed_crash.user_comments, None)
+        eq_(processed_crash.email, None)
 
 
 #==============================================================================
@@ -1747,16 +1747,31 @@ class TestTopMostFilesRule(TestCase):
         raw_dumps = {}
         processed_crash = DotDict()
         processed_crash.json_dump = {
+            'crash_info': {
+                'crashing_thread': 0
+            },
             'crashing_thread': {
                 'frames': [
                     {
-                        'filename': 'dwight.dll'
+                        'source': 'not-the-right-file.dll'
                     },
                     {
-                        'source': 'wilma.cpp'
-                    }
+                        'file': 'not-the-right-file.cpp'
+                    },
                 ]
-            }
+            },
+            'threads': [
+                {
+                    'frames': [
+                        {
+                            'source': 'dwight.dll'
+                        },
+                        {
+                            'file': 'wilma.cpp'
+                        },
+                    ]
+                },
+            ]
         }
 
         processor_meta = self.get_basic_processor_meta()
@@ -1766,7 +1781,7 @@ class TestTopMostFilesRule(TestCase):
          # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        eq_(processed_crash.topmost_filenames, ['wilma.cpp'])
+        eq_(processed_crash.topmost_filenames, 'wilma.cpp')
 
         # raw_crash should be unchanged
         eq_(raw_crash, canonical_standard_raw_crash)

--- a/socorro/unittest/processor/test_skunk_classifiers.py
+++ b/socorro/unittest/processor/test_skunk_classifiers.py
@@ -35,6 +35,7 @@ def create_basic_fake_processor():
     fake_processor.config = DotDict()
     # need help figuring out failures? switch to FakeLogger and read stdout
     fake_processor.config.logger = SilentFakeLogger()
+    fake_processor.processor_notes = []
     #fake_processor.config.logger = FakeLogger()
     return fake_processor
 


### PR DESCRIPTION
Now that Processor2015 has been working for a week in staging, round up all the little nits and differences in the Processed Crash produced by the two processor algorithms.

This covers:
  1) remove unused Skunk Classifiers
  2) set Distributor & Distributor_version to None rather than empty string
  3) set URL, Comments, Email to None rather than empty string
  4) rework TopMostFileRule to reflect new location to get the filename
  5) HybridProcessor sometimes has a list of length one of for TopMostFile and other
times it just has a bare filename.  -- make Processor2015 consistent: never a list
  6) Add new location for a bare offset in signature generation.  the old pDump had module offset and offset in the same variable, while the jDump uses separate variables
  7) Add neglected module to lower case for modules from Windows NT  
  8) Processor2015 using wrong crashing stack frames for signature generation, switch to untruncated stack
  9) rework Skunk Classifier messages to go to Processor Notes rather than the System log
 10) rework the SetWindowsPos Skunk rule to have its own Signature tool
 11) Alter the tests to reflect these changes
