### PR TITLE
Clean up create_basic_fake_processor definitions and usage

### DIFF
--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -1,0 +1,25 @@
+import mock
+
+from socorro.lib.util import DotDict
+from socorro.processor.signature_utilities import CSignatureTool
+
+
+csig_config = DotDict()
+csig_config.irrelevant_signature_re = ''
+csig_config.prefix_signature_re = ''
+csig_config.signatures_with_line_numbers_re = ''
+csig_config.signature_sentinels = []
+csig_config.collapse_arguments = True
+c_signature_tool = CSignatureTool(csig_config)
+
+
+def create_basic_fake_processor():
+    """Creates fake processor configuration"""
+    fake_processor = DotDict()
+    fake_processor.c_signature_tool = c_signature_tool
+    fake_processor.config = DotDict()
+    # need help figuring out failures? switch to FakeLogger and read stdout
+    fake_processor.config.logger = mock.MagicMock()
+    #fake_processor.config.logger = sutil.FakeLogger()
+    fake_processor.processor_notes = []
+    return fake_processor

--- a/socorro/unittest/processor/rules/test_memory_report_extraction.py
+++ b/socorro/unittest/processor/rules/test_memory_report_extraction.py
@@ -10,9 +10,7 @@ from socorro.processor.rules.memory_report_extraction import (
     MemoryReportExtraction,
 )
 from socorro.unittest.testbase import TestCase
-from socorro.unittest.processor.test_signature_utilities import (
-    create_basic_fake_processor
-)
+from socorro.unittest.processor import create_basic_fake_processor
 
 
 HERE = os.path.dirname(__file__)

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -2,10 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 
+import copy
+import json
 import mock
 from nose.tools import eq_, ok_
+import re
 
 from configman.dotdict import DotDict as CDotDict
 
@@ -27,10 +29,8 @@ from socorro.processor.signature_utilities import (
     SignatureShutdownTimeout,
     SignatureIPCMessageName,
 )
+from socorro.unittest.processor import create_basic_fake_processor
 from socorro.unittest.testbase import TestCase
-
-import re
-import copy
 
 
 class BaseTestClass(TestCase):
@@ -1016,25 +1016,6 @@ sample_json_dump_with_templates_and_special_case = {
 
     }
 }
-
-csig_config = DotDict()
-csig_config.irrelevant_signature_re = ''
-csig_config.prefix_signature_re = ''
-csig_config.signatures_with_line_numbers_re = ''
-csig_config.signature_sentinels = []
-csig_config.collapse_arguments = True
-c_signature_tool = CSignatureTool(csig_config)
-
-
-def create_basic_fake_processor():
-    fake_processor = DotDict()
-    fake_processor.c_signature_tool = c_signature_tool
-    fake_processor.config = DotDict()
-    # need help figuring out failures? switch to FakeLogger and read stdout
-    fake_processor.config.logger = mock.MagicMock()
-    #fake_processor.config.logger = sutil.FakeLogger()
-    return fake_processor
-
 
 class TestSignatureGeneration(TestCase):
 

--- a/socorro/unittest/processor/test_skunk_classifiers.py
+++ b/socorro/unittest/processor/test_skunk_classifiers.py
@@ -6,7 +6,7 @@ import copy
 
 from nose.tools import eq_, ok_
 
-from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.util import DotDict
 from socorro.processor.skunk_classifiers import (
     SkunkClassificationRule,
     DontConsiderTheseFilter,
@@ -16,30 +16,14 @@ from socorro.processor.skunk_classifiers import (
     Bug811804,
     Bug812318,
 )
-from socorro.processor.signature_utilities import CSignatureTool
+from socorro.unittest.processor import (
+    create_basic_fake_processor,
+    c_signature_tool,
+)
 from socorro.unittest.processor.test_breakpad_pipe_to_json import (
     cannonical_json_dump
 )
 from socorro.unittest.testbase import TestCase
-
-csig_config = DotDict()
-csig_config.irrelevant_signature_re = ''
-csig_config.prefix_signature_re = ''
-csig_config.signatures_with_line_numbers_re = ''
-csig_config.signature_sentinels = []
-csig_config.collapse_arguments = True
-c_signature_tool = CSignatureTool(csig_config)
-
-
-def create_basic_fake_processor():
-    fake_processor = DotDict()
-    fake_processor.c_signature_tool = c_signature_tool
-    fake_processor.config = DotDict()
-    # need help figuring out failures? switch to FakeLogger and read stdout
-    fake_processor.config.logger = SilentFakeLogger()
-    fake_processor.processor_notes = []
-    #fake_processor.config.logger = FakeLogger()
-    return fake_processor
 
 
 class TestSkunkClassificationRule(TestCase):

--- a/socorro/unittest/processor/test_support_classifiers.py
+++ b/socorro/unittest/processor/test_support_classifiers.py
@@ -8,35 +8,18 @@ from nose.tools import eq_, ok_
 
 from sys import maxint
 
-from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.util import DotDict
 from socorro.processor.support_classifiers import (
     SupportClassificationRule,
     BitguardClassifier,
     OutOfDateClassifier,
 )
 
-from socorro.processor.signature_utilities import CSignatureTool
+from socorro.unittest.processor import create_basic_fake_processor
 from socorro.unittest.processor.test_breakpad_pipe_to_json import (
     cannonical_json_dump,
 )
 from socorro.unittest.testbase import TestCase
-
-csig_config = DotDict()
-csig_config.irrelevant_signature_re = ''
-csig_config.prefix_signature_re = ''
-csig_config.signatures_with_line_numbers_re = ''
-csig_config.signature_sentinels = []
-c_signature_tool = CSignatureTool(csig_config)
-
-
-def create_basic_fake_processor():
-    fake_processor = DotDict()
-    fake_processor.c_signature_tool = c_signature_tool
-    fake_processor.config = DotDict()
-    # need help figuring out failures? switch to FakeLogger and read stdout
-    fake_processor.config.logger = SilentFakeLogger()
-    #fake_processor.config.logger = FakeLogger()
-    return fake_processor
 
 
 class TestSupportClassificationRule(TestCase):


### PR DESCRIPTION
We had this function in three different places and one of those instances was
slightly different than the other two. Seems like it helps to have a centralized
"fake processor" configuration that is used everywhere.

This centralizes that code and updates the other files to use it.