### PR TITLE
Remove MissingSymbolsCronApp from -stage-new list

### DIFF
--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -53,9 +53,11 @@ STAGE_JOBS = ', '.join(
     ]
 )
 
+
 # Jobs that run in the -stage-new environment
 STAGE_NEW_JOBS = ', '.join(
-    DEFAULT_JOBS_BASE + [
+    [job for job in DEFAULT_JOBS_BASE if 'MissingSymbolsCronApp' not in job] +
+    [
         'socorro.cron.jobs.fetch_adi_from_hive.RawADIMoverCronApp|1d'
     ]
 )


### PR DESCRIPTION
We're not going to do missing symbols with the new infra, so this removes that crontabber app from running in -stage-new.

This is termporary to quell errors we're seeing. We'll be able to remove the crontabber app from all the environments soon.