### PR TITLE
fixes bug 1309102 - add _platform_memmove things to prefix list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -79,7 +79,8 @@ memcmp
 __memcmp16
 memcpy
 memmove
-_platform_memmove\$VARIANT\$Haswell
+_platform_memmove\$VARIANT\$
+__platform_memmove\$VARIANT\$
 memset
 mozalloc_abort.*
 mozalloc_handle_oom


### PR DESCRIPTION
`_platform_memmove$VARIANT$Haswell` is already in the list, so this nixes
the Haswell part and generalizes it across the other variations.

This also adds the `__platform_memmove$VARIANT$` version, too, with the
double-underscore.
  