### PR TITLE
Import only less mixins to avoid reapplying reset

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/explosives.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/explosives.less
@@ -1,4 +1,4 @@
-@import "base.less";
+@import "mixins.less";
 
 #explosive-panel {
     br {

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/topcrashers.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/topcrashers.less
@@ -1,4 +1,3 @@
-@import "base.less";
 @import "mixins.less";
 
 .sig-history-container {


### PR DESCRIPTION
fixes bug 1087287

topcrashers and explosive signature reports import base.less to get access to
the contents of mixins.less, which causes reset to get reapplied and overwrite
some of the settings in screen.less

Switch to importing only the necessary mixins class brings these two reports
in line with the visual appearance of the other reports.
