### PR TITLE
fixes Bug 1093888 - fake out middleware to think S3 is HB

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# this is a temporary hack to coerse the middleware to talk to boto S3
+# instead of HBase.
+
+from socorro.external.crash_data_base import CrashDataBase
+
+
+class CrashData(CrashDataBase):
+    """
+    Implement the /crash_data service with HBase.
+    """
+    def get_storage(self):
+        # why does this say hbase? Aren't we a botos3 module?
+        # yes, this seems odd, but the second generation middleware was
+        # built hard coded to using specific resources, though within those
+        # resources, configman was used to get config details for that
+        # resource.  Now that we're moving away from HBase, we can swap
+        # out the implementation of the hard coded HBase section with details
+        # from its replacement: boto S3.  So all indications in the code
+        # are that it is using HBase, but configuration has replaced the
+        # implementation details with boto S3.
+        return self.config.hbase.hbase_class(self.config.hbase)
+


### PR DESCRIPTION
The middleware configuration is hard coded with resources in sections dedicated to each resource. However, within the resource sections, Configman is used.  With that advantage, we can tell the middleware HBase section to use the implementation of the BotoS3 classes.  The middleware calls its resource HBase and thinks it is using HBase, but configman is faking it out by substituting the BotoS3 implementation where ever the middleware references HBase.

This PR ensures that all the services implemented by HBase are also implemented by BotoS3.  This PR alone will not switch the middleware to BotoS3 - there is a configuration component to this circus of deception that makes it work.   

Configuration fully feature flags this change.  Nothing in this PR will change the actual behavior of Socorro by itself.
