### PR TITLE
fixes bug 1382781 - test asset generation doesn't miss source files

### DIFF
--- a/webapp-django/crashstats/base/finders.py
+++ b/webapp-django/crashstats/base/finders.py
@@ -11,7 +11,10 @@ class LeftoverPipelineFinder(PipelineFinder):
     that pipeline.finders.PipelineFinder couldn't find.
     """
     def find(self, path, all=False):
-        # But where was it defined?
+        # If we're here, the file couldn't be found in any of the other
+        # staticfiles finders. Before we raise an error, try to find out where,
+        # in the bundles, this was defined. This will make it easier to correct
+        # the mistake.
         for config_name in 'STYLESHEETS', 'JAVASCRIPT':
             config = settings.PIPELINE[config_name]
             for key, directive in config.items():

--- a/webapp-django/crashstats/base/finders.py
+++ b/webapp-django/crashstats/base/finders.py
@@ -1,0 +1,29 @@
+from pipeline.finders import PipelineFinder
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+class LeftoverPipelineFinder(PipelineFinder):
+    """This finder is expected to come AFTER pipeline.finders.PipelineFinder
+    in settings.STATICFILES_FINDERS.
+    If a path is looked for here it means it's trying to find a file
+    that pipeline.finders.PipelineFinder couldn't find.
+    """
+    def find(self, path, all=False):
+        # But where was it defined?
+        for config_name in 'STYLESHEETS', 'JAVASCRIPT':
+            config = settings.PIPELINE[config_name]
+            for key, directive in config.items():
+                if path in directive['source_filenames']:
+                    raise ImproperlyConfigured(
+                        'Static file {} can not be found anywhere. Defined in '
+                        "PIPELINE[{!r}][{!r}]['source_filenames']".format(
+                            path,
+                            config_name,
+                            key,
+                        )
+                    )
+        # If the file can't be found AND it's not in bundles, there's
+        # got to be something else really wrong.
+        raise NotImplementedError(path)

--- a/webapp-django/crashstats/base/tests/test_finders.py
+++ b/webapp-django/crashstats/base/tests/test_finders.py
@@ -14,15 +14,15 @@ class LeftoverPipelineFinder(DjangoTestCase):
 
     def test_missing_css_source_file(self):
         busted_pipeline = copy.deepcopy(settings.PIPELINE)
-        # Doesn't matter which key we chose to bust
-        for key in busted_pipeline['STYLESHEETS']:
-            filenames = busted_pipeline['STYLESHEETS'][key]['source_filenames']
-            # add a junk one
-            filenames += ('neverheardof.css',)
-            busted_pipeline['STYLESHEETS'][key]['source_filenames'] = (
-                filenames
-            )
-            break
+        # Doesn't matter which key we chose to bust, so let's just
+        # pick the first one.
+        key = busted_pipeline['STYLESHEETS'].keys()[0]
+        filenames = busted_pipeline['STYLESHEETS'][key]['source_filenames']
+        # add a junk one
+        filenames += ('neverheardof.css',)
+        busted_pipeline['STYLESHEETS'][key]['source_filenames'] = (
+            filenames
+        )
         with self.settings(PIPELINE=busted_pipeline):
             assert_raises(
                 ImproperlyConfigured,

--- a/webapp-django/crashstats/base/tests/test_finders.py
+++ b/webapp-django/crashstats/base/tests/test_finders.py
@@ -1,0 +1,33 @@
+import copy
+
+from nose.tools import assert_raises
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
+
+from crashstats.base.tests.testbase import DjangoTestCase
+
+
+class LeftoverPipelineFinder(DjangoTestCase):
+    """Test our custom staticfiles finder class."""
+
+    def test_missing_css_source_file(self):
+        busted_pipeline = copy.deepcopy(settings.PIPELINE)
+        # Doesn't matter which key we chose to bust
+        for key in busted_pipeline['STYLESHEETS']:
+            filenames = busted_pipeline['STYLESHEETS'][key]['source_filenames']
+            # add a junk one
+            filenames += ('neverheardof.css',)
+            busted_pipeline['STYLESHEETS'][key]['source_filenames'] = (
+                filenames
+            )
+            break
+        with self.settings(PIPELINE=busted_pipeline):
+            assert_raises(
+                ImproperlyConfigured,
+                call_command,
+                'collectstatic',
+                '--noinput',
+                interactive=False,
+            )

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -441,6 +441,10 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
+    # Make sure this comes last!
+    '{}.base.finders.LeftoverPipelineFinder'.format(
+        PROJECT_MODULE,
+    )
 )
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 #
 # CSS
 #
@@ -409,6 +411,7 @@ PIPELINE_JS = {
     },
 }
 
+
 # This is sanity checks, primarily for developers. It checks that
 # you haven't haven't accidentally make a string a tuple with an
 # excess comma, no underscores in the bundle name and that the
@@ -430,22 +433,22 @@ for config in PIPELINE_JS, PIPELINE_CSS:  # NOQA
         for asset_file in v['source_filenames']:
             if asset_file in _used:
                 # Consider using warnings.warn here instead
-                print '{:<52} in {:<20} already in {}'.format(
+                print('{:<52} in {:<20} already in {}'.format(
                     asset_file,
                     k,
                     _used[asset_file]
-                )
+                ))
                 _trouble.add(asset_file)
             _used[asset_file] = k
 
     for asset_file in _trouble:
-        print "REPEATED", asset_file
+        print("REPEATED", asset_file)
         found_in = []
         sets = []
         for k, v in config.items():
             if asset_file in v['source_filenames']:
                 found_in.append(k)
                 sets.append(set(list(v['source_filenames'])))
-        print "FOUND IN", found_in
-        print "ALWAYS TOGETHER WITH", set.intersection(*sets)
+        print("FOUND IN", found_in)
+        print("ALWAYS TOGETHER WITH", set.intersection(*sets))
         break


### PR DESCRIPTION
The way I tested this was to edit `bundles.py` and insert some junk on any of the `source_filenames` tuples. Then running `rm -fr static && ./manage.py collectstatic --noinput` it would fail. 

Also, if you run in `DEBUG=True` mode and first `rm -fr static`, then pipeline will do these lookups on the fly during render and if you've messed with `bundles.py` you get errors like this:
```
Traceback (most recent call last):
  File "/opt/boxen/homebrew/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 63, in __call__
    return self.application(environ, start_response)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 189, in __call__
    response = self.get_response(request)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/core/handlers/base.py", line 218, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/csp/decorators.py", line 19, in _wrapped
    r = f(*a, **kw)
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/decorators.py", line 101, in inner
    return view(request, *args, **kwargs)
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/views.py", line 1004, in report_index
    return render(request, 'crashstats/report_index.html', context)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/shortcuts.py", line 67, in render
    template_name, context, request=request, using=using)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/template/loader.py", line 99, in render_to_string
    return template.render(context, request)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django_jinja/backend.py", line 105, in render
    return self.template.render(context)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html", line 9, in top-level template code
    {% extends "crashstats_base.html" %}
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/base/jinja2/crashstats_base.html", line 8, in top-level template code
    {% block site_css %}
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html", line 15, in block "site_css"
    {% stylesheet 'jsonview' %}
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/pipeline/jinja2/__init__.py", line 37, in package_css
    return self.render_compressed(package, package_name, 'css')
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/pipeline/templatetags/pipeline.py", line 72, in render_compressed
    package_type)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/pipeline/templatetags/pipeline.py", line 104, in render_compressed_sources
    paths = packager.compile(package.paths)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/pipeline/packager.py", line 34, in paths
    return [path for path in self.sources
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/pipeline/packager.py", line 27, in sources
    if path not in paths and find(path):
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/django/contrib/staticfiles/finders.py", line 250, in find
    result = finder.find(path, all=all)
  File "/Users/peterbe/dev/MOZILLA/SOCORRO/socorro/webapp-django/crashstats/base/finders.py", line 24, in find
    key,
ImproperlyConfigured: Static file jsXXXXonview/jsonview.custom.less can not be found anywhere. Defined in PIPELINE['STYLESHEETS']['jsonview']['source_filenames']
```
...which is right and expected. 