### PR TITLE
Expose postgres on a port to make connecting via a client easier.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,8 @@ services:
   # https://hub.docker.com/_/postgres/
   postgresql:
     image: postgres:9.4
+    ports:
+      - "8574:5432"
     environment:
       # Create the superuser account
       - POSTGRES_USER=postgres

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -12,6 +12,18 @@ You can run the crontabber job that checks for security vulnerabilities locally:
    make dockerdependencycheck
 
 
+Connect to PostgreSQL Database
+==============================
+
+The local development environment's PostgreSQL database exposes itself on a
+non-standard port when run with docker-compose. You can connect to it with
+the client of your choice using the following connection settings:
+
+* Username: ``postgres``
+* Password: ``aPassword``
+* Port: ``8574``
+
+
 .. Warning::
 
    August 17th, 2017: Everything below this point is outdated.


### PR DESCRIPTION
This makes it easier to use programs like Postico to inspect the database during development.