### PR TITLE
fixes bug 1280374 - reset additional_minidumps every time

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -202,8 +202,8 @@ class BreakpadStackwalkerRule(Rule):
         return stackwalker_data
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        if 'additional_minidumps' not in processed_crash:
-            processed_crash.additional_minidumps = []
+        processed_crash.additional_minidumps = []
+
         with self._temp_raw_crash_json_file(
             raw_crash,
             raw_crash.uuid


### PR DESCRIPTION
If you process a crash, it sets "additional_minidumps". However, if you
re-process a crash, it appends to that field. That's totally not the right thing
to do.

This fixes it so that it always resets the value of that field.