### PR TITLE
fixes bug 1400301 Add rtc::FatalMessage -- webrtc.org's impl for RTC_CHECK/RTC_DCHECK/etc

### DIFF
--- a/socorro/siglists/irrelevant_signature_re.txt
+++ b/socorro/siglists/irrelevant_signature_re.txt
@@ -46,6 +46,7 @@ nvmap@0x.*
 org\.mozilla\.f.*-\d\.apk@0x.*
 PR_WaitCondVar
 RaiseException
+rtc::FatalMessage.*
 RtlpAdjustHeapLookasideDepth
 std::_Atomic_fetch_add_4
 std::panicking::.*


### PR DESCRIPTION
Any assertion within media/webrtc/trunk/webrtc (webrtc imported code) ends up in rtc::FatalMessage::~FatalMessage right now, regardless of which assert it is.