### PR TITLE
Add a proper exception to LoggerWrapper

### DIFF
--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -317,6 +317,10 @@ class LoggerWrapper(object):
             **kwargs
         )
 
+    def exception(self, message, *args, **kwargs):
+        kwargs['exc_info'] = True
+        self.error(message, *args, **kwargs)
+
 
 def setup_logger(config, local_unused, args_unused):
     """This method is sets up and initializes the logger objects.  It is a


### PR DESCRIPTION
The LoggerWrapper didn't have a .exception() method. It's a handy shortcut
that's used in a bazillion places and if Socorro is going to wrap Logger, it
should mimic it properly.

r?