### PR TITLE
Fix bug 1423211: Do not escape stack frames in pre-filled Bugzilla comments.

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
@@ -8,7 +8,7 @@ report bp-{{ uuid }}.
 Top {{ crashing_thread_frames|length }} frames of crashing thread:
 
 {% for frame in crashing_thread_frames -%}
-{{ frame.frame }} {{ frame.module }} {{ frame.signature }} {{ frame.source }}
+{{ frame.frame|safe}} {{ frame.module|safe }} {{ frame.signature|safe }} {{ frame.source|safe }}
 {% endfor %}
 =============================================================
 {% endif %}

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -383,6 +383,26 @@ class TestBugzillaSubmitURL(TestCase):
         ])
         bugzilla_submit_url(report, parsed_dump, 0, 'Core')
 
+    def test_comment_no_html_escaping(self):
+        """If a frame contains <, >, &, or ", they should not be HTML
+        escaped in the comment body.
+
+        """
+        report = self._create_report()
+        parsed_dump = self._create_dump(threads=[
+            self._create_thread(frames=[
+                self._create_frame(
+                    frame=0,
+                    module='&test_module',
+                    signature='foo<char>::bar(char* x, int y)',
+                    file='"foo".cpp',
+                    line=7,
+                ),
+            ])
+        ])
+        url = bugzilla_submit_url(report, parsed_dump, 0, 'Core')
+        assert quote_plus('0 &test_module foo<char>::bar "foo".cpp:7') in url
+
 
 class TestReplaceBugzillaLinks(TestCase):
     def test_simple(self):


### PR DESCRIPTION
The text gets URL-escaped separately, and given that the text is just shoved in a textbox, there's not really anything we're defending against via escaping anyway.