### PR TITLE
Move fxtest-library include into pipeline block

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('fxtest@1.9') _
-
 /** Desired capabilities */
 def capabilities = [
   browserName: 'Firefox',
@@ -9,6 +7,9 @@ def capabilities = [
 
 pipeline {
   agent any
+  libraries {
+    lib('fxtest@1.9')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
@chartjes r?  This small change was recommended by a core Jenkins CI project member, and brings this repo in-line with all the other web-automation suites.

Full passing output: https://gist.github.com/stephendonner/55f723f7b804b8e5f3df0ddcfe84c892