### PR TITLE
bug 1400076 - add Antenna service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,22 @@ services:
   # External services
   # -----------------------------
 
+  # https://hub.docker.com/r/mozilla/antenna/
+  # This seems weird, but for the purposes of Socorro, we should treat
+  # it as an external service.
+  antenna:
+    image: mozilla/antenna:latest
+    environment:
+      - LOGGING_LEVEL=INFO
+      - CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
+      - CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:5000
+      - CRASHSTORAGE_REGION=us-west-2
+      - CRASHSTORAGE_ACCESS_KEY=foo
+      - CRASHSTORAGE_SECRET_ACCESS_KEY=foo
+      - CRASHSTORAGE_BUCKET_NAME=dev_bucket
+    ports:
+      - "8888:8000"
+
   # https://hub.docker.com/r/kamon/grafana_graphite/
   # username: admin, password: admin
   statsd:

--- a/docs/components/processor.rst
+++ b/docs/components/processor.rst
@@ -179,6 +179,28 @@ For example::
    Processing will fail unless the crash data is in the S3 container first!
 
 
+Processing crashes from Antenna
+===============================
+
+`Antenna <https://antenna.readthedocs.io/>`_ is the collector of the Socorro
+crash ingestion pipeline. It was originally part of the Socorro repository, but
+we extracted and rewrote it and now it lives in its own repository and
+infrastructure.
+
+Antenna deployments are based on images pushed to Docker Hub.
+
+To run Antenna in the Socorro local dev environment, do::
+
+  $ docker-compose up antenna
+
+
+It will listen on ``http://localhost:8888/`` for incoming crashes from a
+breakpad crash reporter. It will save crash data to the ``dev_bucket`` in the
+local S3 which is where the processor looks for it.
+
+FIXME(willkg): How to get crash ids into the processing queue?
+
+
 .. Warning::
 
    August 17th, 2017: Everything below this point is outdated.


### PR DESCRIPTION
This completes the local development crash ingestion pipeline by adding the
Antenna service and pointing it to the local S3 `dev_bucket`.