### PR TITLE
fixes bug 1400402 - add --signature-contains to fetch_crashids script

### DIFF
--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -143,12 +143,9 @@ def main(argv):
         print('Using api token: %s%s' % (api_token[:4], 'x' * (len(api_token) - 4)))
 
     # This will pull crash ids from the command line if specified, otherwise it'll pull from stdin
-    if args.crashid:
-        crashids_iteratable = args.crashid
-    else:
-        crashids_iteratable = sys.stdin
+    crashids_iterable = args.crashid or sys.stdin
 
-    for crash_id in crashids_iteratable:
+    for crash_id in crashids_iterable:
         crash_id = crash_id.strip()
 
         print('Working on %s...' % crash_id)

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -66,8 +66,12 @@ def main(argv):
         help='Date to pull crash ids from (YYYY-MM-DD)'
     )
     parser.add_argument(
+        '--signature-contains', default='', dest='signature',
+        help='Signature contains this string'
+    )
+    parser.add_argument(
         '--url', default='',
-        help='Super Search url to pull crash ids from'
+        help='Super Search url to base query on'
     )
     parser.add_argument(
         '--num', default=100, type=int,
@@ -80,6 +84,7 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
+    # Start with params from --url value or product=Firefox
     if args.url:
         params = extract_params(args.url)
     else:
@@ -87,6 +92,7 @@ def main(argv):
             'product': 'Firefox'
         }
 
+    # Override with date if specified
     datestamp = args.date
     if 'date' not in params or datestamp != 'yesterday':
         if datestamp == 'yesterday':
@@ -99,6 +105,11 @@ def main(argv):
             '>=%s' % startdate.strftime('%Y-%m-%d'),
             '<%s' % enddate.strftime('%Y-%m-%d')
         ]
+
+    # Override with signature-contains if specified
+    sig = args.signature
+    if sig:
+        params['signature'] = '~' + sig
 
     params.update({
         '_results_number': args.num,

--- a/socorro/signature/README.rst
+++ b/socorro/signature/README.rst
@@ -20,15 +20,20 @@ To use::
     $ python -m socorro.signature CRASHID [CRASHID ...]
 
 
-Pulling crash ids from a file::
+Pulling crash ids from the file ``crashids.txt``::
 
-    $ cat crashids.txt | xargs python -m socorro.signature
+    $ cat crashids.txt | python -m socorro.signature
+
+
+Pulling crash ids from another script::
+
+    $ ./scripts/fetch_crashids.py --num=10 | python -m socorro.signature
 
 
 Spitting output in CSV format to more easily analyze results for generating
 signatures for multiple crashes::
 
-    $ cat crashids.txt | xargs python -m socorro.signature --format=csv
+    $ cat crashids.txt | python -m socorro.signature --format=csv
 
 
 For more argument help, see::

--- a/socorro/signature/__main__.py
+++ b/socorro/signature/__main__.py
@@ -18,8 +18,8 @@ from socorro.signature import SignatureGenerator
 
 
 DESCRIPTION = """
-Given crash ids, pulls down information from Socorro, generates signatures, and prints
-signature information.
+Given one or more crash ids via command line or stdin (one per line), pulls down information from
+Socorro, generates signatures, and prints signature information.
 """
 
 EPILOG = """
@@ -151,7 +151,7 @@ def main(args):
         '--format', help='specify output format: csv, text (default)'
     )
     parser.add_argument(
-        'crashids', metavar='crashid', nargs='+', help='crash id to generate signatures for'
+        'crashids', metavar='crashid', nargs='*', help='crash id to generate signatures for'
     )
     args = parser.parse_args()
 
@@ -170,9 +170,12 @@ def main(args):
     setup_logging(logging_level)
 
     generator = SignatureGenerator(debug=args.verbose)
+    crashids_iterable = args.crashids or sys.stdin
 
     with outputter() as out:
-        for crash_id in args.crashids:
+        for crash_id in crashids_iterable:
+            crash_id = crash_id.strip()
+
             resp = fetch('/RawCrash/', crash_id, api_token)
             if resp.status_code == 404:
                 out.warning('%s: does not exist.' % crash_id)


### PR DESCRIPTION
This makes it muuuuch easier to test and regression test signature generation
changes.

OMG--this is so amazing. For example, with pull #3992, I could have done this instead:

```
app@175a03e184c1:/app$ ./scripts/fetch_crashids.py --num=5 "--signature-contains=std::_Hash<T>" | xargs python -m socorro.signature
Crash id: 65d1e40a-be91-442c-a244-6f73c0170915
Original: std::_Hash<T>::lower_bound
New:      std::_Hash<T>::lower_bound | CDevice::CreateRasterizerState_Worker
Same?:    False
Crash id: c1a47f6d-f686-4888-bfe7-d980e0170915
Original: std::_Hash<T>::lower_bound
New:      std::_Hash<T>::lower_bound | CDevice::CreateRasterizerState_Worker
Same?:    False
Crash id: 265e6b4f-36b1-4ad6-9190-c62810170915
Original: shutdownhang | ZwWaitForKeyedEvent | RtlSleepConditionVariableCS | std::_Hash<T>::_Insert<T>
New:      shutdownhang | ZwWaitForKeyedEvent | RtlSleepConditionVariableCS | std::_Hash<T>::_Insert<T> | mozilla::detail::ConditionVariableImpl::wait | mozilla::CondVar::Wait | nsEventQueue::GetEvent | nsThread::nsChainedEventQueue::GetEvent | nsThread::GetEvent...
Same?:    False
Notes:    (1)
          SignatureTool: signature truncated due to length
Crash id: 0f9bbd54-058c-4b9b-979a-664010170915
Original: std::_Hash<T>::_End
New:      std::_Hash<T>::_End | std::_Hash<T>::equal_range | mozilla::gfx::DrawEventRecorderPrivate::RemoveStoredObject
Same?:    False
Crash id: 02103e8e-f634-4a15-9116-0f10b0170915
Original: std::_Hash<T>::_End
New:      std::_Hash<T>::_End | std::_Hash<T>::equal_range | mozilla::gfx::DrawEventRecorderPrivate::RemoveStoredObject
Same?:    False
```

That information is super interesting and helpful in regards to understanding how the signature change will affect things in addition to testing the specific examples from the bug.