### PR TITLE
[DO NOT MERGE] bug 1375434 - populate signatures from supersearch

### DIFF
--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -29,6 +29,7 @@ socorro.cron.jobs.clean_missing_symbols.CleanMissingSymbolsCronApp|1d
 socorro.cron.jobs.missingsymbols.MissingSymbolsCronApp|1d
 socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1h
 socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|1h
+socorro.cron.jobs.first_signatures.FirstSignaturesCronApp|1h
 '''
 
 

--- a/socorro/cron/jobs/first_signatures.py
+++ b/socorro/cron/jobs/first_signatures.py
@@ -82,7 +82,6 @@ class FirstSignaturesCronApp(BaseCronApp):
         signatures = [
             x['term'] for x in results['facets']['signature']
         ]
-        print("LIST LENGTH", len(signatures), 'SET LENGTH', len(set(signatures)))
         self.config.logger.info(
             'Found %s unique signatures between %s and %s',
             len(signatures),

--- a/socorro/cron/jobs/first_signatures.py
+++ b/socorro/cron/jobs/first_signatures.py
@@ -74,7 +74,7 @@ class FirstSignaturesCronApp(BaseCronApp):
                 '<{}'.format(date.isoformat()),
             ],
             '_facets': 'signature',
-            '_facets_size': 1000,
+            '_facets_size': 10000,
             '_results_number': 0,
             '_fields': all_fields,
         }

--- a/socorro/cron/jobs/first_signatures.py
+++ b/socorro/cron/jobs/first_signatures.py
@@ -1,0 +1,204 @@
+import datetime
+import sys
+
+import mock
+
+from configman import Namespace
+from configman.converters import class_converter
+from crontabber.base import BaseCronApp
+from crontabber.mixins import (
+    as_backfill_cron_app,
+    with_postgres_transactions
+)
+
+from socorro.external.postgresql.signature_first_date import SignatureFirstDate
+from socorro.external.es.base import ElasticsearchConfig
+from socorro.external.es.supersearch import SuperSearch
+from socorro.external.es.super_search_fields import SuperSearchFields
+from socorro.app.socorro_app import App, main
+from socorro.lib.datetimeutil import string_to_datetime
+
+
+class SuperSearchErrors(Exception):
+    """Happens when we make a SuperSearch query and there's something in the
+    results 'errors' dict."""
+
+
+@with_postgres_transactions()
+@as_backfill_cron_app
+class FirstSignaturesCronApp(BaseCronApp):
+    app_name = 'first-signatures'
+    app_description = 'Using SuperSearch to log when signatures first appeared'
+    app_version = '0.1'
+
+    required_config = Namespace()
+    required_config.add_option(
+        'window_seconds',
+        default=60,  # seconds
+        doc='Number of seconds to search for signature facets back'
+    )
+    required_config.add_option(
+        'sensitive_to_errors',
+        # default=True,
+        default=False,
+        doc=(
+            'If there are, for example, missing indexes in ES you can get errors '
+            "in supersearch doing queries across dates we don't have indices for. "
+            'If this is the case, halt this crontabber app.'
+        )
+    )
+    required_config.add_option(
+        'historic_days',
+        # The number 26 comes from the default in index_cleaner which is used
+        # as a retention policy for cleaning elasticsearch.
+        default=26 * 7,  # days
+        doc=(
+            'When looking for the oldest crash possible (by a specific signature) '
+            'go back this many days'
+        )
+    )
+    required_config.add_option(
+        'elasticsearch_class',
+        default=ElasticsearchConfig,
+    )
+
+    def run(self, date):
+        # First get a list of all unique signatures, in the given timespan
+        all_fields = SuperSearchFields(config=self.config).get()
+        api = SuperSearch(config=self.config)
+        assert isinstance(date, datetime.datetime), type(date)
+        start_date = date - datetime.timedelta(seconds=self.config.window_seconds)
+        params = {
+            'date': [
+                '>={}'.format(start_date.isoformat()),
+                '<{}'.format(date.isoformat()),
+            ],
+            '_facets': 'signature',
+            '_facets_size': 1000,
+            '_results_number': 0,
+            '_fields': all_fields,
+        }
+        results = api.get(**params)
+        signatures = [
+            x['term'] for x in results['facets']['signature']
+        ]
+        self.config.logger.info(
+            'Found %s unique signatures between %s and %s',
+            len(signatures),
+            start_date,
+            date,
+        )
+        if not signatures:
+            self.config.logger.info(
+                'Exit early because no signature facets'
+            )
+            return
+
+        # Now to figure out which ones we've never seen before
+        signature_first_date_api = SignatureFirstDate(config=self.config)
+        results = signature_first_date_api.get(signatures=signatures)
+        new_signatures = set(signatures) - set(results['hits'])
+        self.config.logger.info('%s new signatures', len(new_signatures))
+
+        # Now, for each of these new signatures we have to find the oldest
+        # crash that has it and write down its date and buildid.
+        historic_date = date - datetime.timedelta(
+            days=self.config.historic_days
+        )
+        for signature in new_signatures:
+            # First look up by the oldest 'date'.
+            params = {
+                '_results_number': 1,
+                'signature': '={}'.format(signature),
+                '_sort': 'date',
+                '_fields': all_fields,
+                '_columns': ['date'],
+                '_facets_size': 0,
+                'date': [
+                    '>={}'.format(historic_date.isoformat()),
+                    '<{}'.format(date.isoformat()),
+                ]
+            }
+            results = api.get(**params)
+            if results['errors'] and self.config.sensitive_to_errors:
+                raise SuperSearchErrors(results['errors'])
+            first_crash_date = string_to_datetime(results['hits'][0]['date'])
+
+            # Now, same procedure by sorted by oldest 'build_id'
+            params['_sort'] = 'build_id'
+            params['_columns'] = 'build_id'
+            results = api.get(**params)
+            if results['errors'] and self.config.sensitive_to_errors:
+                raise SuperSearchErrors(results['errors'])
+            first_crash_build_id = results['hits'][0]['build_id']
+
+            # Finally we can insert this
+            signature_first_date_api.post(
+                signature=signature,
+                first_report=first_crash_date,
+                first_build=first_crash_build_id,
+            )
+            self.config.logger.info(
+                'Inserting first signature %r (%s, %s)',
+                signature,
+                first_crash_date,
+                first_crash_build_id,
+            )
+
+
+class FirstSignaturesCronAppDryRunner(App):  # pragma: no cover
+    """This is a utility class that makes it easy to run the scraping
+    and ALWAYS do so in a "dry run" fashion such that stuff is never
+    stored in the database but instead found releases are just printed
+    out stdout.
+
+    To run it, simply execute this file:
+
+        $ python socorro/cron/jobs/ftpscraper.py
+
+    If you want to override what date to run it for (by default it's
+    "now") you simply use this format:
+
+        $ python socorro/cron/jobs/ftpscraper.py --date=2015-10-23
+
+    By default it runs for every, default configured, product
+    (see the configuration set up in the FTPScraperCronApp above). You
+    can override that like this:
+
+        $ python socorro/cron/jobs/ftpscraper.py --product=mobile,thunderbird
+
+    """
+
+    required_config = Namespace()
+    required_config.add_option(
+        'date',
+        default=datetime.datetime.utcnow(),
+        doc='Date to run for',
+        from_string_converter=string_to_datetime
+    )
+    required_config.add_option(
+        'crontabber_job_class',
+        default='socorro.cron.jobs.first_signatures.FirstSignaturesCronApp',
+        doc="doesn't matter",
+        from_string_converter=class_converter,
+    )
+
+    @staticmethod
+    def get_application_defaults():
+        return {
+            'database.database_class': mock.MagicMock()
+        }
+
+    def __init__(self, config):
+        self.config = config
+        if isinstance(self.config.date, basestring):
+            # Why isn't the from_string_converter converter called?!
+            self.config.date = string_to_datetime(self.config.date)
+        self.app = config.crontabber_job_class(config, {})
+
+    def main(self):
+        self.app.run(self.config.date)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(FirstSignaturesCronAppDryRunner))

--- a/socorro/external/postgresql/signature_first_date.py
+++ b/socorro/external/postgresql/signature_first_date.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import datetime
+
 from socorro.lib import MissingArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
@@ -35,3 +37,16 @@ class SignatureFirstDate(PostgreSQLBase):
             'hits': signatures,
             'total': len(signatures)
         }
+
+    def post(self, **kwargs):
+        filters = [
+            ('signature', None, str),
+            ('first_report', None, datetime.datetime),
+            ('first_build', None, str),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        sql_insert = """
+            INSERT INTO signatures (signature, first_report, first_build)
+            VALUES (%s, %s, %s)
+        """
+        self.query(sql_insert, params)


### PR DESCRIPTION
@adngdb Can you please have a look and check that I've got the basics right. 

@willkg Perhaps stall reviewing. But please have a think about how/when this should be executed in docker. Basically, if you don't run this after crashes have been inserted the Top Crashers report won't work. So it should ideally be executed some time after you have run `fetch_crash_data` and that being synced. 

-----

This PR is not ready yet because it doesn't have any test coverage of the new code. I just want to get it out early. Primarily for Adrian's early feedback. 

The idea is that it's supposed to run every 1h. So 24 times per day. It's backfill based so it won't miss any time windows. 
Each hour it then does a facet search for ALL different signatures. The `_facets_size` is 1,000. 
Then once it has the signatures, it removes the ones already in the `signatures` table. 
Now for each new signature it does 2 SuperSearch queries. One by sorting on `date` ascending and one sorting by `build_id` ascending. 

One tricky thing is that when you try to find the oldest crash (by signature) you have to expand the date interval as much as possible. I picked the same number of days as there are weeks in the `index_cleaner`. Perhaps because I tested this with stage's ES1 cluster, I got lots of errors about indexes not existing when going that far back. That's stage ES for you :)
Also, I didn't want this to break and get stuck on that so I made the `sensitive_to_errors` off by default. 

Testing this is in docker is going to be hard since we have so little historic record there. I used stage's ES cluster like this:
```
python socorro/cron/jobs/first_signatures.py --date="2017-09-13T15:13:14.98765Z" --elasticsearch.elasticsearch_urls=localhost:9222
```
...using the virtualenv. 
This testing "obviously fails". Some of the signatures I found were actually first since in 2016-sometime-sometime but this crontabber app can only go back 26 weeks at best. 
However, I'm not worried because this app will slowly replace the old stored procedure that populates `signatures`. In fact, I think we should install this (when it's ready) and look at the logs to make sure it populates. We might want to randomly deleting some entries in `signatures` on stage's PG and make sure it gets filled in by this new app. 