### PR TITLE
Fixes Bug 1102379 -  fixed case where get-key returns None

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -361,6 +361,8 @@ class BotoS3CrashStorage(CrashStorageBase):
         key = self.build_s3_dirs(self.config.prefix, name_of_thing, crash_id)
 
         storage_key = bucket.get_key(key)
+        if storage_key is None:
+            raise CrashIDNotFound('%s not found, no value returned' % crash_id)
         return storage_key.get_contents_as_string()
 
     #--------------------------------------------------------------------------

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -957,6 +957,16 @@ class TestCase(socorro.unittest.testbase.TestCase):
             '0bba929f-dead-dead-dead-a43c20071027'
         )
 
+    def test_not_found_get_key_returns_none(self):
+        boto_s3_store = self.setup_mocked_s3_storage()
+        boto_s3_store._mocked_connection.get_bucket \
+            .return_value.get_key.return_value = None
+        self.assertRaises(
+            CrashIDNotFound,
+            boto_s3_store.get_raw_crash,
+            '0bba929f-dead-dead-dead-a43c20071027'
+        )
+
     def test_s3_dir_builder(self):
         boto_s3_store = self.setup_mocked_s3_storage()
         prefix = 'dev'


### PR DESCRIPTION
we expected S3 to return a `StorageResponseError` when a item was not found. Instead, it's is quietly giving us a None back instead.  

We're now testing for None and translating that into a more palatable `CrashIDNotFound` exception.
