### PR TITLE
fixes Bug 984583 - added abandon transaction behavior

### DIFF
--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -37,6 +37,7 @@ _URL = (
 class NothingUsefulHappened(Exception):
     """an exception to be raised when a pass through the inner loop has
     done nothing useful and we wish to induce a transaction rollback"""
+    abandon_transaction = True
 
 
 @with_postgres_transactions()


### PR DESCRIPTION
the Bugzilla crontabber job uses an Exception for control flow.  There is a complicated transaction that is started, but near the end, we can finally recognise that the transaction is not useful.  The original code just raised an exception and let the TransactionExecutor roll the transaction back.  However, the TransactionExecutor logs it as an error even though it was intentional.

This PR adds the ability for the TransactionExecutor to abandon a transaction if the exception was raised intentionally and has the attribute 'abandon_transaction'.  
