### PR TITLE
fixes bug 1386237 - Display "junk" field keys better in report index

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -697,7 +697,13 @@
                         <tbody>
                             {% for key in raw_keys %}
                             <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
-                                <th scope="row">{{ key }}</th>
+                                <th scope="row">
+                                    {% if key %}
+                                        {{ key }}
+                                    {% else %}
+                                        <i>empty key</i>
+                                    {% endif %}
+                                </th>
                                 {% if key == 'Comments' %}
                                 <td><pre>{{ raw[key] | scrub_pii }}</pre></td>
                                 {% else %}

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
@@ -1,6 +1,10 @@
 #details th,
 #metadata th {
     width: 15%;
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .humanized {


### PR DESCRIPTION
Before:
<img width="1540" alt="screen shot 2017-08-02 at 10 26 20 am" src="https://user-images.githubusercontent.com/26739/28878411-4079f762-776d-11e7-8c9a-d6f56231a44d.png">
After:
<img width="1540" alt="screen shot 2017-08-02 at 10 26 29 am" src="https://user-images.githubusercontent.com/26739/28878426-4a4bdbc0-776d-11e7-9be4-1919445356f0.png">

Other keys that contain other crazy unicode characters is probably best to just leave as is. 

Note; this doesn't so much to do with "unicode junk". It just makes it so that any key that becomes visually longer than 250 pixels gets truncated. 