### PR TITLE
fixes bug 1419856 - implements /__version__ endpoint

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -2702,13 +2702,16 @@ class TestViews(BaseTestViews):
 
 
 class TestDockerflow:
-    def test_version_no_file(self):
+    def test_version_no_file(self, tmpdir):
         """Test with no version.json file"""
-        client = Client()
-        resp = client.get(reverse('crashstats:dockerflow_version'))
-        assert resp.status_code == 200
-        assert resp['Content-Type'] == 'text/json'
-        assert resp.content == '{}'
+        # The tmpdir definitely doesn't have a version.json in it, so we use
+        # that
+        with override_settings(SOCORRO_ROOT=str(tmpdir)):
+            client = Client()
+            resp = client.get(reverse('crashstats:dockerflow_version'))
+            assert resp.status_code == 200
+            assert resp['Content-Type'] == 'text/json'
+            assert resp.content == '{}'
 
     def test_version_with_file(self, tmpdir):
         """Test with a version.json file"""

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -16,12 +16,16 @@ urlpatterns = [
     url('^robots\.txt$',
         views.robots_txt,
         name='robots_txt'),
+
+    # DEPRECATED(willkg): These next two endpoints should be deprecated in
+    # favor of the dockerflow /__version__ one
     url(r'^status/json/$',
         views.status_json,
         name='status_json'),
     url(r'^status/revision/$',
         views.status_revision,
         name='status_revision'),
+
     url(r'^crontabber-state/$',
         views.crontabber_state,
         name='crontabber_state'),
@@ -55,6 +59,11 @@ urlpatterns = [
     url(r'^about/throttling/$',
         views.about_throttling,
         name='about_throttling'),
+
+    # Dockerflow endpoints
+    url(r'__version__',
+        views.dockerflow_version,
+        name='dockerflow_version'),
 
     # if we do a permanent redirect, the browser will "cache" the redirect and
     # it will make it very hard to ever change the DEFAULT_PRODUCT

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1,8 +1,9 @@
 import copy
+import gzip
 import json
 import datetime
+import os
 import urllib
-import gzip
 from collections import defaultdict
 from operator import itemgetter
 from io import BytesIO
@@ -1013,6 +1014,16 @@ def status_revision(request):
         models.Status().get()['socorro_revision'],
         content_type='text/plain'
     )
+
+
+def dockerflow_version(requst):
+    path = os.path.join(settings.SOCORRO_ROOT, 'version.json')
+    if os.path.exists(path):
+        with open(path, 'r') as fp:
+            data = fp.read()
+    else:
+        data = '{}'
+    return http.HttpResponse(data, content_type='text/json')
 
 
 @pass_default_context

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -18,6 +18,9 @@ ROOT = os.path.abspath(
         '..'
     ))
 
+# The socorro root is one directory above the webapp root
+SOCORRO_ROOT = os.path.dirname(ROOT)
+
 
 def path(*dirs):
     return os.path.join(ROOT, *dirs)


### PR DESCRIPTION
Rather than fix the existing `/status/revision/` endpoint to work with the docker-based infrastructure, I implemented the `/__version__` endpoint we want to switch to anyhow. We can leave `/status/revision/` as is for now.

To test, switch to this branch and then do `docker-compose up webapp` and go to http://localhost:8000/__version__ . Because this is the local dev environment, you'll seee `{}`.