### PR TITLE
avoid unnecessary 404s when finding candidate builds

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -343,7 +343,11 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
 
     def _insert_build(self, cursor, *args, **kwargs):
         self.config.logger.debug('adding %s', args)
-        if not self.config.dry_run:
+        if self.config.dry_run:
+            print "INSERT BUILD"
+            print args
+            print kwargs
+        else:
             buildutil.insert_build(cursor, *args, **kwargs)
 
     def _is_final_beta(self, version):


### PR DESCRIPTION
Found this low hanging fruit. Today, about 10% of the URLs going through `download` cause a 404. 