### PR TITLE
bug 948644 - use crash_id instead of undefined 'key'

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -764,8 +764,8 @@ class MissingSymbolsRule(Rule):
             self.database,
         )
         self.sql = (
-            "INSERT INTO missing_symbols(date, debug_file, debug_id) "
-            "VALUES (%s, %s, %s)"
+            "INSERT INTO missing_symbols(date_processed, debug_file, debug_id)"
+            " VALUES (%s, %s, %s)"
         )
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
r? @twobraids - this is working as expected except the add to processor notes is failing since it's using an undefined variable (`key`), this should be `raw_crash.uuid` instead.
