### PR TITLE
fixes bug 1388333 - UnicodeEncodeError in signature report

### DIFF
--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -4,6 +4,7 @@ import isodate
 
 from django import forms
 from django.utils.timezone import utc
+from django.utils.encoding import smart_str
 
 from crashstats.crashstats.utils import parse_isodate
 
@@ -180,6 +181,7 @@ class BooleanField(forms.CharField):
         """
         if value is None:
             return None
-        if str(value).lower() in ('__true__', 'true', 't', '1', 'y', 'yes'):
+        truthy_strings = ('__true__', 'true', 't', '1', 'y', 'yes')
+        if smart_str(value).lower() in truthy_strings:
             return '__true__'
         return '!__true__'

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -172,6 +172,9 @@ class StringField(MultipleValueField):
 
 
 class BooleanField(forms.CharField):
+
+    truthy_strings = ('__true__', 'true', 't', '1', 'y', 'yes')
+
     def to_python(self, value):
         """Return None if the value is None. Return 'true' if the value is one
         of the accepted values. Return 'false' otherwise.
@@ -181,7 +184,7 @@ class BooleanField(forms.CharField):
         """
         if value is None:
             return None
-        truthy_strings = ('__true__', 'true', 't', '1', 'y', 'yes')
-        if smart_str(value).lower() in truthy_strings:
+
+        if smart_str(value).lower() in self.truthy_strings:
             return '__true__'
         return '!__true__'

--- a/webapp-django/crashstats/supersearch/tests/test_form_fields.py
+++ b/webapp-django/crashstats/supersearch/tests/test_form_fields.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import datetime
 from nose.tools import eq_, assert_raises
 
@@ -154,3 +156,32 @@ class TestFormFields(TestCase):
             field.clean,
             ['<2016-08-01', '<2016-08-02', '<2016-08-03']
         )
+
+    def test_boolean_field(self):
+        field = form_fields.BooleanField(required=False)
+        # If the input is None, leave it as None
+        cleaned_value = field.clean(None)
+        eq_(cleaned_value, None)
+
+        # The list of known truthy strings
+        for truthy in ('__TRUE__', 'true', 't', '1', 'Y', 'Yes'):
+            cleaned_value = field.clean(truthy)
+            eq_(cleaned_value, '__true__')
+
+        # Not truthy strings
+        for truthy in ('__False__', 'False', 'f', '0', 'n', 'No'):
+            cleaned_value = field.clean(truthy)
+            eq_(cleaned_value, '!__true__')
+
+        # Actually anything that isn't in the first list is '!__true__' in
+        # supersearch.
+        cleaned_value = field.clean('yeah')
+        eq_(cleaned_value, '!__true__')
+
+        # Should worth with unicode strings and byte strings
+        cleaned_value = field.clean(u'YES')
+        eq_(cleaned_value, '__true__')
+
+        # But not choke on non-ascii strings
+        cleaned_value = field.clean(u'Nöö')
+        eq_(cleaned_value, '!__true__')

--- a/webapp-django/crashstats/supersearch/tests/test_form_fields.py
+++ b/webapp-django/crashstats/supersearch/tests/test_form_fields.py
@@ -164,24 +164,20 @@ class TestFormFields(TestCase):
         eq_(cleaned_value, None)
 
         # The list of known truthy strings
-        for truthy in ('__TRUE__', 'true', 't', '1', 'Y', 'Yes'):
-            cleaned_value = field.clean(truthy)
+        for value in form_fields.BooleanField.truthy_strings:
+            cleaned_value = field.clean(value)
+            eq_(cleaned_value, '__true__')
+        # But it's also case insensitive, so check that it still works
+        for value in form_fields.BooleanField.truthy_strings:
+            cleaned_value = field.clean(value.upper())  # note
             eq_(cleaned_value, '__true__')
 
-        # Not truthy strings
-        for truthy in ('__False__', 'False', 'f', '0', 'n', 'No'):
-            cleaned_value = field.clean(truthy)
-            eq_(cleaned_value, '!__true__')
-
-        # Actually anything that isn't in the first list is '!__true__' in
-        # supersearch.
-        cleaned_value = field.clean('yeah')
+        # Any other string that is NOT in form_fields.BooleanField.truthy_strings
+        # should return `!__true__`
+        cleaned_value = field.clean('FALSE')
         eq_(cleaned_value, '!__true__')
-
-        # Should worth with unicode strings and byte strings
-        cleaned_value = field.clean(u'YES')
-        eq_(cleaned_value, '__true__')
-
+        cleaned_value = field.clean('anything')
+        eq_(cleaned_value, '!__true__')
         # But not choke on non-ascii strings
         cleaned_value = field.clean(u'Nöö')
         eq_(cleaned_value, '!__true__')


### PR DESCRIPTION
Go to any signature report and add `&accessibility=föö` or something. Or just look at the new unit test :)

By the way, that whole `to_python` didn't have any test coverage at all before. 