### PR TITLE
fixes bug 1379665 - Telemetry tab on report index

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -78,6 +78,13 @@
                             <span>Extensions</span>
                         </a>
                     </li>
+                    {% if has_telemetry_environment %}
+                    <li class="ui-state-default ui-corner-top">
+                        <a href="#telemetryenvironment" class="ui-tabs-anchor">
+                            <span>Telemetry Environment</span>
+                        </a>
+                    </li>
+                    {% endif %}
                     <li class="ui-state-default ui-corner-top correlations hidden">
                         <a href="#correlation" class="ui-tabs-anchor">
                             <span>Correlations</span>
@@ -792,6 +799,13 @@
                 </div>
                 <!-- /extensions -->
 
+                {% if has_telemetry_environment %}
+                <div id="telemetryenvironment" class="ui-tabs-hide">
+                    {{ dict_as_html_tree(raw.TelemetryEnvironment) }}
+                </div>
+                <!-- /telemetryenvironment -->
+                {% endif %}
+
                 <div id="correlation" class="ui-tabs-hide">
                     <h3></h3>
                     <pre></pre>
@@ -859,3 +873,4 @@
 </div>
 
 {% endblock %}
+≠

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/tree.css
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/tree.css
@@ -1,0 +1,61 @@
+/* From http://cssdeck.com/labs/pure-css-tree-menu-framework */
+
+.tree, .tree ul {
+    margin: 0 0 0 2em;
+    /* indentation */
+    padding: 0;
+    list-style: none;
+    position: relative;
+}
+
+.tree ul {
+    margin-left: .5em
+}
+
+
+/* (indentation/2) */
+
+.tree:before, .tree ul:before {
+    content: "";
+    display: block;
+    width: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    border-left: 1px solid;
+}
+
+.tree li {
+    margin: 0;
+    padding: 0 1.5em;
+    /* indentation + .5em */
+    line-height: 1.6em;
+    /* default list item's `line-height` */
+    font-weight: bold;
+    position: relative;
+}
+
+.tree li:before {
+    content: "";
+    display: block;
+    width: 10px;
+    /* same with indentation */
+    height: 0;
+    border-top: 1px solid;
+    margin-top: -1px;
+    /* border top width */
+    position: absolute;
+    top: 1em;
+    /* (line-height/2) */
+    left: 0;
+}
+
+.tree li:last-child:before {
+    background: white;
+    /* same with body background */
+    height: auto;
+    top: 1em;
+    /* (line-height/2) */
+    bottom: 0;
+}

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -13,6 +13,7 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.template import engines
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from crashstats import scrubber
 from crashstats.crashstats.utils import parse_isodate
@@ -386,3 +387,41 @@ def show_filesize(bytes, unit='bytes'):
 @library.global_function
 def booleanish_to_boolean(value):
     return str(value).lower() in ('1', 'true', 'yes')
+
+
+@library.global_function
+def dict_as_html_tree(structure):
+    if not isinstance(structure, dict):
+        # then it has to be a JSON string
+        structure = json.loads(structure)
+
+    def tree(container, depth=1):
+        P = ' ' * 4
+        html = []
+
+        # The reason for using `key=lambda s: s.lower()` instead
+        # of just `str.lower` is because it's not a guarantee that
+        # all strings are byte strings. Or unicode for that matter.
+        for key in sorted(container, key=lambda s: s.lower()):
+            values = container[key]
+            html.append('{}<li>{}'.format(P * depth, escape(key)))
+            if isinstance(values, dict):
+                html.append('{}<ul>'.format(P * (depth + 1)))
+                html.append(tree(values, depth=depth + 2))
+                html.append('{}</ul>'.format(P * (depth + 1)))
+            else:
+                if not isinstance(values, list):
+                    values = [values]
+                if isinstance(values, list) and values:
+                    html.append('{}<ul>'.format(P * (depth + 1)))
+                    for value in values:
+                        html.append('{}<li>{}</li>'.format(
+                            P * (depth + 2),
+                            escape(value),
+                        ))
+                    html.append('{}</ul>'.format(P * (depth + 1)))
+
+            html.append('{}</li>'.format(P * depth))
+        return '\n'.join(html)
+
+    return mark_safe('<ul class="tree">\n{}\n</ul>'.format(tree(structure)))

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1773,6 +1773,48 @@ class TestViews(BaseTestViews):
         ok_('Crashing Thread (2)' not in response.content)
         ok_('Crashing Thread (0)' in response.content)
 
+    def test_report_index_with_telemetry_environment(self):
+
+        def mocked_raw_crash_get(**params):
+            assert 'datatype' in params
+            if params['datatype'] == 'meta':
+                crash = copy.deepcopy(_SAMPLE_META)
+                crash['TelemetryEnvironment'] = {
+                    'key': ['values'],
+                    'plainstring': 'I am a string',
+                    'plainint': 12345,
+                    'empty': [],
+                    'foo': {
+                        'keyA': 'AAA',
+                        'keyB': 'BBB',
+                    },
+                }
+                return crash
+            raise NotImplementedError
+
+        models.RawCrash.implementation().get.side_effect = (
+            mocked_raw_crash_get
+        )
+
+        def mocked_processed_crash_get(**params):
+            assert 'datatype' in params
+            if params['datatype'] == 'unredacted':
+                return copy.deepcopy(_SAMPLE_UNREDACTED)
+
+            raise NotImplementedError(params)
+
+        models.UnredactedCrash.implementation().get.side_effect = (
+            mocked_processed_crash_get
+        )
+
+        crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
+        url = reverse('crashstats:report_index', args=(crash_id,))
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+
+        ok_('Telemetry Environment' in response.content)
+        ok_('<li>I am a string</li>' in response.content)
+
     def test_report_index_fennecandroid_report(self):
         comment0 = 'This is a comment\nOn multiple lines'
         comment0 += '\npeterbe@mozilla.com'

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -999,6 +999,10 @@ def report_index(request, crash_id, default_context=None):
             ':'.join(x) for x in context['report']['addons']
         ]
 
+    context['has_telemetry_environment'] = (
+        context['raw'].get('TelemetryEnvironment')
+    )
+
     return render(request, 'crashstats/report_index.html', context)
 
 

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -72,6 +72,7 @@ PIPELINE_CSS = {
     'report_index': {
         'source_filenames': (
             'crashstats/css/report_index.css',
+            'crashstats/css/tree.css',
         ),
         'output_filename': 'css/report-index.min.css',
     },


### PR DESCRIPTION
CC @adngdb @lonnen 

Looks like this:
<img width="1616" alt="screen shot 2017-07-11 at 1 17 31 pm" src="https://user-images.githubusercontent.com/26739/28080849-578e8faa-663b-11e7-8cc3-c9df3786258d.png">

I'm not convinced this is the best way to display the data. The advantage is that it's simple. You can ⌘-F and find what you're looking for. 

Another alternative is to use the JSON syntax highlighter we use in the SuperSearch documentation:
<img width="1430" alt="screen shot 2017-07-11 at 1 20 20 pm" src="https://user-images.githubusercontent.com/26739/28080979-c1add328-663b-11e7-8d28-95740efe0f02.png">
Then you can still use ⌘-F. 

At least it's there. 
But the PR lacks tests (since I'm not sure the work is ideal yet).

Another feature we could consider is one of those jQuery plugins (they all look kinda icky) where you can click little plus and minuses. 