### PR TITLE
fixes bug 1379705 - length restriction on token notes field

### DIFF
--- a/webapp-django/crashstats/tokens/forms.py
+++ b/webapp-django/crashstats/tokens/forms.py
@@ -1,3 +1,5 @@
+from django import forms
+
 from crashstats.crashstats.forms import BaseModelForm
 from . import models
 
@@ -27,3 +29,9 @@ class GenerateTokenForm(BaseModelForm):
         self.fields['notes'].help_text = (
             'Optional. Entirely for your own records.'
         )
+
+    def clean_notes(self):
+        value = self.cleaned_data['notes']
+        if len(value) > 2000:
+            raise forms.ValidationError('Text too long')
+        return value

--- a/webapp-django/crashstats/tokens/tests/test_views.py
+++ b/webapp-django/crashstats/tokens/tests/test_views.py
@@ -101,6 +101,13 @@ class TestViews(BaseTestViews):
         eq_(token.permissions.all().count(), 0)
         token.delete()
 
+        # The 'notes' field can't been too long
+        response = self.client.post(url, {
+            'notes': 'X' * 10000,
+        })
+        eq_(response.status_code, 200)
+        ok_('Text too long' in response.content)
+
         group = Group.objects.create(name='Cool people')
         group.permissions.add(p1)
         group.permissions.add(p3)


### PR DESCRIPTION
The choice of 2,000 chars is quite arbitrary. 

The risk of this bug is low. But anybody can sign in and create API tokens to their hearts content. However, they can't create them with permissions unless the user's permissions are elevated.
So if a rogue user bombards this field it could fill up unnecessarily. 