### PR TITLE
bug 1402037 - improve shutdownhang signatures

### DIFF
--- a/socorro/siglists/irrelevant_signature_re.txt
+++ b/socorro/siglists/irrelevant_signature_re.txt
@@ -48,7 +48,7 @@ nsThread::GetEvent
 nsThread::nsChainedEventQueue::GetEvent
 nsThread::ProcessNextEvent
 NS_ProcessNextEvent
-NtWaitForKeyedEvent
+(Nt|Zw)?WaitForKeyedEvent
 (Nt|Zw)?WaitForSingleObject(Ex)?
 (Nt|Zw)?WaitForMultipleObjects(Ex)?
 nvmap@0x.*
@@ -70,4 +70,3 @@ WaitForMultipleObjectsExImplementation
 RealMsgWaitFor.*
 _ZdlPv
 zero
-ZwWaitForKeyedEvent

--- a/socorro/siglists/irrelevant_signature_re.txt
+++ b/socorro/siglists/irrelevant_signature_re.txt
@@ -37,9 +37,18 @@ mnt@asec@org\.mozilla\.f.*-\d@pkg\.apk@classes\.dex@0x.*
 MOZ_Assert
 MOZ_Crash
 mozcrt19.dll@0x.*
+mozilla::CondVar::Wait
+mozilla::detail::ConditionVariableImpl.*
 mozilla::gfx::Log<.*
 mozilla::ipc::RPCChannel::Call
+mozilla::ThreadEventQueue.*
+nsEventQueue::GetEvent
 _NSRaiseError
+nsThread::GetEvent
+nsThread::nsChainedEventQueue::GetEvent
+nsThread::ProcessNextEvent
+NS_ProcessNextEvent
+NtWaitForKeyedEvent
 (Nt|Zw)?WaitForSingleObject(Ex)?
 (Nt|Zw)?WaitForMultipleObjects(Ex)?
 nvmap@0x.*
@@ -48,6 +57,10 @@ PR_WaitCondVar
 RaiseException
 rtc::FatalMessage.*
 RtlpAdjustHeapLookasideDepth
+RtlSleepConditionVariableCS
+RtlSleepConditionVariableSRW
+SleepConditionVariableCS
+SleepConditionVariableSRW
 std::_Atomic_fetch_add_4
 std::panicking::.*
 system@framework@.*\.jar@classes\.dex@0x.*
@@ -57,3 +70,4 @@ WaitForMultipleObjectsExImplementation
 RealMsgWaitFor.*
 _ZdlPv
 zero
+ZwWaitForKeyedEvent


### PR DESCRIPTION
We have a number of shutdownhang signatures where the stack is rife with
"uninteresting" bits such that the signature gets truncated before getting to
something interesting or relevant or actionable.

This adds a bunch of things to the irrelevant list such that they don't show up
in the signature.

I did some regression testing and these strings only show up in shutdownhang
crashes. If that changes, we should rethink them on a string-by-string basis.