### PR TITLE
fixes Bug 1098698 - Support buckets overriding bucket name

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -88,7 +88,14 @@ class BotoS3CrashStorage(CrashStorageBase):
         reference_value_from='resource.boto',
         likely_to_be_changed=True,
     )
-
+    required_config.add_option(
+        'calling_format',
+        doc="fully qualified python path to the boto calling format function",
+        default='boto.s3.connection.SubdomainCallingFormat',
+        from_string_converter=class_converter,
+        reference_value_from='resource.boto',
+        likely_to_be_changed=True,
+    )
 
     operational_exceptions = (
         socket.timeout,
@@ -117,7 +124,7 @@ class BotoS3CrashStorage(CrashStorageBase):
 
         # short cuts to external resources - makes testing/mocking easier
         self._connect_to_endpoint = boto.connect_s3
-        self._calling_format = boto.s3.connection.SubdomainCallingFormat
+        self._calling_format = config.calling_format
         self._CreateError = boto.exception.S3CreateError
         self._S3ResponseError = boto.exception.S3ResponseError
         self._open = open
@@ -431,10 +438,14 @@ class SupportReasonAPIStorage(BotoS3CrashStorage):
        bug 1066058
     """
 
-    BotoS3CrashStorage.required_config.bucket_name.set_default(
-        val='mozilla-support-reason',
-        force=True
-    )
+    # intially we wanted the support reason class to use a different bucket,
+    # but the following override interferes with the base class.  I suspect
+    # we'll end up using a prefix instead of differing bucket name in the
+    # future.  Leaving this code in place for the moment
+    #BotoS3CrashStorage.required_config.bucket_name.set_default(
+        #val='mozilla-support-reason',
+        #force=True
+    #)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -113,6 +113,7 @@ class TestCase(socorro.unittest.testbase.TestCase):
             'dump_file_suffix': '.dump',
             'bucket_name': 'mozilla-support-reason',
             'prefix': 'dev',
+            'calling_format': mock.Mock()
         })
         if storage_class == 'BotoS3CrashStorage':
             config.bucket_name = 'crash_storage'
@@ -121,7 +122,6 @@ class TestCase(socorro.unittest.testbase.TestCase):
             s3 = SupportReasonAPIStorage(config)
         s3._connect_to_endpoint = mock.Mock()
         s3._mocked_connection = s3._connect_to_endpoint.return_value
-        s3._calling_format = mock.Mock()
         s3._calling_format.return_value = mock.Mock()
         s3._CreateError = mock.Mock()
         s3._S3ResponseError = mock.Mock()


### PR DESCRIPTION
This is an omnibus PR with 3 issues:
1. stop the class SupportReasonAPIStorage from overriding the base class bucket name
2. restore the "secret" attribute to the "secret_access_key" option - don't know how or where that was lost
3. make the boto "calling format" configurable so we remain compatible with other systems (like Ceph)
