### PR TITLE
Add rust oom signature

### DIFF
--- a/socorro/signature/signature_utilities.py
+++ b/socorro/signature/signature_utilities.py
@@ -462,7 +462,8 @@ class OOMSignature(Rule):
         'NS_ABORT_OOM',
         'mozalloc_handle_oom',
         'CrashAtUnhandlableOOM',
-        'AutoEnterOOMUnsafeRegion'
+        'AutoEnterOOMUnsafeRegion',
+        'alloc::oom::oom',
     )
 
     def predicate(self, raw_crash, processed_crash):


### PR DESCRIPTION
It would be nice to add `core::result::unwrap_failed<hashglobe::FailedAllocationError>`, but it apparently is transformed in the signature into a generic `unwrap_failed<T>` per https://crash-stats.mozilla.com/report/index/d54a2975-9c55-4567-a92f-c755c0170903 :/