### PR TITLE
Add cache hits summary to ftpscraper

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -306,6 +306,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
         )
 
         self.cache_hits = 0
+        self.cache_misses = 0
 
     def url_to_filename(self, url):
         fn = re.sub('\W', '_', url)
@@ -326,6 +327,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
                 self.cache_hits += 1
                 with open(fn, 'r') as fp:
                     return fp.read()
+            self.cache_misses += 1
 
         response = self.session.get(
             url,
@@ -368,7 +370,13 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
             )
 
         if self.config.cachedir:
-            self.config.logger.debug('Cache hits: %d' % self.cache_hits)
+            total = float(self.cache_hits + self.cache_misses)
+            self.config.logger.debug('Cache: hits: %d (%2.2f%%) misses: %d (%2.2f%%)' % (
+                self.cache_hits,
+                self.cache_hits / total * 100,
+                self.cache_misses,
+                self.cache_misses / total * 100,
+            ))
 
     def _scrape_json_releases_and_nightlies(
         self,

--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -305,6 +305,8 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
             HTTPAdapter(max_retries=self.config.retries)
         )
 
+        self.cache_hits = 0
+
     def url_to_filename(self, url):
         fn = re.sub('\W', '_', url)
         fn = re.sub('__', '_', fn)
@@ -321,6 +323,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
             if not os.path.isdir(os.path.dirname(fn)):
                 os.makedirs(os.path.dirname(fn))
             if os.path.exists(fn):
+                self.cache_hits += 1
                 with open(fn, 'r') as fp:
                     return fp.read()
 
@@ -363,6 +366,9 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
                 product_name,
                 date
             )
+
+        if self.config.cachedir:
+            self.config.logger.debug('Cache hits: %d' % self.cache_hits)
 
     def _scrape_json_releases_and_nightlies(
         self,


### PR DESCRIPTION
This helps us know whether the file-based cache is helping or not without being
overly verbose.