### PR TITLE
bug 1419585 - all warnings are errors for socorro tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,5 @@ env =
     D:database_password=aPassword
     D:resource.fs.fs_root='./crashes'
     D:resource.elasticsearch.elasticsearch_urls=http://localhost:9200
+# Transform all warnings into errors
+filterwarnings = error

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -420,8 +420,8 @@ class PolyStorageError(Exception, collections.MutableSequence):
     parameters:
         message - an optional over all error message
     """
-    def __init__(self, message=''):
-        super(PolyStorageError, self).__init__(message)
+    def __init__(self, *args):
+        super(PolyStorageError, self).__init__(*args)
         self.exceptions = []  # the collection
 
     def gather_current_exception(self):
@@ -459,7 +459,7 @@ class PolyStorageError(Exception, collections.MutableSequence):
         self.exceptions.__setitem__(index, value)
 
     def __str__(self):
-        return '%s %s' % (self.message,
+        return '%s %s' % (self.args[0],
                           ','.join(repr(e[1]).encode('ascii', 'ignore')
                                    for e in self.exceptions))
 

--- a/socorro/unittest/cron/jobs/test_monitoring.py
+++ b/socorro/unittest/cron/jobs/test_monitoring.py
@@ -1,6 +1,5 @@
 import json
 import os
-from contextlib import nested
 
 import pytest
 import mock
@@ -253,15 +252,11 @@ class TestDependencySecurityCheckCronApp(object):
             description='This is an error',
         )
 
-        mocks = [
-            mock.patch.object(app, 'get_python_vulnerabilities', return_value=[vuln]),
-            mock.patch.object(app, 'get_javascript_vulnerabilities', return_value=[]),
-            mock.patch.object(app, 'alert_log'),
-        ]
-
-        with nested(*mocks):
-            app.run()
-            app.alert_log.assert_called_with([vuln])
+        with mock.patch.object(app, 'get_python_vulnerabilities', return_value=[vuln]):
+            with mock.patch.object(app, 'get_javascript_vulnerabilities', return_value=[]):
+                with mock.patch.object(app, 'alert_log'):
+                    app.run()
+                    app.alert_log.assert_called_with([vuln])
 
     def test_run_raven(self, app_config):
         """Alert via Raven if there's a Sentry DSN configured."""
@@ -276,12 +271,8 @@ class TestDependencySecurityCheckCronApp(object):
             description='This is an error',
         )
 
-        mocks = [
-            mock.patch.object(app, 'get_python_vulnerabilities', return_value=[vuln]),
-            mock.patch.object(app, 'get_javascript_vulnerabilities', return_value=[]),
-            mock.patch.object(app, 'alert_sentry'),
-        ]
-
-        with nested(*mocks):
-            app.run()
-            app.alert_sentry.assert_called_with(dsn, [vuln])
+        with mock.patch.object(app, 'get_python_vulnerabilities', return_value=[vuln]):
+            with mock.patch.object(app, 'get_javascript_vulnerabilities', return_value=[]):
+                with mock.patch.object(app, 'alert_sentry'):
+                    app.run()
+                    app.alert_sentry.assert_called_with(dsn, [vuln])

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -229,9 +229,9 @@ class TestProcessorApp(TestCase):
         assert len(captured_exceptions) == 2
         captured_exception, captured_exception_2 = captured_exceptions
         assert captured_exception.__class__ == NameError
-        assert captured_exception.message == 'waldo'
+        assert captured_exception.args[0] == 'waldo'
         assert captured_exception_2.__class__ == AssertionError
-        assert captured_exception_2.message is False
+        assert captured_exception_2.args[0] is False
 
     @mock.patch('socorro.lib.raven_client.raven')
     def test_transform_misc_error_with_raven_configured_successful(
@@ -275,7 +275,7 @@ class TestProcessorApp(TestCase):
         assert len(captured_exceptions) == 1
         captured_exception, = captured_exceptions
         assert captured_exception.__class__ == ValueError
-        assert captured_exception.message == 'Someone is wrong on the Internet'
+        assert captured_exception.args[0] == 'Someone is wrong on the Internet'
 
     @mock.patch('socorro.lib.raven_client.raven')
     def test_transform_polystorage_error_with_raven_configured_failing(


### PR DESCRIPTION
This fixes the socorro tests such that all warnings are now considered
errors. This also fixes the handful of warnings that were getting kicked
up.

This doesn't fix the webapp tests--we'll do that in another PR.