### PR TITLE
Bug 1388419 correlations js errors on report index

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
@@ -39,7 +39,7 @@ window.correlations = (function () {
             })
             .then(function (totals) {
                 correlationData[product] = {
-                    'date': totals['date'],
+                    'date': totals.date,
                 };
 
                 var channels = $('#mainbody').data('channels');
@@ -64,7 +64,7 @@ window.correlations = (function () {
     function loadCorrelationData(signature, channel, product) {
         return loadChannelsData(product)
         .then(function (channelsData) {
-            if (!channelsData || !channelsData[channel] || signature in channelsData[channel]['signatures']) {
+            if (!channelsData || !channelsData[channel] || signature in channelsData[channel].signatures) {
                 return;
             }
 
@@ -77,7 +77,7 @@ window.correlations = (function () {
                 return response.json();
             })
             .then(function (data) {
-                correlationData[product][channel]['signatures'][signature] = data;
+                correlationData[product][channel].signatures[signature] = data;
             });
         })
         .catch(handleError)
@@ -194,7 +194,7 @@ window.correlations = (function () {
                 return 'No correlation data was generated for the "' + channel + '" channel and the "' + product + '" product.';
             }
 
-            var signatureData = data[product][channel]['signatures'][signature];
+            var signatureData = data[product][channel].signatures[signature];
 
             if (!signatureData || !signatureData.results) {
                 return 'No correlation data was generated for the signature "' + signature + '" on the "' + channel + '" channel, for the "' + product + '" product.';

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
@@ -43,6 +43,12 @@ window.correlations = (function () {
                 };
 
                 var channels = $('#mainbody').data('channels');
+                if (!channels) {
+                    channels = [$('#mainbody').data('channel')];
+                }
+                if (!channels || !channels.length) {
+                    throw new Error('No channel or channels dataset attribute set');
+                }
 
                 channels.forEach(function (ch) {
                     correlationData[product][ch] = {
@@ -50,8 +56,6 @@ window.correlations = (function () {
                         'signatures': {},
                     };
                 });
-            })
-            .then(function () {
                 return correlationData[product];
             });
         });


### PR DESCRIPTION
CC @marco-c 

First of all, this PR is two commits. The first one interesting, the second one just some ESLint cleanups. 

The big change is that the report index page has been erroring ever since I [landed this](https://github.com/mozilla-services/socorro/commit/b27f15d85c9abbc63ce2e30e0d8f693f7cf65d2f).

Now, I'm failing forward by instead making the list of channels be a list of 1 item and it's the channel that the individual crash belongs to. 

So if the crash you're looking at is one that belongs to Firefox Beta it only display correlations based on that channel. 