### PR TITLE
fixes bug 1398116 - fetch lots of test data

### DIFF
--- a/docs/components/processor.rst
+++ b/docs/components/processor.rst
@@ -51,16 +51,19 @@ We have helper scripts for these steps.
 -------------------------------
 
 This will fetch raw crash data from -prod and save it in the appropriate
-directory structure rooted at outputdir.
+directory structure.
+
+By default, this saves crash data to ``crashdata/``, but you can specify the
+directory using the ``--outputdir`` argument.
 
 Usage from host::
 
-  $ docker/as_me.sh scripts/fetch_crash_data.py <outputdir> <crashid> [<crashid> ...]
+  $ docker/as_me.sh scripts/fetch_crash_data.py <crashid> [<crashid> ...]
 
 
 For example (assumes this crash exists)::
 
-  $ docker/as_me.sh scripts/fetch_crash_data.py ./testdata 5c9cecba-75dc-435f-b9d0-289a50170818
+  $ docker/as_me.sh scripts/fetch_crash_data.py 5c9cecba-75dc-435f-b9d0-289a50170818
 
 
 You can get command help::
@@ -72,14 +75,27 @@ You should run this with ``docker/as_me.sh`` so that the files that get saved to
 the file system are owned by the user/group of the account you're using on your
 host.
 
-This script requires that you have a valid API token from the -prod environment
-that has the "View Raw Dumps" permission.
+.. Note::
 
-You can generate API tokens at `<https://crash-stats.mozilla.com/api/tokens/>`_.
+   If you want full crash data including the dumps, then you have a valid API token
+   from the -prod environment that has the "View Raw Dumps" permission.
 
-Add the API token value to your ``my.env`` file::
+   You can generate API tokens at `<https://crash-stats.mozilla.com/api/tokens/>`_.
 
-    SOCORRO_API_TOKEN=apitokenhere
+   Add the API token value to your ``my.env`` file::
+
+       SOCORRO_API_TOKEN=apitokenhere
+
+   If you don't do that, then the crash data you fetch will only be publicly
+   available crash data.
+
+
+You can also run this script to grab a bunch of publicly available raw crash
+data. For example::
+
+  $ docker/as_me.sh scripts/fetch_crash_data.py --num=100 --date=2017-09-01
+
+This will fetch 100 crashes from September 1st, 2017.
 
 
 ``scripts/socorro_aws_s3.sh``

--- a/socorro/scripts/__init__.py
+++ b/socorro/scripts/__init__.py
@@ -10,7 +10,16 @@ class WrappedTextHelpFormatter(argparse.HelpFormatter):
         This makes it easier to do lists and paragraphs.
 
         """
-        parts = text.split('\n')
+        parts = text.split('\n\n')
         for i, part in enumerate(parts):
-            parts[i] = super(WrappedTextHelpFormatter, self)._fill_text(part, width, indent)
-        return '\n'.join(parts)
+            # Check to see if it's a bulleted list--if so, then fill each line
+            if part.startswith('* '):
+                subparts = part.split('\n')
+                for j, subpart in enumerate(subparts):
+                    subparts[j] = super(WrappedTextHelpFormatter, self)._fill_text(
+                        subpart, width, indent
+                    )
+                parts[i] = '\n'.join(subparts)
+            else:
+                parts[i] = super(WrappedTextHelpFormatter, self)._fill_text(part, width, indent)
+        return '\n\n'.join(parts)

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -5,28 +5,42 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import datetime
 import json
 import os
 import os.path
 
 import requests
 
-from socorro.lib.datetimeutil import JsonDTEncoder
+from socorro.lib.datetimeutil import JsonDTEncoder, utc_now
 from socorro.scripts import WrappedTextHelpFormatter
 
 
+DESCRIPTION = """
+Fetches data for specific crashes or most recent crashes
+"""
+
 EPILOG = """
-Given a crash id, fetches crash data and puts it in specified directory
+This script has two modes: fetching specific crashes and fetching arbitrary crashes.
 
-This requires an auth-token to be in the environment::
+If you specify crash ids, then it fetches data for those specific crashes. This mode requires an
+auth-token to be in the environment. For example:
 
-    SOCORRO_API_TOKEN=xyz
+    $ SOCORRO_API_TOKEN=xyz ./scripts/fetch_crash_data.py CRASHID
 
 To create an API token for Socorro in -prod, visit:
 
     https://crash-stats.mozilla.com/api/tokens/
 
+If you don't specify any crashes, then this will fetch N number of crashes. This will not use your
+API token. This will only fetch publicly available raw crash data. For example:
+
+    $ ./scripts/fetch_crash_data.py --num=10
+
 """
+
+# FIXME(willkg): Hard-coded host that we might want to make configurable some day
+HOST = 'https://crash-stats.mozilla.com'
 
 
 class CrashDoesNotExist(Exception):
@@ -39,14 +53,17 @@ def create_dir_if_needed(d):
 
 
 def fetch_crash(outputdir, api_token, crash_id):
-    headers = {
-        'Auth-Token': api_token
-    }
+    if api_token:
+        headers = {
+            'Auth-Token': api_token
+        }
+    else:
+        headers = {}
 
     # Fetch raw crash metadata
     print('Fetching %s' % crash_id)
     resp = requests.get(
-        'https://crash-stats.mozilla.com/api/RawCrash/',
+        HOST + '/api/RawCrash/',
         params={
             'crash_id': crash_id,
             'format': 'meta',
@@ -67,7 +84,7 @@ def fetch_crash(outputdir, api_token, crash_id):
             dump_name = 'dump'
 
         resp = requests.get(
-            'https://crash-stats.mozilla.com/api/RawCrash/',
+            HOST + '/api/RawCrash/',
             params={
                 'crash_id': crash_id,
                 'format': 'raw',
@@ -109,15 +126,68 @@ def fetch_crash(outputdir, api_token, crash_id):
             fp.write(data)
 
 
+def fetch_crashids(outputdir, datestamp, num):
+    if datestamp == 'yesterday':
+        startdate = utc_now() - datetime.timedelta(days=1)
+    else:
+        startdate = datetime.datetime.strptime(datestamp, '%Y-%m-%d')
+
+    enddate = startdate + datetime.timedelta(days=1)
+
+    url = HOST + '/api/SuperSearch/'
+    params = {
+        'product': 'Firefox',
+        '_results_number': 1000,
+        '_columns': 'uuid',
+        'date': ['>=%s' % startdate.strftime('%Y-%m-%d'), '<%s' % enddate.strftime('%Y-%m-%d')],
+    }
+
+    resp = requests.get(url, params)
+    if resp.status_code == 200:
+        crashids = []
+        for hit in resp.json()['hits']:
+            crash_id = hit['uuid']
+            fn = os.path.join(
+                outputdir, 'v2', 'raw_crash', crash_id[0:3], '20' + crash_id[-6:], crash_id
+            )
+            if os.path.exists(fn):
+                continue
+
+            crashids.append(crash_id)
+            if len(crashids) >= num:
+                break
+
+        return crashids
+
+    raise Exception('Bad response: %s %s' % (resp.status_code, resp.content))
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         formatter_class=WrappedTextHelpFormatter,
         prog=os.path.basename(__file__),
-        description='Fetches crash data from crash-stats.mozilla.com system',
+        description=DESCRIPTION.strip(),
         epilog=EPILOG.strip(),
     )
-    parser.add_argument('outputdir', help='directory to place crash data in')
-    parser.add_argument('crashid', nargs='+', help='one or more crash ids to fetch data for')
+    parser.add_argument(
+        '--num', default=10, type=int,
+        help=(
+            'if you are not specifying specific crash ids, this is the number of crashes to '
+            'fetch'
+        )
+    )
+    parser.add_argument(
+        '--date', default='yesterday',
+        help=(
+            'if you are not specifying specific crash ids, this is the date to retreive crashes '
+            'from (YYYY-MM-DD)'
+        )
+    )
+    parser.add_argument(
+        '--outputdir', default='crashdata',
+        help='directory to place crash data in; defaults to "crashdata"'
+    )
+    parser.add_argument('crashid', nargs='*', help='one or more crash ids to fetch data for')
 
     args = parser.parse_args(argv)
 
@@ -127,10 +197,17 @@ def main(argv):
         print('%s is not a directory. Please fix. Exiting.' % outputdir)
         return 1
 
-    api_token = os.environ.get('SOCORRO_API_TOKEN')
-    print('Using api token: %s' % api_token)
+    crashes = []
+    if args.crashid:
+        api_token = os.environ.get('SOCORRO_API_TOKEN')
+        print('Using api token: %s' % api_token)
 
-    for crash_id in args.crashid:
+        crashes = args.crashid
+    else:
+        api_token = None
+        crashes = fetch_crashids(outputdir, args.date, args.num)
+
+    for crash_id in crashes:
         print('Working on %s...' % crash_id)
         fetch_crash(outputdir, api_token, crash_id)
 


### PR DESCRIPTION
This adjusts the `scripts/fetch_crash_data.py` script to have a mode where it can
fetch a bunch of data for specified dates.

To test:

```
$ ./docker/as_me.sh bash

# Fetch 10 crashes from yesterday
app@...:/app$ ./scripts/fetch_crash_data.py

# Fetch 5 crashes from September 1st
app@...:/app$ ./scripts/fetch_crash_data.py --num=5 --date=2017-09-01

# Fetch a specific crash
app@...:/app$ ./scripts/fetch_crash_data.py 19a766c5-e388-481c-bcae-6d4bb0170911
```

This defaults to saving in the directory `./crashdata`. That's a change--previously, you'd have to specify the directory. Now you can optionally specify it.

When fetching a bunch of unspecified crashes, it *only* uses publicly available data. I was thinking this is more responsible to do. If you want to fetch 1000 crashes with the private data, you can still do that, but you have to be explicit about what crashes you're fetching. Seems like that's the right thing to do here.

Two things to note:

1. There are no tests for `fetch_crash_data.py`, yet. It's probably worth writing tests, but since it's mostly hitting production, it'd be a lot of mocking and I'm on the fence about how valuable that ends up being.
2. We've got a lot of fake data generating code that should get removed. I wrote up bug https://bugzilla.mozilla.org/show_bug.cgi?id=1398946 to cover that.

So does this feel good enough for now? Should it get split out into two scripts?