### PR TITLE
bug 1405679 - submitter urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       - my.env
     depends_on:
       - rabbitmq
+      - localstack-s3
     command: ["/app/docker/run_submitter.sh"]
     volumes:
       - .:/app
@@ -122,6 +123,10 @@ services:
       - CRASHSTORAGE_ACCESS_KEY=foo
       - CRASHSTORAGE_SECRET_ACCESS_KEY=foo
       - CRASHSTORAGE_BUCKET_NAME=dev_bucket
+    depends_on:
+      - localstack-s3
+    expose:
+      - 8000
     ports:
       - "8888:8000"
     command: ./bin/run_web.sh

--- a/docker/config/local_dev_submitter.env
+++ b/docker/config/local_dev_submitter.env
@@ -9,7 +9,8 @@
 # ----------------------------------------------------------------------------------
 
 destination.crashstorage_class=socorro.submitter.breakpad_submitter_utilities.BreakpadPOSTDestination
-destination.url=http://antenna:8888/
+destination.urls=http://antenna:8000/submit
+
 
 source.crashstorage_class=socorro.external.boto.crashstorage.BotoS3CrashStorage
 source.temporary_file_system_storage_path=/tmp

--- a/docker/config/local_dev_submitter.env
+++ b/docker/config/local_dev_submitter.env
@@ -11,9 +11,9 @@
 destination.crashstorage_class=socorro.submitter.breakpad_submitter_utilities.BreakpadPOSTDestination
 destination.urls=http://antenna:8000/submit
 
-
 source.crashstorage_class=socorro.external.boto.crashstorage.BotoS3CrashStorage
 source.temporary_file_system_storage_path=/tmp
+resource.boto.keybuilder_class=socorro.external.boto.connection_context.DatePrefixKeyBuilder
 
 new_crash_source.crashstorage_class=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
 new_crash_source.new_crash_source_class=socorro.external.rabbitmq.rmq_new_crash_source.RMQNewCrashSource
@@ -34,3 +34,14 @@ resource.rabbitmq.host=rabbitmq
 resource.rabbitmq.virtual_host=rabbitvhost
 secrets.rabbitmq.rabbitmq_user=rabbituser
 secrets.rabbitmq.rabbitmq_password=rabbitpwd
+resource.boto.host=localstack-s3
+resource.boto.port=5000
+resource.boto.access_key=foo
+secrets.boto.secret_access_key=foo
+resource.boto.bucket_name=dev_bucket
+resource.boto.temporary_file_system_storage_path=/tmp
+resource.boto.calling_format=boto.s3.connection.OrdinaryCallingFormat
+resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3ConnectionContext
+
+# Never on a server!
+resource.boto.secure=False

--- a/socorro/scripts/add_crashid_to_queue.py
+++ b/socorro/scripts/add_crashid_to_queue.py
@@ -29,7 +29,7 @@ Queues:
 
 * socorro.normal - normal processing
 * socorro.priority - priority processing
-* socorro.submitter (-prod only) - sends crash to -stage environment
+* socorro.stagesubmitter (-prod only) - sends crash to -stage environment
 
 """
 

--- a/socorro/submitter/breakpad_submitter_utilities.py
+++ b/socorro/submitter/breakpad_submitter_utilities.py
@@ -1,68 +1,58 @@
-#! /usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
-from configman import Namespace
-from socorro.external.crashstorage_base import CrashStorageBase
 
 import os
 import urllib2
+
+from configman import Namespace
 import poster
+
+from socorro.external.crashstorage_base import CrashStorageBase
+
+
 poster.streaminghttp.register_openers()
 
 
 class BreakpadPOSTDestination(CrashStorageBase):
-    """This a crashstorage derivative that pushes a crash out to a
-    Socorro collector waiting at a url.
+    """This a crashstorage derivative that pushes a crash out to a Socorro collector waiting at a url.
 
     """
     required_config = Namespace()
     required_config.add_option(
-        'url',
-        short_form='u',
-        doc="The url of the Socorro collector to submit to",
-        default="http://127.0.0.1:8882/submit"
+        'urls',
+        doc='One or more urls to submit to separated by commas',
+        default="http://127.0.0.1:8888/submit"
     )
-    required_config.add_option(
-        'echo_response',
-        short_form='e',
-        doc="echo the submission response to stdout",
-        default=False
-    )
-
-    def __init__(self, config, quit_check_callback=None):
-        super(BreakpadPOSTDestination, self).__init__(
-            config,
-            quit_check_callback
-        )
-        self.hang_id_cache = dict()
 
     def save_raw_crash_with_file_dumps(self, raw_crash, dumps, crash_id):
+        """Saves a raw crash by wrapping it up in a multipart/form-data payload and submitting it as an HTTP
+        POST to a collector
+
+        """
+        urls = self.config.urls.split(',')
+
         try:
+            # Create raw crash with file pointers to minidumps for poster to pull from
             for dump_name, dump_pathname in dumps.iteritems():
                 if not dump_name:
                     dump_name = self.config.source.dump_field
                 raw_crash[dump_name] = open(dump_pathname, 'rb')
+
+            # Get uuid for logging purposes
+            uuid = raw_crash.get('uuid', 'NO UUID')
+
+            # Build the payload
             datagen, headers = poster.encode.multipart_encode(raw_crash)
-            request = urllib2.Request(
-                self.config.url,
-                datagen,
-                headers
-            )
-            submission_response = urllib2.urlopen(request).read().strip()
-            try:
+
+            # Submit payload to all urls
+            for url in urls:
+                request = urllib2.Request(url, datagen, headers)
+                submission_response = urllib2.urlopen(request).read().strip()
                 self.config.logger.debug(
-                    'submitted %s (original crash_id)',
-                    raw_crash['uuid']
+                    'submitted %s to %s; response %s', uuid, url, submission_response
                 )
-            except KeyError:
-                pass
-            self.config.logger.debug(
-                'submission response: %s',
-                submission_response
-            )
-            if self.config.echo_response:
-                print(submission_response)
+
         finally:
             for dump_name, dump_pathname in dumps.iteritems():
                 if "TEMPORARY" in dump_pathname:

--- a/socorro/submitter/submitter_app.py
+++ b/socorro/submitter/submitter_app.py
@@ -4,8 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""This app will submit crashes to a socorro collector"""
-
+"""This app submits crashes to a Socorro collector"""
 
 import time
 

--- a/socorro/unittest/submitter/test_breakpad_post.py
+++ b/socorro/unittest/submitter/test_breakpad_post.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from configman.dotdict import DotDict
+import mock
+import pytest
+import requests_mock
+
+from socorro.lib.ooid import create_new_ooid
+from socorro.submitter.breakpad_submitter_utilities import BreakpadPOSTDestination, parse_urls
+
+
+@pytest.mark.parametrize('data, expected', [
+    ('', []),
+    ('http://example.com/', ['http://example.com/']),
+    (
+        'http://example.com/ , http://2.example.com/',
+        ['http://example.com/', 'http://2.example.com/']
+    ),
+])
+def test_parse_urls(data, expected):
+    assert parse_urls(data) == expected
+
+
+class TestBreakpadPOSTDestination:
+    @requests_mock.mock()
+    def test_post(self, req_mock):
+        config = DotDict({
+            'urls': 'http://example.com/submit,http://2.example.com/submit',
+
+            'logger': mock.MagicMock(),
+            'redactor_class': mock.MagicMock(),
+        })
+        bpd = BreakpadPOSTDestination(config)
+
+        raw_crash = DotDict({
+            'Product': 'Firefox'
+        })
+        dumps = {}
+        crash_id = create_new_ooid()
+
+        # Set up the request mock to return what Antenna returns
+        response_text = 'CrashID=bp-%s\n' % crash_id
+        req_mock.post('http://example.com/submit', text=response_text)
+        req_mock.post('http://2.example.com/submit', text=response_text)
+
+        # Run the method in question
+        bpd.save_raw_crash_with_file_dumps(raw_crash, dumps, crash_id)
+
+        # Verify what happened with requests.post
+        assert req_mock.call_count == 2
+        req_history = req_mock.request_history
+        assert req_history[0].method == 'POST'
+        assert req_history[0].url == 'http://example.com/submit'
+
+        assert req_history[1].method == 'POST'
+        assert req_history[1].url == 'http://2.example.com/submit'
+
+        # Generating the paylod involves some random-string bits in poster, so
+        # we can't do a string compare. So it's hard to verify the data that
+        # got posted was correct. Instead, we check to see if some strings
+        # made it and assume that's probably good.
+        history_0_text = str(req_history[0].text)
+        assert 'Content-Disposition: form-data; name="Product"' in history_0_text
+        assert 'Firefox' in history_0_text
+
+        # Assert the same stuff was sent to both urls
+        history_1_text = str(req_history[1].text)
+        assert history_0_text == history_1_text


### PR DESCRIPTION
This adds support for posting to multiple urls. It's a little tricky to test--we want to test both the single value and the multiple value situations.

For single value do this:

1. in terminal 1, run `docker-compose run submitter bash` and then `./docker/run_submitter.sh`
2. in terminal 2, run `docker-compose up antenna`
3. in terminal 3, run `./docker/as_me.sh bash` and then the following:
3.1. `./scripts/fetch_crashids.txt --num=1 > tosubmit.txt`
3.2. `cat tosubmit.txt | ./scripts/fetch_crash_data.py ./crashdata`
3.3. `./scripts/socorro_aws.sh sync ./crashdata s3://dev_bucket/`
3.4. `cat tosubmit.txt | ./scripts/add_crashid_to_queue.py socorro.stagesubmitter`

That downloads a crash, puts it in s3, and tosses the crashid in the `socorro.stagesubmitter` queue.

The submitter will wake up every minute. It'll wake up, see the crash id, and submit it to the url. You should see this in terminal 2.

In terminal 3, you should see Antenna accept the crash and save it.

For the multi-value, in terminal 1, do this:

```
env destination.urls=http://antenna:8000/submit,http://antenna:8000/submit ./docker/run_submitter.sh
```

That'll cause it to submit to Antenna twice. That's goofy, but it'll work fine here. You should see it submitting twice in the submitter terminal and getting received and saved twice in the Antenna terminal.