### PR TITLE
fixes bug 1393533 - remove collectstatic before running webapp

### DIFF
--- a/docker/run_webapp.sh
+++ b/docker/run_webapp.sh
@@ -28,9 +28,6 @@ else
 fi
 
 if [ "$1" == "--dev" ]; then
-    # Collect static files
-    cd /app/webapp-django/ && ${CMDPREFIX} python manage.py collectstatic --noinput
-
     # Run with manage.py
     echo "Running webapp. Connect with browser using http://localhost:8000/ ."
     cd /app/webapp-django/ && ${CMDPREFIX} python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
For local development, the webapp runs with DEBUG=True which sources static
files without needing to run collectstatic. Thus running collecstatic is costly
and not helpful, so we should nix it.