### PR TITLE
bug 1104811; more conservative index settings

### DIFF
--- a/puppet/modules/socorro/files/etc_elasticsearch/elasticsearch.yml
+++ b/puppet/modules/socorro/files/etc_elasticsearch/elasticsearch.yml
@@ -1,0 +1,3 @@
+---
+index.number_of_shards: 1
+index.number_of_replicas: 0

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -179,6 +179,12 @@ class socorro::vagrant {
       path   => '/home/vagrant/.bashrc',
       source => 'puppet:///modules/socorro/home/bashrc',
       owner  => 'vagrant';
+
+    'elasticsearch.yml':
+      ensure => file,
+      path   => '/etc/elasticsearch/elasticsearch.yml',
+      source => 'puppet:///modules/socorro/etc_elasticsearch/elasticsearch.yml',
+      owner  => 'root';
   }
 
 }


### PR DESCRIPTION
The default index settings in Elasticsearch assume a multi-node cluster, which Vagrant is not.

`r+` @rhelmer @AdrianGaudebert 
