### PR TITLE
fixes bug 1407997 - redo mdsw command line config

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -65,8 +65,8 @@ resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3
 # there's only one processor node. For server environments, we probably want to store that
 # in a volume. These three vars are all affected.
 companion_process.symbol_cache_path=/tmp/symbols/cache
-processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.command_line=timeout -s KILL 600 {command_pathname} --raw-json {raw_crash_pathname} --symbols-url {public_symbols_url} --symbols-url {private_symbols_url} --symbols-cache /tmp/symbols/cache --symbols-tmp /tmp/symbols/tmp {dump_file_pathname} 2> /dev/null
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.symbol_cache_path=/tmp/symbols/cache
+processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.symbol_tmp_path=/tmp/symbols/tmp
 
 # webapp
 # ------

--- a/docker/config/processor.env
+++ b/docker/config/processor.env
@@ -55,6 +55,7 @@ processor.processor_class=socorro.processor.mozilla_processor_2015.MozillaProces
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.command_pathname=/stackwalk/stackwalker
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.private_symbols_url=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-private/v1
 processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.public_symbols_url=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1
+processor.raw_to_processed_transform.BreakpadStackwalkerRule2015.kill_timeout=30
 
 producer_consumer.maximum_queue_size=32
 producer_consumer.number_of_threads=16

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -195,59 +195,6 @@ class ExternalProcessRule(Rule):
         return True
 
 
-class DumpLookupExternalRule(ExternalProcessRule):
-
-    required_config = Namespace()
-    required_config.add_option(
-        'dump_field',
-        doc='the default name of a dump',
-        default='upload_file_minidump',
-    )
-    required_config.add_option(
-        'processor_symbols_pathname_list',
-        doc='comma or space separated list of symbol files just as for '
-        'minidump_stackwalk (quote paths with embedded spaces)',
-        default='/mnt/socorro/symbols/symbols_ffx,'
-        '/mnt/socorro/symbols/symbols_sea,'
-        '/mnt/socorro/symbols/symbols_tbrd,'
-        '/mnt/socorro/symbols/symbols_sbrd,'
-        '/mnt/socorro/symbols/symbols_os',
-        from_string_converter=_create_symbol_path_str
-    )
-    required_config.command_pathname = change_default(
-        ExternalProcessRule,
-        'command_pathname',
-        '/data/socorro/stackwalk/bin/dump-lookup'
-    )
-    required_config.command_line = change_default(
-        ExternalProcessRule,
-        'command_line',
-        'timeout -s KILL 30 {command_pathname} '
-        '{dumpfile_pathname} '
-        '{processor_symbols_pathname_list} '
-        '2>/dev/null'
-    )
-    required_config.result_key = change_default(
-        ExternalProcessRule,
-        'result_key',
-        'dump_lookup'
-    )
-    required_config.return_code_key = change_default(
-        ExternalProcessRule,
-        'return_code_key',
-        'dump_lookup_return_code'
-    )
-
-    def _predicate(
-        self,
-        raw_crash,
-        raw_dumps,
-        processed_crash,
-        processor_meta
-    ):
-        return 'create_dump_lookup' in raw_crash
-
-
 class BreakpadStackwalkerRule2015(ExternalProcessRule):
 
     required_config = Namespace()

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -14,7 +14,6 @@ from socorro.processor.breakpad_transform_rules import (
     BreakpadStackwalkerRule2015,
     CrashingThreadRule,
     ExternalProcessRule,
-    DumpLookupExternalRule,
     JitCrashCategorizeRule
 )
 from socorro.unittest.testbase import TestCase
@@ -515,21 +514,6 @@ class TestExternalProcessRule(TestCase):
             'json: Expected String or Unicode',
         ]
         assert processor_meta.processor_notes == expected
-
-
-class TestDumpLookupExternalRule(TestCase):
-
-    def test_default_parameters(self):
-        config = DumpLookupExternalRule.required_config
-
-        assert config.dump_field.default == 'upload_file_minidump'
-        assert config.dump_field is not ExternalProcessRule.required_config.dump_field
-        assert config.command_pathname.default == '/data/socorro/stackwalk/bin/dump-lookup'
-        assert config.command_pathname is not ExternalProcessRule.required_config.command_pathname
-        assert config.result_key.default == 'dump_lookup'
-        assert config.result_key is not ExternalProcessRule.required_config.result_key
-        assert config.return_code_key.default == 'dump_lookup_return_code'
-        assert config.return_code_key is not ExternalProcessRule.required_config.return_code_key
 
 
 class TestBreakpadTransformRule2015(TestCase):

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -488,13 +488,10 @@ class TestBreakpadTransformRule2015(TestCase):
         assert processed_crash.mdsw_return_code == -1
         assert processed_crash.mdsw_status_string == "unknown error"
         assert not processed_crash.success
-        command_line = config.command_line.format(
-            **dict(
-                config,
-                raw_crash_pathname=(
-                    '/tmp/00000000-0000-0000-0000-000002140504.MainThread.TEMPORARY.json'
-                ),
-                dump_file_pathname='a_fake_dump.dump'
+        command_line = rule.expand_commandline(
+            dump_file_pathname='a_fake_dump.dump',
+            raw_crash_pathname=(
+                '/tmp/00000000-0000-0000-0000-000002140504.MainThread.TEMPORARY.json'
             )
         )
         expected = [

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -195,136 +195,6 @@ class MyBreakpadStackwalkerRule2015(BreakpadStackwalkerRule2015):
         yield "%s.json" % raw_crash.uuid
 
 
-class TestBreakpadTransformRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-        config.chatty = True
-        config.dump_field = 'upload_file_minidump'
-        config.command_line = (
-            BreakpadStackwalkerRule2015.required_config .command_line.default
-        )
-        config.command_pathname = '/bin/stackwalker'
-        config.public_symbols_url = 'https://localhost'
-        config.private_symbols_url = 'https://localhost'
-        config.symbol_cache_path = '/mnt/socorro/symbols'
-        config.temporary_file_system_storage_path = '/tmp'
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
-
-    @patch('socorro.processor.breakpad_transform_rules.subprocess')
-    def test_everything_we_hoped_for(self, mocked_subprocess_module):
-        config = self.get_basic_config()
-
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
-
-        mocked_subprocess_handle = (
-            mocked_subprocess_module.Popen.return_value
-        )
-        mocked_subprocess_handle.stdout.read.return_value = (
-            cannonical_stackwalker_output_str
-        )
-        mocked_subprocess_handle.wait.return_value = 0
-
-        rule = MyBreakpadStackwalkerRule2015(config)
-
-        # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert processed_crash.json_dump == cannonical_stackwalker_output
-        assert processed_crash.mdsw_return_code == 0
-        assert processed_crash.mdsw_status_string == "OK"
-        assert processed_crash.success
-
-    @patch('socorro.processor.breakpad_transform_rules.subprocess')
-    def test_stackwalker_fails(self, mocked_subprocess_module):
-        config = self.get_basic_config()
-
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
-
-        mocked_subprocess_handle = \
-            mocked_subprocess_module.Popen.return_value
-        mocked_subprocess_handle.stdout.read.return_value = '{}'
-        mocked_subprocess_handle.wait.return_value = 124
-
-        rule = MyBreakpadStackwalkerRule2015(config)
-
-        # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert processed_crash.json_dump == {}
-        assert processed_crash.mdsw_return_code == 124
-        assert processed_crash.mdsw_status_string == "unknown error"
-        assert not processed_crash.success
-        assert processor_meta.processor_notes == ["MDSW terminated with SIGKILL due to timeout"]
-
-    @patch('socorro.processor.breakpad_transform_rules.subprocess')
-    def test_stackwalker_fails_2(self, mocked_subprocess_module):
-        config = self.get_basic_config()
-
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
-
-        mocked_subprocess_handle = (
-            mocked_subprocess_module.Popen.return_value
-        )
-        mocked_subprocess_handle.stdout.read.return_value = int
-        mocked_subprocess_handle.wait.return_value = -1
-
-        rule = MyBreakpadStackwalkerRule2015(config)
-
-        # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert processed_crash.json_dump == {}
-        assert processed_crash.mdsw_return_code == -1
-        assert processed_crash.mdsw_status_string == "unknown error"
-        assert not processed_crash.success
-        expected = [
-            '/bin/stackwalker output failed in json: Expected String or Unicode',
-            (
-                'MDSW failed on \'timeout -s KILL 30 /bin/stackwalker --raw-json '
-                '00000000-0000-0000-0000-000002140504.json --symbols-url https://localhost '
-                '--symbols-url https://localhost --symbols-cache /mnt/socorro/symbols '
-                'a_fake_dump.dump 2>/dev/null\': unknown error'
-            )
-        ]
-        assert processor_meta.processor_notes == expected
-
-    @patch('socorro.processor.breakpad_transform_rules.os.unlink')
-    def test_temp_file_context(self, mocked_unlink):
-        config = self.get_basic_config()
-
-        rule = BreakpadStackwalkerRule2015(config)
-        with rule._temp_raw_crash_json_file('foo.json', example_uuid):
-            pass
-        mocked_unlink.assert_called_once_with('/tmp/%s.MainThread.TEMPORARY.json' % example_uuid)
-        mocked_unlink.reset_mock()
-
-        try:
-            with rule._temp_raw_crash_json_file('foo.json', example_uuid):
-                raise KeyError('oops')
-        except KeyError:
-            pass
-        mocked_unlink.assert_called_once_with('/tmp/%s.MainThread.TEMPORARY.json' % example_uuid)
-        mocked_unlink.reset_mock()
-
-
 class TestCrashingThreadRule(TestCase):
 
     def get_basic_config(self):
@@ -629,6 +499,24 @@ class TestBreakpadTransformRule2015(TestCase):
             "2>/dev/null': unknown error"
         ]
         assert processor_meta.processor_notes == expected
+
+    @patch('socorro.processor.breakpad_transform_rules.os.unlink')
+    def test_temp_file_context(self, mocked_unlink):
+        config = self.get_basic_config()
+
+        rule = BreakpadStackwalkerRule2015(config)
+        with rule._temp_raw_crash_json_file('foo.json', example_uuid):
+            pass
+        mocked_unlink.assert_called_once_with('/tmp/%s.MainThread.TEMPORARY.json' % example_uuid)
+        mocked_unlink.reset_mock()
+
+        try:
+            with rule._temp_raw_crash_json_file('foo.json', example_uuid):
+                raise KeyError('oops')
+        except KeyError:
+            pass
+        mocked_unlink.assert_called_once_with('/tmp/%s.MainThread.TEMPORARY.json' % example_uuid)
+        mocked_unlink.reset_mock()
 
 
 class TestJitCrashCategorizeRule(TestCase):


### PR DESCRIPTION
This removes some dead code and then redoes the mdsw command line. This comment covers the context of these changes:

https://bugzilla.mozilla.org/show_bug.cgi?id=1407997#c2

Generally, we're adding a symbol tmp path to the default command line and also adding a kill_timeout variable. Adding these two things lets us handle the local development environment, -stage, and -prod configuration needs using the default.

To test:

1. run the tests (or wait for Circle CI and Travis to be happy)
2. run the processor in the local development environment and verify mdsw is running with appropriate values and producing output
   1. in terminal 1, run `dc up processor`
   2. in terminal 2, run `./docker/as_me.sh bash` and then do:
      ```
      you@processor:/app$ ./scripts/fetch_crashids.py --num=1 > id.txt
      you@processor:/app$ cat id.txt | ./scripts/fetch_crash_data.py crashdata
      you@processor:/app$ ./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
      you@processor:/app$ ./scripts/socorro_aws_s3.sh sync crashdata s3://dev_bucket/
      you@processor:/app$ cat id.txt | ./scripts/add_crashid_to_queue.py socorro.normal
      ```
   3. watch terminal 1 logging and verify that mdsw is run with appropriate values
   4. after the processor has saved the processed crash, you can kill the processor and do:
      ```
      you@processor:/app$ ./scripts/socorro_aws_s3.sh sync s3://dev_bucket/ crashdata
      ```
   5. then look at `crashdata/v1/processed_crash/CRASHID` at the processed notes and make sure there isn't an mdsw error there and also make sure there's a `json_dump` key

That's it!