### PR TITLE
Fix bug 1400952: Update Breakpad to a more recent version.

### DIFF
--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -415,6 +415,7 @@ int main(int argc, char** argv)
       if (p && (p - line == 8 || p - line == 16) && !strstr(line, "<.data>:")) {
         frame.instruction = strtoull(line, nullptr, 16);
         symbolizer.FillSourceLineInfo(module_list,
+                                      NULL, // unloaded_modules
                                       &system_info,
                                       &frame);
         print_frame(frame, last_frame);

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -140,6 +140,7 @@ public:
                                               StackFrame* stack_frame) {
     SymbolizerResult res =
       StackFrameSymbolizer::FillSourceLineInfo(modules,
+                                               NULL, // unloaded_modules
                                                system_info,
                                                stack_frame);
     RecordResult(stack_frame->module, res);

--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -14,7 +14,7 @@ set -v -e -x
 
 # Build the revision used in the snapshot unless otherwise specified.
 # Update this if you update the snapshot!
-: BREAKPAD_REV         "${BREAKPAD_REV:=e0f2c17988dadcc7fb760b118b1741883435bbfd}"
+: BREAKPAD_REV         "${BREAKPAD_REV:=a1dbcdcb43148c9eb31cbae74086adbb6ecb970e}"
 
 export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Tested locally by rebuilding my processor container with the new breakpad version and successfully processing the crash from [bug 1400952](https://bugzilla.mozilla.org/show_bug.cgi?id=1400952). I was able to get proper symbols for the crashing thread, and a proper signature.