### PR TITLE
Update to Firefox 57, in Sauce Labs

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -1,7 +1,7 @@
 /** Desired capabilities */
 def capabilities = [
   browserName: 'Firefox',
-  version: '56.0',
+  version: '57',
   platform: 'Windows 10'
 ]
 


### PR DESCRIPTION
@chartjes r?

Sorry for the noisy PRs - Sauce Labs has had two separate failed attempts to deploy the permanent fix for Firefox 57, and suggested we implement this, rather than having to continue waiting.

Passing build here: https://pastebin.com/kycRigiV

I'll close the existing PR to get it out of the way, and return with the proper fix, once they've deployed successfully and I've tested.

Sound good?