### PR TITLE
bug 1377254 - pep8 all crontabber apps

### DIFF
--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -34,7 +34,9 @@ SAMPLE_BUGZILLA_RESULTS = {
         },
         {
             'id': '5',
-            'cf_crash_signature': '[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455',
+            'cf_crash_signature': (
+                '[@ MWSBAR.DLL@0x2589f] and a broken one [@ sadTrombone.DLL@0xb4s455'
+            ),
         },
         {
             'id': '6',

--- a/socorro/unittest/cron/jobs/test_drop_old_partitions.py
+++ b/socorro/unittest/cron/jobs/test_drop_old_partitions.py
@@ -13,7 +13,7 @@ from socorro.unittest.cron.setup_configman import (
 class TestDropOldPartitions(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        _super = super(TestDropOldPartitions, self)._setup_config_manager
+        super(TestDropOldPartitions, self)._setup_config_manager
         return get_config_manager_for_crontabber(
             jobs='socorro.cron.jobs.drop_old_partitions.'
             'DropOldPartitionsCronApp|1m',

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -19,6 +19,7 @@ from socorro.external.postgresql.dbapi2_util import (
 
 
 class Response(object):
+
     def __init__(self, content, status_code=200):
         if not isinstance(content, basestring):
             content = json.dumps(content)

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -22,6 +22,7 @@ from socorro.unittest.cron.setup_configman import (
 
 
 class Response(object):
+
     def __init__(self, content, status_code=200):
         self.content = content
         self.status_code = status_code
@@ -234,7 +235,7 @@ class TestFTPScraper(TestCaseBase):
         eq_(
             list(self.scrapers.get_release('http://x/ONE')),
             [('linux', 'ONE',
-             {'BUILDID': '123', 'version_build': 'build-11'}, [])]
+              {'BUILDID': '123', 'version_build': 'build-11'}, [])]
         )
 
     def test_get_json_nightly(self):
@@ -488,7 +489,6 @@ class TestIntegrationFTPScraper(IntegrationTestBase):
                 u'moz_source_repo':
                 u'http://hg.mozilla.org/releases/mozilla-beta',
                 u'buildid': u'20140113161826',
-                'repository': u'http://hg.mozilla.org/releases/mozilla-beta',
                 u'moz_update_channel': u'beta',
                 u'moz_pkg_platform': u'win32',
                 'buildID': u'20140113161826',
@@ -597,7 +597,7 @@ class TestIntegrationFTPScraper(IntegrationTestBase):
                     <a href="%s-03-02-04-mozilla-central/">txt</a>
                 """ % (today.strftime('%Y-%m-%d'), today.strftime('%Y-%m-%d'))
             if url.endswith(today.strftime('/firefox/nightly/%Y/%m/'
-                            '%Y-%m-%d-03-02-03-mozilla-central/')):
+                                           '%Y-%m-%d-03-02-03-mozilla-central/')):
                 return html_wrap % """
                     <a href="firefox-30.0a1.en-US.linux-i686.json">txt</a>
                 """

--- a/socorro/unittest/cron/jobs/test_matviews.py
+++ b/socorro/unittest/cron/jobs/test_matviews.py
@@ -85,7 +85,9 @@ class TestMatviews(IntegrationTestBase):
     def tearDown(self):
         cursor = self.conn.cursor()
         cursor.execute("DROP FUNCTION harmless(date)")
-        cursor.execute("DROP FUNCTION harmless_twotimestamps(timestamp with time zone, timestamp with time zone)")
+        cursor.execute(
+            "DROP FUNCTION harmless_twotimestamps"
+            "(timestamp with time zone, timestamp with time zone)")
         self.conn.commit()
 
         # restore the old proc_name attributes
@@ -96,10 +98,10 @@ class TestMatviews(IntegrationTestBase):
 
     def test_one_matview_alone(self):
         config_manager = self._setup_config_manager(
-          'socorro.unittest.cron.jobs.test_matviews.ReportsCleanJob|1d\n'
-          'socorro.unittest.cron.jobs.test_matviews.FTPScraperJob|1d\n'
-          ''
-          'socorro.cron.jobs.matviews.ProductVersionsCronApp|1d'
+            'socorro.unittest.cron.jobs.test_matviews.ReportsCleanJob|1d\n'
+            'socorro.unittest.cron.jobs.test_matviews.FTPScraperJob|1d\n'
+            ''
+            'socorro.cron.jobs.matviews.ProductVersionsCronApp|1d'
         )
 
         with config_manager.context() as config:
@@ -131,15 +133,15 @@ class TestMatviews(IntegrationTestBase):
         mocked_utc_now.side_effect = mock_utc_now
 
         config_manager = self._setup_config_manager(
-          'socorro.unittest.cron.jobs.test_matviews.ReportsCleanJob|1d\n'
-          'socorro.unittest.cron.jobs.test_matviews.FTPScraperJob|1d\n'
-          'socorro.unittest.cron.jobs.test_matviews.FetchADIFromHiveCronApp|1d\n'
-          ''
-          'socorro.cron.jobs.matviews.ProductVersionsCronApp|1d\n'
-          'socorro.cron.jobs.matviews.SignaturesCronApp|1d|02:00\n'
-          'socorro.cron.jobs.matviews.ADUCronApp|1d\n'
-          'socorro.cron.jobs.matviews.BuildADUCronApp|1d|02:00\n'
-          'socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|02:00\n'
+            'socorro.unittest.cron.jobs.test_matviews.ReportsCleanJob|1d\n'
+            'socorro.unittest.cron.jobs.test_matviews.FTPScraperJob|1d\n'
+            'socorro.unittest.cron.jobs.test_matviews.FetchADIFromHiveCronApp|1d\n'
+            ''
+            'socorro.cron.jobs.matviews.ProductVersionsCronApp|1d\n'
+            'socorro.cron.jobs.matviews.SignaturesCronApp|1d|02:00\n'
+            'socorro.cron.jobs.matviews.ADUCronApp|1d\n'
+            'socorro.cron.jobs.matviews.BuildADUCronApp|1d|02:00\n'
+            'socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|02:00\n'
         )
 
         with config_manager.context() as config:
@@ -166,8 +168,8 @@ class TestMatviews(IntegrationTestBase):
 
     def test_reports_clean_with_dependency(self):
         config_manager = self._setup_config_manager(
-          'socorro.cron.jobs.matviews.DuplicatesCronApp|1h\n'
-          'socorro.cron.jobs.matviews.ReportsCleanCronApp|1h'
+            'socorro.cron.jobs.matviews.DuplicatesCronApp|1h\n'
+            'socorro.cron.jobs.matviews.ReportsCleanCronApp|1h'
         )
 
         with config_manager.context() as config:
@@ -181,7 +183,7 @@ class TestMatviews(IntegrationTestBase):
 
     def test_duplicates(self):
         config_manager = self._setup_config_manager(
-          'socorro.cron.jobs.matviews.DuplicatesCronApp|1d'
+            'socorro.cron.jobs.matviews.DuplicatesCronApp|1d'
         )
 
         with config_manager.context() as config:


### PR DESCRIPTION
No output is good:
```
▶ flake8 socorro/unittest/cron/jobs
▶ flake8 socorro/cron/jobs
```
