### PR TITLE
Fix bugs which prevented out-of-box VM provisioning and RPM install.

### DIFF
--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -184,7 +184,9 @@ class socorro::vagrant {
       ensure => file,
       path   => '/etc/elasticsearch/elasticsearch.yml',
       source => 'puppet:///modules/socorro/etc_elasticsearch/elasticsearch.yml',
-      owner  => 'root';
+      owner  => 'root',
+      require => Package['elasticsearch'],
+      notify => Service['elasticsearch'];
   }
 
 }

--- a/scripts/package/after-install.sh
+++ b/scripts/package/after-install.sh
@@ -48,6 +48,21 @@ if [ $? != 0 ]; then
     echo "See /var/log/socorro/django-syncdb.log for more info"
 fi
 
+# create ElasticSearch indexes
+echo "Creating ElasticSearch indexes"
+pushd /data/socorro/application/scripts > /dev/null
+su socorro -c "PYTHONPATH=. /data/socorro/socorro-virtualenv/bin/python \
+    setup_supersearch_app.py \
+    &> /var/log/socorro/setup_supersearch.log"
+
+if [ $? != 0 ]; then
+    echo "WARN could not create ElasticSearch indexes"
+    echo "See /var/log/socorro/setup_supersearch.log for more info"
+    echo "You may want to run"
+    echo "/data/socorro/application/scripts/setup_supersearch_app.py manually"
+fi
+popd > /dev/null
+
 # ensure that partitions have been created
 pushd /data/socorro/application > /dev/null
 su socorro -c "PYTHONPATH=. /data/socorro/socorro-virtualenv/bin/python \


### PR DESCRIPTION
- Fix minor bug in puppet manifest which fired error during ElasticSearch
  provisioning;
- Add ElasticSearch index init for socorro.

Now you can provision VM, build and install Socorro using following simple
steps:

 $ vagrant up
 $ vagrant ssh
 $ cd socorro
 $ make BUILD_TYPE=rpm package
 $ sudo rpm -ivh socorro*rpm

Signed-off-by: Selena Deckelmann selenamarie@gmail.com
