### PR TITLE
Clarify supuser permissions

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/permissions.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/permissions.html
@@ -21,40 +21,36 @@ Your Permissions
     </div>
 
     <div class="panel">
-        <div class="body notitle">
-
-        <p>
-        You are logged in as <b>{{ request.user.email }}</b>.<br>
-        {% if request.user.is_superuser %}
-        You are a <b>superuser</b>, meaning you have <b>unrestricted access to everything</b>.
-        {% endif %}
-        </p>
-
-        <table class="permissions">
-          <thead>
-            <tr>
-              <th>Permission</th>
-              <th>You</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for permission in permissions %}
-            <tr>
-              <td>{{ permission.name }}</td>
-              <td>
-              {% if request.user.has_perm('crashstats.' + permission.codename) %}
-                Yes!
-              {% else %}
-                No
-              {% endif %}
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-
+        <div class="title">
+            You are logged in as <b>{{ request.user.email }}</b>.
         </div>
-
+        <div class="body">
+        {% if request.user.is_superuser %}
+            <p>You are a <b>superuser</b>. You have <b>unrestricted access to everything</b>.</p>
+        {% else %}
+        <table class="permissions">
+            <thead>
+                <tr>
+                  <th>Permission</th>
+                  <th>You</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for permission in permissions %}
+                <tr>
+                  <td>{{ permission.name }}</td>
+                  <td>
+                  {% if request.user.has_perm('crashstats.' + permission.codename) %}
+                    Yes!
+                  {% else %}
+                    No
+                  {% endif %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        </div>
     </div>
-
 </div>
 {% endblock %}


### PR DESCRIPTION
fixes bug 1087298

This sets up some switching so that superusers no longer have individual
permissions enumerated, since they implictly have all permissions. This avoids
the confusing situation where a superuser is told "you have all permissions"
and then told about some missing permission because of the group the user
account is in. Since we honor superuser status over group status, avoid
confusing the user and display that first.
