### PR TITLE
Fix "make dockertest" to sync files better

### DIFF
--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -17,7 +17,6 @@ set -v -e -x
 PS4="+ (run_tests_in_docker.sh): "
 
 DC="$(which docker-compose)"
-DOCKER="$(which docker)"
 APP_UID="10001"
 APP_GID="10001"
 
@@ -35,8 +34,6 @@ ${DC} up -d rabbitmq
 # to /app.
 if [ "$1" == "--shell" ]; then
     echo "Running shell..."
-    DOCKER_COMMAND="/bin/bash"
-    DOCKER_ARGS="-t -i"
 
     docker run \
            --rm \
@@ -70,7 +67,7 @@ else
            --user root \
            --volumes-from socorro-repo \
            --workdir /app \
-           local/socorro_webapp rm -rf /app/*
+           local/socorro_webapp rm -rf "/app/*"
 
     # Copy the repo root into /app
     docker cp . socorro-repo:/app

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -65,6 +65,14 @@ else
                ${BASEIMAGENAME} /bin/true
     fi
     echo "Copying contents..."
+    # Wipe whatever might be in there from past runs
+    docker run \
+           --user root \
+           --volumes-from socorro-repo \
+           --workdir /app \
+           local/socorro_webapp rm -rf /app/*
+
+    # Copy the repo root into /app
     docker cp . socorro-repo:/app
 
     # Fix permissions in data container
@@ -88,5 +96,6 @@ else
            --env-file ./docker/config/docker_common.env \
            --env-file ./docker/config/test.env \
            local/socorro_webapp /app/docker/run_tests.sh
+
     echo "Done!"
 fi


### PR DESCRIPTION
When you run "make dockertest" it copies the contents of the repository
directory into /app in a data container and then runs the tests in that. The
problem is that it doesn't remove files that have been removed.

This fixes the script to remove all the files in /app and then copy the files
from the repository directory into /app. In this way, it better handles files
that have been removed.