### PR TITLE
fixes bug 1399120 - fixes symbol upload in local dev environment

### DIFF
--- a/docker/config/docker_common.env
+++ b/docker/config/docker_common.env
@@ -89,6 +89,8 @@ processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.symbol_cache_pa
 # ------
 
 ALLOWED_HOSTS=localhost
+AWS_HOST=localstack-s3
+AWS_PORT=5000
 AWS_ACCESS_KEY=foo
 AWS_SECRET_ACCESS_KEY=foo
 CACHE_LOCATION=memcached:11211
@@ -109,5 +111,5 @@ RABBITMQ_VIRTUAL_HOST=rabbitvhost
 RAVEN_DSN=
 SECRET_KEY=secretkey
 SESSION_COOKIE_SECURE=False
-SYMBOLS_BUCKET_DEFAULT_NAME=
+SYMBOLS_BUCKET_DEFAULT_NAME=symbols
 SYMBOLS_BUCKET_EXCEPTIONS=

--- a/docker/config/local_development.env
+++ b/docker/config/local_development.env
@@ -15,3 +15,6 @@ DEBUG=True
 # static files for the webapp get put in /tmp/crashstats-static/ so we
 # need to set STATIC_ROOT to that.
 STATIC_ROOT=/tmp/crashstats-static/
+
+# For connecting to local S3, we need to connect insecurely.
+AWS_SECURE=False

--- a/webapp-django/bin/ci.sh
+++ b/webapp-django/bin/ci.sh
@@ -18,11 +18,12 @@ echo "Linting..."
 git ls-files crashstats | grep '\.py$' | xargs flake8 | bin/linting.py
 
 echo "Starting tests..."
+# Override configuration with better defaults for the tests
 export SECRET_KEY="doesn't matter, tests"
 export CACHE_BACKEND="django.core.cache.backends.locmem.LocMemCache"
 export CACHE_LOCATION="crashstats"
-export OLD_PYTHONPATH=$PYTHONPATH
-export PYTHONPATH=../:$PYTHONPATH
-FORCE_DB=true python manage.py test --noinput
-export PYTHONPATH=$OLD_PYTHONPATH
+# Change AWS_HOST to empty string so tests use boto.s3.connect_to_region
+export AWS_HOST=
+
+PYTHONPATH=../:$PYTHONPATH FORCE_DB=true python manage.py test --noinput
 echo "Tests finished."

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -536,6 +536,9 @@ ANALYZE_MODEL_FETCHES = config('ANALYZE_MODEL_FETCHES', False, cast=bool)
 # Credentials for being able to make an S3 connection
 AWS_ACCESS_KEY = config('AWS_ACCESS_KEY', None)
 AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', None)
+AWS_HOST = config('AWS_HOST', None)
+AWS_PORT = config('AWS_PORT', 0, cast=int)
+AWS_SECURE = config('AWS_SECURE', True, cast=bool)
 
 # Information for uploading symbols to S3
 SYMBOLS_BUCKET_DEFAULT_NAME = config('SYMBOLS_BUCKET_DEFAULT_NAME', '')


### PR DESCRIPTION
The local dev environment requires that we can specify host, port, and whether
to use a secure connection in order to connect to the local S3. Other parts of
Socorro already handle this, but symbol upload didn't.

This fixes that.