### PR TITLE
bug 1390847 - remove update-crash-adu-by-build-signature as default job

### DIFF
--- a/config/crontabber.ini-dist
+++ b/config/crontabber.ini-dist
@@ -242,7 +242,6 @@
   socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00
   socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00
   socorro.cron.jobs.matviews.ExploitabilityCronApp|1d|05:00
-  socorro.cron.jobs.matviews.CrashAduByBuildSignatureCronApp|1d|07:30
   #socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
   #socorro.cron.jobs.automatic_emails.AutomaticEmailsCronApp|1h
   socorro.cron.jobs.reprocessingjobs.ReprocessingJobsApp|5m
@@ -602,44 +601,6 @@
 
         # time
         #time=08:00
-
-        [[[database]]]
-
-            # None
-            # see "resource.postgresql.database_class" for the default or override it here
-            #database_class=socorro.external.postgresql.connection_context.ConnectionContext
-
-            # the hostname of the database
-            # see "resource.postgresql.database_hostname" for the default or override it here
-            #database_hostname=localhost
-
-            # the name of the database
-            # see "resource.postgresql.database_name" for the default or override it here
-            #database_name=breakpad
-
-            # the user's database password
-            # see "secrets.postgresql.database_password" for the default or override it here
-            #database_password=aPassword
-
-            # the port for the database
-            # see "resource.postgresql.database_port" for the default or override it here
-            #database_port=5432
-
-            # a class that will execute transactions
-            # see "resource.postgresql.database_transaction_executor_class" for the default or override it here
-            #database_transaction_executor_class=crontabber.transaction_executor.TransactionExecutor
-
-            # the name of the user within the database
-            # see "secrets.postgresql.database_username" for the default or override it here
-            #database_username=breakpad_rw
-
-    [[class-CrashAduByBuildSignatureCronApp]]
-
-        # frequency
-        #frequency=1d
-
-        # time
-        #time=07:30
 
         [[[database]]]
 

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -19,7 +19,6 @@ socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
 socorro.cron.jobs.matviews.BuildADUCronApp|1d|08:30
 socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00
 socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00
-socorro.cron.jobs.matviews.CrashAduByBuildSignatureCronApp|1d|08:30
 socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
 socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|7d
 socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d


### PR DESCRIPTION
Gently removing all remnants of this now deprecated stored procedure. 
Earlier today [I removed it from consulate `socorro/crontabber/crontabber.jobs`](https://bugzilla.mozilla.org/show_bug.cgi?id=1390847#c3).

I want to make sure it not running in -prod admin any more doesn't break anything. 
After this I can start to really remove all its code. 