### PR TITLE
bug 1388449 - add socorro_aws_s3.sh script

### DIFF
--- a/docker/Dockerfile.processor
+++ b/docker/Dockerfile.processor
@@ -11,4 +11,7 @@ COPY . /app/
 
 USER app
 
+# Install aws cli using --user so it doesn't mess with Socorro requirements
+RUN /app/docker/set_up_awscli.sh
+
 CMD ["/app/docker/run_processor.sh"]

--- a/docker/run_socorro_aws.sh
+++ b/docker/run_socorro_aws.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Convenience wrapper for running socorro_aws.sh script in a container with a
+# uid/gid that will respect file permissions.
+
+HOSTUSER=$(id -u):$(id -g)
+
+docker-compose run -u ${HOSTUSER} processor /app/scripts/socorro_aws_s3.sh $@

--- a/docker/set_up_awscli.sh
+++ b/docker/set_up_awscli.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Install aws cli as the current user in /tmp so it doesn't interfere with
+# socorro/system requirements
+HOME=/tmp pip install awscli --user
+
+# Fix permissions so anyone can use it
+find /tmp/.local/ -type d -exec '/bin/chmod' '755' '{}' ';'
+find /tmp/.local/ -type f -exec '/bin/chmod' '644' '{}' ';'
+chmod 755 /tmp/.local/bin/*

--- a/scripts/socorro_aws_s3.sh
+++ b/scripts/socorro_aws_s3.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -e
+
+# Wrapper for aws script that pulls connection bits from the environment.
+#
+# Usage:
+#
+# make bucket
+#
+#     scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+#
+# list bucket
+#
+#     scripts/socorro_aws_s3.sh ls s3://dev_bucket/
+#
+# copy files into s3 container
+#
+#     scripts/socorro_aws_s3.sh cp --recursive ./my_s3_root/ s3://dev_bucket/
+#
+# sync local directory and s3 container
+#
+#     scripts/socorro_aws_s3.sh sync ./my_s3_root/ s3://dev_bucket/
+
+# First convert configman environment vars which have bad identifiers to ones
+# that don't
+function getenv {
+    python -c "import os; print os.environ['$1']"
+}
+
+AWS_HOST="$(getenv 'resource.boto.host')"
+AWS_PORT="$(getenv 'resource.boto.port')"
+AWS_ACCESS_KEY_ID="$(getenv 'resource.boto.access_key')"
+AWS_SECRET_ACCESS_KEY="$(getenv 'secrets.boto.secret_access_key')"
+AWS_BUCKET="$(getenv 'resource.boto.bucket_name')"
+
+# Create required configuration files for aws
+if [[ ! -d /tmp/.aws ]]
+then
+    mkdir /tmp/.aws
+fi
+if [[ ! -f /tmp/.aws/config ]]
+then
+    cat > /tmp/.aws/config <<EOF
+[default]
+EOF
+fi
+if [[ ! -f /tmp/.aws/credentials ]]
+then
+    cat > /tmp/.aws/credentials <<EOF
+[default]
+aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+EOF
+fi
+
+AWSOPTIONS="--endpoint-url=http://${AWS_HOST}:${AWS_PORT}/"
+
+echo "S3 container bucket is ${AWS_BUCKET}"
+
+HOME=/tmp /tmp/.local/bin/aws ${AWSOPTIONS} s3 $@


### PR DESCRIPTION
* add awscli to the processor in a place where it shouldn't affect anything
* create socorro_aws_s3.sh script and friends that wrap aws by pulling
  configuration out of the environment making it easier to use

The end result of this is that we can copy files into and out of the s3
container, see what's in there, manipulate buckets, and so on.