### PR TITLE
bug 1296238 - reduce vars in local_dev.env

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -13,23 +13,15 @@
 # -------
 
 alembic_config=/app/docker/config/alembic.ini
+sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/breakpad
 
 # postgres
 # --------
-
-database_hostname=postgresql
-database_port=5432
-database_username=postgres
-database_password=aPassword
-database_superusername=postgres
-database_superuserpassword=aPassword
 
 resource.postgresql.database_hostname=postgresql
 resource.postgresql.database_port=5432
 secrets.postgresql.database_username=postgres
 secrets.postgresql.database_password=aPassword
-
-sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/breakpad
 
 # statsd
 # ------
@@ -52,9 +44,7 @@ secrets.rabbitmq.rabbitmq_password=rabbitpwd
 # elasticsearch
 # -------------
 
-elasticsearch_url=http://elasticsearch:9200
 resource.elasticsearch.elasticsearch_urls=http://elasticsearch:9200
-resource.elasticsearch.elasticSearchHostname=elasticsearch
 
 # boto
 # ----
@@ -89,11 +79,6 @@ AWS_ACCESS_KEY=foo
 AWS_SECRET_ACCESS_KEY=foo
 CACHE_LOCATION=memcached:11211
 DATABASE_URL=postgres://postgres:aPassword@postgresql:5432/breakpad
-DATABASE_USER=postgres
-DATASERVICE_DATABASE_HOSTNAME=postgresql
-DATASERVICE_DATABASE_PASSWORD=aPassword
-DATASERVICE_DATABASE_PORT=5432
-DATASERVICE_DATABASE_USERNAME=postgres
 ELASTICSEARCH_URLS=http://elasticsearch:9200
 GOOGLE_ANALYTICS_ID=
 OAUTH2_CLIENT_ID=

--- a/docker/config/never_on_a_server.env
+++ b/docker/config/never_on_a_server.env
@@ -23,3 +23,8 @@ resource.boto.secure=false
 # For webapp sessions, we need to allow cookies to be sent insecurely
 # since it's using HTTP and not HTTPS.
 SESSION_COOKIE_SECURE=False
+
+# These are used by setupdb_app and tests and are for a user that has
+# access to create new databases.
+database_superusername=postgres
+database_superuserpassword=aPassword

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -1,4 +1,4 @@
-# Environment variables used by the unittests and webapp tests.
+# Environment variables used by the Socorro unittests and webapp tests.
 
 # alembic configuration location
 alembic_config=/app/docker/config/alembic.ini
@@ -9,3 +9,11 @@ resource.fs.fs_root=/tmp/test_crashes
 # use socorro_integration_test for postgres and alembic
 database_url=postgres://postgres:aPassword@postgresql:5432/socorro_integration_test
 sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test
+
+# used for PostgresSQLTestCase derivatives
+# FIXME(willkg): Why can't the tests use the resource.postgresql.* variables
+# that already exist?
+database_hostname=postgresql
+database_port=5432
+database_username=postgres
+database_password=aPassword


### PR DESCRIPTION
This removes a bunch of unneeded vars from local_dev.env and moves a few others
to better files.