### PR TITLE
Bug 1390880 add accessibilityinprocclient and accessibilityclient to super search fieldsjson

### DIFF
--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -1,4 +1,40 @@
 {
+    "accessibility_client": {
+        "default_value": null,
+        "is_mandatory": false,
+        "name": "accessibility_client",
+        "is_returned": true,
+        "query_type": "string",
+        "permissions_needed": [],
+        "storage_mapping": {
+            "type": "keyword"
+        },
+        "namespace": "raw_crash",
+        "has_full_version": false,
+        "data_validation_type": "str",
+        "in_database_name": "AccessibilityClient",
+        "is_exposed": true,
+        "form_field_choices": [],
+        "description": "Out-of-process accessibility client program name and version information."
+    },
+    "accessibility_in_proc_client": {
+        "default_value": null,
+        "is_mandatory": false,
+        "name": "accessibility_in_proc_client",
+        "is_returned": true,
+        "query_type": "string",
+        "permissions_needed": [],
+        "storage_mapping": {
+            "type": "keyword"
+        },
+        "namespace": "raw_crash",
+        "has_full_version": false,
+        "data_validation_type": "str",
+        "in_database_name": "AccessibilityInProcClient",
+        "is_exposed": true,
+        "form_field_choices": [],
+        "description": "In-process accessibility client detection information. See Compatibility.h for more details."
+    },
     "InstallTime": {
         "default_value": null,
         "is_mandatory": false,

--- a/socorro/external/es/data/super_search_fields.json
+++ b/socorro/external/es/data/super_search_fields.json
@@ -7,7 +7,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,
@@ -25,7 +26,8 @@
         "query_type": "string",
         "permissions_needed": [],
         "storage_mapping": {
-            "type": "keyword"
+            "type": "keyword",
+            "ignore_above": 10922
         },
         "namespace": "raw_crash",
         "has_full_version": false,


### PR DESCRIPTION
How I tested this:

```
docker/as_me.sh scripts/fetch_crash_data.py ./samplecrashdata 20e25952-7271-44da-8e0a-816260170815
docker/as_me.sh scripts/socorro_aws_s3.sh mb s3://dev_bucket/
docker/as_me.sh scripts/socorro_aws_s3.sh sync ./samplecrashdata s3://dev_bucket/
docker-compose run processor scripts/add_crashid_to_queue.py socorro.normal 20e25952-7271-44da-8e0a-816260170815
docker-compose up webapp
open http://localhost:8000/report/index/20e25952-7271-44da-8e0a-816260170815#tab-metadata
```

And the fields are there even though I'm not signed in. Meaning, they're displayed in that table because they're in the super search fields.

<img width="935" alt="screen shot 2017-08-24 at 11 26 42 am" src="https://user-images.githubusercontent.com/26739/29674736-0a3133e0-88c1-11e7-9090-30b168f84e64.png">
