### PR TITLE
1398116 fetch crashids

### DIFF
--- a/docs/components/processor.rst
+++ b/docs/components/processor.rst
@@ -92,7 +92,7 @@ Use with ``scripts/fetch_crashids.py`` to fetch crash data from 100 crashes from
 yesterday for Firefox::
 
   $ docker/as_me.sh bash
-  app@...:/app$ scripts/fetch_crashids.py | xargs scripts/fetch_crash_data.py ./testdata
+  app@...:/app$ scripts/fetch_crashids.py | scripts/fetch_crash_data.py ./testdata
 
 
 You can get command help::

--- a/docs/components/processor.rst
+++ b/docs/components/processor.rst
@@ -47,6 +47,31 @@ crash id to the "socorro.normal" RabbitMQ queue.
 We have helper scripts for these steps.
 
 
+``scripts/fetch_crashids.py``
+-----------------------------
+
+This will generate a list of crash ids from -prod that meet specified criteria.
+Crash ids are printed to stdout, so you can use this in conjunction with other
+scripts or redirect to a file.
+
+This pulls 100 crash ids from yesterday for Firefox product::
+
+  $ docker/as_me.sh scripts/fetch_crashids.py
+
+This pulls 5 crash ids from 2017-09-01::
+
+  $ docker/as_me.sh scripts/fetch_crashids.py --num=5 --date=2017-09-01
+
+This pulls 100 crash ids for criteria specified with a Super Search url that we
+copy and pasted::
+
+  $ docker/as_me.sh scripts/fetch_crashids.py "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature"
+
+You can get command help::
+
+  $ docker/as_me.sh scripts/fetch_crash_data.py --help
+
+
 ``scripts/fetch_crash_data.py``
 -------------------------------
 
@@ -61,6 +86,13 @@ Usage from host::
 For example (assumes this crash exists)::
 
   $ docker/as_me.sh scripts/fetch_crash_data.py ./testdata 5c9cecba-75dc-435f-b9d0-289a50170818
+
+
+Use with ``scripts/fetch_crashids.py`` to fetch crash data from 100 crashes from
+yesterday for Firefox::
+
+  $ docker/as_me.sh bash
+  app@...:/app$ scripts/fetch_crashids.py | xargs scripts/fetch_crash_data.py ./testdata
 
 
 You can get command help::
@@ -80,6 +112,11 @@ You can generate API tokens at `<https://crash-stats.mozilla.com/api/tokens/>`_.
 Add the API token value to your ``my.env`` file::
 
     SOCORRO_API_TOKEN=apitokenhere
+
+.. Note::
+
+   Make sure you treat any data you pull from production in accordance with our
+   data policies that you agreed to when granted access to it.
 
 
 ``scripts/socorro_aws_s3.sh``

--- a/docs/components/processor.rst
+++ b/docs/components/processor.rst
@@ -50,9 +50,9 @@ We have helper scripts for these steps.
 ``scripts/fetch_crashids.py``
 -----------------------------
 
-This will generate a list of crash ids from -prod that meet specified criteria.
-Crash ids are printed to stdout, so you can use this in conjunction with other
-scripts or redirect to a file.
+This will generate a list of crash ids from crash-stats.mozilla.com that meet
+specified criteria. Crash ids are printed to stdout, so you can use this in
+conjunction with other scripts or redirect to a file.
 
 This pulls 100 crash ids from yesterday for Firefox product::
 
@@ -65,7 +65,7 @@ This pulls 5 crash ids from 2017-09-01::
 This pulls 100 crash ids for criteria specified with a Super Search url that we
 copy and pasted::
 
-  $ docker/as_me.sh scripts/fetch_crashids.py "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature"
+  $ docker/as_me.sh scripts/fetch_crashids.py "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform"
 
 You can get command help::
 
@@ -75,8 +75,8 @@ You can get command help::
 ``scripts/fetch_crash_data.py``
 -------------------------------
 
-This will fetch raw crash data from -prod and save it in the appropriate
-directory structure rooted at outputdir.
+This will fetch raw crash data from crash-stats.mozilla.com and save it in the
+appropriate directory structure rooted at outputdir.
 
 Usage from host::
 
@@ -104,8 +104,8 @@ You should run this with ``docker/as_me.sh`` so that the files that get saved to
 the file system are owned by the user/group of the account you're using on your
 host.
 
-This script requires that you have a valid API token from the -prod environment
-that has the "View Raw Dumps" permission.
+This script requires that you have a valid API token from the
+crash-stats.mozilla.com environment that has the "View Raw Dumps" permission.
 
 You can generate API tokens at `<https://crash-stats.mozilla.com/api/tokens/>`_.
 

--- a/scripts/fetch_crashids.py
+++ b/scripts/fetch_crashids.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# See socorro/scripts/fetch_crashids.py
+
+import sys
+
+from socorro.scripts import fetch_crashids
+
+
+if __name__ == '__main__':
+    sys.exit(fetch_crashids.main(sys.argv[1:]))

--- a/socorro/scripts/__init__.py
+++ b/socorro/scripts/__init__.py
@@ -10,7 +10,17 @@ class WrappedTextHelpFormatter(argparse.HelpFormatter):
         This makes it easier to do lists and paragraphs.
 
         """
-        parts = text.split('\n')
+        parts = text.split('\n\n')
         for i, part in enumerate(parts):
-            parts[i] = super(WrappedTextHelpFormatter, self)._fill_text(part, width, indent)
-        return '\n'.join(parts)
+            # Check to see if it's a bulleted list--if so, then fill each line
+            if part.startswith('* '):
+                subparts = part.split('\n')
+                for j, subpart in enumerate(subparts):
+                    subparts[j] = super(WrappedTextHelpFormatter, self)._fill_text(
+                        subpart, width, indent
+                    )
+                parts[i] = '\n'.join(subparts)
+            else:
+                parts[i] = super(WrappedTextHelpFormatter, self)._fill_text(part, width, indent)
+
+        return '\n\n'.join(parts)

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import os
 import os.path
+import sys
 
 import requests
 
@@ -20,7 +21,8 @@ Fetches crash data from crash-stats.mozilla.com system
 """
 
 EPILOG = """
-Given a crash id, fetches crash data and puts it in specified directory
+Given one or more crash ids via command line or stdin (one per line), fetches crash data and puts it
+in specified directory.
 
 This requires an auth-token to be in the environment::
 
@@ -126,7 +128,7 @@ def main(argv):
         epilog=EPILOG.strip(),
     )
     parser.add_argument('outputdir', help='directory to place crash data in')
-    parser.add_argument('crashid', nargs='+', help='one or more crash ids to fetch data for')
+    parser.add_argument('crashid', nargs='*', help='one or more crash ids to fetch data for')
 
     args = parser.parse_args(argv)
 
@@ -140,7 +142,14 @@ def main(argv):
     if api_token:
         print('Using api token: %s%s' % (api_token[:4], 'x' * (len(api_token) - 4)))
 
-    for crash_id in args.crashid:
+    if args.crashid:
+        crashids_iterator = iter(args.crashid)
+    else:
+        crashids_iterator = sys.stdin
+
+    for crash_id in crashids_iterator:
+        crash_id = crash_id.strip()
+
         print('Working on %s...' % crash_id)
         fetch_crash(outputdir, api_token, crash_id)
 

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -142,12 +142,13 @@ def main(argv):
     if api_token:
         print('Using api token: %s%s' % (api_token[:4], 'x' * (len(api_token) - 4)))
 
+    # This will pull crash ids from the command line if specified, otherwise it'll pull from stdin
     if args.crashid:
-        crashids_iterator = iter(args.crashid)
+        crashids_iteratable = args.crashid
     else:
-        crashids_iterator = sys.stdin
+        crashids_iteratable = sys.stdin
 
-    for crash_id in crashids_iterator:
+    for crash_id in crashids_iteratable:
         crash_id = crash_id.strip()
 
         print('Working on %s...' % crash_id)

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import datetime
+import os
+import os.path
+from urlparse import urlparse, parse_qs
+
+import requests
+
+from socorro.lib.datetimeutil import utc_now
+from socorro.scripts import WrappedTextHelpFormatter
+
+
+DESCRIPTION = """
+Fetches a set of crash ids using Super Search
+
+There are two ways to run this. First is to use a url from an actual Super Search on crash-stats.
+This script will then pull out the parameters and base the query on that. You can override those
+parameters with command line arguments.
+
+The second is to just specify command line arguments and the query will be based on that.
+
+"""
+
+HOST = 'https://crash-stats.mozilla.com'
+
+
+def fetch_crashids(params):
+    url = HOST + '/api/SuperSearch/'
+
+    resp = requests.get(url, params)
+    if resp.status_code == 200:
+        hits = resp.json()['hits']
+        crashids = [hit['uuid'] for hit in hits]
+        return crashids
+
+    raise Exception('Bad response: %s %s' % (resp.status_code, resp.content))
+
+
+def extract_params(url):
+    """Parses out params from the query string and drops any that start with _"""
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+
+    for key in list(params.keys()):
+        # Remove any params that start with a _
+        if key.startswith('_'):
+            del params[key]
+
+    return params
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        formatter_class=WrappedTextHelpFormatter,
+        prog=os.path.basename(__file__),
+        description=DESCRIPTION.strip(),
+    )
+    parser.add_argument(
+        '--date', default='yesterday',
+        help='Date to pull crash ids from (YYYY-MM-DD)'
+    )
+    parser.add_argument(
+        '--url', default='',
+        help='Super Search url to pull crash ids from'
+    )
+    parser.add_argument(
+        '--num', default=100, type=int,
+        help='The number of crash ids you want'
+    )
+    parser.add_argument(
+        '-v', '--verbose', action='store_true',
+        help='Increase verbosity of output'
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.url:
+        params = extract_params(args.url)
+    else:
+        params = {
+            'product': 'Firefox'
+        }
+
+    datestamp = args.date
+    if 'date' not in params or datestamp != 'yesterday':
+        if datestamp == 'yesterday':
+            startdate = utc_now() - datetime.timedelta(days=1)
+        else:
+            startdate = datetime.datetime.strptime(datestamp, '%Y-%m-%d')
+
+        enddate = startdate + datetime.timedelta(days=1)
+        params['date'] = [
+            '>=%s' % startdate.strftime('%Y-%m-%d'),
+            '<%s' % enddate.strftime('%Y-%m-%d')
+        ]
+
+    params.update({
+        '_results_number': args.num,
+        '_columns': 'uuid'
+    })
+    if args.verbose:
+        print('Params: %s' % params)
+
+    crashids = fetch_crashids(params)
+    for crashid in crashids:
+        print(crashid)
+
+    return 0

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -48,8 +48,8 @@ def extract_params(url):
     params = parse_qs(parsed.query)
 
     for key in list(params.keys()):
-        # Remove any params that start with a _
-        if key.startswith('_'):
+        # Remove any params that start with a _ except _sort since that's helpful
+        if key.startswith('_') and key != '_sort':
             del params[key]
 
     return params


### PR DESCRIPTION
This adds a `scripts/fetch_crashids.py` script that will generate a list of crash ids based on specified parameters.

In this first pass, we're keeping the parameters pretty limited to date and number and a url. We can enhance that later as needs arise.

To test, first get into a bash session in the processor container:

```
$ docker-compose run processor bash
```

Then to get command help:

```
app@...:/app$ ./scripts/fetch_crashids.py --help
```

To pull 100 crashes for Firefox from yesterday:

```
app@...:/app$ ./scripts/fetch_crashids.py
```

To pull 5 crashes for Firefox from September 1st:

```
app@...:/app$ ./scripts/fetch_crashids.py --date=2017-09-01 --num=5
```

To pull 100 crashes from the results of a Super Search query:

```
app@...:/app$ ./scripts/fetch_crashids.py "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature"
```

Specifying `--date` will override date params in any specified `--url` query.

If you also add `-v`, then it'll print out the params it's using to do the search with. That's super helpful for debugging and verification.