### PR TITLE
fixes Bug 1086651 - add setupdb_app to apps known by socorro app launcher

### DIFF
--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -46,6 +46,7 @@ class ApplicationDefaultsProxy(object):
         return {
             'collector': 'socorro.collector.collector_app.CollectorApp',
             'crashmover': 'socorro.collector.crashmover_app.CrashMoverApp',
+            'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDB',
             'submitter': 'socorro.collector.submitter_app.SubmitterApp',
             # crontabber not yet supported in this environment
             #'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -473,6 +473,15 @@ class SocorroDB(App):
         doc='Create all tables with UNLOGGED for running tests',
     )
 
+    @staticmethod
+    def get_application_defaults():
+        """since this app is more of an interactive app than the others, the
+        logging of config information is rather disruptive.  Override the
+        default logging level to one that is less annoying."""
+        return {
+            'logging.stderr_error_logging_level': 50
+        }
+
     def bulk_load_table(self, db, table):
         io = cStringIO.StringIO()
         for line in table.generate_rows():


### PR DESCRIPTION
just as the title says, add the postgres setupdb app to the apps known by the new socorro app launcher.  At the same time, add the "get_application_defaults" method to the setupdb_app, to quiet down the logging to stderr.

@rhelmer r?
