### PR TITLE
fixes bug 1407655 - implement RawADIMoverCronApp

### DIFF
--- a/scripts/rawadimover_integration_test.sh
+++ b/scripts/rawadimover_integration_test.sh
@@ -7,7 +7,11 @@
 # This is an integration test for the RawADIMoverCronApp. This test
 # must be run by hand in a local development environment.
 #
-# To run it, do:
+# To run it, first add this to your ``my.env`` file:
+#
+# crontabber.jobs=socorro.cron.crontabber_app.STAGE_NEW_JOBS
+#
+# Then do:
 #
 # ./scripts/rawadimover_integration_test.sh
 #

--- a/scripts/rawadimover_integration_test.sh
+++ b/scripts/rawadimover_integration_test.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This is an integration test for the RawADIMoverCronApp. This test
+# must be run by hand in a local development environment.
+#
+# To run it, do:
+#
+# ./scripts/rawadimover_integration_test.sh
+#
+# While you're doing that, open it up in an editor and follow along. You'll know
+# when to turn the page when you hear Lonnen yell like this: YARGGH!!!
+
+set -e
+
+# Figure out yesterday's date.
+DATE=$(date --utc --date="-1 days" +%Y-%m-%d)
+
+echo "Using date ${DATE}"
+
+# Create three records--two for the day that we're looking for, and one for
+# another day that we're not.
+SQLDATA=`cat <<EOF
+INSERT INTO raw_adi (
+    adi_count,
+    date,
+    product_name,
+    product_os_platform,
+    product_os_version,
+    product_version,
+    build,
+    product_guid,
+    update_channel
+)
+VALUES (
+    15471,
+    '${DATE}',
+    'Firefox',
+    'Darwin',
+    '16.7.0',
+    '57.0',
+    '20171112125346',
+    'ec8030f7-c20a-464f-9b0e-13a3a9e97384',
+    'release'
+), (
+    20104,
+    '${DATE}',
+    'Firefox',
+    'Windows_NT',
+    '6.3',
+    '58.0',
+    '20171127135700',
+    'ec8030f7-c20a-464f-9b0e-13a3a9e97384',
+    'beta'
+), (
+    1464,
+    '2017-12-04',
+    'Firefox',
+    'Darwin',
+    '17.2.0',
+    '58.0',
+    '20171123161455',
+    'ec8030f7-c20a-464f-9b0e-13a3a9e97384',
+    'beta'
+);
+EOF`
+
+
+echo ""
+echo "==============="
+echo "Test 1: Dry run"
+echo "==============="
+echo ""
+
+# Wipe the table
+docker-compose exec postgresql psql -U postgres breakpad -c "TRUNCATE raw_adi;"
+
+# Insert some raw_adi data into postgres of the source db
+docker-compose exec postgresql psql -U postgres breakpad -c "$SQLDATA"
+
+# Reset the crontabber state for the job ignoring any error code
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --reset-job=fetch-adi-from-hive || true
+
+# Run the job as a dry run--it should print out two rows
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --job=fetch-adi-from-hive \
+               --crontabber.class-RawADIMoverCronApp.dry_run
+
+echo ""
+echo "Verify: Should have said it would have inserted two row."
+
+
+echo ""
+echo "==============================================="
+echo "Test 2: run for reals, but source_db == dest_db"
+echo "==============================================="
+echo ""
+
+# Reset the crontabber state for the job ignoring any error code
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --reset-job=fetch-adi-from-hive || true
+
+# Run the job
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --job=fetch-adi-from-hive
+
+# Since the source and dest were the same, we inserted the two raw_adi rows into
+# the souce db, so now they're in there twice
+echo ""
+echo "Verify: Data in breakpad--should be five rows; two sets of duplicates:"
+docker-compose exec postgresql psql -U postgres breakpad -c "SELECT * FROM raw_adi;"
+
+
+echo ""
+echo "======================================="
+echo "Test 3: Different source_db and dest_db"
+echo "======================================="
+echo ""
+
+# Wipe the table and insert the raw_adi in again
+docker-compose exec postgresql psql -U postgres breakpad -c "TRUNCATE raw_adi;"
+docker-compose exec postgresql psql -U postgres breakpad2 -c "TRUNCATE raw_adi;" || true
+docker-compose exec postgresql psql -U postgres breakpad -c "$SQLDATA"
+
+# Set up a second db
+# This will prompt you to say "y". Sorry about that.
+docker-compose run -e DATASERVICE_DATABASE_NAME=breakpad2 webapp ./docker/run_setup_postgres.sh
+
+# Reset the crontabber state for the job ignoring any error code
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --reset-job=fetch-adi-from-hive || true
+
+# Run the job with source_db != dest_db
+docker-compose run crontabber ./scripts/socorro crontabber \
+               --job=fetch-adi-from-hive \
+               --crontabber.class-RawADIMoverCronApp.destination.database_name=breakpad2
+
+echo ""
+echo "Verify: Data in breakpad--should be three rows:"
+docker-compose exec postgresql psql -U postgres breakpad -c "SELECT * FROM raw_adi;"
+
+echo ""
+echo "Verify: Data in breakpad2--should be two rows:"
+docker-compose exec postgresql psql -U postgres breakpad2 -c "SELECT * FROM raw_adi;"

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -44,10 +44,19 @@ DEFAULT_JOBS_BASE = [
 ]
 
 DEFAULT_JOBS = ', '.join(DEFAULT_JOBS_BASE)
+
+# Jobs that run in the -stage environment
 STAGE_JOBS = ', '.join(
     DEFAULT_JOBS_BASE + [
         'socorro.cron.jobs.fetch_adi_from_hive.FAKEFetchADIFromHiveCronApp|1d',
         'socorro.cron.jobs.monitoring.DependencySecurityCheckCronApp|1d',
+    ]
+)
+
+# Jobs that run in the -stage-new environment
+STAGE_NEW_JOBS = ', '.join(
+    DEFAULT_JOBS_BASE + [
+        'socorro.cron.jobs.fetch_adi_from_hive.RawADIMoverCronApp|1d'
     ]
 )
 

--- a/socorro/cron/jobs/fetch_adi_from_hive.py
+++ b/socorro/cron/jobs/fetch_adi_from_hive.py
@@ -374,3 +374,130 @@ class FAKEFetchADIFromHiveCronApp(BaseCronApp):
         self.config.logger.info(
             'Faking the fetching of ADI from Hive :)'
         )
+
+
+@as_backfill_cron_app
+class RawADIMoverCronApp(BaseCronApp):
+    """Moves raw ADI data from one db to another
+
+    Use this instead of ``FAKEFetchADIFromHiveCronApp`` and
+    FetchADIFromHiveCronApp``.
+
+    It uses the same app_name to fulfill cron job depdencies.
+
+    To force a dry run, reset the state::
+        ./scripts/socorro crontabber --reset-job=fetch-adi-from-hive
+
+        ./scripts/socorro crontabber --job=fetch-adi-from-hive \
+            --crontabber.class-RawADIMoverCronApp.dry_run
+
+    """
+
+    app_name = 'fetch-adi-from-hive'
+    app_description = 'Raw ADI mover app'
+    app_version = '0.1'
+
+    required_config = Namespace()
+
+    required_config.add_option(
+        'dry_run',
+        default=False,
+        doc='Print instead of storing raw_adi data',
+    )
+
+    required_config.namespace('source')
+    required_config.source.add_option(
+        'database_class',
+        default=ConnectionContext,
+        doc='The class responsible for connecting to Postgres',
+        reference_value_from='resource.postgresql',
+    )
+
+    required_config.namespace('destination')
+    required_config.destination.add_option(
+        'transaction_executor_class',
+        default='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff',
+        doc='a class that will manage transactions',
+        from_string_converter=class_converter,
+        reference_value_from='resource.postgresql',
+    )
+    required_config.destination.add_option(
+        'database_class',
+        default='socorro.external.postgresql.connection_context.ConnectionContext',
+        doc=(
+            'The class responsible for connecting to Postgres. '
+            'Optionally set this to an empty string to entirely '
+            'disable the secondary destination.'
+        ),
+        from_string_converter=class_converter,
+        reference_value_from='resource.postgresql',
+    )
+
+    def get_source_data(self, connection, target_date):
+        """Retrives the raw_adi_logs data from the source for the given target date"""
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            SELECT
+                adi_count,
+                date,
+                product_name,
+                product_os_platform,
+                product_os_version,
+                product_version,
+                build,
+                product_guid,
+                update_channel
+            FROM raw_adi
+            WHERE date = %s;
+            """,
+            vars=(target_date,)
+        )
+        data = [row for row in cursor]
+        return data
+
+    def save_data_to_destination(self, connection, source_data):
+        """Saves data to destination db"""
+        cursor = connection.cursor()
+        for row in source_data:
+            cursor.execute(
+                """
+                INSERT INTO raw_adi (
+                    adi_count,
+                    date,
+                    product_name,
+                    product_os_platform,
+                    product_os_version,
+                    product_version,
+                    build,
+                    product_guid,
+                    update_channel
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+                """,
+                vars=row
+            )
+
+    def run(self, date):
+        source_db = self.config.source.database_class(self.config.source)
+
+        dest_db = self.config.destination.database_class(self.config.destination)
+        tx_class = self.config.destination.transaction_executor_class
+        transaction = tx_class(self.config, dest_db)
+
+        # NOTE(willkg): Running on day x pulls in ADI from day x - 1 to match
+        # the other fetch-adi-from-hive job.
+        target_date = (date - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+
+        source_data = self.get_source_data(source_db.connection(), target_date)
+        self.config.logger.info('Source data for %s: %s rows' % (target_date, len(source_data)))
+        if not source_data:
+            self.config.logger.info('Nothing to do.')
+            return
+
+        if self.config.dry_run:
+            for row in source_data:
+                self.config.logger.info('row: %s', row)
+        else:
+            transaction(self.save_data_to_destination, source_data)
+        self.config.logger.debug('Done!')


### PR DESCRIPTION
This implements a third fetch-adi-from-hive cron app. This variation has
a source db and a dest db and copies the data in the raw_adi table over.

This has no unit tests. There is a single integration test that's run
as a shell script by hand and it requires manual verification.