### PR TITLE
Fixes bug 1370484 - Refactored bugzilla query to use REST API and JSON.

### DIFF
--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -59,12 +59,6 @@ def find_signatures(content):
     return signatures
 
 
-class BugzillaConnectionError(Exception):
-    """Raised when an HTTP request to bugzilla did not return a 2XX status.
-    """
-    pass
-
-
 class NothingUsefulHappened(Exception):
     """an exception to be raised when a pass through the inner loop has
     done nothing useful and we wish to induce a transaction rollback"""
@@ -185,7 +179,7 @@ class BugzillaCronApp(BaseCronApp):
         payload['chfieldfrom'] = from_date
         r = requests.get(BUGZILLA_BASE_URL, params=payload)
         if r.status_code < 200 or r.status_code >= 300:
-            raise BugzillaConnectionError()
+            r.raise_for_status()
         results = r.json()
         for report in results['bugs']:
             yield (

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -218,7 +218,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
             # There has been an error.
             last_error = information['bugzilla-associations']['last_error']
             assert last_error
-            assert 'BugzillaConnectionError' in last_error['type']
+            assert 'HTTPError' in last_error['type']
             assert not information['bugzilla-associations']['last_success']
 
 


### PR DESCRIPTION
This query used to be a very long, hand-written URL, using the old bugzilla query system that returned CSV data. With this, it now uses the REST API instead, manipulating JSON data with the requests library. The query is much simpler to read and has only the few arguments it actually needs. Also, the query is not configurable anymore, because that option was never used and it would have made the code less maintainable.