### PR TITLE
fixes bug 1397926 - remove [clone .cold.xxx] from signatures

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -206,7 +206,15 @@ class CSignatureTool(SignatureTool):
                     '',
                     ('anonymous namespace', 'operator')
                 )
-
+            if 'clone .cold' in function:
+                # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
+                function = self._collapse(
+                    function,
+                    '[',
+                    '',
+                    ']',
+                    ''
+                )
             if self.signatures_with_line_numbers_re.match(function):
                 function = "%s:%s" % (function, line)
             # Remove spaces before all stars, ampersands, and commas


### PR DESCRIPTION
GCC 6 includes an optimizer that identifies hot and cold code sections and marks
them. That messes up signatures because it includes a number at the end that
changes.

This strips the frame function of that tawdry bit so as to make signatures
bucket better.