### PR TITLE
 fixes bug 1381877 - ignore winsock_lsp gt 30000

### DIFF
--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -3042,7 +3042,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 30000
                 }
             }
         },

--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -80,7 +80,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -132,7 +133,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -156,7 +158,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -215,7 +218,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "b2g_os_version",
@@ -300,7 +304,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "uuid",
@@ -386,7 +391,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -457,7 +463,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -478,7 +485,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "theme",
@@ -497,7 +505,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -518,7 +527,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -627,7 +637,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -666,7 +677,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -754,7 +766,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -793,7 +806,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -813,7 +827,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_brand",
@@ -832,7 +847,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "adapter_vendor_id",
@@ -870,7 +886,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "productid",
@@ -907,7 +924,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -946,7 +964,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -1006,7 +1025,8 @@
             "crashstats.view_pii"
         ],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "email",
@@ -1117,7 +1137,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -1241,7 +1262,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash.json_dump",
         "has_full_version": false,
@@ -1293,7 +1315,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "distributor",
@@ -1360,7 +1383,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "adapter_device_id",
@@ -1414,7 +1438,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "release_channel",
@@ -1484,7 +1509,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "distributor_version",
@@ -1503,7 +1529,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -1521,7 +1548,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "has_full_version": false,
@@ -1557,7 +1585,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_device",
@@ -1609,7 +1638,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "is_returned": true,
@@ -1660,7 +1690,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "bios_manufacturer",
@@ -1732,7 +1763,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "cpu_name",
@@ -1754,7 +1786,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -1796,7 +1829,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -1836,7 +1870,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "address",
@@ -1941,7 +1976,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -1976,7 +2012,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_version",
@@ -1995,7 +2032,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_board",
@@ -2037,7 +2075,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2081,7 +2120,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2214,7 +2254,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2237,7 +2278,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2279,7 +2321,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2302,7 +2345,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2437,7 +2481,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_hardware",
@@ -2476,7 +2521,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "description": "",
@@ -2499,7 +2545,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "is_returned": true,
@@ -2517,7 +2564,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "flash_version",
@@ -2588,7 +2636,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2630,7 +2679,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2728,7 +2778,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2767,7 +2818,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_manufacturer",
@@ -2811,13 +2863,15 @@
                     "dynamic": "true",
                     "properties": {
                         "classification_version": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 10922
                         },
                         "classification_data": {
                             "type": "text"
                         },
                         "classification": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 10922
                         }
                     }
                 },
@@ -2825,13 +2879,15 @@
                     "dynamic": "true",
                     "properties": {
                         "classification_version": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 10922
                         },
                         "classification_data": {
                             "type": "text"
                         },
                         "classification": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 10922
                         }
                     }
                 }
@@ -2856,7 +2912,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -2949,7 +3006,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -3043,7 +3101,7 @@
             "fields": {
                 "full": {
                     "type": "keyword",
-                    "ignore_above": 30000
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3173,7 +3231,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3250,7 +3309,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "process_type",
@@ -3294,7 +3354,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3366,7 +3427,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3405,7 +3467,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "has_full_version": false,
@@ -3426,7 +3489,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3450,7 +3514,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3524,7 +3589,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_cpu_abi2",
@@ -3580,7 +3646,8 @@
             "type": "text",
             "fields": {
                 "full": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "ignore_above": 10922
                 }
             }
         },
@@ -3619,7 +3686,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "description": "A list of the addons currently enabled at the time of the crash. This takes the form of \"addonid:version,[addonid:version...]\". This value could be empty if the crash happens during startup before the addon manager is enabled, and on products/platforms which don't support addons.",
@@ -3653,7 +3721,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "name": "android_cpu_abi",
@@ -3689,7 +3758,8 @@
             "crashstats.view_pii"
         ],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "processed_crash",
         "name": "url",
@@ -3761,7 +3831,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -3779,7 +3850,8 @@
         "query_type": "enum",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -3797,7 +3869,8 @@
        "query_type": "string",
        "permissions_needed": [],
        "storage_mapping": {
-          "type": "keyword"
+           "type": "keyword",
+           "ignore_above": 10922
        },
        "namespace": "raw_crash",
        "has_full_version": false,


### PR DESCRIPTION
The winsock_lsp field is being indexed using the keyword analyzer. That's fine,
except this field value is pretty big and exceeds the maximum size.

This changes that to ignore any values larger than 30000 in size.