### PR TITLE
bug 1399979 - move environment vars around

### DIFF
--- a/docker/config/docker_common.env
+++ b/docker/config/docker_common.env
@@ -2,8 +2,8 @@
 # Environment-specific configuration
 # -------------------------------------------------------------
 
-# These configuration variable values match the environment created using
-# docker-compose for the purposes of local development.
+# These configuration variable values are for a local dev environment that
+# uses docker-compose.
 #
 # To create configuration for a server environment, you can copy this file
 # and then update the values with hosts, usernames, passwords, and such
@@ -66,7 +66,6 @@ resource.elasticsearch.elasticSearchHostname=elasticsearch
 
 resource.boto.host=localstack-s3
 resource.boto.port=5000
-resource.boto.secure=false
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
 resource.boto.bucket_name=dev_bucket
@@ -110,6 +109,5 @@ RABBITMQ_PASSWORD=rabbitpwd
 RABBITMQ_VIRTUAL_HOST=rabbitvhost
 RAVEN_DSN=
 SECRET_KEY=secretkey
-SESSION_COOKIE_SECURE=False
 SYMBOLS_BUCKET_DEFAULT_NAME=symbols
 SYMBOLS_BUCKET_EXCEPTIONS=

--- a/docker/config/local_development.env
+++ b/docker/config/local_development.env
@@ -18,3 +18,8 @@ STATIC_ROOT=/tmp/crashstats-static/
 
 # For connecting to local S3, we need to connect insecurely.
 AWS_SECURE=False
+resource.boto.secure=false
+
+# For webapp sessions, we need to allow cookies to be sent insecurely
+# since it's using HTTP and not HTTPS.
+SESSION_COOKIE_SECURE=False


### PR DESCRIPTION
This moves another couple of environment variables that should never get set
this way in a server environment into the local_development.env file where they
should be.