### PR TITLE
fixes bug 1385962 - Handle AsyncShutdownTimeout string conditions

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -662,12 +662,22 @@ class SignatureShutdownTimeout(Rule):
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
         return bool(raw_crash.get('AsyncShutdownTimeout'))
 
+    def get_name(self, c):
+        """Return best name for an AsyncShutdownTimeout notation condition"""
+        # The AsyncShutdownTimeout notation condition can either be a string that looks like a
+        # "name" or a dict with a "name" in it.
+        #
+        # This handles both variations.
+        if isinstance(c, dict):
+            return c.get('name')
+        return c
+
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         parts = ['AsyncShutdownTimeout']
         try:
             shutdown_data = ujson.loads(raw_crash['AsyncShutdownTimeout'])
             parts.append(shutdown_data['phase'])
-            conditions = [c['name'] for c in shutdown_data['conditions']]
+            conditions = [self.get_name(c) for c in shutdown_data['conditions']]
             if conditions:
                 conditions.sort()
                 parts.append(','.join(conditions))

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -662,22 +662,19 @@ class SignatureShutdownTimeout(Rule):
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
         return bool(raw_crash.get('AsyncShutdownTimeout'))
 
-    def get_name(self, c):
-        """Return best name for an AsyncShutdownTimeout notation condition"""
-        # The AsyncShutdownTimeout notation condition can either be a string that looks like a
-        # "name" or a dict with a "name" in it.
-        #
-        # This handles both variations.
-        if isinstance(c, dict):
-            return c.get('name')
-        return c
-
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         parts = ['AsyncShutdownTimeout']
         try:
             shutdown_data = ujson.loads(raw_crash['AsyncShutdownTimeout'])
             parts.append(shutdown_data['phase'])
-            conditions = [self.get_name(c) for c in shutdown_data['conditions']]
+            conditions = [
+                # NOTE(willkg): The AsyncShutdownTimeout notation condition can either be a string
+                # that looks like a "name" or a dict with a "name" in it.
+                #
+                # This handles both variations.
+                c['name'] if isinstance(c, dict) else c
+                for c in shutdown_data['conditions']
+            ]
             if conditions:
                 conditions.sort()
                 parts.append(','.join(conditions))

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -1975,6 +1975,35 @@ class TestSignatureShutdownTimeout(TestCase):
             'Signature replaced with a Shutdown Timeout signature, was: "foo"'
         )
 
+    def test_action_success_string_conditions(self):
+        config = self.get_config()
+        rule = SignatureShutdownTimeout(config)
+
+        processed_crash = {
+            'signature': 'foo'
+        }
+        processor_meta = {
+            'processor_notes': []
+        }
+        raw_crash = {
+            'AsyncShutdownTimeout': json.dumps({
+                'phase': 'beginning',
+                'conditions': ['A', 'B', 'C']
+            })
+        }
+
+        action_result = rule.action(raw_crash, {}, processed_crash, processor_meta)
+        ok_(action_result)
+
+        eq_(
+            processed_crash['signature'],
+            'AsyncShutdownTimeout | beginning | A,B,C'
+        )
+        eq_(
+            processor_meta['processor_notes'][0],
+            'Signature replaced with a Shutdown Timeout signature, was: "foo"'
+        )
+
     def test_action_success_empty_conditions_key(self):
         config = self.get_config()
         rule = SignatureShutdownTimeout(config)


### PR DESCRIPTION
If the condition is a dict with a "name" key, then this worked fine. However,
Socorro would occasionally see conditions that were just strings.

This fixes the rule behavior to work with strings as well.