### PR TITLE
fixes bug 1403172 - add android-api-16 and mozilla-central-android-api-16

### DIFF
--- a/alembic/versions/77856f165be7_bug_1403172_fix_fennecandroid_api_16.py
+++ b/alembic/versions/77856f165be7_bug_1403172_fix_fennecandroid_api_16.py
@@ -23,17 +23,12 @@ from sqlalchemy.sql import table, column
 def upgrade():
     op.execute("""
     INSERT INTO release_repositories VALUES ('mozilla-central-android-api-16');
-    INSERT INTO release_repositories VALUES ('mozilla-aurora-android-api-16');
     INSERT INTO release_repositories VALUES ('mozilla-beta-android-api-16');
     INSERT INTO release_repositories VALUES ('mozilla-release-android-api-16');
     INSERT INTO special_product_platforms
         (platform, repository, release_channel, release_name, product_name, min_version)
     VALUES
         ('android-arm', 'mozilla-central-android-api-16', 'nightly', 'mobile', 'FennecAndroid', '37.0');
-    INSERT INTO special_product_platforms
-        (platform, repository, release_channel, release_name, product_name, min_version)
-    VALUES
-        ('android-arm', 'mozilla-aurora-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0');
     INSERT INTO special_product_platforms
         (platform, repository, release_channel, release_name, product_name, min_version)
     VALUES
@@ -48,7 +43,6 @@ def upgrade():
 def downgrade():
     op.execute("""
     DELETE FROM release_repositories WHERE repository = 'mozilla-central-android-api-16';
-    DELETE FROM release_repositories WHERE repository = 'mozilla-aurora-android-api-16';
     DELETE FROM release_repositories WHERE repository = 'mozilla-beta-android-api-16';
     DELETE FROM release_repositories WHERE repository = 'mozilla-release-android-api-16';
     DELETE FROM special_product_platforms
@@ -56,14 +50,6 @@ def downgrade():
         platform = 'android-arm'
         AND repository = 'mozilla-central-android-api-16'
         AND release_channel = 'nightly'
-        AND release_name = 'mobile'
-        AND product_name = 'FennecAndroid'
-        AND min_version = '37.0';
-    DELETE FROM special_product_platforms
-    WHERE
-        platform = 'android-arm'
-        AND repository = 'mozilla-aurora-android-api-16'
-        AND release_channel = 'aurora'
         AND release_name = 'mobile'
         AND product_name = 'FennecAndroid'
         AND min_version = '37.0';

--- a/alembic/versions/77856f165be7_bug_1403172_fix_fennecandroid_api_16.py
+++ b/alembic/versions/77856f165be7_bug_1403172_fix_fennecandroid_api_16.py
@@ -1,0 +1,86 @@
+"""bug 1403172 fix fennecandroid api 16
+
+Revision ID: 77856f165be7
+Revises: a38b03765a79
+Create Date: 2017-09-28 20:41:56.221487
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '77856f165be7'
+down_revision = 'a38b03765a79'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+
+def upgrade():
+    op.execute("""
+    INSERT INTO release_repositories VALUES ('mozilla-central-android-api-16');
+    INSERT INTO release_repositories VALUES ('mozilla-aurora-android-api-16');
+    INSERT INTO release_repositories VALUES ('mozilla-beta-android-api-16');
+    INSERT INTO release_repositories VALUES ('mozilla-release-android-api-16');
+    INSERT INTO special_product_platforms
+        (platform, repository, release_channel, release_name, product_name, min_version)
+    VALUES
+        ('android-arm', 'mozilla-central-android-api-16', 'nightly', 'mobile', 'FennecAndroid', '37.0');
+    INSERT INTO special_product_platforms
+        (platform, repository, release_channel, release_name, product_name, min_version)
+    VALUES
+        ('android-arm', 'mozilla-aurora-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0');
+    INSERT INTO special_product_platforms
+        (platform, repository, release_channel, release_name, product_name, min_version)
+    VALUES
+        ('android-arm', 'mozilla-beta-android-api-16', 'beta', 'mobile', 'FennecAndroid', '37.0');
+    INSERT INTO special_product_platforms
+        (platform, repository, release_channel, release_name, product_name, min_version)
+    VALUES
+        ('android-arm', 'mozilla-release-android-api-16', 'release', 'mobile', 'FennecAndroid', '37.0');
+    """)
+
+
+def downgrade():
+    op.execute("""
+    DELETE FROM release_repositories WHERE repository = 'mozilla-central-android-api-16';
+    DELETE FROM release_repositories WHERE repository = 'mozilla-aurora-android-api-16';
+    DELETE FROM release_repositories WHERE repository = 'mozilla-beta-android-api-16';
+    DELETE FROM release_repositories WHERE repository = 'mozilla-release-android-api-16';
+    DELETE FROM special_product_platforms
+    WHERE
+        platform = 'android-arm'
+        AND repository = 'mozilla-central-android-api-16'
+        AND release_channel = 'nightly'
+        AND release_name = 'mobile'
+        AND product_name = 'FennecAndroid'
+        AND min_version = '37.0';
+    DELETE FROM special_product_platforms
+    WHERE
+        platform = 'android-arm'
+        AND repository = 'mozilla-aurora-android-api-16'
+        AND release_channel = 'aurora'
+        AND release_name = 'mobile'
+        AND product_name = 'FennecAndroid'
+        AND min_version = '37.0';
+    DELETE FROM special_product_platforms
+    WHERE
+        platform = 'android-arm'
+        AND repository = 'mozilla-beta-android-api-16'
+        AND release_channel = 'beta'
+        AND release_name = 'mobile'
+        AND product_name = 'FennecAndroid'
+        AND min_version = '37.0';
+    DELETE FROM special_product_platforms
+    WHERE
+        platform = 'android-arm'
+        AND repository = 'mozilla-release-android-api-16'
+        AND release_channel = 'release'
+        AND release_name = 'mobile'
+        AND product_name = 'FennecAndroid'
+        AND min_version = '37.0';
+    """)

--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -148,7 +148,7 @@ class ScrapersMixin(object):
 
         possible_platforms = (
             'linux', 'mac', 'win', 'debug',  # for Firefox
-            'android-api-15', 'android-x86',  # for mobile
+            'android-api-16', 'android-api-15', 'android-x86',  # for mobile
         )
 
         for platform in possible_platforms:

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -123,6 +123,7 @@ class ReleaseRepositories(BaseTable):
         ['mozilla-aurora-android-api-15'],
         ['mozilla-beta-android-api-15'],
         ['mozilla-release-android-api-15'],
+        ['mozilla-central-android-api-16'],
         ['mozilla-esr38'],
         ['mozilla-esr45'],
         ['comm-esr38'],
@@ -265,7 +266,11 @@ class SpecialProductPlatforms(BaseTable):
         ['android-arm', 'mozilla-central-android-api-15', 'nightly', 'mobile', 'FennecAndroid', '37.0'],
         ['android-arm', 'mozilla-aurora-android-api-15', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
         ['android-arm', 'mozilla-beta-android-api-15', 'beta', 'mobile', 'FennecAndroid', '37.0'],
-        ['android-arm', 'mozilla-release-android-api-15', 'release', 'mobile', 'FennecAndroid', '37.0']
+        ['android-arm', 'mozilla-release-android-api-15', 'release', 'mobile', 'FennecAndroid', '37.0'],
+
+        # FennecAndroid 56+
+        ['android-arm', 'mozilla-aurora-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-central-android-api-16', 'nightly', 'mobile', 'FennecAndroid', '37.0'],
     ]
 
 

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -269,8 +269,9 @@ class SpecialProductPlatforms(BaseTable):
         ['android-arm', 'mozilla-release-android-api-15', 'release', 'mobile', 'FennecAndroid', '37.0'],
 
         # FennecAndroid 56+
-        ['android-arm', 'mozilla-aurora-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
         ['android-arm', 'mozilla-central-android-api-16', 'nightly', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-beta-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
+        ['android-arm', 'mozilla-release-android-api-16', 'aurora', 'mobile', 'FennecAndroid', '37.0'],
     ]
 
 


### PR DESCRIPTION
FennecAndroid builds are now coming from the mozilla-central-android-api-16
repository, so we need to add support for that otherwise we don't see builds.