### PR TITLE
bug 1390530 - Add https scheme to crash-stats CSP srcs

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -731,8 +731,8 @@ CSP_OBJECT_SRC = (
 )
 CSP_SCRIPT_SRC = (
     "'self'",
-    'apis.google.com',
-    'www.google-analytics.com',
+    'https://apis.google.com',
+    'https://www.google-analytics.com',
 )
 CSP_STYLE_SRC = (
     "'self'",
@@ -745,7 +745,7 @@ CSP_IMG_SRC = (
 )
 CSP_CHILD_SRC = (
     "'self'",
-    'accounts.google.com',  # Google Sign-In uses an iframe
+    'https://accounts.google.com',  # Google Sign-In uses an iframe
 )
 CSP_CONNECT_SRC = (
     "'self'",


### PR DESCRIPTION
fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1390530

As April pointed out these domains the HSTS preloaded, so this will only help people with older browsers that don't support HSTS.

This also makes things consistent with the img-src.

r? @peterbe or @willkg