### PR TITLE
Bug 1373997 - fixes toctree issue

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -71,8 +71,11 @@ All products must have one or more releases:
 http://crash-stats/admin/releases/
 
 Make sure to restart memcached so you see your changes right away:
+
 ::
-  sudo systemctl restart memcached
+
+    sudo systemctl restart memcached
+
 
 Now go to the front page for your application. For example, if your application
 was named "KillerApp" then it will appear at:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,8 @@ Contents
 
 .. toctree::
    :numbered:
-   :hidden:
+   :includehidden:
+   :maxdepth: 2
    :glob:
 
    gettingstarted


### PR DESCRIPTION
This fixes one of the options in the toctree declaration such that the docs
build a toctree.

It also fixes a syntax error and caps the number of levels in the toctree.