### PR TITLE
Add docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ e2e-tests/.cache/
 # docker things
 .docker-build
 .cache/
+docker-compose.override.yml


### PR DESCRIPTION
docker-compose.override.yml allows people to override docker-compose things
without having to create a new file and point to it. These files shouldn't get
added to git, so let's ignore them.