### PR TITLE
fixes bug 1394834 - fix alembic in local dev environment

### DIFF
--- a/docker/config/alembic.ini
+++ b/docker/config/alembic.ini
@@ -11,8 +11,6 @@ file_template = %%(rev)s_%%(slug)s
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test
-
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -29,12 +29,7 @@ resource.postgresql.database_port=5432
 secrets.postgresql.database_username=postgres
 secrets.postgresql.database_password=aPassword
 
-# resource.postgresql.database_replication_hostname=
-# secrets.postgresql.database_replication_password=
-# secrets.postgresql.database_replication_username=
-
-# postgres things for alembic
-# FIXME - sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test
+sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/breakpad
 
 # statsd
 # ------


### PR DESCRIPTION
Prior to this fix, alembic had the wrong sqlalchemy.url, so it was tricky to do
migration testing in the local dev environment.