### PR TITLE
fixes bug 13785966 - fix UnicodeEncodeError in AbortSignature

### DIFF
--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -8,6 +8,22 @@ import threading
 import traceback
 
 
+def drop_unicode(text):
+    """Takes a text and drops all unicode characters
+
+    :arg str/unicode text: the text to fix
+
+    :returns: text with all unicode characters dropped
+
+    """
+    if isinstance(text, str):
+        # Convert any str to a unicode so that we can convert it back and drop any non-ascii
+        # characters
+        text = text.decode('unicode_escape')
+
+    return text.encode('ascii', 'ignore')
+
+
 class FakeLogger(object):
     loggingLevelNames = {
         logging.DEBUG: "DEBUG",

--- a/socorro/unittest/lib/test_util.py
+++ b/socorro/unittest/lib/test_util.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from socorro.lib.util import drop_unicode
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('', ''),
+    (u'', ''),
+
+    ('123', '123'),
+    (u'123', '123'),
+
+    # Drop any unicode characters
+    ('1\xc6\x8a23', '123'),
+    (u'1\u018a23', '123'),
+])
+def test_drop_unicode(text, expected):
+    assert drop_unicode(text) == expected


### PR DESCRIPTION
This fixes the UnicodeEncodeError in AbortSignature by stripping abort_message
of unicode characters.

This also fixes a bucketing issue for "unable to find a usable font (...)" where
the ... part contains a number of different fonts, thus all these crashes are
falling into separate buckets. This removes that parenthesized bit.