### PR TITLE
fixes bug 1395681 - cache .json files on disk for ftpscraper

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -322,7 +322,6 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
                 os.makedirs(os.path.dirname(fn))
             if os.path.exists(fn):
                 with open(fn, 'r') as fp:
-                    print('hit')
                     return fp.read()
 
         response = self.session.get(


### PR DESCRIPTION
This adds a cachedir configuration property letting you specify a directory on
disk to cache .json files. It defaults to "don't cache on disk", but this
enables the disk cache for the local dev environment.