### PR TITLE
fixes bug 1408448 - stomp on signature when parentBuildID != childBuildID

### DIFF
--- a/socorro/signature/__init__.py
+++ b/socorro/signature/__init__.py
@@ -21,6 +21,7 @@ from socorro.signature.rules import (
     SigTrim,
     SigTrunc,
     SignatureJitCategory,
+    SignatureParentIDNotEqualsChildID,
 )
 
 
@@ -33,9 +34,10 @@ DEFAULT_PIPELINE = [
     SignatureRunWatchDog(),
     SignatureIPCChannelError(),
     SignatureIPCMessageName(),
+    SignatureParentIDNotEqualsChildID(),
+    SignatureJitCategory(),
     SigTrim(),
     SigTrunc(),
-    SignatureJitCategory(),
 ]
 
 

--- a/socorro/signature/__main__.py
+++ b/socorro/signature/__main__.py
@@ -209,6 +209,7 @@ def main(args):
                 'ipc_channel_error': raw_crash.get('ipc_channel_error', None),
                 'additional_minidumps': raw_crash.get('additional_minidumps', None),
                 'IPCMessageName': raw_crash.get('IPCMessageName', None),
+                'MozCrashReason': raw_crash.get('MozCrashReason', None),
             }
 
             resp = fetch('/ProcessedCrash/', crash_id, api_token)

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -712,20 +712,6 @@ class SignatureIPCMessageName(Rule):
         return True
 
 
-class SignatureIPCMessageName(Rule):
-    """augments the signature if there is a IPC message name in the crash"""
-
-    def predicate(self, raw_crash, processed_crash):
-        return bool(raw_crash.get('IPCMessageName'))
-
-    def action(self, raw_crash, processed_crash, notes):
-        processed_crash['signature'] = '{} | IPC_Message_Name={}'.format(
-            processed_crash['signature'],
-            raw_crash['IPCMessageName']
-        )
-        return True
-
-
 class SignatureParentIDNotEqualsChildID(Rule):
     """Stomp on the signature if MozCrashReason is parentBuildID != childBuildID
 
@@ -737,7 +723,7 @@ class SignatureParentIDNotEqualsChildID(Rule):
 
     def predicate(self, raw_crash, processed_crash):
         value = 'MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)'
-        return bool(raw_crash.get('MozCrashReason', '') == value)
+        return raw_crash.get('MozCrashReason', '') == value
 
     def action(self, raw_crash, processed_crash, notes):
         notes.append(
@@ -745,8 +731,7 @@ class SignatureParentIDNotEqualsChildID(Rule):
             % processed_crash['signature']
         )
 
-        # This is a failed assertion and the crash reason is the assertion that failed, so we put
-        # "!=" in the signature because that's what caused the assertion failure.
+        # The MozCrashReason lists the assertion that failed, so we put "!=" in the signature
         processed_crash['signature'] = 'parentBuildID != childBuildID'
 
         return True


### PR DESCRIPTION
If `MozCrashReason` is `"MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)"`, then
stomp on the signature with `"parentBuildID != childBuildID"`. This allows all
these crashes to end up in the same bucket where the original signature is
likely to be bogus since there are two different builds involved.

This also adds `raw_crash['MozCrashReason']` to the list of things that we use to
generate signatures.

I tested this out in this bug comment with the specific crashes and Andrew approved the output.

I think to test, we should let Travis/Circle do their thing. You can also rerun what I did in this comment and verify the output is the same:

https://bugzilla.mozilla.org/show_bug.cgi?id=1408448#c6