### PR TITLE
WIP: fixes bug 1410167 - fix UploadCrashReportJSONSchemaCronApp bucket name

### DIFF
--- a/socorro/cron/jobs/upload_crash_report_json_schema.py
+++ b/socorro/cron/jobs/upload_crash_report_json_schema.py
@@ -44,14 +44,30 @@ class UploadCrashReportJSONSchemaCronApp(BaseCronApp):
         default='crash_report.json',
         doc="Name of the file/key we're going to upload to"
     )
+    required_config.add_option(
+        'telemetry_bucket_name',
+        default='',
+        reference_value_from='resource.boto',
+        doc='if set, overrides resource_class bucket name'
+    )
+
+    def get_bucket_name(self):
+        if self.config.telemetry_bucket_name:
+            # If we have a telemetry.bucket_name set, then stomp on it with
+            # config.telemetry_bucket_name.
+
+            # FIXME(willkg): It'd be better if we could detect whether the
+            # connection context bucket_name was set at all (it's a default
+            # value, or the value of resource.boto.bucket_name).
+            return self.config.telemetry_bucket_name
+        else:
+            return self.config.bucket_name
 
     def run(self):
         connection_context = self.config.resource_class(self.config)
+
         connection = connection_context._connect()
-        bucket = connection_context._get_bucket(
-            connection,
-            self.config.bucket_name
-        )
+        bucket = connection_context._get_bucket(connection, self.get_bucket_name())
         key = bucket.get_key(self.config.json_filename)
         if not key:
             key = bucket.new_key(self.config.json_filename)

--- a/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
+++ b/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
@@ -2,20 +2,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from configman.dotdict import DotDict
 import mock
 
 from socorro.cron.crontabber_app import CronTabberApp
+from socorro.cron.jobs.upload_crash_report_json_schema import UploadCrashReportJSONSchemaCronApp
 from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 
 class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
+    job = 'socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|30d'
 
     def _setup_config_manager(self):
         return super(TestUploadCrashReportJSONSchemaCronApp, self)._setup_config_manager(
-            jobs_string=(
-                'socorro.cron.jobs.upload_crash_report_json_schema.UploadCrashReportJSONSchemaCronApp|30d'  # noqa
-            )
+            jobs_string=self.job
         )
 
     @mock.patch('boto.connect_s3')
@@ -38,3 +39,19 @@ class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
         key.set_contents_from_string.assert_called_with(
             CRASH_REPORT_JSON_SCHEMA_AS_STRING
         )
+
+    @mock.patch('boto.connect_s3')
+    def test_override_telemetry_bucket_name(self, connect_s3):
+        config = DotDict({
+            'telemetry_bucket_name': '',
+            'bucket_name': 'dev_bucket'
+        })
+        app = UploadCrashReportJSONSchemaCronApp(config, job_information=None)
+        assert app.get_bucket_name() == 'dev_bucket'
+
+        config = DotDict({
+            'telemetry_bucket_name': 'telemetry_bucket',
+            'bucket_name': 'dev_bucket'
+        })
+        app = UploadCrashReportJSONSchemaCronApp(config, job_information=None)
+        assert app.get_bucket_name() == 'telemetry_bucket'


### PR DESCRIPTION
This fixes the `UploadCrashReportJSONSchemaCronApp` cron job to use similar
logic to determine the bucket name to use to save the schema file as the
`TelemetryBotoS3CrashStorage` class does.