### PR TITLE
bug 1405679 - add submitter as a docker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,25 @@ services:
     volumes:
       - .:/app
 
+  # Submitter app
+  #
+  # NOTE(willkg): This app runs only in -prod and lets us slurp crashes from
+  # -prod to -stage. This service is here so we can test changes to the
+  # submitter, but you should probably never need to run this in your local
+  # development environment. It does configuration differently than all the
+  # other services because otherwise we end up with conflicts with things
+  # we care about.
+  submitter:
+    image: local/socorro_processor
+    env_file:
+      - docker/config/local_dev_submitter.env
+      - my.env
+    depends_on:
+      - rabbitmq
+    command: ["/app/docker/run_submitter.sh"]
+    volumes:
+      - .:/app
+
   # -----------------------------
   # External services
   # -----------------------------

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -68,7 +68,6 @@ companion_process.symbol_cache_path=/tmp/symbols/cache
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.command_line=timeout -s KILL 600 {command_pathname} --raw-json {raw_crash_pathname} --symbols-url {public_symbols_url} --symbols-url {private_symbols_url} --symbols-cache /tmp/symbols/cache --symbols-tmp /tmp/symbols/tmp {dump_file_pathname} 2> /dev/null
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.symbol_cache_path=/tmp/symbols/cache
 
-
 # webapp
 # ------
 

--- a/docker/config/local_dev_submitter.env
+++ b/docker/config/local_dev_submitter.env
@@ -1,0 +1,35 @@
+# Submitter configuration file covering all configuration for the stage
+# submitter
+
+# NOTE: Configuration for the submitter is different than all other components
+# because otherwise we'd have conflicts with things we care about.
+
+# ----------------------------------------------------------------------------------
+# from socorro/submitter
+# ----------------------------------------------------------------------------------
+
+destination.crashstorage_class=socorro.submitter.breakpad_submitter_utilities.BreakpadPOSTDestination
+destination.url=http://antenna:8888/
+
+source.crashstorage_class=socorro.external.boto.crashstorage.BotoS3CrashStorage
+source.temporary_file_system_storage_path=/tmp
+
+new_crash_source.crashstorage_class=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
+new_crash_source.new_crash_source_class=socorro.external.rabbitmq.rmq_new_crash_source.RMQNewCrashSource
+new_crash_source.filter_on_legacy_processing=False
+new_crash_source.priority_queue_name=socorro.stagesubmitter
+new_crash_source.reprocessing_queue_name=socorro.stagesubmitter
+new_crash_source.standard_queue_name=socorro.stagesubmitter
+new_crash_source.routing_key=socorro.stagesubmitter
+producer_consumer.number_of_threads=2
+producer_consumer.producer_consumer_class=socorro.lib.threaded_task_manager.ThreadedTaskManager
+submitter.delay=0.0
+submitter.number_of_submissions=forever
+
+# Note: These are local dev environment values.
+new_crash_source.host=rabbitmq
+new_crash_source.virtual_host=rabbitvhost
+resource.rabbitmq.host=rabbitmq
+resource.rabbitmq.virtual_host=rabbitvhost
+secrets.rabbitmq.rabbitmq_user=rabbituser
+secrets.rabbitmq.rabbitmq_password=rabbitpwd

--- a/docker/run_submitter.sh
+++ b/docker/run_submitter.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Runs stage submitter in a local dev environment.
+
+# NOTE(willkg): Don't use this in a server environment. If we ever get to the
+# point where we want to run this in a server environment with this scaffolding,
+# we should redo it.
+
+set -e
+
+# Run submitter sleeping 1 minute between runs
+while true
+do
+    python socorro/submitter/submitter_app.py || true
+    echo "Sleep 1 minutes..."
+    sleep 60
+done

--- a/docker/run_submitter.sh
+++ b/docker/run_submitter.sh
@@ -16,6 +16,6 @@ set -e
 while true
 do
     python socorro/submitter/submitter_app.py || true
-    echo "Sleep 1 minutes..."
+    echo "Sleep 1 minute..."
     sleep 60
 done


### PR DESCRIPTION
This adds the submitter as a docker service with configuration and a run script.
This is different than other services because the configuration conflicts with
configuration for other services.

For now, I'm just slapping this together for the purposes of being able to test
changes to the submitter in the local development environment. If we decide to
use this for other purposes, we can redo it then.