### PR TITLE
Fix bug 1421988: Update Breakpad.

### DIFF
--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -14,7 +14,7 @@ set -v -e -x
 
 # Build the revision used in the snapshot unless otherwise specified.
 # Update this if you update the snapshot!
-: BREAKPAD_REV         "${BREAKPAD_REV:=a1dbcdcb43148c9eb31cbae74086adbb6ecb970e}"
+: BREAKPAD_REV         "${BREAKPAD_REV:=a61afe7a3e865f1da7ff7185184fe23977c2adca}"
 
 export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Built this locally with no issues, and processed 100 or so crashes with no issues locally as well.

If you want to try this locally, edit `set_up_stackwalk.sh` and comment out the if statement around the "Build breakpad" line so that the docker build will manually build breakpad. Build the docker containers, process some crashes, and check that there were no processing errors.