### PR TITLE
Fix bug 1406121: Display all threads when no crashing thread is available.

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -590,6 +590,7 @@
 
                     {% if parsed_dump.threads %}
                     <div id="frames">
+                        {% if crashing_thread is not none %}
                         <h2>Crashing Thread ({{ crashing_thread }}){% if parsed_dump.threads[crashing_thread].thread_name %}, Name: {{ parsed_dump.threads[crashing_thread].thread_name }}{% endif %}</h2>
                         <table class="data-table">
                             <thead>
@@ -624,12 +625,12 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-
                         <p>
                             <a href="#allthreads" data-show="Show other threads" data-hide="Hide other threads">Show other threads</a>
                         </p>
+                        {% endif %}
 
-                        <div id="allthreads">
+                        <div id="allthreads" class="{{ 'hidden' if crashing_thread is not none }}">
                             {% for thread in parsed_dump.threads %}
                             {% if thread.thread != crashing_thread %}
                             <h2>Thread {{ thread.thread }}{% if thread.thread_name %}, Name: {{ thread.thread_name }}{% endif %}</h2>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -851,7 +851,7 @@ div.code {
 #report-index {
     clear: right;
 }
-#allthreads {
+#allthreads.hidden {
     display: none;
 }
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -871,15 +871,7 @@ def report_index(request, crash_id, default_context=None):
         context['raw_stackwalker_output'] = 'No dump available'
         parsed_dump = {}
 
-    # If the parsed_dump lacks a `parsed_dump.crash_info.crashing_thread`
-    # we can't loop over the frames :(
-    crashing_thread = parsed_dump.get('crash_info', {}).get('crashing_thread')
-    if crashing_thread is None:
-        # the template does a big `{% if parsed_dump.threads %}`
-        parsed_dump['threads'] = None
-    else:
-        context['crashing_thread'] = crashing_thread
-
+    context['crashing_thread'] = parsed_dump.get('crash_info', {}).get('crashing_thread')
     if context['report']['signature'].startswith('shutdownhang'):
         # For shutdownhang signatures, we want to use thread 0 as the
         # crashing thread, because that's the thread that actually contains


### PR DESCRIPTION
That test is more or less a copy-paste of the test above it with minor changes. Ideally I'd also like to test something about the "hidden" class being present but it seemed kind of awkward to do and falls into the "frontend is getting replaced soon anyway" area. But I can totally add it if we think we need it.

I also tested this manually against three crashes from the [query spohl provided](https://bugzilla.mozilla.org/show_bug.cgi?id=1406121#c4).