### PR TITLE
bug 1413925 - Update jinja_helpers.py

### DIFF
--- a/webapp-django/crashstats/base/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/base/templatetags/jinja_helpers.py
@@ -107,7 +107,9 @@ def is_dangerous_cpu(cpu_info):
     # for ease of find by users.
     return (
         cpu_info.startswith('AuthenticAMD family 20 model 1') or
-        cpu_info.startswith('AuthenticAMD family 20 model 2')
+        cpu_info.startswith('AuthenticAMD family 20 model 2') or
+        cpu_info.startswith('family 20 model 1') or
+        cpu_info.startswith('family 20 model 2')
     )
 
 


### PR DESCRIPTION
reports from the buggy amd cpus have a different cpu_info when they come from win64 firefox builds.
sample: https://crash-stats.mozilla.com/report/index/fa0c831d-cff4-4337-8dc6-53ac30171102

(also see https://bugzilla.mozilla.org/show_bug.cgi?id=1269894)