### PR TITLE
Fixed bug 1085624 - updated TOC intro and install docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,16 +5,28 @@
 
 Socorro
 =======
+Socorro is a set of components for collecting, processing and reporting on crashes. It is used by Mozilla for tracking crashes of Firefox, B2G, Thunderbird and other projects. The production Mozilla install is public and hosted at https://crash-stats.mozilla.com/
 
-The current focus of Socorro development is to make a server which can
-accept crash reports from Firefox. See
-http://wiki.mozilla.org/Breakpad for more information.
+The components which make up Socorro are:
 
-Socorro mailing list https://lists.mozilla.org/listinfo/tools-socorro
+* Collector - collects breakpad minidump crashes which come in over HTTP POST
+* Processor - turn breakpad minidump crashes into stack traces and other info
+* Middleware - provide HTTP REST interface for JSON reports and real-time data
+* Web UI aka crash-stats - django-based web app for visualizing crash data
 
-`This documentation is available on Github
-<https://github.com/mozilla/socorro/tree/master/docs>`_, and if you want to, feel
-free to  clone the repo, make some changes in a fork and send us a pull request.
+For help with installation, start with :ref:`intro-chapter`.
+
+We welcome contributions!
+
+* Start here to contribute to documentation: :ref:`writingdocs-chapter`.
+* Start here to contribute code: :ref:`newdeveloperguide-chapter`.
+
+See http://wiki.mozilla.org/Breakpad for up-to-date information about development team activity and our meetings.
+
+This documentation is `available on readthedocs <http://socorro.readthedocs.org>`_. The source and current development activity is `available on Github <https://github.com/mozilla/socorro/tree/master>`_.
+
+The Socorro development mailing list is https://lists.mozilla.org/listinfo/tools-socorro
+
 
 Contents:
 

--- a/docs/installation/deps.rst
+++ b/docs/installation/deps.rst
@@ -31,6 +31,8 @@ You can quickly spin up a CentOS VM using Vagrant:
 
 :ref:`vagrant-chapter`
 
+.. _local-installation:
+
 On your own machine
 -------------------
 

--- a/docs/installation/download.rst
+++ b/docs/installation/download.rst
@@ -1,7 +1,7 @@
 .. index:: download
 
-Download
-========
+Downloading source code from our git repo
+=========================================
 
 Clone from github
 ::

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -2,14 +2,23 @@
 
 .. _intro-chapter:
 
-Intro
------
+Installation
+------------
 
-Socorro is a set of components for collecting, processing and reporting on crashes. It is used by Mozilla for tracking crashes of Firefox, B2G, Thunderbird and other projects. The production Mozilla install is public and hosted at https://crash-stats.mozilla.com/
+We provide documentation for setting up a complete Socorro instance :ref:`with a VM <vagrant-chapter>` or :ref:`locally on your system without a VM <local-installation>`.
 
-The components which make up Socorro are:
+Socorro provides :ref:`an RPM binary package <install_binary_package-chapter>` for easier installation with every release. For people working on modifying or contributing changes to Socorro code, you will also be interested in :ref:`installing from source <install_from_source-chapter>`.
 
-* Collector - collects breakpad minidump crashes which come in over HTTP POST
-* Processor - turn breakpad minidump crashes into stack traces and other info
-* Middleware - provide HTTP REST interface for JSON reports and real-time data
-* Web UI aka crash-stats - django-based web app for visualizing crash data
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+
+   deps
+   download
+   install-binary
+   install-src-dev
+   install-src-prod
+   setup-socorro
+   systemtest
+   troubleshoot

--- a/docs/installation/systemtest.rst
+++ b/docs/installation/systemtest.rst
@@ -10,6 +10,12 @@ Generate a test crash:
 1) Install http://code.google.com/p/crashme/ add-on for Firefox
 2) Point your Firefox install at http://crash-reports/submit
 
+Note: crashme is `currently not working on Mac OS X <https://bugzilla.mozilla.org/show_bug.cgi?id=1086624>`_. The workaround is to kill the Firefox process manually in the Terminal:
+
+.. code-block:: bash
+
+    $ kill -ABRT <firefox pid>
+
 Note that if you're running a dev install (e.g. "honcho start") and 
 not under Apache, you'll need to specify the port number:
 


### PR DESCRIPTION
Updates our main table of contents by moving the old "intro/install" text blurb to the top level. Also updates information about crashme and makes links to the binary/RPM install docs and VM building more prominent.
