### PR TITLE
Do not show other threads link in case we only have a crashing thread

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -625,9 +625,15 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-                        <p>
-                            <a href="#allthreads" data-show="Show other threads" data-hide="Hide other threads">Show other threads</a>
-                        </p>
+                        {% if parsed_dump.threads|length == 1 %}
+                            <p>
+                                No more threads to show.
+                            </p>
+                        {% else %}
+                            <p>
+                                <a href="#allthreads" data-show="Show other threads" data-hide="Hide other threads">Show other threads</a>
+                            </p>
+                        {% endif %}
                         {% endif %}
 
                         <div id="allthreads" class="{{ 'hidden' if crashing_thread is not none }}">


### PR DESCRIPTION
Minor improvement: remove "Show other threads" link in case we don't have any other threads to show.