### PR TITLE
fixes bug 1422639 - prefix nsStringBuffer::FromDataCanaryCheckFailed

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -142,6 +142,7 @@ nsObjCExceptionLogAbort
 nsRefPtr.*
 NSS.*
 nss.*
+nsStringBuffer::FromDataCanaryCheckFailed
 nsTArray<.*
 nsTArray_base<.*
 nsTArray_Impl<.*


### PR DESCRIPTION
This adds that frame to the prefix list allowing signature generation
to proceed to the next frame.

Example:

```
you@processor:/app$ python -m socorro.signature f9a31f4f-7ddd-4d10-ab06-064080171203
Crash id: f9a31f4f-7ddd-4d10-ab06-064080171203
Original: nsStringBuffer::FromDataCanaryCheckFailed
New:      nsStringBuffer::FromDataCanaryCheckFailed | mozilla::dom::Element::GetAttribute
Same?:    False
you@processor:/app$
```