### PR TITLE
Fixes bug 1372999 - add document size metrics for elasticsearch crashstorage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -326,3 +326,6 @@ pytest-wholenodeid==0.2 \
     --hash=sha256:bdcb4df88ca182a19752ef95150c0881deaafc2c593ef67c61515894e5309206
 pytest-env==0.6.0 \
     --hash=sha256:f4d61885b0befcb474e73e775597a798bd37808f8856ebb624b0822f054f6c0c
+pytest-catchlog==1.2.2 \
+    --hash=sha256:4be15dc5ac1750f83960897f591453040dff044b5966fe24a91c2f7d04ecfcf0 \
+    --hash=sha256:a692966da726b918197cabd20dc0ad4da5503fbdc99baaa192e62579c8a45773

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -362,6 +362,61 @@ def setup_logger(config, local_unused, args_unused):
     return wrapped_logger
 
 
+def setup_metrics(config, local_unused, args_unused):
+    """Sets up metrics client which is either a DogStatsd client or a LoggingClient
+
+    NOTE(willkg): This is a little gross, but that's mostly to keep all the code in one place and
+    minimal which makes it easier to deal with for now. If this ever grows, then we'll probably want
+    to split this out into its own module.
+
+    This gets tossed in config (along with everything else), so you can use it like this::
+
+        class SomeComponent(RequiredConfig):
+            def something(self):
+                self.config.metrics.increment('somekey')
+
+    """
+    # We do the import here in case there are parts of Socorro that are running in environments that
+    # don't have this library installed.
+    #
+    # FIXME(willkg): We're using a *super* old version of dogstatsd-python which doesn't have the
+    # DogStatsd class. We should upgrade.
+    try:
+        from datadog.dogstatsd import statsd
+    except ImportError as ioe:
+        statsd is None
+
+    host = config.metricscfg.statsd_host
+    port = config.metricscfg.statsd_port
+
+    if host and statsd:
+        statsd.host = host
+        statsd.port = port
+        return statsd
+
+    class LoggingMetrics(object):
+        """Logging-based metrics class that mimics DogStatsd class"""
+        def __init__(self):
+            self.logger = logging.getLogger('socorro.metrics')
+
+        def _log(self, operation, metric, value, tags):
+            self.logger.info('%s: %s=%s tags=%s', operation, metric, value, tags or [])
+
+        def increment(self, metric, value=1, tags=None):
+            self._log('increment', metric, value, tags)
+
+        def gauge(self, metric, value, tags=None):
+            self._log('gauge', metric, value, tags)
+
+        def timing(self, metric, value, tags=None):
+            self._log('timing', metric, value, tags)
+
+        def histogram(self, metric, value, tags=None):
+            self._log('histogram', metric, value, tags)
+
+    return LoggingMetrics()
+
+
 class App(SocorroApp):
     """The base class from which Socorro apps are based"""
     required_config = Namespace()
@@ -414,10 +469,27 @@ class App(SocorroApp):
         default=10,
         reference_value_from='resource.logging',
     )
-
     required_config.add_aggregation(
         'logger',
         setup_logger
+    )
+
+    required_config.namespace('metricscfg')
+    required_config.metricscfg.add_option(
+        'statsd_host',
+        doc='host for statsd server',
+        default='',
+        reference_value_from='resource.statsd_host'
+    )
+    required_config.metricscfg.add_option(
+        'statsd_port',
+        doc='port for statsd server',
+        default=8125,
+        reference_value_from='resource.statsd_port'
+    )
+    required_config.add_aggregation(
+        'metrics',
+        setup_metrics
     )
 
 

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -383,8 +383,8 @@ def setup_metrics(config, local_unused, args_unused):
     # DogStatsd class. We should upgrade.
     try:
         from datadog.dogstatsd import statsd
-    except ImportError as ioe:
-        statsd is None
+    except ImportError:
+        statsd = None
 
     host = config.metricscfg.statsd_host
     port = config.metricscfg.statsd_port

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -128,7 +128,7 @@ class ESCrashStorage(CrashStorageBase):
                 'processor.es.raw_crash_size',
                 len(json.dumps(raw_crash, cls=JsonDTEncoder))
             )
-        except Exception as exc:
+        except Exception:
             # NOTE(willkg): An error here shouldn't screw up saving data. Log it so we can fix it
             # later.
             self.config.logger.exception('something went wrong when capturing raw_crash_size')
@@ -138,7 +138,7 @@ class ESCrashStorage(CrashStorageBase):
                 'processor.es.processed_crash_size',
                 len(json.dumps(processed_crash, cls=JsonDTEncoder))
             )
-        except Exception as exc:
+        except Exception:
             # NOTE(willkg): An error here shouldn't screw up saving data. Log it so we can fix it
             # later.
             self.config.logger.exception('something went wrong when capturing raw_crash_size')

--- a/socorro/unittest/external/es/base.py
+++ b/socorro/unittest/external/es/base.py
@@ -800,14 +800,16 @@ class TestCaseWithConfig(TestCase):
             sources = [sources]
 
         mock_logging = mock.Mock()
+        mock_metrics = mock.Mock()
 
         config_definitions = []
         for source in sources:
             conf = source.get_required_config()
             conf.add_option('logger', default=mock_logging)
+            conf.add_option('metrics', default=mock_metrics)
             config_definitions.append(conf)
 
-        values_source = {'logger': mock_logging}
+        values_source = {'logger': mock_logging, 'metrics': mock_metrics}
         if extra_values:
             values_source.update(extra_values)
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -64,6 +64,9 @@ def config_from_configman():
     definition_source.namespace('logging')
     definition_source.logging = socorro_app.App.required_config.logging
 
+    definition_source.namespace('metricscfg')
+    definition_source.metricscfg = socorro_app.App.required_config.metricscfg
+
     definition_source.namespace('elasticsearch')
     definition_source.elasticsearch.add_option(
         'elasticsearch_class',


### PR DESCRIPTION
I had to implement a new metrics infrastructure before I could do anything. But I think that's good in the long run. We can probably retire a bunch of the statsd stuff we've got now and add more granular metrics capture to relevant parts.

The metrics infrastructure degrades to logging metrics data if statsd isn't set up. This re-uses existing statsd configuration keys, so theoretically, it should just work without requiring configuration changes.

r?