### PR TITLE
fixes bug 1388130 - redo crontabber jobs configuration

### DIFF
--- a/docker/run_crontabber.sh
+++ b/docker/run_crontabber.sh
@@ -26,7 +26,7 @@ while true
 do
     # FIXME(willkg): We don't want crontabber to exit weird and then have that
     # kill the container, but this is a lousy thing to do.
-    ${CMDPREFIX} python socorro/cron/crontabber_app.py || true
+    ${CMDPREFIX} ./scripts/socorro crontabber || true
     echo "Sleep 5 minutes..."
     sleep 300
 done

--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -13,17 +13,17 @@ CACHEDIR=/app/.cache/ftpscraper
 
 # Fetch and update release information for these products (comma-delimited)
 PRODUCTS="firefox,mobile"
-CRONTABBER="docker-compose run crontabber python socorro/cron/crontabber_app.py"
+CRONTABBERCMD="./scripts/socorro crontabber"
 
 
 # Fetch release data -- do it as the user so it can cache things
-docker-compose run -u "${HOSTUSER}" crontabber python socorro/cron/crontabber_app.py \
+docker-compose run -u "${HOSTUSER}" crontabber ${CRONTABBERCMD} \
                --job=ftpscraper \
                --crontabber.class-FTPScraperCronApp.cachedir=${CACHEDIR} \
                --crontabber.class-FTPScraperCronApp.products=${PRODUCTS}
 
 # Update featured versions data based on release data
-${CRONTABBER} --job=featured-versions-automatic \
+docker-compose run crontabber ${CRONTABBERCMD} --job=featured-versions-automatic \
               --crontabber.class-FeaturedVersionsAutomaticCronApp.products=${PRODUCTS}
 
 # Fetch normalization data for versions we know about

--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -43,8 +43,7 @@ class ApplicationDefaultsProxy(object):
         return {
             'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
             'submitter': 'socorro.submitter.submitter_app.SubmitterApp',
-            # crontabber not yet supported in this environment
-            #'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',
+            'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',
             'processor': 'socorro.processor.processor_app.ProcessorApp',
             'reprocess_crashlist':
                 'socorro.external.rabbitmq.reprocess_crashlist.ReprocessCrashlistApp',

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -3,67 +3,109 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from crontabber.app import CronTabberBase, CronTabber
+import sys
 
-# this class is for eventual support of CronTabber with the universal
-# socorro app.
+from configman import Namespace, class_converter
+from crontabber.app import (
+    CronTabberBase,
+    classes_in_namespaces_converter_with_compression,
+    get_extra_as_options,
+    line_splitter,
+    main,
+    pipe_splitter,
+)
+
 from socorro.app.socorro_app import App
 
 
 # NOTE(willkg): This is what we have in -prod
-DEFAULT_JOBS = '''
-socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d
-socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|05:00
-socorro.cron.jobs.matviews.SignaturesCronApp|1d|05:00
-socorro.cron.jobs.matviews.RawUpdateChannelCronApp|1d|05:00
-socorro.cron.jobs.matviews.ADUCronApp|1d|08:30
-socorro.cron.jobs.matviews.DuplicatesCronApp|1h
-socorro.cron.jobs.matviews.ReportsCleanCronApp|1h
-socorro.cron.jobs.bugzilla.BugzillaCronApp|1h
-socorro.cron.jobs.matviews.BuildADUCronApp|1d|08:30
-socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00
-socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00
-socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h
-socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|7d
-socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d
-socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|7d
-socorro.cron.jobs.clean_raw_adi_logs.CleanRawADILogsCronApp|1d
-socorro.cron.jobs.clean_raw_adi.CleanRawADICronApp|1d
-socorro.cron.jobs.clean_missing_symbols.CleanMissingSymbolsCronApp|1d
-socorro.cron.jobs.missingsymbols.MissingSymbolsCronApp|1d
-socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1h
-socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|1h
-'''
+DEFAULT_JOBS_BASE = [
+    'socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|7d',
+    'socorro.cron.jobs.matviews.ProductVersionsCronApp|1d|05:00',
+    'socorro.cron.jobs.matviews.SignaturesCronApp|1d|05:00',
+    'socorro.cron.jobs.matviews.RawUpdateChannelCronApp|1d|05:00',
+    'socorro.cron.jobs.matviews.ADUCronApp|1d|08:30',
+    'socorro.cron.jobs.matviews.DuplicatesCronApp|1h',
+    'socorro.cron.jobs.matviews.ReportsCleanCronApp|1h',
+    'socorro.cron.jobs.bugzilla.BugzillaCronApp|1h',
+    'socorro.cron.jobs.matviews.BuildADUCronApp|1d|08:30',
+    'socorro.cron.jobs.matviews.AndroidDevicesCronApp|1d|05:00',
+    'socorro.cron.jobs.matviews.GraphicsDeviceCronApp|1d|05:00',
+    'socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h',
+    'socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|7d',
+    'socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d',
+    'socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|7d',
+    'socorro.cron.jobs.clean_raw_adi_logs.CleanRawADILogsCronApp|1d',
+    'socorro.cron.jobs.clean_raw_adi.CleanRawADICronApp|1d',
+    'socorro.cron.jobs.clean_missing_symbols.CleanMissingSymbolsCronApp|1d',
+    'socorro.cron.jobs.missingsymbols.MissingSymbolsCronApp|1d',
+    'socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1h',
+    'socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|1h',
+]
+
+DEFAULT_JOBS = ', '.join(DEFAULT_JOBS_BASE)
+STAGE_JOBS = ', '.join(
+    DEFAULT_JOBS_BASE +
+    ['socorro.cron.jobs.fetch_adi_from_hive.FAKEFetchADIFromHiveCronApp|1d']
+)
+
+
+def jobs_converter(path_or_jobs):
+    """Takes a Python dotted path or a jobs spec and returns crontabber jobs
+
+    Example Python dotted path::
+
+        jobs_converter('socorro.cron.crontabber_app.DEFAULT_JOBS')
+
+    Example jobs spec::
+
+        jobs_converter('socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1h')
+
+
+    :arg str path_or_jobs: a Python dotted path or a crontabber jobs spec
+
+    :returns: crontabber jobs InnerClassList
+
+    """
+    if '|' not in path_or_jobs:
+        # NOTE(willkg): crontabber's class_converter returns the value pointed
+        # to by a Python dotted path
+        input_str = class_converter(path_or_jobs)
+    else:
+        input_str = path_or_jobs
+
+    from_string_converter = classes_in_namespaces_converter_with_compression(
+        reference_namespace=Namespace(),
+        list_splitter_fn=line_splitter,
+        class_extractor=pipe_splitter,
+        extra_extractor=get_extra_as_options
+    )
+    return from_string_converter(input_str)
 
 
 class CronTabberApp(CronTabberBase, App):
-    @staticmethod
-    def get_application_defaults():
-        return {
-            'jobs': DEFAULT_JOBS,
-            'crontabber.database_class':
-            'socorro.external.postgresql.connection_context.ConnectionContext',
-            'crontabber.transaction_executor_class':
-            'socorro.database.transaction_executor.TransactionExecutor',
-            'crontabber.job_state_db_class.database_class':
-            'socorro.external.postgresql.connection_context.ConnectionContext',
+    required_config = CronTabberBase.required_config.safe_copy()
 
-        }
-
-
-# These settings should ideally be done in config, but because, at
-# the moment, it's easier for us to maintain python we're doing it here.
-CronTabber.required_config.crontabber.jobs.default = DEFAULT_JOBS
-CronTabber.required_config.crontabber.database_class.default = (
-    'socorro.external.postgresql.connection_context.ConnectionContext'
-)
-CronTabber.required_config.crontabber.job_state_db_class.default \
-    .required_config.database_class.default = (
-        'socorro.external.postgresql.connection_context.ConnectionContext'
+    # Stomp on the existing "crontabber.jobs" configuration with one that can
+    # also take Python dotted paths
+    required_config.crontabber.add_option(
+        'jobs',
+        default='socorro.cron.crontabber_app.DEFAULT_JOBS',
+        from_string_converter=jobs_converter,
+        doc='Crontabber jobs spec or Python dotted path to jobs spec',
     )
 
 
-if __name__ == '__main__':  # pragma: no cover
-    from crontabber.app import main
-    import sys
-    sys.exit(main(CronTabber))
+# NOTE(willkg): We need to "fix" the defaults here rather than use App's
+# get_application_defaults() because that doesn't support nested configuration
+# defaults
+CronTabberApp.required_config.crontabber.database_class.default = (
+    'socorro.external.postgresql.connection_context.ConnectionContext'
+)
+CronTabberApp.required_config.crontabber.job_state_db_class.default.required_config.database_class.default = (  # noqa
+    'socorro.external.postgresql.connection_context.ConnectionContext'
+)
+
+
+if __name__ == '__main__':
+    sys.exit(main(CronTabberApp))

--- a/socorro/unittest/cron/crontabber_tests_base.py
+++ b/socorro/unittest/cron/crontabber_tests_base.py
@@ -20,6 +20,8 @@ import configman
 from crontabber import app
 from crontabber.generic_app import environment
 
+from socorro.cron.crontabber_app import CronTabberApp
+
 
 class TestCaseBase(unittest.TestCase):
 
@@ -46,7 +48,7 @@ class TestCaseBase(unittest.TestCase):
 
         """
         mock_logging = mock.Mock()
-        required_config = app.CronTabber.get_required_config()
+        required_config = CronTabberApp.get_required_config()
         required_config.add_option('logger', default=mock_logging)
 
         value_source = [
@@ -108,7 +110,7 @@ class IntegrationTestCaseBase(TestCaseBase):
     def get_standard_config(cls):
         config_manager = configman.ConfigurationManager(
             # [cls.required_config],
-            [app.CronTabber.get_required_config(),
+            [CronTabberApp.get_required_config(),
              app.JobStateDatabase.get_required_config()],
             values_source_list=[
                 configman.ConfigFileFutureProxy,

--- a/socorro/unittest/cron/jobs/test_bugzilla.py
+++ b/socorro/unittest/cron/jobs/test_bugzilla.py
@@ -4,8 +4,8 @@
 
 import pytest
 import requests_mock
-from crontabber.app import CronTabber
 
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs.bugzilla import find_signatures
 from socorro.cron.jobs.bugzilla import BUGZILLA_BASE_URL
 from socorro.unittest.cron.setup_configman import (
@@ -78,7 +78,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         config_manager = self._setup_config_manager(3)
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -121,7 +121,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         self.conn.commit()
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -149,7 +149,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         self.conn.commit()
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -184,7 +184,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         # second time
         config_manager = self._setup_config_manager(0)
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             state = tab.job_state_database.copy()
@@ -198,7 +198,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
 
         config_manager = self._setup_config_manager(0)
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -215,7 +215,7 @@ class IntegrationTestBugzilla(IntegrationTestBase):
         config_manager = self._setup_config_manager(3)
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_clean_missing_symbols.py
+++ b/socorro/unittest/cron/jobs/test_clean_missing_symbols.py
@@ -1,26 +1,17 @@
 import datetime
 
-from crontabber.app import CronTabber
-
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestCleanMissingSymbolsCronApp(IntegrationTestBase):
 
     def _setup_config_manager(self, days_to_keep=None):
-        super(TestCleanMissingSymbolsCronApp, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.clean_missing_symbols.'
-                'CleanMissingSymbolsCronApp|1d'
-            ),
-            overrides={
-                'crontabber.class-CleanMissingSymbolsCronApp'
-                '.days_to_keep': days_to_keep
+        return super(TestCleanMissingSymbolsCronApp, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.clean_missing_symbols.CleanMissingSymbolsCronApp|1d',
+            extra_value_source={
+                'crontabber.class-CleanMissingSymbolsCronApp.days_to_keep': days_to_keep
             },
         )
 
@@ -54,7 +45,7 @@ class TestCleanMissingSymbolsCronApp(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager(days_to_keep=1)
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_clean_raw_adi.py
+++ b/socorro/unittest/cron/jobs/test_clean_raw_adi.py
@@ -1,26 +1,17 @@
 import datetime
 
-from crontabber.app import CronTabber
-
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestCleanRawADICronApp(IntegrationTestBase):
 
     def _setup_config_manager(self, days_to_keep=None):
-        super(TestCleanRawADICronApp, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.clean_raw_adi.'
-                'CleanRawADICronApp|1d'
-            ),
-            overrides={
-                'crontabber.class-CleanRawADICronApp'
-                '.days_to_keep': days_to_keep
+        return super(TestCleanRawADICronApp, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.clean_raw_adi.CleanRawADICronApp|1d',
+            extra_value_source={
+                'crontabber.class-CleanRawADICronApp.days_to_keep': days_to_keep
             },
         )
 
@@ -53,7 +44,7 @@ class TestCleanRawADICronApp(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager(days_to_keep=1)
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_clean_raw_adi_logs.py
+++ b/socorro/unittest/cron/jobs/test_clean_raw_adi_logs.py
@@ -1,26 +1,17 @@
 import datetime
 
-from crontabber.app import CronTabber
-
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestCleanRawADILogsCronApp(IntegrationTestBase):
 
     def _setup_config_manager(self, days_to_keep=None):
-        super(TestCleanRawADILogsCronApp, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.clean_raw_adi_logs.'
-                'CleanRawADILogsCronApp|1d'
-            ),
-            overrides={
-                'crontabber.class-CleanRawADILogsCronApp'
-                '.days_to_keep': days_to_keep
+        return super(TestCleanRawADILogsCronApp, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.clean_raw_adi_logs.CleanRawADILogsCronApp|1d',
+            extra_value_source={
+                'crontabber.class-CleanRawADILogsCronApp.days_to_keep': days_to_keep
             },
         )
 
@@ -53,7 +44,7 @@ class TestCleanRawADILogsCronApp(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager(days_to_keep=1)
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_drop_old_partitions.py
+++ b/socorro/unittest/cron/jobs/test_drop_old_partitions.py
@@ -2,21 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from crontabber.app import CronTabber
-
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestDropOldPartitions(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        super(TestDropOldPartitions, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs='socorro.cron.jobs.drop_old_partitions.'
-            'DropOldPartitionsCronApp|1m',
+        return super(TestDropOldPartitions, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|1m'
         )
 
     def setUp(self):
@@ -63,7 +57,7 @@ class TestDropOldPartitions(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager()
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_elasticsearch_cleanup.py
+++ b/socorro/unittest/cron/jobs/test_elasticsearch_cleanup.py
@@ -2,27 +2,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from crontabber.app import CronTabber
 import mock
 
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class IntegrationTestElasticsearchCleanup(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        return get_config_manager_for_crontabber(
-            jobs='socorro.cron.jobs.elasticsearch_cleanup.'
-                 'ElasticsearchCleanupCronApp|30d',
+        return super(IntegrationTestElasticsearchCleanup, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.elasticsearch_cleanup.ElasticsearchCleanupCronApp|30d'
         )
 
     @mock.patch('socorro.external.es.connection_context.ConnectionContext')
     def test_run(self, connection_context):
-        with self._setup_config_manager().context() as config:
-            tab = CronTabber(config)
+        config_manager = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -2,11 +2,8 @@ import datetime
 import json
 
 import mock
-from crontabber.app import CronTabber
 
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.external.postgresql.dbapi2_util import (
@@ -179,14 +176,12 @@ class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
         self.conn.commit()
 
     def _setup_config_manager(self):
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.featured_versions_automatic'
-                '.FeaturedVersionsAutomaticCronApp|1d'
+        return super(IntegrationTestFeaturedVersionsAutomatic, self)._setup_config_manager(
+            jobs_string=(
+                'socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1d'
             ),
-            overrides={
-                'crontabber.class-FeaturedVersionsAutomaticCronApp'
-                '.api_endpoint_url': (
+            extra_value_source={
+                'crontabber.class-FeaturedVersionsAutomaticCronApp.api_endpoint_url': (
                     'https://example.com/{product}_versions.json'
                 ),
             }
@@ -254,7 +249,7 @@ class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
         self.conn.commit()
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -294,7 +289,7 @@ class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
         rget.side_effect = mocked_get
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
+++ b/socorro/unittest/cron/jobs/test_fetch_adi_from_hive.py
@@ -6,14 +6,11 @@
 import contextlib
 import datetime
 
-from crontabber.app import CronTabber
 import mock
 
-from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs.fetch_adi_from_hive import NoRowsWritten
+from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 
 class TestFetchADIFromHive(IntegrationTestBase):
@@ -61,12 +58,11 @@ class TestFetchADIFromHive(IntegrationTestBase):
         super(TestFetchADIFromHive, self).tearDown()
 
     def _setup_config_manager(self, overrides=None):
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.fetch_adi_from_hive'
-                '.FetchADIFromHiveCronApp|1d'
+        return super(TestFetchADIFromHive, self)._setup_config_manager(
+            jobs_string=(
+                'socorro.cron.jobs.fetch_adi_from_hive.FetchADIFromHiveCronApp|1d'
             ),
-            overrides=overrides,
+            extra_value_source=overrides,
         )
 
     @mock.patch('socorro.cron.jobs.fetch_adi_from_hive.pyhs2')
@@ -138,7 +134,7 @@ class TestFetchADIFromHive(IntegrationTestBase):
             .cursor.return_value.__iter__ = return_test_data
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -325,7 +321,7 @@ class TestFetchADIFromHive(IntegrationTestBase):
             .cursor.return_value.__iter__ = return_test_data
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -361,7 +357,7 @@ class TestFetchADIFromHive(IntegrationTestBase):
             .cursor.return_value.__iter__ = return_test_data
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -395,10 +391,9 @@ class TestFetchADIFromHive(IntegrationTestBase):
 class TestFAKEFetchADIFromHive(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.fetch_adi_from_hive'
-                '.FAKEFetchADIFromHiveCronApp|1d'
+        return super(TestFAKEFetchADIFromHive, self)._setup_config_manager(
+            jobs_string=(
+                'socorro.cron.jobs.fetch_adi_from_hive.FAKEFetchADIFromHiveCronApp|1d'
             ),
         )
 
@@ -406,7 +401,7 @@ class TestFAKEFetchADIFromHive(IntegrationTestBase):
         config_manager = self._setup_config_manager()
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -6,16 +6,16 @@ import datetime
 from functools import wraps
 import json
 
-from crontabber.app import CronTabber
 import mock
 import requests
 import pytest
 
-from socorro.lib.datetimeutil import utc_now
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs import ftpscraper
+from socorro.lib.datetimeutil import utc_now
+from socorro.lib.util import DotDict
 from socorro.unittest.cron.crontabber_tests_base import TestCaseBase
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.lib.util import DotDict
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,
 )
@@ -361,9 +361,9 @@ class TestIntegrationFTPScraper(IntegrationTestBase):
         # Set a completely bogus looking base_url so it can never
         # accidentally work if the network request mocking leaks
         base_url = 'https://archive.muzilla.hej/pub/'
-        return get_config_manager_for_crontabber(
-            jobs='socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1d',
-            overrides={
+        return super(TestIntegrationFTPScraper, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.ftpscraper.FTPScraperCronApp|1d',
+            extra_value_source={
                 'crontabber.class-FTPScraperCronApp.products': 'firefox',
                 'crontabber.class-FTPScraperCronApp.base_url': base_url,
             }
@@ -633,7 +633,7 @@ class TestIntegrationFTPScraper(IntegrationTestBase):
 
         config_manager = self._setup_config_manager_firefox()
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_matviews.py
+++ b/socorro/unittest/cron/jobs/test_matviews.py
@@ -3,23 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from crontabber import base
-from crontabber.app import CronTabber
 import mock
 
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs import matviews
 from socorro.lib.datetimeutil import utc_now
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 
 class TestMatviews(IntegrationTestBase):
 
     def _setup_config_manager(self, jobs):
-
-        return get_config_manager_for_crontabber(
-            jobs=jobs,
+        return super(TestMatviews, self)._setup_config_manager(
+            jobs_string=jobs
         )
 
     def setUp(self):
@@ -103,7 +99,7 @@ class TestMatviews(IntegrationTestBase):
         )
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -143,7 +139,7 @@ class TestMatviews(IntegrationTestBase):
         )
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -165,7 +161,7 @@ class TestMatviews(IntegrationTestBase):
         )
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()
@@ -179,7 +175,7 @@ class TestMatviews(IntegrationTestBase):
         )
 
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_missingsymbols.py
+++ b/socorro/unittest/cron/jobs/test_missingsymbols.py
@@ -3,12 +3,9 @@ import datetime
 from cStringIO import StringIO
 
 import mock
-from crontabber.app import CronTabber
 
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestMissingSymbolsCronApp(IntegrationTestBase):
@@ -98,14 +95,12 @@ class TestMissingSymbolsCronApp(IntegrationTestBase):
         super(TestMissingSymbolsCronApp, self).tearDown()
 
     def _setup_config_manager(self, days_to_keep=None):
-        super(TestMissingSymbolsCronApp, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs=(
+        return super(TestMissingSymbolsCronApp, self)._setup_config_manager(
+            jobs_string=(
                 'socorro.cron.jobs.missingsymbols.MissingSymbolsCronApp|1d'
             ),
-            overrides={
-                'crontabber.class-MissingSymbolsCronApp'
-                '.boto_class': self.mock_boto_class
+            extra_value_source={
+                'crontabber.class-MissingSymbolsCronApp.boto_class': self.mock_boto_class
             },
         )
 
@@ -119,7 +114,7 @@ class TestMissingSymbolsCronApp(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager()
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_truncate_partitions.py
+++ b/socorro/unittest/cron/jobs/test_truncate_partitions.py
@@ -2,21 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from crontabber.app import CronTabber
-
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestTruncatePartitions(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        super(TestTruncatePartitions, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs='socorro.cron.jobs.truncate_partitions.'
-            'TruncatePartitionsCronApp|1m',
+        return super(TestTruncatePartitions, self)._setup_config_manager(
+            jobs_string='socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|1m'
         )
 
     def setUp(self):
@@ -66,7 +60,7 @@ class TestTruncatePartitions(IntegrationTestBase):
         # Run the crontabber job to remove the test table.
         config_manager = self._setup_config_manager()
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
         # Basic assertion test of stored procedure.

--- a/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
+++ b/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
@@ -2,22 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from crontabber.app import CronTabber
 import mock
 
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
 
     def _setup_config_manager(self):
-        return get_config_manager_for_crontabber(
-            jobs='socorro.cron.jobs.upload_crash_report_json_schema.'
-                 'UploadCrashReportJSONSchemaCronApp|30d',
+        return super(TestUploadCrashReportJSONSchemaCronApp, self)._setup_config_manager(
+            jobs_string=(
+                'socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|30d'  # noqa
+            )
         )
 
     @mock.patch('boto.connect_s3')
@@ -28,7 +26,7 @@ class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
         connect_s3().get_bucket().new_key.return_value = key
 
         with self._setup_config_manager().context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/jobs/test_weekly_reports_partitions.py
+++ b/socorro/unittest/cron/jobs/test_weekly_reports_partitions.py
@@ -3,33 +3,23 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from crontabber.app import CronTabber
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-
-from socorro.unittest.cron.setup_configman import (
-    get_config_manager_for_crontabber,
-)
 
 
 class TestWeeklyReportsPartitions(IntegrationTestBase):
 
-    @classmethod
-    def get_standard_config(cls):
-        return get_config_manager_for_crontabber().get_config()
-
     def _setup_config_manager(self):
-        super(TestWeeklyReportsPartitions, self)._setup_config_manager
-        return get_config_manager_for_crontabber(
-            jobs=(
-                'socorro.cron.jobs.weekly_reports_partitions.'
-                'WeeklyReportsPartitionsCronApp|1d'
+        return super(TestWeeklyReportsPartitions, self)._setup_config_manager(
+            jobs_string=(
+                'socorro.cron.jobs.weekly_reports_partitions.WeeklyReportsPartitionsCronApp|1d'
             ),
         )
 
     def test_run_weekly_reports_partitions(self):
         config_manager = self._setup_config_manager()
         with config_manager.context() as config:
-            tab = CronTabber(config)
+            tab = CronTabberApp(config)
             tab.run_all()
 
             information = self._load_structure()

--- a/socorro/unittest/cron/setup_configman.py
+++ b/socorro/unittest/cron/setup_configman.py
@@ -6,7 +6,7 @@ from mock import Mock
 
 from collections import Sequence
 
-from socorro.cron.crontabber_app import CronTabber
+from socorro.cron.crontabber_app import CronTabberApp
 from socorro.lib.util import SilentFakeLogger
 
 from configman import (
@@ -69,15 +69,15 @@ def get_config_manager_for_crontabber(
 ):
     if isinstance(more_definitions, Sequence):
         more_definitions = more_definitions.append(
-            CronTabber.get_required_config()
+            CronTabberApp.get_required_config()
         )
     elif more_definitions is not None:
         more_definitions = [
             more_definitions,
-            CronTabber.get_required_config()
+            CronTabberApp.get_required_config()
         ]
     else:
-        more_definitions = [CronTabber.get_required_config()]
+        more_definitions = [CronTabberApp.get_required_config()]
 
     local_overrides = {
         'logger': Mock(),

--- a/socorro/unittest/cron/test_crontabber_app.py
+++ b/socorro/unittest/cron/test_crontabber_app.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from socorro.cron.crontabber_app import jobs_converter, DEFAULT_JOBS
+
+
+class TestJobsConverter:
+    expected_job_names = [
+        'ADUCronApp',
+        'AndroidDevicesCronApp',
+        'BugzillaCronApp',
+        'BuildADUCronApp',
+        'CleanMissingSymbolsCronApp',
+        'CleanRawADICronApp',
+        'CleanRawADILogsCronApp',
+        'DropOldPartitionsCronApp',
+        'DuplicatesCronApp',
+        'ElasticsearchCleanupCronApp',
+        'FTPScraperCronApp',
+        'FeaturedVersionsAutomaticCronApp',
+        'GraphicsDeviceCronApp',
+        'MissingSymbolsCronApp',
+        'ProductVersionsCronApp',
+        'RawUpdateChannelCronApp',
+        'ReportsCleanCronApp',
+        'SignaturesCronApp',
+        'TruncatePartitionsCronApp',
+        'UploadCrashReportJSONSchemaCronApp',
+        'WeeklyReportsPartitionsCronApp',
+    ]
+
+    def test_dotted_path(self):
+        # This generates an "InnerClassList" which has a list of tuples of the
+        # form (class name, class). We verify we have the expected set here.
+        jobs = jobs_converter('socorro.cron.crontabber_app.DEFAULT_JOBS')
+        job_names = sorted([job_name for job_name, job_class in jobs.class_list])
+        assert job_names == self.expected_job_names
+
+    def test_jobs_spec(self):
+        # This generates an "InnerClassList" which has a list of tuples of the
+        # form (class name, class). We verify we have the expected set here.
+        jobs = jobs_converter(DEFAULT_JOBS)
+        job_names = sorted([job_name for job_name, job_class in jobs.class_list])
+        assert job_names == self.expected_job_names


### PR DESCRIPTION
This redoes crontabber jobs configuration such that it can take a Python dotted path to a string with the configuration.

In order to do that, we also had to redo things so that CronTabberApp was a valid socorro app. This means it now works with the socorro script.

This updates the related docker scripts to use the new way to run it.

In doing all that, I discovered the tests weren't consistent in how they set up a config manager. This fixes tests, too.

This supports the current configuration model as well as the new one (Python dotted paths), so we can make configuration changes after this lands and deploys all the way to -prod.

To test:

1. run `make dockerupdatedata` -- that runs crontabber with a single job
2. run `docker-compose up crontabber` -- that runs the crontabber container and all jobs
3. make sure Travis and Circle are happy

We need to be able to specify different crontabber jobs for our server environments, so this sort of blocks the new docker infrastructure work. Hence it's sort of important to at least get this to stage.