### PR TITLE
fixes Bug 1099297 - correct the name of the default dump

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -263,8 +263,8 @@ class BotoS3CrashStorage(CrashStorageBase):
             dumps_mapping = boto_s3_store.get_raw_dumps(crash_id)
             name_to_pathname_mapping = {}
             for a_dump_name, a_dump in dumps_mapping.iteritems():
-                if a_dump_name in (None, '', 'upload_file_minidump'):
-                    a_dump_name = 'dump'
+                if a_dump_name in (None, '', 'dump'):
+                    a_dump_name = 'upload_file_minidump'
                 dump_pathname = os.path.join(
                     boto_s3_store.config.temporary_file_system_storage_path,
                     "%s.%s.TEMPORARY%s" % (

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -816,8 +816,8 @@ class TestCase(socorro.unittest.testbase.TestCase):
                 'city_dump': '/i/am/hiding/junk/files/here/936ce666-ff3b-4c7'
                 'a-9674-367fe2120408.city_dump.TEMPORARY.dump',
 
-                'dump': '/i/am/hiding/junk/files/here/936ce666-ff3b-4c7a-96'
-                '74-367fe2120408.dump.TEMPORARY.dump'
+                'upload_file_minidump': '/i/am/hiding/junk/files/here/936ce666-ff3b-4c7a-96'
+                '74-367fe2120408.upload_file_minidump.TEMPORARY.dump'
             }
         )
         boto_s3_store._open.assert_has_calls([
@@ -834,7 +834,7 @@ class TestCase(socorro.unittest.testbase.TestCase):
             mock.call().__enter__().write('this is "city_dump", the last one'),
             mock.call().__exit__(None, None, None),
             mock.call(u'/i/am/hiding/junk/files/here/936ce666-ff3b-4c7a-9674-'
-                      '367fe2120408.dump.TEMPORARY.dump', 'wb'),
+                      '367fe2120408.upload_file_minidump.TEMPORARY.dump', 'wb'),
             mock.call().__enter__(),
             mock.call().__enter__().write('this is "dump", the first one'),
             mock.call().__exit__(None, None, None)


### PR DESCRIPTION
the BotoS3 storage class is naming the default dump as 

```
<uuid>.dump.TEMPORARY.dump
```

when it really should be doing:

```
<uuid>.upload_file_minidump.TEMPORARY.dump
```
