### PR TITLE
fixes bug 1386781 - fix issues in run_setup_postgres.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,9 @@ dockerbuild:
 
 # NOTE(willkg): We run setup in the webapp container because the webapp will own
 # postgres going forward and has the needed environment variables.
-# FIXME(willkg): These are not idempotent, but they should be. Plus we should
-# run migrations here, too.
 dockersetup: .docker-build
-	-${DC} run webapp /app/docker/run_setup_postgres.sh
-	-${DC} run webapp /app/docker/run_setup_elasticsearch.sh
+	${DC} run webapp /app/docker/run_setup_postgres.sh
+	${DC} run webapp /app/docker/run_setup_elasticsearch.sh
 
 dockerclean:
 	rm .docker-build

--- a/docker/config/docker_common.env
+++ b/docker/config/docker_common.env
@@ -3,6 +3,9 @@
 
 # NOTE: These shouldn't be used on -dev, -stage, or -prod environments.
 
+# alembic
+alembic_config=/app/docker/config/alembic.ini
+
 # postgres
 database_hostname=postgresql
 database_port=5432

--- a/docker/config/processor.env
+++ b/docker/config/processor.env
@@ -7,8 +7,6 @@
 # ----------------------------------------------------------------------------------
 # from socorro/processor
 # ----------------------------------------------------------------------------------
-alembic_config=/app/docker/config/alembic.ini
-
 companion_process.companion_class=socorro.processor.symbol_cache_manager.SymbolLRUCacheManager
 companion_process.symbol_cache_path=/mnt/symbols/cache
 companion_process.symbol_cache_size=40G

--- a/docker/run_setup_postgres.sh
+++ b/docker/run_setup_postgres.sh
@@ -4,10 +4,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Sets up postgres tables, stored procedures, and such.
+set -e
 
-# This should get run only to initialize Postgres and probably only in local
-# development environments.
+# Sets up postgres tables, stored procedures, types, and such.
+
+# NOTE: This should only be run if you want to drop an existing database and
+# create a new one from scratch for a development environment.
 
 cd /app
 
@@ -18,14 +20,13 @@ DATABASE="${DATASERVICE_DATABASE_NAME:-breakpad}"
 # Wait until postgres is listening
 urlwait "${DATABASE_URL}" 10
 
-# FIXME(willkg): Make this idempotent so it doesn't affect anything if run
-# multiple times
-# NOTE(willkg): add --dropdb to this if you want to recreate the db
-echo "Setting up the db (${DATABASE}) and generating fake data..."
+# This drops and re-creates the db; the --dropdb code will prompt the user
+# before it does anything giving the user a chance to do a "oh no--don't do
+# that!" kind of thing
+echo "Dropping existing db and creating new db named (${DATABASE})..."
 ./scripts/socorro setupdb \
                   --database_name="${DATABASE}" \
-                  --fakedata \
-                  --fakedata_days=3 \
+                  --dropdb \
                   --createdb
 
 # This does Django migrations and is idempotent

--- a/scripts/socorro
+++ b/scripts/socorro
@@ -1,5 +1,11 @@
 #! /usr/bin/env python
 
+import sys
+
 from socorro.app.socorro_app import SocorroWelcomeApp
 
-SocorroWelcomeApp.run()
+ret = SocorroWelcomeApp.run()
+
+# If the app returned an integer that's not zero, then that's the exit code.
+if ret in (1, 2):
+    sys.exit(ret)

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -320,8 +320,9 @@ class SocorroDBApp(App):
                     confirm = raw_input(
                         'drop database %s [y/N]: ' % database_name)
                     if not confirm == "y":
-                        self.config.logger.warn('NOT dropping table')
+                        self.config.logger.warning('NOT dropping table')
                         return 2
+
                 db.drop_database(database_name)
                 db.commit()
 

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -162,15 +162,6 @@ class SocorroDBApp(App):
         exclude_from_dump_conf=True
     )
 
-    @staticmethod
-    def get_application_defaults():
-        """since this app is more of an interactive app than the others, the
-        logging of config information is rather disruptive.  Override the
-        default logging level to one that is less annoying."""
-        return {
-            'logging.stderr_error_logging_level': 40  # only ERROR or worse
-        }
-
     def bulk_load_table(self, db, table):
         io = cStringIO.StringIO()
         for line in table.generate_rows():


### PR DESCRIPTION
This moves the alembic_config to docker_common.env so it's available in both the
processor and webapp containers.

This adds a urlwait to docker/run_setup_postgres.sh to force it to wait for
postgres db to be ready for connections before trying to setup tables and run
migrations.

This moves the database name to a variable that exists already so it's not
hard-coded.

This removes the code in setupdb_app that prevents logging lines from happening
because that makes understanding what happened and debugging it much much
harder.