### PR TITLE
1382506 json dump

### DIFF
--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -25,7 +25,7 @@ class CPUInfoRule(Rule):
         cpu_name = ''
         cpu_info = ''
 
-        system_info = processed_crash.json_dump.get('system_info')
+        system_info = processed_crash.get('json_dump', {}).get('system_info')
         if system_info:
             cpu_name = system_info.get('cpu_arch', '')
 

--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -22,22 +22,25 @@ class CPUInfoRule(Rule):
         return '1.0'
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.cpu_info = ''
-        processed_crash.cpu_name = ''
+        cpu_name = ''
+        cpu_info = ''
 
         system_info = processed_crash.json_dump.get('system_info')
         if system_info:
-            processed_crash.cpu_name = system_info.get('cpu_arch', '')
-            try:
-                processed_crash.cpu_info = (
+            cpu_name = system_info.get('cpu_arch', '')
+
+            if 'cpu_info' in system_info and 'cpu_count' in system_info:
+                cpu_info = (
                     '%s | %s' % (
                         system_info['cpu_info'],
                         system_info['cpu_count']
                     )
                 )
-            except KeyError:
-                # cpu_count is likely missing
-                processed_crash.cpu_info = system_info.get('cpu_info', '')
+            else:
+                cpu_info = system_info.get('cpu_info', '')
+
+        processed_crash['cpu_name'] = cpu_name
+        processed_crash['cpu_info'] = cpu_info
 
         return True
 

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -189,30 +189,23 @@ class TestCPUInfoRule(TestCase):
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        eq_(
-            processed_crash.cpu_info,
-            "GenuineIntel family 6 model 42 stepping 7 | 4"
-        )
-        eq_(processed_crash.cpu_name, 'x86')
+        assert processed_crash.cpu_info == 'GenuineIntel family 6 model 42 stepping 7 | 4'
+        assert processed_crash.cpu_name == 'x86'
 
         # raw crash should be unchanged
-        eq_(raw_crash, canonical_standard_raw_crash)
+        assert raw_crash == canonical_standard_raw_crash
 
-    def test_stuff_missing(self):
+    def test_missing_cpu_count(self):
         config = self.get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
-
         raw_dumps = {}
-        system_info = copy.copy(
-            canonical_processed_crash['json_dump']['system_info']
-        )
+        system_info = copy.copy(canonical_processed_crash['json_dump']['system_info'])
         del system_info['cpu_count']
         processed_crash = DotDict()
         processed_crash.json_dump = {
             'system_info': system_info
         }
-
         processor_meta = self.get_basic_processor_meta()
 
         rule = CPUInfoRule(config)
@@ -220,14 +213,11 @@ class TestCPUInfoRule(TestCase):
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        eq_(
-            processed_crash.cpu_info,
-            "GenuineIntel family 6 model 42 stepping 7"
-        )
-        eq_(processed_crash.cpu_name, 'x86')
+        assert processed_crash.cpu_info == 'GenuineIntel family 6 model 42 stepping 7'
+        assert processed_crash.cpu_name == 'x86'
 
         # raw crash should be unchanged
-        eq_(raw_crash, canonical_standard_raw_crash)
+        assert raw_crash == canonical_standard_raw_crash
 
 
 class TestOSInfoRule(TestCase):

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -219,6 +219,25 @@ class TestCPUInfoRule(TestCase):
         # raw crash should be unchanged
         assert raw_crash == canonical_standard_raw_crash
 
+    def test_missing_json_dump(self):
+        config = self.get_basic_config()
+
+        raw_crash = {}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = self.get_basic_processor_meta()
+
+        rule = CPUInfoRule(config)
+
+        # the call to be tested
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+
+        assert processed_crash['cpu_info'] == ''
+        assert processed_crash['cpu_name'] == ''
+
+        # raw crash should be unchanged
+        assert raw_crash == {}
+
 
 class TestOSInfoRule(TestCase):
 


### PR DESCRIPTION
Minor changes to the code so that it always uses getitem notation and switched out `eq_` for assert.

After that, I fixed `json_dump` access to use `.get()` and default to `{}`.

That fixes the specific issue in the bug.