### PR TITLE
fixes bug 1097590 - No bug title of Related Bugs on report index

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
@@ -64,7 +64,7 @@ var BugLinks = (function() {
             // When the data has been downloaded and attached to
             // each link tag run this to update
             fetch_remotely(bug_ids.slice(i, j))
-              .done(BugLinks.transform_with_data);
+              .done(transform_with_data);
             i = j;
         }
     }


### PR DESCRIPTION
@AdrianGaudebert r?

The reason we didn't catch this the first time was because we relied on the server caching some of the bug data and it would render the html looking like this:

```
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1097590" data-summary="Something">1097590</a>
```

But if you start with a cleaned cache it would start like this:

```
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1097590">1097590</a>
```

And we'd have to do an AJAX request to fetch the data and then set `data-summary="Something"`. After it had done that it had to execute the function `transform_with_data()` which takes that `data-summary` (and other things) and put it into a span. 

You can't reference `BugLinks` inside a closure function when the function it references is a closured one. 
