### PR TITLE
Fix bug 1412281: Update how we configure flatpickr.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,10 @@ exclude =
     stackwalk/,
     tools/,
     webapp-django/crashstats/*/migrations/*,
-    webapp-django/node_modules/
+    webapp-django/node_modules/,
+    build/,
+    depot_tools/,
+    breakpad/
 max-line-length = 100
 
 [tool:pytest]

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
@@ -12,8 +12,18 @@ $(function () {
      */
     window.DateFilters = (function () {
         var filters = {
-            from: $('.datetime-picker.date_from').flatpickr(),
-            to: $('.datetime-picker.date_to').flatpickr(),
+            from: $('.datetime-picker.date_from').flatpickr({
+                onChange: function (dateObjs) {
+                    removeSelectedShortcut();
+                    filters.to.set('minDate', dateObjs[0]);
+                },
+            }),
+            to: $('.datetime-picker.date_to').flatpickr({
+                onChange: function (dateObjs) {
+                    removeSelectedShortcut();
+                    filters.from.set('maxDate', dateObjs[0]);
+                },
+            }),
         };
 
         function setDate(key, value) {
@@ -31,15 +41,6 @@ $(function () {
         // Limit filters based on the other filter's value.
         filters.to.set('minDate', getDate('from'));
         filters.from.set('maxDate', getDate('to'));
-
-        filters.from.config.onChange = function (dateObj) {
-            removeSelectedShortcut();
-            filters.to.set('minDate', dateObj);
-        };
-        filters.to.config.onChange = function (dateObj) {
-            removeSelectedShortcut();
-            filters.from.set('maxDate', dateObj);
-        };
 
         // Enable the date filters range shortcuts.
         $('.date-shortcuts').on('click', 'a', function (e) {


### PR DESCRIPTION
Flatpickr now returns a list of selected dates instead of a single date object,
so the onChange callbacks have been updated to unpack the list being returned.
The callbacks themselves were also moved to the initial config object, although
this isn't strictly necessary.

The .eslintrc config was also updated to support the object function shorthand
being used in this patch.