### PR TITLE
fixes bug 1399299 - how to run webapp with DEBUG=False

### DIFF
--- a/docs/components/webapp.rst
+++ b/docs/components/webapp.rst
@@ -225,9 +225,10 @@ Running Web App in a Prod-like Way
 
 By default, for local development when you run ``docker-compose up webapp`` it
 starts the web app geared towards local development. This means it starts
-Django's ``runserver`` and you most likely have ``DEBUG=True`` in your
-``my.env`` file. That means that static assets are automatically served from
-within the individual Django apps rather than serving the minified and
+Django's ``runserver`` and you have ``DEBUG=True`` in the
+``docker/config/local_development.env`` file. That means that static
+assets are automatically served from within the individual Django
+apps rather than serving the minified and
 concatenated static assets you'd get in a production-like environment.
 
 If you want to, locally on your laptop, run the web app in a more

--- a/requirements.txt
+++ b/requirements.txt
@@ -330,3 +330,6 @@ pytest-catchlog==1.2.2 \
 Pygments==2.2.0 \
     --hash=sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d \
     --hash=sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc
+whitenoise==3.3.0 \
+    --hash=sha256:1d62a003a0ab747de96da45c831cbb512dcb7f69c1ef0bd20b1cd4ae45d8a0c4 \
+    --hash=sha256:d098327276de6fd189398a7bcb95789d1bb2d41b3e011eeae4562f6b1a107dd4

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -102,6 +102,7 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 
 MIDDLEWARE_CLASSES = (
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -442,6 +443,7 @@ STATICFILES_FINDERS = (
 )
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+
 
 PIPELINE = {
     'STYLESHEETS': PIPELINE_CSS,


### PR DESCRIPTION
This works really well actually. We talked about the confusion of why there's a `docker/config/docker_common.env` (the webapp part) and `docker/config/local_development.env` but I hope that doesn't affect this. 

Basically, when I follow the instructions I mention in `webapp.rst` I get something really close to prod. I get DEBUG disabled and I get uwsgi. And since the instructions "force" to seting `DEBUG=False` as part of it I don't need to explain how to temporarily mess with your `my.env` file. 

When I go back to regular `docker-compose up webapp` things work great still. If I edit a file like `documention.less` simply editing that file (and Ctrl-S) doesn't restart the runserver but if I make that change AND edit any .py file it does restart runserver and the changes I made in the .less file are immediately reflected. 

Also, the reason this works with httP://localhost:8000 is thanks to [`docker_common.env`](https://github.com/mozilla-services/socorro/blob/dcd868ce9933644725c99a78ed68d9b582fc0282/docker/config/docker_common.env#L111)