### PR TITLE
Bug 1292594 - Remove test_that_products_are_sorted_correctly

### DIFF
--- a/e2e-tests/pages/base_page.py
+++ b/e2e-tests/pages/base_page.py
@@ -89,11 +89,6 @@ class CrashStatsBasePage(Page):
             select = Select(element)
             return select.first_selected_option.text
 
-        @property
-        def product_list(self):
-            element = self.find_element(*self._product_select_locator)
-            return [option.text for option in Select(element).options]
-
         def select_product(self, application):
             '''
                 Select the Mozilla Product you want to report on

--- a/e2e-tests/tests/test_crash_reports.py
+++ b/e2e-tests/tests/test_crash_reports.py
@@ -33,14 +33,6 @@ class TestCrashReports:
         assert 'Login Required' in csp.page_heading
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="bug 1351757: Cease exposing SeaMonkey and bug 1292594: Fennec shouldn't be an option")
-    def test_that_products_are_sorted_correctly(self, base_url, selenium):
-        csp = CrashStatsHomePage(selenium, base_url).open()
-        products = csp.header.product_list
-
-        assert self._expected_products == products, 'Expected products not in the product dropdown'
-
-    @pytest.mark.nondestructive
     @pytest.mark.parametrize('product', _expected_products)
     def test_that_reports_form_has_same_product(self, base_url, selenium, product):
         csp = CrashStatsHomePage(selenium, base_url).open()


### PR DESCRIPTION
After some discussion it has been decided that this test is not providing enough value, especially as it has been marked as expected to fail for at least six months.