### PR TITLE
bug 1429437 - first pass at login troubleshooting docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,10 +41,11 @@ Contents
 
    gettingstarted
    contributing
-   symbols
+   troubleshooting
    architecture/*
    components/*
    services/*
    tests/*
+   symbols
    deploy
    howto

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,26 @@
+.. index:: troubleshooting
+
+===============
+Troubleshooting
+===============
+
+Login problems
+==============
+
+Socorro uses Google to authenticate users.
+
+The "Sign in" button is in the footer of the Crash Stats web interface.
+
+If you are having problems logging in, here are some things to try:
+
+1. Make sure your browser is set to accept third-party cookies.
+
+   Your browser needs to accept third-party cookies during authentication. After
+   you've authenticated, you can switch it off again.
+
+2. Disable tracking protection.
+
+   This has helped some people in some cases.
+
+
+If none of those steps worked, please open up a bug.


### PR DESCRIPTION
This is a first pass at login troubleshooting docs. I figure any information is better than no information, so any steps forward--even if they're not complete and comprehensive and perfect--are better than where we are now.

This creates a section that has a url that we can point people to, so that satisfies my need for a one-liner response for login problems to catch common scenarios.

What can we improve in the actual steps? Are there other good troubleshooting steps that users can try?