### PR TITLE
fixes bug 1409745 - update python image in test container

### DIFF
--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -22,7 +22,7 @@ APP_GID="10001"
 
 # Use the same image we use for building docker images because it'll be cached
 # already
-BASEIMAGENAME="python:2.7.13-slim"
+BASEIMAGENAME="python:2.7.14-slim"
 
 # Start services in background (this is idempotent)
 echo "Starting services in the background..."


### PR DESCRIPTION
I missed this when I updated the image in the `Dockerfile`.

This affects Circle CI and `make dockertest` and that's it. If Circle is happy, we're fine.