### PR TITLE
bug 1386234 - hide junk missing supersearchfields keys

### DIFF
--- a/webapp-django/crashstats/manage/jinja2/manage/supersearch_fields_missing.html
+++ b/webapp-django/crashstats/manage/jinja2/manage/supersearch_fields_missing.html
@@ -5,7 +5,15 @@
 {% block admin_title %}{{ super() }} - Super Search Missing Fields{% endblock %}
 
 {% block site_css %}
-  {{ super() }}
+{{ super() }}
+<style type="text/css">
+table.data-table tr td {
+    max-width: 500px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+</style>
 {% endblock %}
 
 {% block mainbody %}


### PR DESCRIPTION
I wanted to do more but decided not to. 
Once ES5 is ready, we're going to **re-land** https://github.com/mozilla-services/socorro/pull/3854/files#diff-c6eb45ff84ef342b75c7ca9e0a9ddf36 and thus I don't want to make it more complicated by introducing a merge conflict. 

Once this lands, at least the crazy horizontal scrolling will go away
<img width="1540" alt="screen shot 2017-08-01 at 12 04 48 pm" src="https://user-images.githubusercontent.com/26739/28835006-fb53ba8a-76b1-11e7-8347-a034414cd393.png">

See note in bug what else can/should be done. 
