### PR TITLE
Fixes bug 1363712 - Use a placeholder in addons without version.

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -151,6 +151,16 @@ class AddonsRule(Rule):
     def version(self):
         return '1.0'
 
+    def _get_formatted_addon(self, addon):
+        """Return a properly formatted addon string.
+
+        Format is: addon_identifier:addon_version
+
+        This is used because some addons are missing a version. In order to
+        simplify subsequent queries, we make sure the format is consistent.
+        """
+        return ':' in addon and addon or addon + ':NO_VERSION'
+
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
 
         processed_crash.addons_checked = None
@@ -185,7 +195,8 @@ class AddonsRule(Rule):
                         'AddonsRule: trying to split addons'
                     )
                 processed_crash.addons = [
-                    unquote_plus(x) for x in original_addon_str.split(',')
+                    unquote_plus(self._get_formatted_addon(x))
+                    for x in original_addon_str.split(',')
                 ]
             if self.config.chatty:
                 self.config.logger.debug(

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -159,7 +159,7 @@ class AddonsRule(Rule):
         This is used because some addons are missing a version. In order to
         simplify subsequent queries, we make sure the format is consistent.
         """
-        return ':' in addon and addon or addon + ':NO_VERSION'
+        return addon if ':' in addon else addon + ':NO_VERSION'
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
 

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -476,7 +476,7 @@ class TestAddonsRule(TestCase):
         addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected_addon_list = [
-            'naoenut813teq;mz;<[`19ntaotannn8999anxse `',
+            'naoenut813teq;mz;<[`19ntaotannn8999anxse `:NO_VERSION',
         ]
         eq_(processed_crash.addons, expected_addon_list)
         ok_(processed_crash.addons_checked)


### PR DESCRIPTION
In order to make queries easier, we want to ensure that all addons have the same format of addon_identifier:addon_version. We thus add a placeholder version to addons that miss it, to make things consistent.