### PR TITLE
fixes Bug 1090376 - new setup.py entry point for the setupdb_app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     dependency_links=find_dependency_links(),
     entry_points={
         'console_scripts': [
-            'socorro-setupdb = socorro.external.postgresql.setupdb_app:main'
+                'socorro = socorro.app.socorro_app:SocorroWelcomeApp.run'
             ],
         },
     test_suite='nose.collector',

--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -46,7 +46,7 @@ class ApplicationDefaultsProxy(object):
         return {
             'collector': 'socorro.collector.collector_app.CollectorApp',
             'crashmover': 'socorro.collector.crashmover_app.CrashMoverApp',
-            'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDB',
+            'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
             'submitter': 'socorro.collector.submitter_app.SubmitterApp',
             # crontabber not yet supported in this environment
             #'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.schema import CreateTable
 
-from socorro.app.generic_app import App, main as configman_main
+from socorro.app.socorro_app import App, main
 from socorro.external.postgresql import staticdata, fakedata
 from socorro.external.postgresql.models import *
 from socorro.external.postgresql.postgresqlalchemymanager import PostgreSQLAlchemyManager
@@ -33,9 +33,9 @@ from socorro.external.postgresql.postgresqlalchemymanager import PostgreSQLAlche
 ###########################################
 ##  Database creation object
 ###########################################
-class SocorroDB(App):
+class SocorroDBApp(App):
     """
-    SocorroDB
+    SocorroDBApp
         This function creates a base PostgreSQL schema for Socorro
 
     Notes:
@@ -169,7 +169,7 @@ class SocorroDB(App):
         logging of config information is rather disruptive.  Override the
         default logging level to one that is less annoying."""
         return {
-            'logging.stderr_error_logging_level': 50
+            'logging.stderr_error_logging_level': 40  # only ERROR or worse
         }
 
     def bulk_load_table(self, db, table):
@@ -332,8 +332,5 @@ class SocorroDB(App):
 
         return 0
 
-def main():
-    return configman_main(SocorroDB)
-
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(SocorroDBApp))

--- a/socorro/unittest/external/postgresql/test_setupdb_app.py
+++ b/socorro/unittest/external/postgresql/test_setupdb_app.py
@@ -68,7 +68,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
             extra_value_source = {}
         mock_logging = mock.Mock()
 
-        required_config = setupdb_app.SocorroDB.required_config
+        required_config = setupdb_app.SocorroDBApp.required_config
         required_config.add_option('logger', default=mock_logging)
 
         # We manually set the database_name to something deliberately
@@ -99,7 +99,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
         raise SkipTest
         config_manager = self._setup_config_manager({'dropdb': True})
         with config_manager.context() as config:
-            db = setupdb_app.SocorroDB(config)
+            db = setupdb_app.SocorroDBApp(config)
             db.main()
 
             # we can't know exactly because it would be tedious to have to


### PR DESCRIPTION
eliminate a bit of code and make a new entry point for the setupdb_app in setup.py

plus a couple clean up things:
- rename the SetupDB class to SetupDBApp to make the class work with the upcoming automatic app discovery mechanism
- drop the default stderr logging level for SetupDBApp to ERROR from CRITICAL
- 
