### PR TITLE
Fixes bug 1368498 - Do not use bugs table in bugzilla cron job.

### DIFF
--- a/alembic/versions/a5e0f0bc87d6_removed_foreign_key_between_bug_.py
+++ b/alembic/versions/a5e0f0bc87d6_removed_foreign_key_between_bug_.py
@@ -1,0 +1,31 @@
+"""removed foreign key between bug_associations and bugs
+
+Revision ID: a5e0f0bc87d6
+Revises: 495e6c766315
+Create Date: 2017-05-29 19:17:39.607018
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a5e0f0bc87d6'
+down_revision = '495e6c766315'
+
+from alembic import op
+
+
+def upgrade():
+    op.drop_constraint(
+        'bug_associations_bug_id_fkey',
+        'bug_associations',
+        type_='foreignkey'
+    )
+
+
+def downgrade():
+    op.create_foreign_key(
+        'bug_associations_bug_id_fkey',
+        'bug_associations',
+        'bugs',
+        ['bug_id'],
+        ['id'],
+    )

--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -13,7 +13,6 @@ from crontabber.mixins import with_postgres_transactions
 
 from socorro.lib.datetimeutil import utc_now
 from socorro.external.postgresql.dbapi2_util import (
-    single_row_sql,
     execute_query_fetchall,
     execute_no_results,
     SQLDidNotReturnSingleRow

--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -30,8 +30,7 @@ _URL = (
     'tes=&chfieldfrom=%s&chfieldto=Now&chfield=[Bug+creation]&chfield=reso'
     'lution&chfield=bug_status&chfield=short_desc&chfield=cf_crash_signatu'
     're&chfieldvalue=&cmdtype=doit&order=Importance&field0-0-0=noop&type0-'
-    '0-0=noop&value0-0-0=&columnlist=bug_id,bug_status,resolution,short_de'
-    'sc,cf_crash_signature&ctype=csv'
+    '0-0=noop&value0-0-0=&columnlist=bug_id,cf_crash_signature&ctype=csv'
 )
 
 
@@ -81,9 +80,6 @@ class BugzillaCronApp(BaseCronApp):
         query = self.config.query % last_run_formatted
         for (
             bug_id,
-            status,
-            resolution,
-            short_desc,
             signature_set
         ) in self._iterator(query):
             try:
@@ -91,9 +87,6 @@ class BugzillaCronApp(BaseCronApp):
                 self.database_transaction_executor(
                     self.inner_transaction,
                     bug_id,
-                    status,
-                    resolution,
-                    short_desc,
                     signature_set
                 )
             except NothingUsefulHappened:
@@ -103,14 +96,11 @@ class BugzillaCronApp(BaseCronApp):
         self,
         connection,
         bug_id,
-        status,
-        resolution,
-        short_desc,
         signature_set
     ):
         self.config.logger.debug(
-            "bug %s (%s, %s) %s: %s",
-            bug_id, status, resolution, short_desc, signature_set
+            "bug %s: %s",
+            bug_id, signature_set
         )
         if not signature_set:
             execute_no_results(
@@ -169,9 +159,6 @@ class BugzillaCronApp(BaseCronApp):
         for report in csv.DictReader(urllib2.urlopen(query)):
             yield (
                 int(report['bug_id']),
-                report['bug_status'],
-                report['resolution'],
-                report['short_desc'],
                 self._signatures_found(report['cf_crash_signature'])
             )
 

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -518,11 +518,8 @@ class BugAssociation(DeclarativeBase):
     __tablename__ = 'bug_associations'
 
     #column definitions
-    bug_id = Column(u'bug_id', INTEGER(), ForeignKey('bugs.id'), primary_key=True, nullable=False, index=True)
+    bug_id = Column(u'bug_id', INTEGER(), primary_key=True, nullable=False, index=True)
     signature = Column(u'signature', TEXT(), primary_key=True, nullable=False)
-
-    #relationship definitions
-    bugs = relationship('Bug', primaryjoin='BugAssociation.bug_id==Bug.id')
 
 
 class BuildAdu(DeclarativeBase):

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -14,26 +14,22 @@ from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 
 SAMPLE_CSV = [
-   'bug_id,"bug_status","resolution","short_desc","cf_crash_signature"',
-   '1,"RESOLVED",,"this is a comment","This sig, while bogus, has a ] bracket"',
-   '2,"CLOSED","WONTFIX","comments are not too important","single [@ BogusClass::bogus_sig (const char**) ] signature"',
-   '3,"ASSIGNED",,"this is a comment. [@ nanojit::LIns::isTramp()]","[@ js3250.dll@0x6cb96] [@ valid.sig@0x333333]"',
-   '4,"CLOSED","RESOLVED","two sigs enter, one sig leaves","[@ layers::Push@0x123456] [@ layers::Push@0x123456]"',
-   '5,"ASSIGNED","INCOMPLETE",,"[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455"',
-   '6,"ASSIGNED",,"empty crash sigs should not throw errors",""',
-   '7,"CLOSED",,"gt 525355 gt","[@gfx::font(nsTArray<nsRefPtr<FontEntry> > const&)]"',
-   '8,"CLOSED","RESOLVED","newlines in sigs","[@ legitimate(sig)] \n junk \n [@ another::legitimate(sig) ]"'
+    'bug_id,"bug_status","resolution","short_desc","cf_crash_signature"',
+    '1,"RESOLVED",,"this is a comment","This sig, while bogus, has a ] bracket"',
+    '2,"CLOSED","WONTFIX","comments are not too important","single [@ BogusClass::bogus_sig (const char**) ] signature"',
+    '3,"ASSIGNED",,"this is a comment. [@ nanojit::LIns::isTramp()]","[@ js3250.dll@0x6cb96] [@ valid.sig@0x333333]"',
+    '4,"CLOSED","RESOLVED","two sigs enter, one sig leaves","[@ layers::Push@0x123456] [@ layers::Push@0x123456]"',
+    '5,"ASSIGNED","INCOMPLETE",,"[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455"',
+    '6,"ASSIGNED",,"empty crash sigs should not throw errors",""',
+    '7,"CLOSED",,"gt 525355 gt","[@gfx::font(nsTArray<nsRefPtr<FontEntry> > const&)]"',
+    '8,"CLOSED","RESOLVED","newlines in sigs","[@ legitimate(sig)] \n junk \n [@ another::legitimate(sig) ]"'
 ]
 
 
 class IntegrationTestBugzilla(IntegrationTestBase):
 
     def tearDown(self):
-        self.conn.cursor().execute("""
-        TRUNCATE
-            bug_associations
-        CASCADE
-        """)
+        self.conn.cursor().execute("TRUNCATE bug_associations CASCADE")
         self.conn.commit()
         super(IntegrationTestBugzilla, self).tearDown()
 
@@ -54,19 +50,14 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         return get_config_manager_for_crontabber(
             jobs='socorro.cron.jobs.bugzilla.BugzillaCronApp|1d',
             overrides={
-              'crontabber.class-BugzillaCronApp.query': query,
-              'crontabber.class-BugzillaCronApp.days_into_past': days_into_past,
+                'crontabber.class-BugzillaCronApp.query': query,
+                'crontabber.class-BugzillaCronApp.days_into_past': days_into_past,
             }
         )
 
     def test_basic_run_job(self):
         config_manager = self._setup_config_manager(3)
 
-        cursor = self.conn.cursor()
-        cursor.execute('select count(*) from bug_associations')
-        count, = cursor.fetchone()
-        assert count == 0, "'bug_associations' table not cleaned"
-
         with config_manager.context() as config:
             tab = CronTabber(config)
             tab.run_all()
@@ -76,25 +67,35 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
 
+        cursor = self.conn.cursor()
         cursor.execute('select bug_id from bug_associations order by bug_id')
         associations = cursor.fetchall()
+
+        # Verify we have the expected number of associations.
         assert len(associations) == 8
         bug_ids = [x[0] for x in associations]
+
+        # Verify bugs with no crash signatures are missing.
         assert 6 not in bug_ids
 
+        cursor.execute(
+            'select signature from bug_associations where bug_id = 8'
+        )
+        associations = cursor.fetchall()
+        # New signatures have correctly been inserted.
+        expected = [('legitimate(sig)',), ('another::legitimate(sig)',)]
+        assert associations == expected
+
     def test_run_job_with_reports_with_existing_bugs_different(self):
+        """Verify that an association to a signature that no longer is part
+        of the crash signatures list gets removed.
+        """
         config_manager = self._setup_config_manager(3)
-
         cursor = self.conn.cursor()
-        cursor.execute('select count(*) from bug_associations')
-        count, = cursor.fetchone()
-        assert not count, count
 
-        # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into bug_associations
-        (bug_id,signature)
-        values
-        (8, '@different');
+        cursor.execute("""
+            insert into bug_associations (bug_id, signature)
+            values (8, '@different');
         """)
         self.conn.commit()
 
@@ -108,20 +109,20 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert information['bugzilla-associations']['last_success']
 
         cursor.execute(
-            'select signature from bug_associations where bug_id = 8')
+            'select signature from bug_associations where bug_id = 8'
+        )
         associations = cursor.fetchall()
-        assert ('legitimate(sig)',) in associations
-        assert ('another::legitimate(sig)',) in associations
+        # The previous association, to signature '@different' that is not in
+        # crash signatures, is now missing.
+        assert ('@different',) not in associations
 
     def test_run_job_with_reports_with_existing_bugs_same(self):
         config_manager = self._setup_config_manager(3)
-
         cursor = self.conn.cursor()
-        # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into bug_associations
-        (bug_id,signature)
-        values
-        (8, 'legitimate(sig)');
+
+        cursor.execute("""
+            insert into bug_associations (bug_id, signature)
+            values (8, 'legitimate(sig)');
         """)
         self.conn.commit()
 
@@ -135,59 +136,15 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert information['bugzilla-associations']['last_success']
 
         cursor.execute(
-            'select signature from bug_associations where bug_id = 8')
+            'select signature from bug_associations where bug_id = 8'
+        )
         associations = cursor.fetchall()
-        assert ('legitimate(sig)',) in associations
-        assert ('another::legitimate(sig)',) in associations
-
-    def test_run_job_virgin_run(self):
-        """specifically setting 0 days back and no priror run
-        will pick it up from now's date"""
-        config_manager = self._setup_config_manager(0)
-
-        cursor = self.conn.cursor()
-        # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into bug_associations
-        (bug_id,signature)
-        values
-        (8, 'legitimate(sig)');
-        """)
-        self.conn.commit()
-
-        with config_manager.context() as config:
-            tab = CronTabber(config)
-            tab.run_all()
-
-            information = self._load_structure()
-            assert information['bugzilla-associations']
-            assert not information['bugzilla-associations']['last_error']
-            assert information['bugzilla-associations']['last_success']
-
-    def test_run_job_one_day_back(self):
-        """specifically setting 0 days back and no priror run
-        will pick it up from now's date"""
-        config_manager = self._setup_config_manager(1)
-
-        cursor = self.conn.cursor()
-        # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into bug_associations
-        (bug_id,signature)
-        values
-        (8, 'legitimate(sig)');
-        """)
-        self.conn.commit()
-
-        with config_manager.context() as config:
-            tab = CronTabber(config)
-            tab.run_all()
-
-            information = self._load_structure()
-            assert information['bugzilla-associations']
-            assert not information['bugzilla-associations']['last_error']
-            assert information['bugzilla-associations']['last_success']
+        # New signatures have correctly been inserted.
+        expected = [('another::legitimate(sig)',), ('legitimate(sig)',)]
+        assert associations == expected
 
     def test_run_job_based_on_last_success(self):
-        """specifically setting 0 days back and no priror run
+        """specifically setting 0 days back and no prior run
         will pick it up from now's date"""
         config_manager = self._setup_config_manager(0)
 

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -83,8 +83,9 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         )
         associations = cursor.fetchall()
         # New signatures have correctly been inserted.
-        expected = [('legitimate(sig)',), ('another::legitimate(sig)',)]
-        assert associations == expected
+        assert len(associations) == 2
+        assert ('another::legitimate(sig)',) in associations
+        assert ('legitimate(sig)',) in associations
 
     def test_run_job_with_reports_with_existing_bugs_different(self):
         """Verify that an association to a signature that no longer is part
@@ -140,8 +141,9 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         )
         associations = cursor.fetchall()
         # New signatures have correctly been inserted.
-        expected = [('another::legitimate(sig)',), ('legitimate(sig)',)]
-        assert associations == expected
+        assert len(associations) == 2
+        assert ('another::legitimate(sig)',) in associations
+        assert ('legitimate(sig)',) in associations
 
     def test_run_job_based_on_last_success(self):
         """specifically setting 0 days back and no prior run

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -14,15 +14,15 @@ from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 
 SAMPLE_CSV = [
-    'bug_id,"bug_status","resolution","short_desc","cf_crash_signature"',
-    '1,"RESOLVED",,"this is a comment","This sig, while bogus, has a ] bracket"',
-    '2,"CLOSED","WONTFIX","comments are not too important","single [@ BogusClass::bogus_sig (const char**) ] signature"',
-    '3,"ASSIGNED",,"this is a comment. [@ nanojit::LIns::isTramp()]","[@ js3250.dll@0x6cb96] [@ valid.sig@0x333333]"',
-    '4,"CLOSED","RESOLVED","two sigs enter, one sig leaves","[@ layers::Push@0x123456] [@ layers::Push@0x123456]"',
-    '5,"ASSIGNED","INCOMPLETE",,"[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455"',
-    '6,"ASSIGNED",,"empty crash sigs should not throw errors",""',
-    '7,"CLOSED",,"gt 525355 gt","[@gfx::font(nsTArray<nsRefPtr<FontEntry> > const&)]"',
-    '8,"CLOSED","RESOLVED","newlines in sigs","[@ legitimate(sig)] \n junk \n [@ another::legitimate(sig) ]"'
+    'bug_id,"cf_crash_signature"',
+    '1,"This sig, while bogus, has a ] bracket"',
+    '2,"single [@ BogusClass::bogus_sig (const char**) ] signature"',
+    '3,"[@ js3250.dll@0x6cb96] [@ valid.sig@0x333333]"',
+    '4,"[@ layers::Push@0x123456] [@ layers::Push@0x123456]"',
+    '5,"[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455"',
+    '6,""',
+    '7,"[@gfx::font(nsTArray<nsRefPtr<FontEntry> > const&)]"',
+    '8,"[@ legitimate(sig)] \n junk \n [@ another::legitimate(sig) ]"'
 ]
 
 

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -4,7 +4,6 @@
 
 import datetime
 import os
-from nose.tools import eq_, ok_
 from dateutil import tz
 from crontabber.app import CronTabber
 from socorro.unittest.cron.setup_configman import (
@@ -32,7 +31,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
     def tearDown(self):
         self.conn.cursor().execute("""
         TRUNCATE
-            reports, bugs, bug_associations
+            bug_associations
         CASCADE
         """)
         self.conn.commit()
@@ -60,16 +59,10 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             }
         )
 
-    def test_basic_run_job_without_reports(self):
+    def test_basic_run_job(self):
         config_manager = self._setup_config_manager(3)
 
         cursor = self.conn.cursor()
-        cursor.execute('select count(*) from reports')
-        count, = cursor.fetchone()
-        assert count == 0, "reports table not cleaned"
-        cursor.execute('select count(*) from bugs')
-        count, = cursor.fetchone()
-        assert count == 0, "'bugs' table not cleaned"
         cursor.execute('select count(*) from bug_associations')
         count, = cursor.fetchone()
         assert count == 0, "'bug_associations' table not cleaned"
@@ -83,84 +76,21 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
 
-        # now, because there we no matching signatures in the reports table
-        # it means that all bugs are rejected
-        cursor.execute('select count(*) from bugs')
-        count, = cursor.fetchone()
-        ok_(not count)
-        cursor.execute('select count(*) from bug_associations')
-        count, = cursor.fetchone()
-        ok_(not count)
-
-    def test_basic_run_job_with_some_reports(self):
-        config_manager = self._setup_config_manager(3)
-
-        cursor = self.conn.cursor()
-        # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        self.conn.commit()
-
-        with config_manager.context() as config:
-            tab = CronTabber(config)
-            tab.run_all()
-
-            information = self._load_structure()
-            assert information['bugzilla-associations']
-            assert not information['bugzilla-associations']['last_error']
-            assert information['bugzilla-associations']['last_success']
-
-        cursor.execute('select id from bugs order by id')
-        bugs = cursor.fetchall()
-        eq_(len(bugs), 2)
-        # the only bugs with matching those signatures are: 5 and 8
-        bug_ids = [x[0] for x in bugs]
-        eq_(bug_ids, [5, 8])
-
         cursor.execute('select bug_id from bug_associations order by bug_id')
         associations = cursor.fetchall()
-        eq_(len(associations), 2)
+        assert len(associations) == 8
         bug_ids = [x[0] for x in associations]
-        eq_(bug_ids, [5, 8])
+        assert 6 not in bug_ids
 
     def test_run_job_with_reports_with_existing_bugs_different(self):
         config_manager = self._setup_config_manager(3)
 
         cursor = self.conn.cursor()
-        cursor.execute('select count(*) from bugs')
-        count, = cursor.fetchone()
-        assert not count, count
         cursor.execute('select count(*) from bug_associations')
-        count, = cursor.fetchone()
-        assert not count, count
-        cursor.execute('select count(*) from reports')
         count, = cursor.fetchone()
         assert not count, count
 
         # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        cursor.execute("""insert into bugs
-        (id,status,resolution,short_desc)
-        values
-        (8, 'CLOSED', 'RESOLVED', 'Different');
-        """)
         cursor.execute("""insert into bug_associations
         (bug_id,signature)
         values
@@ -177,36 +107,17 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
 
-        cursor.execute('select id, short_desc from bugs where id = 8')
-        bug = cursor.fetchone()
-        eq_(bug[1], 'newlines in sigs')
-
         cursor.execute(
-          'select signature from bug_associations where bug_id = 8')
-        association = cursor.fetchone()
-        eq_(association[0], 'legitimate(sig)')
+            'select signature from bug_associations where bug_id = 8')
+        associations = cursor.fetchall()
+        assert ('legitimate(sig)',) in associations
+        assert ('another::legitimate(sig)',) in associations
 
     def test_run_job_with_reports_with_existing_bugs_same(self):
         config_manager = self._setup_config_manager(3)
 
         cursor = self.conn.cursor()
         # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        # exactly the same as the fixture
-        cursor.execute("""insert into bugs
-        (id,status,resolution,short_desc)
-        values
-        (8, 'CLOSED', 'RESOLVED', 'newlines in sigs');
-        """)
         cursor.execute("""insert into bug_associations
         (bug_id,signature)
         values
@@ -223,15 +134,11 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
 
-        cursor.execute('select id, short_desc from bugs where id = 8')
-        bug = cursor.fetchone()
-        eq_(bug[1], 'newlines in sigs')
-
         cursor.execute(
-          'select signature from bug_associations where bug_id = 8')
-        association = cursor.fetchone()
-        eq_(association[0], 'legitimate(sig)')
-        cursor.execute('select * from bug_associations')
+            'select signature from bug_associations where bug_id = 8')
+        associations = cursor.fetchall()
+        assert ('legitimate(sig)',) in associations
+        assert ('another::legitimate(sig)',) in associations
 
     def test_run_job_virgin_run(self):
         """specifically setting 0 days back and no priror run
@@ -240,22 +147,6 @@ class IntegrationTestBugzilla(IntegrationTestBase):
 
         cursor = self.conn.cursor()
         # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        # exactly the same as the fixture
-        cursor.execute("""insert into bugs
-        (id,status,resolution,short_desc)
-        values
-        (8, 'CLOSED', 'RESOLVED', 'newlines in sigs');
-        """)
         cursor.execute("""insert into bug_associations
         (bug_id,signature)
         values
@@ -271,10 +162,6 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert information['bugzilla-associations']
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
-
-        cursor.execute('select id, short_desc from bugs where id = 8')
-        bug = cursor.fetchone()
-        eq_(bug[1], 'newlines in sigs')
 
     def test_run_job_one_day_back(self):
         """specifically setting 0 days back and no priror run
@@ -283,22 +170,6 @@ class IntegrationTestBugzilla(IntegrationTestBase):
 
         cursor = self.conn.cursor()
         # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        # exactly the same as the fixture
-        cursor.execute("""insert into bugs
-        (id,status,resolution,short_desc)
-        values
-        (8, 'CLOSED', 'RESOLVED', 'newlines in sigs');
-        """)
         cursor.execute("""insert into bug_associations
         (bug_id,signature)
         values
@@ -315,10 +186,6 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
 
-        cursor.execute('select id, short_desc from bugs where id = 8')
-        bug = cursor.fetchone()
-        eq_(bug[1], 'newlines in sigs')
-
     def test_run_job_based_on_last_success(self):
         """specifically setting 0 days back and no priror run
         will pick it up from now's date"""
@@ -326,22 +193,6 @@ class IntegrationTestBugzilla(IntegrationTestBase):
 
         cursor = self.conn.cursor()
         # these are matching the SAMPLE_CSV above
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('123', 'legitimate(sig)');
-        """)
-        cursor.execute("""insert into reports
-        (uuid,signature)
-        values
-        ('456', 'MWSBAR.DLL@0x2589f');
-        """)
-        # exactly the same as the fixture
-        cursor.execute("""insert into bugs
-        (id,status,resolution,short_desc)
-        values
-        (8, 'CLOSED', 'RESOLVED', 'newlines in sigs');
-        """)
         cursor.execute("""insert into bug_associations
         (bug_id,signature)
         values
@@ -373,7 +224,3 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             assert information['bugzilla-associations']
             assert not information['bugzilla-associations']['last_error']
             assert information['bugzilla-associations']['last_success']
-
-        cursor.execute('select id, short_desc from bugs where id = 8')
-        bug = cursor.fetchone()
-        eq_(bug[1], 'newlines in sigs')


### PR DESCRIPTION
This makes the bugzilla cron job stop writing any data into the bugs table. It also removes the foreign key from bug_associations to bugs in a migration, which is needed for the cron job to keep working.