### PR TITLE
fixes bug 1397857 - fix calling format

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -659,7 +659,7 @@ SOCORRO_IMPLEMENTATIONS_CONFIG = {
             'port': config('resource.boto.port', None),
             'secure': config('resource.boto.secure', True),
             'calling_format': config(
-                'resource.boto.calling_format', 'boto.s3.connection.SubdomainCallingFormat'
+                'resource.boto.calling_format', 'boto.s3.connection.OrdinaryCallingFormat'
             ),
         }
     }


### PR DESCRIPTION
For boto connections, we use RegionalS3ConnectionContext and subclasses. This
family of connection contexts default to OrdinaryCallingFormat rather than
SubdomainCallingFormat. This is important because we have periods in our bucket
names and thus SubdomainCallingFormat doesn't work.

However, when I picked the default for resource.boto.calling_format in the
original commit, I looked at S3ConnectionContext rather than
RegionalS3ConnectionContext and thus used the wrong one and now everything is
hosed in -stage and Sentry is giving me dirty looks late on a Friday just before
the weekend.

This fixes all of that.