### PR TITLE
bug 1100354 - fix fields mutations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     test_suite='nose.collector',
     zip_safe=False,
     data_files=[
-        ('socorro/external/es/data', glob.glob('socorro/external/es/data/*.json')),
         ('socorro/external/postgresql/raw_sql/procs',
             glob.glob('socorro/external/postgresql/raw_sql/procs/*.sql')),
         ('socorro/external/postgresql/raw_sql/views',

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 
 from socorro.external.es import query
@@ -41,7 +42,7 @@ class SuperSearchFieldsWithoutConfig(super_search_fields.SuperSearchFields):
     needed to reach Elasticsearch.
 
     This way we can call `.get()` on an instance of this class, which
-    just reads a .json file.
+    just returns the fields.
     """
 
     def __init__(self, *args, **kwargs):
@@ -232,15 +233,15 @@ class SuperSearchUnredacted(SuperSearch):
 
 class SuperSearchFields(ESSocorroMiddleware):
 
-    # Read it in once as a class attribute since it'll never change
-    # unless the .json file on disk changes and if that happens you
-    # will have reloaded the Python process.
+    # Read it in once as a class attribute since it'll never change unless the
+    # Python code changes and if that happens you will have reloaded the
+    # Python process.
     _fields = SuperSearchFieldsWithoutConfig().get()
 
     API_WHITELIST = None
 
     def get(self):
-        return self._fields
+        return copy.deepcopy(self._fields)
 
 
 class SuperSearchMissingFields(ESSocorroMiddleware):


### PR DESCRIPTION
Super search fields come from a Python module now and are handed around and some
of the users mutate the value. Because of that, we want to hand around a copy of
the structure--not the structure itself. This fixes that.

Additionally, this cleans up some comments that were wrong because we're not
storing the fields in JSON anymore.