### PR TITLE
remove the defunct .notitle html class

### DIFF
--- a/webapp-django/crashstats/api/templates/api/documentation.html
+++ b/webapp-django/crashstats/api/templates/api/documentation.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
         <p class="tokens-callout">
 	  You current have <a href="{{ url('tokens:home') }}">{{ count_tokens }} active API Token{{ count_tokens|pluralize }}</a>.
 	</p>

--- a/webapp-django/crashstats/base/templates/404.html
+++ b/webapp-django/crashstats/base/templates/404.html
@@ -12,8 +12,10 @@ Page Not Found
     <h2>Page not Found</h2>
   </div>
   <div class="panel">
-    <div class="body notitle">
-      <p>The requested page could not be found.</p>
+    <div class="title">
+      <h2>The requested page could not be found.</h2>
+    </div>
+    <div class="body">
       <p>If you followed a dead link on the website, please file an <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=General&amp;bug_file_loc={{ request.build_absolute_uri() | urlencode }}">issue in Bugzilla</a> describing what happened, and please include the URL for this page.</p>
     </div>
   </div>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/builds.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/builds.html
@@ -12,11 +12,10 @@ Nightly Builds for {{ product }} {% if version %}{{ version }}{% endif %}
 </div>
 
 <div class="panel">
-    <div class="body notitle">
-
+    <div class="body">
         <p>
-          The following nightly builds were scraped from the
-          <a href="http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/">Mozilla Nightly Builds FTP site</a>.
+            The following nightly builds were scraped from the
+            <a href="http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/">Mozilla Nightly Builds FTP site</a>.
         </p>
 
         <table class="builds data-table">

--- a/webapp-django/crashstats/crashstats/templates/crashstats/exploitability.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/exploitability.html
@@ -24,8 +24,7 @@ $(function () {
     </div>
 
     <div class="panel">
-        <div class="body notitle">
-
+        <div class="body">
             {% if current_page == 1 %}
                 <strong>&lt;&lt;First</strong>
             {% else %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/login.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/login.html
@@ -15,18 +15,16 @@
 </div>
 
 <div class="panel">
-    <div class="body notitle">
-
+    <div class="body">
         {% if request.user.is_authenticated() %}
-	<p>
-	  You are signed in but you do not have sufficient permissions to reach the resource you requested.
-	</p>
+                <p>
+                  You are signed in but you do not have sufficient permissions to reach the resource you requested.
+                </p>
 	{% else %}
-        <p>
-          The page you requested requires authentication. Use the login button at the lower right to log in.
-        </p>
+            <p>
+              The page you requested requires authentication. Use the login button at the lower right to log in.
+            </p>
 	{% endif %}
-
     </div>
 </div>
 

--- a/webapp-django/crashstats/crashstats/templates/crashstats/permissions.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/permissions.html
@@ -22,11 +22,13 @@ Your Permissions
 
     <div class="panel">
         <div class="title">
-            You are logged in as <b>{{ request.user.email }}</b>.
+            <h2>You are logged in as <b>{{ request.user.email }}</b>.</h2>
         </div>
         <div class="body">
         {% if request.user.is_superuser %}
-            <p>You are a <b>superuser</b>. You have <b>unrestricted access to everything</b>.</p>
+          <p>
+            You are a <b>superuser</b>. You have <b>unrestricted access to everything</b>.
+          </p>
         {% else %}
         <table class="permissions">
             <thead>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/query.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/query.html
@@ -187,7 +187,7 @@
     </div>
 
     <div class="panel">
-        <div class="body notitle">
+        <div class="body">
     <p>
     Results within {{ params.date_range_value }} {{ params.date_range_unit }} of {{ params.end_date }}
 {%- if params.query %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
@@ -31,7 +31,7 @@
   </div>
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
       <div id="sumo-link"><a href="http://support.mozilla.org/search?q={{ report.signature|urlencode }}" title="Find more answers at support.mozilla.org!">Search Mozilla Support for Help</a></div>
 
       {% if hang_id %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index_not_found.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index_not_found.html
@@ -7,7 +7,7 @@
       <h2>Crash Not Found</h2>
     </div>
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
         <p>We couldn't find the OOID you're after. If you recently submitted this crash, it may still be in the queue.</p>
 
         <p>If you believe this message is an error, please

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_list_base.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_list_base.html
@@ -9,30 +9,28 @@ Crash Reports in {{ signature }}
 
     <div class="page-heading">
         <h2>Crash Reports for {{ signature }}</h2>
-    <div>
-    <ul class="options">
-      {% for day in [3, 7, 14, 28] %}
-      <li>
-        <a href="{{ change_query_string(range_value=day, range_unit='days') }}" {% if day == current_day %} class="selected" {% endif %}>{{ day }} days</a>
-      </li>
-      {% endfor %}
-    </ul>
+        <div>
+            <ul class="options">
+              {% for day in [3, 7, 14, 28] %}
+              <li>
+                <a href="{{ change_query_string(range_value=day, range_unit='days') }}" {% if day == current_day %} class="selected" {% endif %}>{{ day }} days</a>
+              </li>
+              {% endfor %}
+            </ul>
+        </div>
     </div>
 
+    <div class="panel">
+        <div class="body">
+            <p>
+                Results within {{ current_day }} days of {{ end_date }}{% if selected_products %}, and the product is {{ product }} {% if product_versions %} and
+                the version is one of {{ product_versions|join(', ') }}{% endif %}{% endif %} and the crashing process was of any
+                type (including unofficial release channels).
+            </p>
+            {% block report %}
+            {% endblock %}
+       </div>
     </div>
-
-<div class="panel">
-    <div class="body notitle">
-
-<p>
-    Results within {{ current_day }} days of {{ end_date }}{% if selected_products %}, and the product is {{ product }} {% if product_versions %} and
-    the version is one of {{ product_versions|join(', ') }}{% endif %}{% endif %} and the crashing process was of any
-    type (including unofficial release channels).
-</p>
-{% block report %}
-{% endblock %}
-   </div>
-</div>
 <!-- end content -->
 </div>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/topchangers.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topchangers.html
@@ -16,6 +16,7 @@ Top Changing Top Crashers for {{ product }}
   </div>
 
   <div class="panel">
+<<<<<<< HEAD
     <div class="title">
       <h2>{{ product }} {{ versions|join(', ') }}</h2>
     </div>
@@ -46,6 +47,42 @@ Top Changing Top Crashers for {{ product }}
         {% else %}
           <p>There were no top changers that matched the criteria you specified.</p>
         {% endif %}
+=======
+    <div class="body">
+      <div>
+        <div class="product_topchanger">
+          {% if topchangers %}
+          <table id="top_changers_up" class="top_changers">
+            <tr>
+              <th scope="col">Change</th>
+              <th scope="col">Rank</th>
+              <th scope="col">Signature</th>
+            </tr>
+            {% for result in topchangers|dictsort|reverse %}
+            {% with changer = result[1][0] %}
+            <tr>
+              <td>
+                {% if changer.changeInRank <= -5 %}
+                <div class="trend down">{{ changer.changeInRank }}</div>
+                {% elif changer.changeInRank >= 5 %}
+                <div class="trend up">{{ changer.changeInRank }}</div>
+                {% else %}
+                <div>{{ changer.changeInRank }}</div>
+                {% endif %}
+              </td>
+              <td>{{ changer.currentRank + 1 }}</td>
+              <td><a class="signature" href="{{ url('crashstats:report_list') }}?product={{ product }}&amp;range_value={{ days }}&amp;range_unit=days&amp;signature={{ changer.signature|urlencode }}{% for product_version in product_versions %}&amp;version={{ product_version }}{% endfor %}" title="View reports with this crasher.">{{ changer.signature }}</a></td>
+            </tr>
+            {% endwith %}
+            {% endfor %}
+          </table>
+          {% else %}
+            <p>There were no top changers that matched the criteria you specified.</p>
+          {% endif %}
+        </div>
+        <br class="clear">
+      </div>
+>>>>>>> remove the defunct .notitle html class
     </div>
   </div>
 </div>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher.html
@@ -36,7 +36,7 @@ Top Crashers for {{ product }} {{ version }}
         </div>
 
         <div class="panel">
-            <div class="body notitle">
+            <div class="body">
             {% if total_crashing_signatures %}
             <div>
                 Top {{ total_crashing_signatures }} Crashing Signatures.

--- a/webapp-django/crashstats/crashstats/templates/crashstats/your_crashes.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/your_crashes.html
@@ -20,11 +20,10 @@ Your Crash Reports
     </div>
 
     <div class="panel">
-        <div class="body notitle">
-            <p>
-                You are signed in as <b>{{ request.user.email }}</b>.
-            </p>
-
+        <div class="title">
+            <h2>You are signed in as <b>{{ request.user.email }}</b>.</h2>
+        </div>
+        <div class="body">
             {% if crashes_list %}
 
             <p>

--- a/webapp-django/crashstats/manage/templates/manage/analyze-model-fetches.html
+++ b/webapp-django/crashstats/manage/templates/manage/analyze-model-fetches.html
@@ -7,7 +7,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
     <ul class="only-filter">
       <li><a href="#" class="only-classes">Only API Classes</a></li>

--- a/webapp-django/crashstats/manage/templates/manage/featured_versions.html
+++ b/webapp-django/crashstats/manage/templates/manage/featured_versions.html
@@ -34,7 +34,7 @@
 {% block mainbody %}
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
         <div class="add-products-versions-link">
           <p>
             If you want to <b>add a new product or release</b> go to<br>
@@ -51,7 +51,7 @@
       </div>
     </div>
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
       <form action="{{ url('manage:update_featured_versions') }}" class="products" method="post">
       {{ csrf() }}
       {% for product in products %}

--- a/webapp-django/crashstats/manage/templates/manage/fields.html
+++ b/webapp-django/crashstats/manage/templates/manage/fields.html
@@ -23,7 +23,7 @@
 {% block mainbody %}
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
       <form action="{{ url('manage:field_lookup') }}" method="post" class="lookup">
         <p>
           <label for="id_name">Name:</label>

--- a/webapp-django/crashstats/manage/templates/manage/graphics_devices.html
+++ b/webapp-django/crashstats/manage/templates/manage/graphics_devices.html
@@ -26,7 +26,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
       <h3>Edit or Add a Graphic Device</h3>
       <form class="edit" action="" method="post"

--- a/webapp-django/crashstats/manage/templates/manage/group.html
+++ b/webapp-django/crashstats/manage/templates/manage/group.html
@@ -7,8 +7,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
-
+    <div class="body">
 
       <form class="edit" action="" method="post">
         {{ csrf() }}

--- a/webapp-django/crashstats/manage/templates/manage/groups.html
+++ b/webapp-django/crashstats/manage/templates/manage/groups.html
@@ -29,7 +29,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
       <h3>Existings Groups</h3>
       <form action="" method="post" class="filter" data-dataurl="{{ url('manage:groups') }}">

--- a/webapp-django/crashstats/manage/templates/manage/home.html
+++ b/webapp-django/crashstats/manage/templates/manage/home.html
@@ -16,7 +16,7 @@
 {% block mainbody %}
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
 
       <p>
         <a href="{{ url('manage:featured_versions') }}">Featured Versions</a>

--- a/webapp-django/crashstats/manage/templates/manage/products.html
+++ b/webapp-django/crashstats/manage/templates/manage/products.html
@@ -17,7 +17,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
       <h3>Add New Product</h3>
 

--- a/webapp-django/crashstats/manage/templates/manage/skiplist.html
+++ b/webapp-django/crashstats/manage/templates/manage/skiplist.html
@@ -25,7 +25,7 @@
 {% block mainbody %}
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
 
       <p class="pleasewait">
         <img src="{{ static('img/loading.png') }}" alt="Loading animation" />

--- a/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
+++ b/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
@@ -31,7 +31,7 @@ var ALL_PERMISSIONS = {{ all_permissions | json_dumps }};
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
         <p class="api-exposure-warning">
           <b>A Word of Warning!</b><br>

--- a/webapp-django/crashstats/manage/templates/manage/supersearch_fields.html
+++ b/webapp-django/crashstats/manage/templates/manage/supersearch_fields.html
@@ -15,7 +15,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
         <p>
             Here are all the known fields in our indexed documents.

--- a/webapp-django/crashstats/manage/templates/manage/user.html
+++ b/webapp-django/crashstats/manage/templates/manage/user.html
@@ -7,8 +7,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
-
+    <div class="body">
 
       <form class="edit" action="" method="post">
         {{ csrf() }}

--- a/webapp-django/crashstats/manage/templates/manage/users.html
+++ b/webapp-django/crashstats/manage/templates/manage/users.html
@@ -48,7 +48,7 @@
 {% block mainbody %}
 
   <div class="panel">
-    <div class="body notitle">
+    <div class="body">
 
       <p class="pleasewait">
         <img src="{{ static('img/loading.png') }}" alt="Loading animation" />

--- a/webapp-django/crashstats/symbols/templates/symbols/home.html
+++ b/webapp-django/crashstats/symbols/templates/symbols/home.html
@@ -85,14 +85,12 @@
     </div>
   {% else %}
     <div class="panel">
-      <div class="body notitle">
+      <div class="title">
+        <h2>You currently do not have permission to upload symbols.</h2>
+      </div>
+      <div class="body">
         <p>
-          <b>You currently do not have permission to upload symbols.</b>
-        </p>
-        <p>
-          The necessary permission you need to have is
-          <b>{{ permission.name }}</b> and this needs to be manually given
-          to you and your account.
+          You lack the <b>{{ permission.name }}</b> permission, which needs to be manually granted to you and your account.
         </p>
         {% if symbols_request_link %}
         <p>

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="panel">
-      <div class="body notitle">
+      <div class="body">
         <p>
         You need <b>API Tokens to be able to connect to the API</b> so that the API
         knows who you are and thus what permissions you have.<br>


### PR DESCRIPTION
fixes bug 1087295

The HTML class .notitle exists only in templates, and is unused by CSS or JS. This patch removes it, and adds missing title elements where appropriate
