### PR TITLE
fixes bug 1376913 - Refresh the report index page after reprocessing

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -825,16 +825,13 @@
                             </strong>
                         </p>
                         <p>
-                            But unfortunately, it's hard to predict when this
+
+                            It's hard to predict when this
                             crash will be precisely reprocessed and the new
                             processed crash uploaded.
-                            Also, there's <b>caching on the
-                            webapp</b> that might hold on to old crash a little
-                            bit longer.
                         </p>
                         <p>
-                            Expect to <a href="">Reload this crash</a> in about
-                            1 hour.
+                            <a href="?refresh=cache">Reload this page without cache</a>
                         </p>
                     </div>
                     <div class="reprocessing-error" style="display:none">

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
@@ -30,8 +30,4 @@ $(function() {
         });
     });
 
-    $('.reprocessing-success a', parent).on('click', function(event) {
-        event.preventDefault();
-        document.location.reload(true);
-    });
 });

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -812,7 +812,6 @@ def report_index(request, crash_id, default_context=None):
     context = default_context or {}
     context['crash_id'] = crash_id
 
-    # cache_seconds = 0 if request.GET.get('refresh') == 'cache' else None
     refresh_cache = request.GET.get('refresh') == 'cache'
 
     raw_api = models.RawCrash()

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -812,9 +812,15 @@ def report_index(request, crash_id, default_context=None):
     context = default_context or {}
     context['crash_id'] = crash_id
 
+    # cache_seconds = 0 if request.GET.get('refresh') == 'cache' else None
+    refresh_cache = request.GET.get('refresh') == 'cache'
+
     raw_api = models.RawCrash()
     try:
-        context['raw'] = raw_api.get(crash_id=crash_id)
+        context['raw'] = raw_api.get(
+            crash_id=crash_id,
+            refresh_cache=refresh_cache,
+        )
     except CrashIDNotFound:
         # If the raw crash can't be found, we can't do much.
         tmpl = 'crashstats/report_index_not_found.html'
@@ -827,7 +833,10 @@ def report_index(request, crash_id, default_context=None):
 
     api = models.UnredactedCrash()
     try:
-        context['report'] = api.get(crash_id=crash_id)
+        context['report'] = api.get(
+            crash_id=crash_id,
+            refresh_cache=refresh_cache,
+        )
     except CrashIDNotFound:
         # ...if we haven't already done so.
         cache_key = 'priority_job:{}'.format(crash_id)


### PR DESCRIPTION
@luser is going to like this! Mind you, it's only applicable on a "per report index page" basis. 

The honest truth is that just because you press that "Reload this page without cache" link and load it again, it will ignore our memcache but the crash might not have been processed yet. 
<img width="2032" alt="screen shot 2017-06-28 at 2 04 02 pm" src="https://user-images.githubusercontent.com/26739/27660135-e862b500-5c0a-11e7-84ac-0d4237b29eac.png">
