### PR TITLE
bug 1387100 - improve webapp in dev environment

### DIFF
--- a/docker/run_update_release_data.sh
+++ b/docker/run_update_release_data.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Updates product release data in the docker environment.
+#
+# Usage: docker/run_update_release_data.sh
+
+# Fetch and update release information for these products (comma-delimited)
+PRODUCTS="firefox"
+
+# Update with this frequency
+FREQUENCY="1d"
+
+# Fetch release data
+python socorro/cron/crontabber_app.py --job=ftpscraper \
+       --crontabber.class-FTPScraperCronApp.frequency=${FREQUENCY} \
+       --crontabber.class-FTPScraperCronApp.products=${PRODUCTS}
+
+# Update featured versions data based on release data
+python socorro/cron/crontabber_app.py --job=featured-versions-automatic \
+       --crontabber.class-FeaturedVersionsAutomaticCronApp.frequency=${FREQUENCY} \
+       --crontabber.class-FeaturedVersionsAutomaticCronApp.products=${PRODUCTS}

--- a/docker/run_update_release_data.sh
+++ b/docker/run_update_release_data.sh
@@ -4,6 +4,8 @@
 #
 # Usage: docker/run_update_release_data.sh
 
+set -eo pipefail
+
 # Fetch and update release information for these products (comma-delimited)
 PRODUCTS="firefox"
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -41,15 +41,18 @@ Quickstart
 
      $ make dockersetup
 
+
+   You can run ``make dockersetup`` any time you want to wipe the database, pick
+   up changes in static data, stored procedures, types, migrations, etc.
+
    .. Warning::
 
-      This is a work in progress, isn't idempotent, and is fussy about the state
-      of things.
+      This is a work in progress and might be fussy about some things.
 
       Pull requests welcome!
 
 
-At that point, you should have a basic functional Socorro development
+At this point, you should have a basic functional Socorro development
 environment.
 
 See :ref:`webapp-chapter` for additional setup and running the webapp.
@@ -57,8 +60,47 @@ See :ref:`webapp-chapter` for additional setup and running the webapp.
 See :ref:`processor-chapter` for additional setup and running the processor.
 
 
+Updating data in a dev environment
+==================================
+
+Wiping the db
+-------------
+
+Any time you want to wipe the database and start over, run ``make dockersetup``.
+
+
+Updating release data
+---------------------
+
+Data on releases comes from running ftpscraper. After you run ftpscraper, you
+have to run featured-versions-automatic which will update the featured versions
+list.
+
+We put all that in a single shell script.
+
+Run::
+
+  $ docker-compose run processor docker/run_update_release_data.sh
+
+
+.. Warning::
+
+   This can take a long while to run and if you're running it against an
+   existing database, then ftpscraper will "catch up" since the last time it ran
+   which can take a long time, maybe hours.
+
+
+General architecture
+====================
+
+.. image:: block-diagram.png
+
+Arrows direction represents the flow of interesting information (crashes,
+authentication assertions, cached values), not trivia like acks.
+
+
 Configuration
-=============
+-------------
 
 All configuration is done with ENV files located in ``/app/docker/config/``.
 
@@ -84,15 +126,6 @@ Each service uses ``docker_common.env`` and then a service-specific ENV file.
 
 In this way, we have behavioral configuration versioned alongside code changes
 and we can more easily push and revert changes.
-
-
-General architecture
-====================
-
-.. image:: block-diagram.png
-
-Arrows direction represents the flow of interesting information (crashes,
-authentication assertions, cached values), not trivia like acks.
 
 
 Top-level folders
@@ -140,7 +173,11 @@ Here are descriptions of every submodule in there:
 +-------------------+---------------------------------------------------------------+
 | external          | Here are APIs related to external resources like databases.   |
 +-------------------+---------------------------------------------------------------+
+| processor         | Code for the processor component.                             |
++-------------------+---------------------------------------------------------------+
+| submitter         | Code for the stage submitter component.                       |
++-------------------+---------------------------------------------------------------+
 | unittest          | All our unit tests are here.                                  |
 +-------------------+---------------------------------------------------------------+
-| webapi            | Contains a few tools used by web-based services.              |
+| webapp            | Code for the webapp component.                                |
 +-------------------+---------------------------------------------------------------+

--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -312,6 +312,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
         self.scrape_json_nightlies(connection, product_name, date)
 
     def _insert_build(self, cursor, *args, **kwargs):
+        self.config.logger.debug('adding %s', args)
         if self.config.dry_run:
             print "INSERT BUILD"
             print args
@@ -374,7 +375,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
                         version > '26.0' and
                         kvpairs.get('buildID')
                     ):
-                        logger.debug('is final beta version %s', version)
+                        logger.debug('adding final beta version %s', version)
                         repository = 'mozilla-beta'
                         build_id = kvpairs['buildID']
                         build_type = 'beta'

--- a/socorro/external/postgresql/postgresqlalchemymanager.py
+++ b/socorro/external/postgresql/postgresqlalchemymanager.py
@@ -85,7 +85,7 @@ class PostgreSQLAlchemyManager(object):
         return status
 
     def bulk_load(self, data, table, columns, sep):
-        self.logger.debug('bulk loading data')
+        self.logger.debug('bulk loading data into %s', table)
         connection = self.engine.raw_connection()
         with connection.cursor() as cursor:
             cursor.copy_from(data, table, columns=columns, sep=sep)

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -229,14 +229,14 @@ class Products(BaseTable):
 class ProductBuildTypes(BaseTable):
     table = 'product_build_types'
     columns = [
-        'product_name', 'build_type'
+        'product_name', 'build_type', 'throttle'
     ]
     rows = [
-        ['Firefox', 'release'],
-        ['Firefox', 'esr'],
-        ['Firefox', 'aurora'],
-        ['Firefox', 'beta'],
-        ['Firefox', 'nightly'],
+        ['Firefox', 'esr', '1.0',],
+        ['Firefox', 'aurora', '1.0'],
+        ['Firefox', 'beta', '1.0'],
+        ['Firefox', 'release', '0.1'],
+        ['Firefox', 'nightly', '1.0'],
     ]
 
 
@@ -244,14 +244,14 @@ class ProductBuildTypes(BaseTable):
 class ProductReleaseChannels(BaseTable):
     table = 'product_release_channels'
     columns = [
-        'product_name', 'release_channel'
+        'product_name', 'release_channel', 'throttle'
     ]
     rows = [
-        ['Firefox', 'Release'],
-        ['Firefox', 'ESR'],
-        ['Firefox', 'Aurora'],
-        ['Firefox', 'Beta'],
-        ['Firefox', 'Nightly'],
+        ['Firefox', 'ESR', '1.0'],
+        ['Firefox', 'Aurora', '1.0'],
+        ['Firefox', 'Beta', '1.0'],
+        ['Firefox', 'Release', '0.1'],
+        ['Firefox', 'Nightly', '1.0'],
     ]
 
 

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -100,14 +100,37 @@ class OSVersions(BaseTable):
 class ReleaseRepositories(BaseTable):
     table = 'release_repositories'
     columns = ['repository']
-    rows = [['dev'],
-            ['beta'],
-            ['release'],
-            ['esr'],
-            ['other-dev'],
-            ['other-beta'],
-            ['other-release'],
-            ['other-esr']]
+    rows = [
+        ['mozilla-central'],
+        ['mozilla-1.9.2'],
+        ['comm-central'],
+        ['comm-1.9.2'],
+        ['comm-central-trunk'],
+        ['mozilla-central-android'],
+        ['mozilla-release'],
+        ['mozilla-beta'],
+        ['mozilla-aurora'],
+        ['mozilla-aurora-android'],
+        ['mozilla-esr10'],
+        ['mozilla-esr10-android'],
+        ['b2g-release'],
+        ['mozilla-aurora-android-xul'],
+        ['mozilla-central-android-xul'],
+        ['comm-aurora'],
+        ['mozilla-central-android-api-11'],
+        ['mozilla-aurora-android-api-11'],
+        ['mozilla-central-android-api-15'],
+        ['mozilla-aurora-android-api-15'],
+        ['mozilla-beta-android-api-15'],
+        ['mozilla-release-android-api-15'],
+        ['mozilla-esr38'],
+        ['mozilla-esr45'],
+        ['comm-esr38'],
+        ['comm-esr45'],
+        ['comm-beta'],
+        ['mozilla-esr52'],
+        ['comm-esr52'],
+    ]
 
 
 class CrashTypes(BaseTable):
@@ -189,8 +212,79 @@ class ReportPartitionInfo(BaseTable):
              'date_processed', 'DATE']]
 
 
+class Products(BaseTable):
+    table = 'products'
+    columns = [
+        'product_name', 'sort', 'rapid_release_version', 'release_name', 'rapid_beta_version'
+    ]
+    rows = [
+        ['Fennec', '3', '5.0', 'mobile', '999.0'],
+        ['Thunderbird', '2', '6.0', 'thunderbird', '999.0'],
+        ['Firefox', '1', '5.0', 'firefox', '23.0'],
+        ['SeaMonkey', '6', '2.3', 'seamonkey', '999.0'],
+        ['FennecAndroid', '4', '5.0', '**SPECIAL**', '999.0'],
+    ]
+
+
+class ProductBuildTypes(BaseTable):
+    table = 'product_build_types'
+    columns = [
+        'product_name', 'build_type'
+    ]
+    rows = [
+        ['Firefox', 'release'],
+        ['Firefox', 'esr'],
+        ['Firefox', 'aurora'],
+        ['Firefox', 'beta'],
+        ['Firefox', 'nightly'],
+    ]
+
+
+# DEPRECATED
+class ProductReleaseChannels(BaseTable):
+    table = 'product_release_channels'
+    columns = [
+        'product_name', 'release_channel'
+    ]
+    rows = [
+        ['Firefox', 'Release'],
+        ['Firefox', 'ESR'],
+        ['Firefox', 'Aurora'],
+        ['Firefox', 'Beta'],
+        ['Firefox', 'Nightly'],
+    ]
+
+
+class SpecialProductPlatforms(BaseTable):
+    table = 'special_product_platforms'
+    columns = [
+        'platform', 'repository', 'release_channel', 'release_name', 'product_name', 'min_version'
+    ]
+    rows = [
+        ['android', 'mozilla-release', 'release', 'mobile', 'FennecAndroid', '10.0'],
+        ['android', 'mozilla-release', 'beta', 'mobile', 'FennecAndroid', '10.0'],
+        ['android', 'mozilla-beta', 'beta', 'mobile', 'FennecAndroid', '10.0'],
+        ['android-arm', 'mozilla-central-android', 'nightly', 'mobile', 'FennecAndroid', '10.0'],
+        ['android-arm', 'mozilla-central-android', 'aurora', 'mobile', 'FennecAndroid', '10.0'],
+        ['android-arm', 'mozilla-aurora-android', 'aurora', 'mobile', 'FennecAndroid', '10.0'],
+        ['android-arm', 'mozilla-central-android-api-11', 'nightly', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-aurora-android-api-11', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-x86', 'mozilla-beta', 'beta', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-api-9', 'mozilla-beta', 'beta', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-api-11', 'mozilla-beta', 'beta', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-x86', 'mozilla-release', 'release', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-api-9', 'mozilla-release', 'release', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-api-11', 'mozilla-release', 'release', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-central-android-api-15', 'nightly', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-aurora-android-api-15', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-beta-android-api-15', 'beta', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-release-android-api-15', 'release', 'mobile', 'FennecAndroid', '37.0']
+    ]
+
+
 # the order that tables are loaded is important.
 tables = [OSNames, OSNameMatches, ProcessTypes, ReleaseChannels,
           ReleaseChannelMatches, UptimeLevels, WindowsVersions,
           OSVersions, ReleaseRepositories,
-          CrashTypes, ReportPartitionInfo]
+          CrashTypes, ReportPartitionInfo,
+          Products, ProductBuildTypes, ProductReleaseChannels, SpecialProductPlatforms]


### PR DESCRIPTION
This adds lookup table data population and documented run lines that add release
data to the db. These make it possible to go to
http://localhost:8000/home/product/Firefox and have it mostly work.

Note that this only pulls release data for Firefox. Each additional product
takes another like 10 minutes to run. The thinking is that we're primarily
working on Firefox crashes, so if someone needs release data for something else,
they can adjust the scripts accordingly. If we need to make that more flexible,
we can make that change later.