### PR TITLE
Fix instances of "except Exception, e" and some other things

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -249,7 +249,7 @@ class FetchTransformSaveApp(App):
             # RabbitMQ, this is what removes the job from the queue.
             try:
                 finished_func()
-            except Exception, x:
+            except Exception as x:
                 # when run in a thread, a failure here is not a problem, but if
                 # we're running all in the same thread, a failure here could
                 # derail the the whole processor. Best just log the problem

--- a/socorro/cron/buildutil.py
+++ b/socorro/cron/buildutil.py
@@ -55,7 +55,7 @@ def insert_build(cursor, product_name, version, platform, build_id, build_type,
     try:
         cursor.execute(sql, params)
         cursor.connection.commit()
-    except psycopg2.Error, e:
+    except psycopg2.Error as e:
         cursor.connection.rollback()
         logger.error("Failed inserting new release: %s" % e)
         raise

--- a/socorro/database/cachedIdAccess.py
+++ b/socorro/database/cachedIdAccess.py
@@ -105,7 +105,7 @@ class IdCache:
           if None != cacheMap:
             cacheMap[key] = id
             countMap[key] = 1
-        except psycopg2.IntegrityError,x: # in case of race condition
+        except psycopg2.IntegrityError as x: # in case of race condition
           logger.info("%s - Failed (%s) insert %s into %s",threading.currentThread().getName(),x,key,table)
           self.cursor.connection.rollback()
           self.cursor.execute(getSql,sqlKey)

--- a/socorro/database/database.py
+++ b/socorro/database/database.py
@@ -73,7 +73,7 @@ def singleValueSql (aCursor, sql, parameters=None):
   result = aCursor.fetchall()
   try:
     return result[0][0]
-  except Exception, x:
+  except Exception as x:
     raise SQLDidNotReturnSingleValue("%s: %s" % (str(x), sql))
 
 
@@ -82,7 +82,7 @@ def singleRowSql (aCursor, sql, parameters=None):
   result = aCursor.fetchall()
   try:
     return result[0]
-  except Exception, x:
+  except Exception as x:
     raise SQLDidNotReturnSingleRow("%s: %s" % (str(x), sql))
 
 
@@ -163,7 +163,7 @@ class Database(object):
     #self.logger.info("%s - %s", threadName, self.dsn)
     try:
       return databaseModule.connect(self.dsn)
-    except Exception, x:
+    except Exception as x:
       self.logger.critical("%s - cannot connect to the database", threadName)
       raise CannotConnectToDatabase(x)
 

--- a/socorro/database/transaction_executor.py
+++ b/socorro/database/transaction_executor.py
@@ -41,7 +41,7 @@ class TransactionExecutor(RequiredConfig):
                 result = function(connection, *args, **kwargs)
                 connection.commit()
                 return result
-            except BaseException, x:
+            except BaseException as x:
                 connection.rollback()
                 if hasattr(x, 'abandon_transaction'):
                     self.config.logger.debug(
@@ -110,7 +110,7 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
                         connection.rollback()
                         raise
 
-            except self.db_conn_context_source.conditional_exceptions, x:
+            except self.db_conn_context_source.conditional_exceptions as x:
                 # these exceptions may or may not be retriable
                 # the test is for is a last ditch effort to see if
                 # we can retry
@@ -137,7 +137,7 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
                     self.connection_source_type,
                     exc_info=True)
 
-            except BaseException, x:
+            except BaseException as x:
                 if hasattr(x, 'abandon_transaction'):
                     self.config.logger.debug(
                         '%s transaction intentionally abandoned by exception',

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -188,7 +188,7 @@ class BotoCrashStorage(CrashStorageBase):
                 raw_crash_as_string,
                 object_hook=json_object_hook
             )
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -207,7 +207,7 @@ class BotoCrashStorage(CrashStorageBase):
                 name = 'dump'
             a_dump = boto_connection.fetch(crash_id, name)
             return a_dump
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -236,7 +236,7 @@ class BotoCrashStorage(CrashStorageBase):
                     dump_name
                 )
             return dumps
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -269,7 +269,7 @@ class BotoCrashStorage(CrashStorageBase):
                 processed_crash_as_string,
                 object_hook=json_object_hook,
             )
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -535,7 +535,7 @@ class PolyCrashStorage(CrashStorageBase):
         for a_store in self.stores.itervalues():
             try:
                 a_store.close()
-            except Exception, x:
+            except Exception as x:
                 self.logger.error('%s failure: %s', a_store.__class__,
                                   str(x))
                 storage_exception.gather_current_exception()
@@ -555,7 +555,7 @@ class PolyCrashStorage(CrashStorageBase):
             self.quit_check()
             try:
                 a_store.save_raw_crash(raw_crash, dumps, crash_id)
-            except Exception, x:
+            except Exception as x:
                 self.logger.error('%s failure: %s', a_store.__class__,
                                   str(x))
                 storage_exception.gather_current_exception()
@@ -573,7 +573,7 @@ class PolyCrashStorage(CrashStorageBase):
             self.quit_check()
             try:
                 a_store.save_processed(processed_crash)
-            except Exception, x:
+            except Exception as x:
                 self.logger.error('%s failure: %s', a_store.__class__,
                                   str(x), exc_info=True)
                 storage_exception.gather_current_exception()

--- a/socorro/external/es/index_creator.py
+++ b/socorro/external/es/index_creator.py
@@ -102,7 +102,7 @@ class IndexCreator(RequiredConfig):
             self.config.logger.info(
                 'Created new elasticsearch index: %s', es_index
             )
-        except elasticsearch.exceptions.RequestError, e:
+        except elasticsearch.exceptions.RequestError as e:
             # If this index already exists, swallow the error.
             # NOTE! This is NOT how the error looks like in ES 2.x
             if 'IndexAlreadyExistsException' not in str(e):

--- a/socorro/external/es/query.py
+++ b/socorro/external/es/query.py
@@ -66,12 +66,12 @@ class Query(ElasticsearchBase):
                 body=json.dumps(params.query),
                 **search_args
             )
-        except elasticsearch.exceptions.NotFoundError, e:
+        except elasticsearch.exceptions.NotFoundError as e:
             missing_index = re.findall(BAD_INDEX_REGEX, e.error)[0]
             raise ResourceNotFound(
                 "elasticsearch index '%s' does not exist" % missing_index
             )
-        except elasticsearch.exceptions.TransportError, e:
+        except elasticsearch.exceptions.TransportError as e:
             raise DatabaseError(e)
 
         return results

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -311,7 +311,7 @@ class SuperSearchFields(ElasticsearchBase):
                 )
                 properties = mapping[index]['mappings'][doctype]['properties']
                 all_existing_fields.update(parse_mapping(properties, None))
-            except elasticsearch.exceptions.NotFoundError, e:
+            except elasticsearch.exceptions.NotFoundError as e:
                 # If an index does not exist, this should not fail
                 self.config.logger.warning(
                     'Missing index in elasticsearch while running '

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -454,7 +454,7 @@ class SuperSearch(SearchBase):
                 shards = getattr(results, '_shards', {})
 
                 break  # Yay! Results!
-            except NotFoundError, e:
+            except NotFoundError as e:
                 missing_index = re.findall(BAD_INDEX_REGEX, e.error)[0]
                 if missing_index in indices:
                     del indices[indices.index(missing_index)]

--- a/socorro/external/fs/filesystem.py
+++ b/socorro/external/fs/filesystem.py
@@ -30,7 +30,7 @@ def cleanEmptySubdirectories(topLimit, leafPath, osModule=os):
             break
         try:
             osModule.rmdir(opath)
-        except OSError, e:
+        except OSError as e:
             if errno.ENOTEMPTY == e.errno:
                 break
             else:
@@ -89,7 +89,7 @@ def makedirs(name, mode=0777, osModule=os):
             return
     try:
         osModule.mkdir(name, mode)
-    except OSError, e:
+    except OSError as e:
         #be happy if someone already created the path
         if e.errno != errno.EEXIST:
             raise

--- a/socorro/external/postgresql/base.py
+++ b/socorro/external/postgresql/base.py
@@ -127,7 +127,7 @@ class PostgreSQLBase(object):
             # logger.debug(connection.cursor().mogrify(sql, params))
             result = actor_function(connection, sql, params)
             connection.commit()
-        except psycopg2.Error, e:
+        except psycopg2.Error as e:
             error_message = "%s - %s" % (error_message, str(e))
             logger.error(error_message, exc_info=True)
             if connection:

--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -229,7 +229,7 @@ class PostgreSQLBasicCrashStorage(CrashStorageBase):
                 plugin_filename = processed_crash['PluginFilename']
                 plugin_name = processed_crash['PluginName']
                 plugin_version = processed_crash['PluginVersion']
-            except KeyError, x:
+            except KeyError as x:
                 self.config.logger.error(
                     'the crash is missing a required field: %s', str(x)
                 )
@@ -319,7 +319,7 @@ class PostgreSQLCrashStorage(PostgreSQLBasicCrashStorage):
                     raw_crash_table_name
         try:
             return single_value_sql(connection, fetch_sql, (crash_id,))
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             err = 'relation "%s" does not exist' % raw_crash_table_name
             if err in str(e):
                 raise CrashIDNotFound(crash_id)
@@ -345,7 +345,7 @@ class PostgreSQLCrashStorage(PostgreSQLBasicCrashStorage):
                     processed_crash_table_name
         try:
             return single_value_sql(connection, fetch_sql, (crash_id,))
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             err = 'relation "%s" does not exist' % processed_crash_table_name
             if err in str(e):
                 raise CrashIDNotFound(crash_id)

--- a/socorro/external/postgresql/dbapi2_util.py
+++ b/socorro/external/postgresql/dbapi2_util.py
@@ -7,11 +7,11 @@
 from collections import Sequence
 
 
-class SQLDidNotReturnSingleValue (Exception):
+class SQLDidNotReturnSingleValue(Exception):
     pass
 
 
-class SQLDidNotReturnSingleRow (Exception):
+class SQLDidNotReturnSingleRow(Exception):
     pass
 
 
@@ -63,7 +63,7 @@ def single_value_sql(connection, sql, parameters=None):
         result = a_cursor.fetchall()
         try:
             return result[0][0]
-        except Exception, x:
+        except Exception as x:
             raise SQLDidNotReturnSingleValue("%s: %s" % (str(x), sql))
 
 
@@ -73,7 +73,7 @@ def single_row_sql(connection, sql, parameters=None):
         result = a_cursor.fetchall()
         try:
             return result[0]
-        except Exception, x:
+        except Exception as x:
             raise SQLDidNotReturnSingleRow("%s: %s" % (str(x), sql))
 
 

--- a/socorro/external/postgresql/postgresqlalchemymanager.py
+++ b/socorro/external/postgresql/postgresqlalchemymanager.py
@@ -76,7 +76,7 @@ class PostgreSQLAlchemyManager(object):
             raw_sql = open(myfile).read()
             try:
                 self.session.execute(raw_sql)
-            except exc.SQLAlchemyError, e:
+            except exc.SQLAlchemyError as e:
                 self.logger.error("Something went horribly wrong: %s" % e)
                 raise
         return True
@@ -220,7 +220,7 @@ class PostgreSQLAlchemyManager(object):
                 self.session.begin_nested()
                 self.session.execute(r)
                 self.session.commit()
-            except exc.DatabaseError, e:
+            except exc.DatabaseError as e:
                 if e.orig.pgerror.strip() in errors:
                     self.session.rollback()
                     continue
@@ -325,12 +325,12 @@ class PostgreSQLAlchemyManager(object):
                 self.session.begin_nested()
                 self.session.execute(r)
                 self.session.commit()
-            except exc.ProgrammingError, e:
+            except exc.ProgrammingError as e:
                 if 'already exists' not in e.orig.pgerror.strip():
                     raise
                 self.session.rollback()
                 continue
-            except exc.DatabaseError, e:
+            except exc.DatabaseError as e:
                 raise
 
         # Need to close the outer transaction
@@ -350,7 +350,7 @@ class PostgreSQLAlchemyManager(object):
             # work around for autocommit behavior
             connection.execute('commit')
             connection.execute('DROP DATABASE %s' % database_name)
-        except (exc.OperationalError, exc.ProgrammingError), e:
+        except (exc.OperationalError, exc.ProgrammingError) as e:
             if re.search(
                 'database "%s" does not exist' % database_name,
                 e.orig.pgerror.strip()
@@ -367,7 +367,7 @@ class PostgreSQLAlchemyManager(object):
             connection.execute('commit')
             connection.execute("CREATE DATABASE %s ENCODING 'utf8'" %
                                database_name)
-        except (exc.OperationalError, exc.ProgrammingError), e:
+        except (exc.OperationalError, exc.ProgrammingError) as e:
             if re.search(
                 'database "%s" already exists' % database_name,
                 e.orig.pgerror.strip()

--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -370,7 +370,7 @@ class TransformRuleSystem(RequiredConfig):
                     self.rules.append(
                         a_rule_class(config[ns_name])
                     )
-                except KeyError, x:
+                except KeyError as x:
                     self.rules.append(
                         a_rule_class(config)
                     )

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -104,7 +104,7 @@ def reportExceptionAndContinue(logger=FakeLogger(), loggingLevel=logging.ERROR, 
           logger.log(loggingLevel, aLine.strip())
     finally:
       loggingReportLock.release()
-  except Exception, x:
+  except Exception as x:
     print >>sys.stderr, x
 
 

--- a/socorro/lib/ver_tools.py
+++ b/socorro/lib/ver_tools.py
@@ -128,7 +128,7 @@ def normalize(version_string, max_version_parts=4):
     for part_count, version_part in enumerate(version_string.split('.')):
         try:
             groups = _version_part_re.match(version_part).groups()
-        except Exception, x:
+        except Exception as x:
             raise NotAVersionException(version_string)
         version_list.extend(t(x) for x, t in zip(groups, _normalize_fn_list))
     version_list.extend(_padding_list * (max_version_parts - part_count - 1))
@@ -170,4 +170,3 @@ def compare (v1, v2):
     if v1_norm > v2_norm:
         return 1
     return 0
-

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -161,7 +161,7 @@ class BreakpadStackwalkerRule(Rule):
         with closing(subprocess_handle.stdout):
             try:
                 stackwalker_output = ujson.load(subprocess_handle.stdout)
-            except Exception, x:
+            except Exception as x:
                 processor_notes.append(
                     "MDSW output failed in json: %s" % x
                 )
@@ -335,7 +335,7 @@ class ExternalProcessRule(Rule):
     def _interpret_external_command_output(self, fp, processor_meta):
         try:
             return ujson.load(fp)
-        except Exception, x:
+        except Exception as x:
             processor_meta.processor_notes.append(
                 "%s output failed in json: %s" % (
                     self.config.command_pathname,
@@ -686,7 +686,7 @@ class JitCrashCategorizeRule(ExternalProcessRule):
     def _interpret_external_command_output(self, fp, processor_meta):
         try:
             result = fp.read()
-        except IOError, x:
+        except IOError as x:
             processor_meta.processor_notes.append(
                 "%s unable to read external command output: %s" % (
                     self.config.command_pathname,
@@ -696,6 +696,6 @@ class JitCrashCategorizeRule(ExternalProcessRule):
             return ''
         try:
             return result.strip()
-        except AttributeError, x:
+        except AttributeError as x:
             # there's no strip method
             return result

--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -392,7 +392,7 @@ class HybridCrashProcessor(RequiredConfig):
                         processed_crash,
                         self
                     )
-            except Exception, x:
+            except Exception as x:
                 # let's catch any unexpected error here and not let them
                 # derail the rest of the processing.
                 self.config.logger.error(
@@ -409,7 +409,7 @@ class HybridCrashProcessor(RequiredConfig):
                     processed_crash,
                     self
                 )
-            except Exception, x:
+            except Exception as x:
                 # let's catch any unexpected error here and not let them
                 # derail the rest of the processing.
                 self.config.logger.error(
@@ -427,7 +427,7 @@ class HybridCrashProcessor(RequiredConfig):
                         processed_crash,
                         self
                     )
-            except Exception, x:
+            except Exception as x:
                 # let's catch any unexpected error here and not let them
                 # derail the rest of the processing.
                 self.config.logger.error(
@@ -439,7 +439,7 @@ class HybridCrashProcessor(RequiredConfig):
             # end of transforms
             # the rest of this method is just clean up
 
-        except Exception, x:
+        except Exception as x:
             self.config.logger.warning(
                 'Error while processing %s: %s',
                 crash_id,
@@ -889,13 +889,13 @@ class HybridCrashProcessor(RequiredConfig):
         file"""
         try:
             fd = gzip.open(dump_pathname, "rb")
-        except IOError, x:
+        except IOError as x:
             error_message = "error in gzip for %s: %r" % (dump_pathname, x)
             processor_notes.append(error_message)
             return {"ERROR": error_message}
         try:
             memory_info = json.load(fd)
-        except ValueError, x:
+        except ValueError as x:
             error_message = "error in json for %s: %r" % (dump_pathname, x)
             processor_notes.append(error_message)
             return {"ERROR": error_message}
@@ -976,7 +976,7 @@ class HybridCrashProcessor(RequiredConfig):
             json_dump_str = ''.join(json_dump_lines)
             try:
                 processed_crash_update.json_dump = json.loads(json_dump_str)
-            except ValueError, x:
+            except ValueError as x:
                 processed_crash_update.json_dump = {}
                 processor_notes.append("no json output found from MDSW")
 
@@ -1131,7 +1131,7 @@ class HybridCrashProcessor(RequiredConfig):
             return None
         try:
             m = self.flash_re.match(filename)
-        except TypeError, x:
+        except TypeError as x:
             self.config.logger.debug(
                 "bad module line %s, bad filename in second field (%s)",
                 moduleData,
@@ -1409,7 +1409,7 @@ class HybridCrashProcessor(RequiredConfig):
         except (KeyError, AttributeError):
             notes_list.append("WARNING: raw_crash missing %s" % key)
             return default
-        except TypeError, x:
+        except TypeError as x:
             notes_list.append(
                 "WARNING: raw_crash [%s] contains unexpected value: %s" %
                 (key, str(x))

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -337,7 +337,7 @@ class LegacyCrashProcessor(RequiredConfig):
                 except (KeyError, AttributeError):
                     processor_notes.append(
                         "Pipe dump missing from '%s'" % name)
-                except Exception, x:
+                except Exception as x:
                     error_message = (
                         "Conversion to json dump format has failed for '%s'" %
                         name
@@ -361,7 +361,7 @@ class LegacyCrashProcessor(RequiredConfig):
                     processed_crash,
                     self
                 )
-            except Exception, x:
+            except Exception as x:
                 # let's catch any unexpected error here and not let them
                 # derail the rest of the processing.
                 self.config.logger.error(
@@ -372,7 +372,7 @@ class LegacyCrashProcessor(RequiredConfig):
             #self.config.logger.debug('done with classifier rules')
 
 
-        except Exception, x:
+        except Exception as x:
             self.config.logger.warning(
                 'Error while processing %s: %s',
                 crash_id,
@@ -1227,7 +1227,7 @@ class LegacyCrashProcessor(RequiredConfig):
         except (KeyError, AttributeError):
             notes_list.append("WARNING: raw_crash missing %s" % key)
             return default
-        except TypeError, x:
+        except TypeError as x:
             notes_list.append(
                 "WARNING: raw_crash [%s] contains unexpected value: %s" %
                 (key, str(x))

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -1,8 +1,8 @@
-import ujson
 from configman import Namespace
+import ujson
 
-from socorro.processor.processor_2015 import Processor2015
 from socorro.lib.converters import change_default
+from socorro.processor.processor_2015 import Processor2015
 
 
 # these are the steps that define processing a crash at Mozilla.
@@ -28,8 +28,7 @@ mozilla_processor_rule_sets = [
         "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.general_transform_rules.IdentifierRule, "
-        "socorro.processor.breakpad_transform_rules"
-        ".BreakpadStackwalkerRule2015, "
+        "socorro.processor.breakpad_transform_rules.BreakpadStackwalkerRule2015, "
         "socorro.processor.mozilla_transform_rules.ProductRule, "
         "socorro.processor.mozilla_transform_rules.UserDataRule, "
         "socorro.processor.mozilla_transform_rules.EnvironmentRule, "
@@ -55,8 +54,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.mozilla_transform_rules.TopMostFilesRule, "
         "socorro.processor.mozilla_transform_rules.MissingSymbolsRule, "
         "socorro.processor.mozilla_transform_rules.ThemePrettyNameRule, "
-        "socorro.processor.rules.memory_report_extraction"
-        ".MemoryReportExtraction, "
+        "socorro.processor.rules.memory_report_extraction.MemoryReportExtraction, "
         "socorro.processor.signature_utilities.SignatureGenerationRule,"
         "socorro.processor.signature_utilities.StackwalkerErrorSignatureRule, "
         "socorro.processor.signature_utilities.OOMSignature, "

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -31,7 +31,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
     required_config = Namespace()
     # configuration is broken into three namespaces: processor,
     # new_crash_source, and companion_process
- 
+
     # processor namespace
     #     this namespace is for config parameter having to do with the
     #     implementation of the algorithm of converting raw crashes into
@@ -95,7 +95,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
                 'this crash cannot be found in raw crash storage'
             )
             return
-        except Exception, x:
+        except Exception as x:
             self.config.logger.warning(
                 'error loading crash %s',
                 crash_id,
@@ -191,7 +191,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
                 try:
                     if "TEMPORARY" in a_dump_pathname:
                         os.unlink(a_dump_pathname)
-                except OSError, x:
+                except OSError as x:
                     # the file does not actually exist
                     self.config.logger.info(
                         'deletion of dump failed: %s',

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -496,7 +496,7 @@ class SignatureGenerationRule(Rule):
                 )
             else:
                 signature_list = []
-        except Exception, x:
+        except Exception as x:
             processor_meta.processor_notes.append(
                 'No crashing frames found because of %s' % x
             )
@@ -704,7 +704,7 @@ class SignatureShutdownTimeout(Rule):
                 parts.append(','.join(conditions))
             else:
                 parts.append("(none)")
-        except (ValueError, KeyError), e:
+        except (ValueError, KeyError) as e:
             parts.append("UNKNOWN")
             processor_meta['processor_notes'].append(
                 'Error parsing AsyncShutdownTimeout: {}'.format(e)

--- a/socorro/processor/skunk_classifiers.py
+++ b/socorro/processor/skunk_classifiers.py
@@ -73,7 +73,7 @@ class SkunkClassificationRule(Rule):
         """
         try:
             return self._predicate(*args, **kwargs)
-        except Exception, x:
+        except Exception as x:
             if not self.config:
                 if 'processor' in kwargs:
                     self.config = kwargs['processor'].config
@@ -128,7 +128,7 @@ class SkunkClassificationRule(Rule):
         classification system itself."""
         try:
             return self._action(*args, **kwargs)
-        except KeyError, x:
+        except KeyError as x:
             # skunk classifiers originally did not have access to a config
             # object and used the 'processor' keyword argument (a reference
             # to the actual processor class) to "borrow" a logger.  This code
@@ -144,7 +144,7 @@ class SkunkClassificationRule(Rule):
                 self.__class__,
                 x,
             )
-        except Exception, x:
+        except Exception as x:
             if not self.config:
                 if 'processor' in kwargs:
                     self.config = kwargs['processor'].config
@@ -264,7 +264,7 @@ class SkunkClassificationRule(Rule):
             stack = a_json_dump['crashing_thread']['frames']
         # these exceptions are kept as separate cases just to help keep track
         # of what situations they cover
-        except KeyError, x:
+        except KeyError as x:
             # no threads or no crash_info or no crashing_thread
             return False
         except IndexError:
@@ -428,7 +428,7 @@ class DontConsiderTheseFilter(SkunkClassificationRule):
                     'architecture',
                 )
                 return True
-        except (KeyError, AttributeError), x:
+        except (KeyError, AttributeError) as x:
             log(
                 'skunk_classifier: reject - no architecture info found',
             )
@@ -516,7 +516,7 @@ class UpdateWindowAttributes(SkunkClassificationRule):
                 classification_data,
                 processor.config.logger
             )
-        except Exception, x:
+        except Exception as x:
             print x
 
         return True

--- a/socorro/processor/support_classifiers.py
+++ b/socorro/processor/support_classifiers.py
@@ -43,7 +43,7 @@ class SupportClassificationRule(Rule):
         """
         try:
             return self._predicate(*args, **kwargs)
-        except Exception, x:
+        except Exception as x:
             if not self.config:
                 if 'processor' in kwargs:
                     self.config = kwargs['processor'].config
@@ -66,7 +66,7 @@ class SupportClassificationRule(Rule):
         classification system itself."""
         try:
             return self._action(*args, **kwargs)
-        except KeyError, x:
+        except KeyError as x:
             if not self.config:
                 if 'processor' in kwargs:
                     self.config = kwargs['processor'].config
@@ -77,7 +77,7 @@ class SupportClassificationRule(Rule):
                 to_str(self.__class__),
                 x,
             )
-        except Exception, x:
+        except Exception as x:
             if not self.config and 'processor' in kwargs:
                 self.config = kwargs['processor'].config
             if not self.config:

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -255,7 +255,7 @@ class TestBase(TestCase):
             except AttributeError:
                 p.gather_current_exception()
             raise p
-        except PolyStorageError, x:
+        except PolyStorageError as x:
             eq_(len(x), 3)
             ok_(x.has_exceptions())
             types = [NameError, KeyError, AttributeError]


### PR DESCRIPTION
This fixes instances of `except Exception, e` (deprecated syntax) to `except Exception as e` (correct syntax and the only one supported by Python 3).

https://docs.python.org/3.0/whatsnew/3.0.html#changed-syntax

https://www.python.org/dev/peps/pep-3110/

There are a couple of other fixes that accidentally pop in, too.

r?