### PR TITLE
bug 1399459 - halt if there are no versions

### DIFF
--- a/docker/fetch_normalization_data.py
+++ b/docker/fetch_normalization_data.py
@@ -169,6 +169,9 @@ def main(args):
     for product in args.products.split(','):
         # Fetch versions from the product_versions table that we should pull data for
         versions = get_versions(conn, product)
+        if not versions:
+            print('ERROR: No versions to fetch for %s. That seems bad. Exiting.' % product)
+            return 1
 
         for platform in PLATFORMS:
             print('Fetching data for (%s, %s, %s)...' % (product, versions, platform))


### PR DESCRIPTION
When fetching normalization data, we really need valid product versions. If
there aren't any valid product versions, then we should throw our hands in the
air and give up with an error.