### PR TITLE
Fixed missing_symbols partition creation

### DIFF
--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -180,7 +180,7 @@ class ReportPartitionInfo(BaseTable):
              '{}',
              'report_date', 'DATE'],
             ['missing_symbols', '14',
-             '{"date_processed,debug_file,debug_id"}',
+             '{}',
              '{}',
              '{}',
              'date_processed', 'DATE']]


### PR DESCRIPTION
This should prevent fresh socorro installation from wrong state of
report_partition_info table.

Think this relates Bug 1123742.