### PR TITLE
fixes bug 1429434 - fix e2e-tests README missing in RTD

### DIFF
--- a/docker/run_build_docs.sh
+++ b/docker/run_build_docs.sh
@@ -4,12 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Change directory to docs directory to use that Makefile and cwd
 cd docs
-
-# Copy the e2e-test README to this directory because otherwise we can't
-# pull it in because there isn't a way to do a file include for Markdown
-# files.
-cp ../e2e-tests/README.md tests/e2e_readme.md
 
 # Build the docs
 make html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,5 +16,10 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile copyreadme
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Copy the e2e-test README to this directory because otherwise we can't pull it
+# in because there isn't a way to do a file include for Markdown files.
+copyreadme:
+	cp ../e2e-tests/README.md tests/e2e_readme.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,10 +16,9 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile copyreadme
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
+#
 # Copy the e2e-test README to this directory because otherwise we can't pull it
 # in because there isn't a way to do a file include for Markdown files.
-copyreadme:
+%: Makefile
 	cp ../e2e-tests/README.md tests/e2e_readme.md
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
This fixes the docs build scripts such that readthedocs will copy the
e2e-tests README before building the docs. Otherwise, the e2e-tests README
doesn't get compiled into the docs on readthedocs.

To test this, run `make dockerdocs` and verify that `docs/tests/e2e_readme.md` exists.