### PR TITLE
bug 1425245 - log boto fetch errors

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -72,7 +72,8 @@ class SimplifiedCrashData(BotoS3CrashStorage):
                 return get(params.uuid, name=params.name)
             else:
                 return get(params.uuid)
-        except CrashIDNotFound:
+        except CrashIDNotFound as cidnf:
+            self.config.logger.error('%s not found: %s' % (params.datatype, cidnf))
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message
             # contains information about buckets and prefix keys.

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -40,7 +40,7 @@ from crashstats import scrubber
 from crashstats.base.utils import requests_retry_session
 
 
-logger = logging.getLogger('crashstats_models')
+logger = logging.getLogger('crashstats.models')
 
 
 class DeprecatedModelError(DeprecationWarning):


### PR DESCRIPTION
This adds logging for boto fetch errors. Previously, error messages
were getting thrown away.

This also fixes logging for crashstats models. Previously the logging
configuration didn't cover them, so they were silently ignored.