### PR TITLE
Bug 1409425 - Add mozilla::PrioritizedEventQueue<T>::GetEvent to the …

### DIFF
--- a/socorro/siglists/irrelevant_signature_re.txt
+++ b/socorro/siglists/irrelevant_signature_re.txt
@@ -46,6 +46,7 @@ nsEventQueue::GetEvent
 _NSRaiseError
 nsThread::GetEvent
 nsThread::nsChainedEventQueue::GetEvent
+mozilla::PrioritizedEventQueue<T>::GetEvent
 nsThread::ProcessNextEvent
 NS_ProcessNextEvent
 (Nt|Zw)?WaitForKeyedEvent


### PR DESCRIPTION
…irrelevant signature list.