### PR TITLE
fixes bug 1416168 - add nsTArrayInfallibleAllocator to prefix list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -120,7 +120,7 @@ nsAString_internal::Assign.*
 nsACString_internal::BeginWriting
 nsAString_internal::BeginWriting
 nsACString_internal::SetCapacity
-nsTArrayInfallibleAllocator.*
+nsTArrayInfallibleAllocator
 NS_strcmp
 nsBaseHashtable<.*>::.*
 nsClassHashtable<.*>::.*

--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -120,6 +120,7 @@ nsAString_internal::Assign.*
 nsACString_internal::BeginWriting
 nsAString_internal::BeginWriting
 nsACString_internal::SetCapacity
+nsTArrayInfallibleAllocator.*
 NS_strcmp
 nsBaseHashtable<.*>::.*
 nsClassHashtable<.*>::.*


### PR DESCRIPTION
This fixes signatures like this one:

```
app@processor:/app$ python -m socorro.signature 10fb304e-2d3b-4b39-aad7-6a4e90171101
Crash id: 10fb304e-2d3b-4b39-aad7-6a4e90171101
Original: OOM | large | NS_ABORT_OOM | nsTArrayInfallibleAllocator::ResultTypeProxy nsTArray_base<T>::EnsureCapacity<T>
New:      OOM | large | NS_ABORT_OOM | nsTArrayInfallibleAllocator::ResultTypeProxy nsTArray_base<T>::EnsureCapacity<T> | nsHtml5TreeBuilder::createElement
Same?:    False
```

You can see other signatures like this:

https://crash-stats.mozilla.com/search/?signature=~nsTArrayInfallibleAllocator&product=Firefox&date=%3E%3D2017-11-06T11%3A35%3A52.000Z&date=%3C2017-11-13T11%3A35%3A52.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#crash-reports