### PR TITLE
bug 1388130 - copy -prod crontabber jobs to DEFAULT_JOBS

### DIFF
--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -6,24 +6,30 @@
 from crontabber.app import CronTabberBase
 
 
+# NOTE(willkg): This is what we have in -prod
 DEFAULT_JOBS = '''
-  socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
-  socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|05:00
-  socorro.cron.jobs.matviews.SignaturesCronApp|1d|05:00
-  socorro.cron.jobs.matviews.RawUpdateChannelCronApp|1d|05:00
-  socorro.cron.jobs.matviews.ADUCronApp|1d|07:30
-  socorro.cron.jobs.fetch_adi_from_hive.FetchADIFromHiveCronApp|1d|07:00
-  socorro.cron.jobs.matviews.DuplicatesCronApp|1h
-  socorro.cron.jobs.matviews.ReportsCleanCronApp|1h
-  socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
-  socorro.cron.jobs.matviews.BuildADUCronApp|1d|07:30
-  socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00
-  socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00
-  socorro.cron.jobs.matviews.CrashAduByBuildSignatureCronApp|1d|07:30
-  socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
-  socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|7d
-  socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d
-  socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|7d
+socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
+socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|05:00
+socorro.cron.jobs.matviews.SignaturesCronApp|1d|05:00
+socorro.cron.jobs.matviews.RawUpdateChannelCronApp|1d|05:00
+socorro.cron.jobs.matviews.ADUCronApp|1d|08:30
+socorro.cron.jobs.matviews.DuplicatesCronApp|1h
+socorro.cron.jobs.matviews.ReportsCleanCronApp|1h
+socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
+socorro.cron.jobs.matviews.BuildADUCronApp|1d|08:30
+socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00
+socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00
+socorro.cron.jobs.matviews.CrashAduByBuildSignatureCronApp|1d|08:30
+socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
+socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|7d
+socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d
+socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|7d
+socorro.cron.jobs.clean_raw_adi_logs.CleanRawADILogsCronApp|1d
+socorro.cron.jobs.clean_raw_adi.CleanRawADICronApp|1d
+socorro.cron.jobs.clean_missing_symbols.CleanMissingSymbolsCronApp|1d
+socorro.cron.jobs.missingsymbols.MissingSymbolsCronApp|1d
+socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1h
+socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|1h
 '''
 
 


### PR DESCRIPTION
This syncs the crontabber.jobs value that we have in -prod with DEFAULT_JOBS
enabling us to run all the jobs we're running in -prod in local dev
environments.