### PR TITLE
bug 1407980 - use antenna dev script to alleviate missing bucket issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,12 @@ services:
   # -----------------------------
 
   # https://hub.docker.com/r/mozilla/antenna/
+  #
   # This seems weird, but for the purposes of Socorro, we should treat
   # it as an external service.
+  #
+  # This uses the development ./bin/run_web.sh script from the Antenna
+  # container since that creates a bucket before running Antenna.
   antenna:
     image: mozilla/antenna:latest
     environment:
@@ -101,6 +105,7 @@ services:
       - CRASHSTORAGE_BUCKET_NAME=dev_bucket
     ports:
       - "8888:8000"
+    command: ./bin/run_web.sh
 
   # https://hub.docker.com/r/kamon/grafana_graphite/
   # username: admin, password: admin


### PR DESCRIPTION
Bug #1407980 covers how Antenna says absolutely nothing helpful if the bucket it needs to use isn't there. That's annoying and should get fixed.

In the meantime, we (Socorro) can use the dev `bin/run_web.sh` script from the Antenna container which creates the bucket if it doesn't exist and then runs Antenna instead of using the image default command. That gets us around our issue nicely.

This implements that.

To test, run:

```
$ docker-compose up antenna
```

Towards the top of the output, you will see this line:

```
antenna_1        | Checking to see if bucket "dev_bucket" exists...
```

Then depending on if the bucket exists for you, you might also see these lines:

```
antenna_1        | An error occurred (404) when calling the HeadBucket operation: Not Found
antenna_1        | Bucket not found. Creating dev_bucket ...
antenna_1        | Bucket created.
```

What you won't see is Antenna shutting down with something unhelpfully vague like this:

```
antenna_1        | [2017-10-16 20:21:41 +0000] [7] [INFO] Shutting down: Master
antenna_1        | [2017-10-16 20:21:41 +0000] [7] [INFO] Reason: Worker failed to boot.
```