### PR TITLE
fixes bug 1231672 - Delete explosiveness table

### DIFF
--- a/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
+++ b/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
@@ -41,24 +41,24 @@ def downgrade():
     """
     op.create_table(
         'explosiveness',
-        day0=Column(u'day0', NUMERIC()),
-        day1=Column(u'day1', NUMERIC()),
-        day2=Column(u'day2', NUMERIC()),
-        day3=Column(u'day3', NUMERIC()),
-        day4=Column(u'day4', NUMERIC()),
-        day5=Column(u'day5', NUMERIC()),
-        day6=Column(u'day6', NUMERIC()),
-        day7=Column(u'day7', NUMERIC()),
-        day8=Column(u'day8', NUMERIC()),
-        day9=Column(u'day9', NUMERIC()),
-        last_date=Column(
+        Column(u'day0', NUMERIC()),
+        Column(u'day1', NUMERIC()),
+        Column(u'day2', NUMERIC()),
+        Column(u'day3', NUMERIC()),
+        Column(u'day4', NUMERIC()),
+        Column(u'day5', NUMERIC()),
+        Column(u'day6', NUMERIC()),
+        Column(u'day7', NUMERIC()),
+        Column(u'day8', NUMERIC()),
+        Column(u'day9', NUMERIC()),
+        Column(
             u'last_date',
             DATE(),
             primary_key=True,
             nullable=False
         ),
-        oneday=Column(u'oneday', NUMERIC()),
-        product_version_id=Column(
+        Column(u'oneday', NUMERIC()),
+        Column(
             u'product_version_id',
             INTEGER(),
             primary_key=True,
@@ -66,12 +66,12 @@ def downgrade():
             autoincrement=False,
             index=True
         ),
-        signature_id=Column(
+        Column(
             u'signature_id',
             INTEGER(),
             primary_key=True,
             nullable=False,
             index=True
         ),
-        threeday=Column(u'threeday', NUMERIC())
+        Column(u'threeday', NUMERIC())
     )

--- a/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
+++ b/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
@@ -1,0 +1,77 @@
+"""remove explosiveness remnants
+
+Revision ID: 77395783fce5
+Revises: e5a31e87d305
+Create Date: 2017-08-28 13:58:03.355534
+
+"""
+from alembic import op
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import INTEGER, NUMERIC, DATE
+
+
+# revision identifiers, used by Alembic.
+revision = '77395783fce5'
+down_revision = 'e5a31e87d305'
+
+
+def upgrade():
+    op.drop_table('explosiveness')
+
+
+def downgrade():
+    """
+        CREATE TABLE explosiveness (
+            product_version_id integer NOT NULL,
+            signature_id integer NOT NULL,
+            last_date date NOT NULL,
+            oneday numeric,
+            threeday numeric,
+            day0 numeric,
+            day1 numeric,
+            day2 numeric,
+            day3 numeric,
+            day4 numeric,
+            day5 numeric,
+            day6 numeric,
+            day7 numeric,
+            day8 numeric,
+            day9 numeric
+        )
+    """
+    op.create_table(
+        'explosiveness',
+        day0=Column(u'day0', NUMERIC()),
+        day1=Column(u'day1', NUMERIC()),
+        day2=Column(u'day2', NUMERIC()),
+        day3=Column(u'day3', NUMERIC()),
+        day4=Column(u'day4', NUMERIC()),
+        day5=Column(u'day5', NUMERIC()),
+        day6=Column(u'day6', NUMERIC()),
+        day7=Column(u'day7', NUMERIC()),
+        day8=Column(u'day8', NUMERIC()),
+        day9=Column(u'day9', NUMERIC()),
+        last_date=Column(
+            u'last_date',
+            DATE(),
+            primary_key=True,
+            nullable=False
+        ),
+        oneday=Column(u'oneday', NUMERIC()),
+        product_version_id=Column(
+            u'product_version_id',
+            INTEGER(),
+            primary_key=True,
+            nullable=False,
+            autoincrement=False,
+            index=True
+        ),
+        signature_id=Column(
+            u'signature_id',
+            INTEGER(),
+            primary_key=True,
+            nullable=False,
+            index=True
+        ),
+        threeday=Column(u'threeday', NUMERIC())
+    )

--- a/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
+++ b/alembic/versions/77395783fce5_remove_explosiveness_remnants.py
@@ -16,7 +16,7 @@ down_revision = 'e5a31e87d305'
 
 
 def upgrade():
-    op.drop_table('explosiveness')
+    op.execute('DROP TABLE IF EXISTS explosiveness')
 
 
 def downgrade():


### PR DESCRIPTION
For some reason the `Explosiveness` class in `models.py` [was removed](https://bugzilla.mozilla.org/show_bug.cgi?id=1231672#c2) but no alembic migration was made for deleting the actual table. 