### PR TITLE
fixes bug 1389218 - redo behavior configuration in docker environment

### DIFF
--- a/bin/build_env.py
+++ b/bin/build_env.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Opens the specified env file, pulls in configuration, then executes the specified command in that
+environment.
+
+Usage:
+
+    build_env.py somefile.env somecmd
+
+Note: This will happily inject environment variables with invalid bash identifiers into the
+environment.
+
+"""
+
+import os
+import subprocess
+import sys
+
+
+USAGE = 'build_env.py [ENVFILE] [CMD...]'
+
+
+class ParseException(Exception):
+    pass
+
+
+def parse_env_file(envfile):
+    """Parses an env file and returns the env
+
+    :arg str envfile: the path to the env file to open
+
+    :returns: environment as a dict
+
+    """
+    env = {}
+    with open(envfile, 'r') as fp:
+        for lineno, line in enumerate(fp):
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' not in line:
+                raise ParseException('%d: No = in line' % lineno)
+            key, val = line.split('=', 1)
+            env[key.strip()] = val.strip()
+
+    return env
+
+
+def main(argv):
+    if not argv:
+        print(USAGE)
+        print('Error: env file required.')
+        return 1
+
+    env_file = argv.pop(0)
+
+    if not argv:
+        print(USAGE)
+        print('Error: cmd required.')
+        return 1
+
+    try:
+        env = parse_env_file(env_file)
+    except (OSError, IOError) as exc:
+        raise ParseException('File error: %s' % exc)
+
+    for key, val in env.items():
+        os.environ[key] = val
+
+    print('Running %s in new env' % argv)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return subprocess.call(argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/docker/config/crontabber.env
+++ b/docker/config/crontabber.env
@@ -4,6 +4,9 @@
 # NOTE: This file shouldn't contain any environment-specific or secret
 # configuration.
 
+# Marker to denote this file's contents are in the environment.
+CRONTABBER_BEHAVIOR=1
+
 # ----------------------------------------------------------------------------------
 # from socorro/crontabber
 # ----------------------------------------------------------------------------------

--- a/docker/config/processor.env
+++ b/docker/config/processor.env
@@ -4,6 +4,9 @@
 # NOTE: This file shouldn't contain any environment-specific or secret
 # configuration.
 
+# Marker to denote this file's contents are in the environment.
+PROCESSOR_BEHAVIOR=1
+
 # ----------------------------------------------------------------------------------
 # from socorro/processor
 # ----------------------------------------------------------------------------------

--- a/docker/config/webapp.env
+++ b/docker/config/webapp.env
@@ -3,6 +3,9 @@
 # NOTE: This file shouldn't contain any environment-specific or secret
 # configuration.
 
+# Marker to denote this file's contents are in the environment.
+WEBAPP_BEHAVIOR=1
+
 # ----------------------------------------------------------------------------------
 # from socorro/webapp-django
 # ----------------------------------------------------------------------------------

--- a/docker/run_crontabber.sh
+++ b/docker/run_crontabber.sh
@@ -6,9 +6,27 @@
 
 # Runs crontabber.
 
+set -e
+
+# If this was kicked off via docker-compose, then it has a behavior
+# configuration already. If it wasn't, then we need to add behavior
+# configuration to the environment.
+if [[ -z "${CRONTABBER_BEHAVIOR}" ]];
+then
+    echo "Pulling in crontabber behavior configuration..."
+    CMDPREFIX="/app/bin/build_env.py /app/docker/config/crontabber.env"
+else
+    echo "Already have crontabber behavior configuration..."
+    CMDPREFIX=
+fi
+
+
 # Run crontabber sleeping 5 minutes between runs
-while true; do
-    python socorro/cron/crontabber_app.py
+while true
+do
+    # FIXME(willkg): We don't want crontabber to exit weird and then have that
+    # kill the container, but this is a lousy thing to do.
+    ${CMDPREFIX} python socorro/cron/crontabber_app.py || true
     echo "Sleep 5 minutes..."
     sleep 300
 done

--- a/docker/run_processor.sh
+++ b/docker/run_processor.sh
@@ -6,8 +6,22 @@
 
 # Runs the processor.
 
+set -e
+
+# If this was kicked off via docker-compose, then it has a behavior
+# configuration already. If it wasn't, then we need to add behavior
+# configuration to the environment.
+if [[ -z "${PROCESSOR_BEHAVIOR}" ]];
+then
+    echo "Pulling in processor behavior configuration..."
+    CMDPREFIX="/app/bin/build_env.py /app/docker/config/processor.env"
+else
+    echo "Already have processor behavior configuration..."
+    CMDPREFIX=
+fi
+
 # Add /stackwalk to the path
 PATH=/stackwalk:${PATH}
 
 # Run the processor
-python /app/socorro/processor/processor_app.py
+${CMDPREFIX} python /app/socorro/processor/processor_app.py


### PR DESCRIPTION
This redoes how behavior configuration works. Previously, docker-compose would
inject the behavior configuration into the docker container environment. It can
do this because it's being run in a working directory that has the socorro code
in it, so the necessary env files exist *outside* the container it's running.

When we go to run these containers in a server environment or any environment
where you don't have the socorro repo as the working directory, then the
behavior configuration needs to be pulled in from *inside* the container.

This fixes the run_ scripts so that if an indicator flag isn't in the
environment, it pulls the appropriate env file in and executes the component in
the new environment with the behavior configuration.