### PR TITLE
Fix bug 1413164: Downgrade to d3-sankey 0.4.2.

### DIFF
--- a/webapp-django/package-lock.json
+++ b/webapp-django/package-lock.json
@@ -84,27 +84,27 @@
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
       "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
     },
-    "d3-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+    "d3-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
+      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+    },
+    "d3-interpolate": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.5.tgz",
+      "integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58=",
+      "requires": {
+        "d3-color": "1.0.3"
+      }
     },
     "d3-sankey": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.7.1.tgz",
-      "integrity": "sha1-0imDImj8aaf+yEgD6WwiVqYUxSE=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.4.2.tgz",
+      "integrity": "sha1-NKFRLytEBqNfgOrH/rz1gi2+xa0=",
       "requires": {
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",
-        "d3-shape": "1.2.0"
-      }
-    },
-    "d3-shape": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
-      "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
-      "requires": {
-        "d3-path": "1.0.5"
+        "d3-interpolate": "1.1.5"
       }
     },
     "decamelize": {

--- a/webapp-django/package.json
+++ b/webapp-django/package.json
@@ -18,7 +18,7 @@
     "Select2": "github:select2/select2#3.5.4",
     "ace-builds": "1.2.8",
     "d3": "3.5.17",
-    "d3-sankey": "0.7.1",
+    "d3-sankey": "0.4.2",
     "filesize": "2.0.3",
     "flatpickr": "4.0.3",
     "font-awesome": "4.6.1",


### PR DESCRIPTION
This should be the version of d3-sankey we were using before, instead of the
latest version.

I had trouble testing this locally, because there is [a bug in d3-sankey that triggers when links in the chart all have a value of 0](https://github.com/d3/d3-sankey/pull/39). In our case, we hit this bug when none of the crontabber tasks have any dependencies. When I run crontabber locally, it populates the database with data about some crontabber tasks, but none of them have dependencies: https://gist.github.com/Osmose/3b39699117677ebc2991ea7ec0d02168

It looks like this is normally not an issue since crontabber on the servers and other dev environments has at least one job with a dependency. Fixing that issue requires a more extensive rewrite of the crontabber page that I don't think we should bother with for this bug. Advice on how to either get my crontabber data fixed locally, or on alternative methods for testing, would be appreciated.