### PR TITLE
fixes bug 794524 - drop plugins_report table

### DIFF
--- a/alembic/versions/a38b03765a79_drop_plugins_reports_tables.py
+++ b/alembic/versions/a38b03765a79_drop_plugins_reports_tables.py
@@ -1,0 +1,48 @@
+"""drop plugins_reports tables
+
+Revision ID: a38b03765a79
+Revises: ae2c8ff8c073
+Create Date: 2017-09-08 13:23:44.142686
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a38b03765a79'
+down_revision = 'ae2c8ff8c073'
+
+
+def upgrade():
+    # Get a list of ALL tables that start with 'signature_summary_*'
+    connection = op.get_bind()
+    cursor = connection.connection.cursor()
+    cursor.execute("""
+        SELECT c.relname FROM pg_catalog.pg_class c
+        WHERE c.relkind = 'r' AND c.relname LIKE 'plugins_reports_%'
+    """)
+    all_table_names = []
+    for records in cursor.fetchall():
+        table_name, = records
+        all_table_names.append(table_name)
+
+    # Now delete all these tables.
+    # But make sure that we drop them in the "right" order.
+    # In particular we want to make sure we first drop
+    # 'plugins_reports_20170227' *before* we drop 'plugins_reports'
+    # since the former depends on the latter.
+    all_table_names.sort(reverse=True)
+    for table_name in all_table_names:
+        op.execute('DROP TABLE IF EXISTS {}'.format(table_name))
+
+    # Remove all mentions of signature_summary_* from the table that
+    # handles making more partitions.
+    op.execute("""
+        DELETE FROM report_partition_info
+        WHERE table_name LIKE 'plugins_reports_%'
+    """)
+
+
+def downgrade():
+    # There is no going back.
+    pass

--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -118,7 +118,7 @@ class PostgreSQLBasicCrashStorage(CrashStorageBase):
         self._save_plugins(connection, processed_crash, report_id)
 
     def _save_processed_report(self, connection, processed_crash):
-        """ Here we INSERT or UPDATE a row in the reports table.
+        """Here we INSERT or UPDATE a row in the reports table.
         This is the first stop before imported data gets into our normalized
         batch reporting (next table: reports_clean).
 
@@ -143,6 +143,7 @@ class PostgreSQLBasicCrashStorage(CrashStorageBase):
         _save_processed_crash(), but is much simpler seeming because there are
         far fewer columns being passed into the parameterized query.
         """
+
         column_list = []
         placeholder_list = []
         # create a list of values to go into the reports table

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -377,19 +377,6 @@ class ExploitabilityReport(DeclarativeBase):
     )
 
 
-class PluginsReport(DeclarativeBase):
-    __tablename__ = 'plugins_reports'
-
-    # column definitions
-    report_id = Column(u'report_id', INTEGER(), nullable=False)
-    plugin_id = Column(u'plugin_id', INTEGER(), nullable=False)
-    date_processed = Column(u'date_processed', TIMESTAMP(timezone=True))
-    version = Column(u'version', TEXT(), nullable=False)
-
-    __mapper_args__ = {"primary_key": (
-        report_id, plugin_id, date_processed, version)}
-
-
 class RawAdiLogs(DeclarativeBase):
     __tablename__ = 'raw_adi_logs'
 

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -161,15 +161,6 @@ class ReportPartitionInfo(BaseTable):
             'TIMESTAMPTZ'
         ),
         (
-            'plugins_reports',
-            '2',
-            '{"report_id,plugin_id"}',
-            '{"report_id,date_processed"}',
-            '{"(plugin_id) REFERENCES plugins(id)","(report_id) REFERENCES reports_WEEKNUM(id)"}',
-            'date_processed',
-            'TIMESTAMPTZ'
-        ),
-        (
             'extensions',
             '3',
             '{"report_id,extension_key"}',


### PR DESCRIPTION
When I started working on this, I discovered that it appears that we're still actively writing to these tables. I can't find any reference to it ever being queried. Which kinda makes sense since it used to be used by the search we had before we had super search. 

So I'm going to be careful and first make a PR that deprecates the writes. Then we'll let that go into stage and check that all is well with the world. 