### PR TITLE
Fixes Bug 1104790 - moved dump file deletion to the transform function

### DIFF
--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -96,7 +96,7 @@ class TestProcessorApp(TestCase):
         fake_raw_crash = DotDict()
         mocked_get_raw_crash = mock.Mock(return_value=fake_raw_crash)
         pa.source.get_raw_crash = mocked_get_raw_crash
-        fake_dump = {'upload_file_minidump': 'fake dump'}
+        fake_dump = {'upload_file_minidump': 'fake_dump_TEMPORARY.dump'}
         mocked_get_raw_dumps_as_files = mock.Mock(return_value=fake_dump)
         pa.source.get_raw_dumps_as_files = mocked_get_raw_dumps_as_files
         mocked_convert_raw_crash_to_processed_crash = mock.Mock(return_value=7)
@@ -104,9 +104,11 @@ class TestProcessorApp(TestCase):
             mocked_convert_raw_crash_to_processed_crash
         pa.destination.save_processed = mock.Mock()
         finished_func = mock.Mock()
-        # the call being tested
-        pa.transform(17, finished_func)
+        with mock.patch('socorro.processor.processor_app.os.unlink') as mocked_unlink:
+            # the call being tested
+            pa.transform(17, finished_func)
         # test results
+        mocked_unlink.assert_called_with('fake_dump_TEMPORARY.dump')
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.convert_raw_crash_to_processed_crash.assert_called_with(
           fake_raw_crash,


### PR DESCRIPTION
In the processor, the 'transform' method creates the file system copies of the dumps to feed to the stackwalker.  The Breakpad stackwalker rule deletes the files when it it uses the dumps.  This is not a good idea, for two reasons:

1) the system that creates something temporary should take the responsibility to make sure that it deleted properly. 

2) if the stalkwalker deletes the temporary dump files, those files are not available for any further rules that may want to examine them.  For example, the upcoming 'dumplookup' rule will need to process the dump file, too. 

This PR moves the deletion of the tempfiles from the stackwalker rule into the finally clause of the processor_app transform method.
