### PR TITLE
fixes bug 1382505 - remove FennecBetaError20150430 rule

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -19,8 +19,6 @@ mozilla_processor_rule_sets = [
         "socorro.processor.mozilla_transform_rules.ESRVersionRewrite,"
         "socorro.processor.mozilla_transform_rules.PluginContentURL,"
         "socorro.processor.mozilla_transform_rules.PluginUserComment,"
-        "socorro.processor.mozilla_transform_rules.FennecBetaError20150430"
-
     ],
     [   # rules to transform a raw crash into a processed crash
         "raw_to_processed_transform",

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -903,21 +903,6 @@ class BetaVersionRule(Rule):
         return True
 
 
-class FennecBetaError20150430(Rule):
-
-    def version(self):
-        return '1.0'
-
-    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        return raw_crash['ProductName'].startswith('Fennec') and \
-            raw_crash['BuildID'] == '20150427090529' and \
-            raw_crash['ReleaseChannel'] == 'release'
-
-    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        raw_crash['ReleaseChannel'] = 'beta'
-        return True
-
-
 class OSPrettyVersionRule(Rule):
     required_config = Namespace()
     required_config.add_option(


### PR DESCRIPTION
This rule kicks up a KeyError if the raw crash is missing the keys it checks. I
went to fix that, but then noticed there are no tests for this rule and it's to
fix a situation that was a problem over 2 years ago. I don't think this is
relevant anymore.

Given that, this removes the rule altogether.