### PR TITLE
Add socorro_env script

### DIFF
--- a/bin/activate_socorro
+++ b/bin/activate_socorro
@@ -4,15 +4,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Launches bash in a socorro-ized environment to use on the servers. This
-# includes the Socorro Python virtualenv as well as pulling in consul
-# configuration.
+# Launches bash in a Socorro-ized environment to use on the servers for
+# running one-off scripts. This includes the Socorro Python virtualenv
+# as well as pulling in consul configuration.
 #
 # This doesn't work in docker and isn't needed.
 #
 # Usage:
 #
-#     /data/socorro/bin/socorro_env.sh
+#     /data/socorro/bin/activate_socorro
 
 set -e
 
@@ -26,5 +26,8 @@ export "$(envconsul -prefix socorro/common -prefix socorro/processor -prefix soc
 echo "Set prompt..."
 export PS1='(socorro) \u@\h:\w\$ '
 
+echo
+echo "Note: Use this for running one-off scripts only."
+echo 
 echo "Launch bash... (type 'exit' when finished)"
 /bin/bash

--- a/bin/socorro_env.sh
+++ b/bin/socorro_env.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Launches bash in a socorro-ized environment to use on the servers. This
+# includes the Socorro Python virtualenv as well as pulling in consul
+# configuration.
+#
+# This doesn't work in docker and isn't needed.
+#
+# Usage:
+#
+#     /data/socorro/bin/socorro_env.sh
+
+set -e
+
+echo "Activate Python virtualenv..."
+# Active virtualenv in this environment
+. /data/socorro/socorro-virtualenv/bin/activate
+
+echo "Add all the stuff from envconsul..."
+export "$(envconsul -prefix socorro/common -prefix socorro/processor -prefix socorro/webapp -prefix socorro/crontabber env)"
+
+echo "Set prompt..."
+export PS1='(socorro) \u@\h:\w\$ '
+
+echo "Launch bash... (type 'exit' when finished)"
+/bin/bash

--- a/bin/socorro_env.sh
+++ b/bin/socorro_env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,7 +21,7 @@ echo "Activate Python virtualenv..."
 . /data/socorro/socorro-virtualenv/bin/activate
 
 echo "Add all the stuff from envconsul..."
-export "$(envconsul -prefix socorro/common -prefix socorro/processor -prefix socorro/webapp -prefix socorro/crontabber env)"
+export "$(envconsul -prefix socorro/common -prefix socorro/processor -prefix socorro/webapp-django -prefix socorro/crontabber env)"
 
 echo "Set prompt..."
 export PS1='(socorro) \u@\h:\w\$ '

--- a/socorro/scripts/add_crashid_to_queue.py
+++ b/socorro/scripts/add_crashid_to_queue.py
@@ -14,12 +14,12 @@ from socorro.lib.ooid import is_crash_id_valid
 EPILOG = """
 To use in a docker-based local dev environment:
 
-    scripts/add_crashid_to_queue.py socorro.normal <CRASHID>
+  $ scripts/add_crashid_to_queue.py socorro.normal <CRASHID>
 
 To use in -prod:
 
-    envconsul -once -prefix socorro/common -prefix socorro/processor env | \
-        /path/to/python scripts/add_crashid_to_queue.py socorro.submitter <CRASHID>
+  $ /data/socorro/bin/socorro_env.sh
+  (socorro) $ python scripts/add_crashid_to_queue.py socorro.submitter <CRASHID>
 
 Queues:
 


### PR DESCRIPTION
This adds a socorro_env script that launches bash in a modified environment with
the Python virtual environment activated and with all the configuration loaded.

This makes running Socorro scripts much easier.

So instead of:

```
    $ . /data/socorro/socorro-virtualenv/bin/activate
    $ envconsul -prefix some/nonsense mycmd
    $ envconsul -prefix some/nonsense someothercmd
```

You can do:

```
    $ /data/socorro/bin/socorro_env.sh
    (socorro) $ mycmd
    (socorro) $ someothercmd
```