### PR TITLE
Fix boto prefix configuration value

### DIFF
--- a/docker/config/processor.env
+++ b/docker/config/processor.env
@@ -60,7 +60,7 @@ producer_consumer.maximum_queue_size=32
 producer_consumer.number_of_threads=16
 
 resource.boto.keybuilder_class=socorro.external.boto.connection_context.DatePrefixKeyBuilder
-resource.boto.prefix=None
+resource.boto.prefix=
 
 # FIXME(willkg): Where does this file come from?
 resource.elasticsearch.elasticsearch_index_settings=/app/socorro/external/elasticsearch/socorro_index_settings.json


### PR DESCRIPTION
The value we use in -prod is the empty string. This fixes a bad value that came
about from the way I pulled the -prod configuration to generate the
configuration files.