### PR TITLE
Restoring SeaMonkey to list of expected products

### DIFF
--- a/e2e-tests/tests/test_crash_reports.py
+++ b/e2e-tests/tests/test_crash_reports.py
@@ -15,7 +15,8 @@ class TestCrashReports:
     _expected_products = [
         'Firefox',
         'Thunderbird',
-        'FennecAndroid']
+        'FennecAndroid',
+        'SeaMonkey']
 
     @pytest.mark.nondestructive
     def test_that_bugzilla_link_contain_current_site(self, base_url, selenium):


### PR DESCRIPTION
Bug 1351757 was resolved as invalid, and the SeaMonkey product is expected in the list.