### PR TITLE
fixes bug 1379662 - add TelemetryEnvironment to super_search_fields.json

### DIFF
--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -3796,8 +3796,7 @@
        "query_type": "string",
        "permissions_needed": [],
        "storage_mapping": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
        },
        "namespace": "raw_crash",
        "has_full_version": false,

--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -3787,5 +3787,24 @@
         "is_exposed": true,
         "form_field_choices": [],
         "description": "'extension' if a WebExtension, 'web' or missing otherwise. This is only set for content crashes."
+    },
+    "telemetry_environment": {
+       "default_value": null,
+       "is_mandatory": false,
+       "description": "A field containing the entire Telemetry Environment, as sent with crash pings to Telemetry.",
+       "is_returned": true,
+       "query_type": "string",
+       "permissions_needed": [],
+       "storage_mapping": {
+          "index": "not_analyzed",
+          "type": "string"
+       },
+       "namespace": "raw_crash",
+       "has_full_version": false,
+       "data_validation_type": "str",
+       "in_database_name": "TelemetryEnvironment",
+       "is_exposed": true,
+       "form_field_choices": [],
+       "name": "telemetry_environment"
     }
 }


### PR DESCRIPTION
Before I forget, I found something odd whilst doing this. 

I compared the output of https://crash-stats.mozilla.com/api/SuperSearchFields/ with the contents of `socorro/external/es/data/super_search_fields.json` and found that, beyond `telemetry_environment` there was 1 more field that was only in the prod SuperSearchFields: `dump`. It looks like this::

```
{
   "default_value": null,
   "is_mandatory": false,
   "form_field_type": "StringField",
   "has_full_version": false,
   "query_type": "string",
   "permissions_needed": [],
   "storage_mapping": {
      "index": "not_analyzed",
      "type": "string"
   },
   "namespace": "processed_crash",
   "description": "",
   "is_returned": false,
   "in_database_name": "dump",
   "data_validation_type": "str",
   "is_exposed": false,
   "form_field_choices": [],
   "name": "dump"
}
```

Should that not be also be in `super_search_fields.json`?