### PR TITLE
fix errant script name

### DIFF
--- a/docs/development/elasticsearch.rst
+++ b/docs/development/elasticsearch.rst
@@ -63,7 +63,7 @@ quantity of data you deal with, etc.
 Once elasticsearch is installed, you will want to set up the basic data
 required by Socorro. There is a script that will do that for you::
 
-    $ python scripts/setup_elasticsearch_app.py
+    $ cd scripts && python ./setup_supersearch_app.py
 
 Use the ``--help`` option to see the different parameters you can use. The only
 one you should have to change is ``elasticsearch_urls`` to make it reflect


### PR DESCRIPTION
This script had the wrong name in the docs.

Also, it needs to be [moved elsewhere](https://bugzilla.mozilla.org/show_bug.cgi?id=1116149) in order to run without error; `cd`'ing into `scripts/` is a temporary work-around.
