### PR TITLE
fixes bug 1410167 - fixes TelemetryS3CrashStorage bucket_name

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -54,6 +54,7 @@ resource.boto.port=5000
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
 resource.boto.bucket_name=dev_bucket
+resource.boto.telemetry_bucket_name=telemetry_bucket
 resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.calling_format=boto.s3.connection.OrdinaryCallingFormat
 resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3ConnectionContext

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -6,6 +6,10 @@ alembic_config=/app/docker/config/alembic.ini
 # put filesystem crashstorage stuff in /tmp/test_crashes
 resource.fs.fs_root=/tmp/test_crashes
 
+# unset telemetry_bucket_name so that TelemetryS3CrashStorage configuration
+# tests work correctly
+resource.boto.telemetry_bucket_name=
+
 # use socorro_integration_test for postgres and alembic
 database_url=postgres://postgres:aPassword@postgresql:5432/socorro_integration_test
 sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -1053,6 +1053,36 @@ class TelemetryTestCase(ElasticsearchTestCase, BaseTestCase):
 
         return s3
 
+    def test_bucket_name_override(self):
+        """Verify that setting "resource.boto.telemetry_bucket_name" stomps on whatever
+        value bucket_name picked up.
+
+        """
+        tcs = TelemetryBotoS3CrashStorage(
+            config=self.get_tuned_config(
+                TelemetryBotoS3CrashStorage,
+                extra_values={
+                    'resource_class': S3ConnectionContext,
+                    'logger': mock.Mock(),
+                    'bucket_name': 'telemetry_crashes',
+                }
+            )
+        )
+        assert tcs.connection_source.config.bucket_name == 'telemetry_crashes'
+
+        tcs = TelemetryBotoS3CrashStorage(
+            config=self.get_tuned_config(
+                TelemetryBotoS3CrashStorage,
+                extra_values={
+                    'resource_class': S3ConnectionContext,
+                    'logger': mock.Mock(),
+                    'bucket_name': 'telemetry_crashes',
+                    'resource.boto.telemetry_bucket_name': 'override_bucket'
+                }
+            )
+        )
+        assert tcs.connection_source.config.bucket_name == 'override_bucket'
+
     def test_save_raw_and_processed(self):
         boto_s3_store = self.get_s3_store()
 


### PR DESCRIPTION
This allows us to set the `bucket_name` value without having to specify it in the
`destination4` configuration key like we do now.

That makes it easier for us to move crashstorage classes around without bumping
into an environment configuration variable which will be defined in a different
place in the new infrastructure.

This will help us fix TelemetryS3 issues with the docker-based infrastructure.