### PR TITLE
Bug 1411036: Add package_json_path config to dependency check cronjob.

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -100,3 +100,4 @@ SYMBOLS_BUCKET_EXCEPTIONS=
 crontabber.jobs=socorro.cron.crontabber_app.STAGE_JOBS
 crontabber.class-DependencySecurityCheckCronApp.nsp_path=/webapp-frontend-deps/node_modules/.bin/nsp
 crontabber.class-DependencySecurityCheckCronApp.safety_path=/usr/local/bin/safety
+crontabber.class-DependencySecurityCheckCronApp.package_json_path=/app/webapp-django/package.json


### PR DESCRIPTION
Turns out the directory layout in the RPM build is not the same as in the repo. Thus, running the dependency check on staging failed because it determines the path to `package.json` relative to it's location in the repo.

This fixes the issue by making the path to the package.json file configurable.

You can test this locally by running `make dockerdependencycheck`.