### PR TITLE
fixes bug 1400085 - add stdext::hash_map<T>::.* to prefix list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -206,6 +206,7 @@ std::list<.*>::.*
 std::panicking::begin_panic<.*>
 std::panicking::rust_panic_with_hook
 std::collections::hash::map::.*
+stdext::hash_map<T>::.*
 strcat
 strncmp
 ssl3_.*


### PR DESCRIPTION
Here's the change in signatures:

```
app@90ae9bd26804:/app$ python -m socorro.signature 7b1e019c-68c0-4c55-8ddc-99fe30170913
Crash id: 7b1e019c-68c0-4c55-8ddc-99fe30170913
Original: stdext::hash_map<T>::operator[]
New:      stdext::hash_map<T>::operator[] | mozilla::ipc::IToplevelProtocol::ShmemCreated
Same?:    False
```