### PR TITLE
fixes bug 1426186 - add reprocessing howto

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -24,6 +24,53 @@ the client of your choice using the following connection settings:
 * Port: ``8574``
 
 
+Reprocess crashes
+=================
+
+Reprocessing individual crashes
+-------------------------------
+
+If you have appropriate permissions, you can reprocess an individual crash by
+viewing the crash report on the Crash Stats site, clicking on the "Reprocess"
+tab, and clicking on the "Reprocess this crash" button.
+
+
+Reprocessing lots of crashes if you're not an admin
+---------------------------------------------------
+
+If you need to reprocess a lot of crashes, please `write up a bug
+<https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro>`_.
+In the bug description, include a Super Search url with the crashes you want
+reprocessed.
+
+
+Reprocessing crashes if you're an admin
+---------------------------------------
+
+If you're an admin, you can create an API token with the "Reprocess Crashes"
+permission. You can use this token in conjunction with the
+``scripts/reprocess.py`` script to set crashes up for reprocessing.
+
+For example, this reprocesses a single crash::
+
+    $ docker-compose run processor bash
+    app@processor:app$ ./scripts/reprocess.py c2815fd1-e87b-45e9-9630-765060180110
+
+This reprocesses crashes all crashes with a specified signature::
+
+    $ docker-compose run processor bash
+    app@processor:app$ ./scripts/fetch_crashids.py --signature="some | signature" | ./scripts/reprocess.py
+
+
+.. Warning::
+
+   If you're reprocessing more than 10,000 crashes, make sure to specify the
+   ``--sleep`` argument and use a value like 10 seconds. This will slow down
+   adding items to the reprocessing queue such that the rate of crashes being
+   added is roughly the rate of crashes being processed. Otherwise, you'll
+   exceed our alert triggers for queue sizes and it'll page people.
+
+
 .. Warning::
 
    August 17th, 2017: Everything below this point is outdated.

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -64,11 +64,11 @@ This reprocesses crashes all crashes with a specified signature::
 
 .. Warning::
 
-   If you're reprocessing more than 10,000 crashes, make sure to specify the
-   ``--sleep`` argument and use a value like 10 seconds. This will slow down
-   adding items to the reprocessing queue such that the rate of crashes being
-   added is roughly the rate of crashes being processed. Otherwise, you'll
-   exceed our alert triggers for queue sizes and it'll page people.
+   If you're reprocessing more than 10,000 crashes, make sure to add a sleep
+   argument of 10 seconds (``--sleep 10``). This will slow down adding items to
+   the reprocessing queue such that the rate of crashes being added is roughly
+   the rate of crashes being processed. Otherwise, you'll exceed our alert
+   triggers for queue sizes and it'll page people.
 
 
 .. Warning::

--- a/socorro/scripts/reprocess.py
+++ b/socorro/scripts/reprocess.py
@@ -24,10 +24,13 @@ Sends specified crashes for reprocessing
 This requires SOCORRO_REPROCESS_API_TOKEN to be set in the environment to a
 valid API token.
 
-Note: If you're reprocessing more than 10,000 crashes, you should use a sleep
-value of 10 seconds. This slows down adding items to the reprocessing queue so
-they're being added roughly at the same rate as they're being processed. This
-way, the queue doesn't back up and the system doesn't start paging people.
+Note: If you're processing more than 10,000 crashes, you should use a sleep
+value that balances the rate of crash ids being added to the queue and the rate
+of crash ids being processed. For example, you could use "--sleep 10" which
+will sleep for 10 seconds between submitting groups of crashes.
+
+Also, if you're processing a lot of crashes, you should let ops know and maybe
+they should increase the number of processor nodes.
 
 """
 

--- a/socorro/scripts/reprocess.py
+++ b/socorro/scripts/reprocess.py
@@ -21,7 +21,13 @@ from socorro.scripts import WrappedTextHelpFormatter
 DESCRIPTION = """
 Sends specified crashes for reprocessing
 
-This requires SOCORRO_REPROCESS_API_TOKEN to be set in the environment to a valid API token.
+This requires SOCORRO_REPROCESS_API_TOKEN to be set in the environment to a
+valid API token.
+
+Note: If you're reprocessing more than 10,000 crashes, you should use a sleep
+value of 10 seconds. This slows down adding items to the reprocessing queue so
+they're being added roughly at the same rate as they're being processed. This
+way, the queue doesn't back up and the system doesn't start paging people.
 
 """
 


### PR DESCRIPTION
This adds some crude documentation for reprocessing crashes including some
hand-wavey warnings about being cautious about adding crash ids to the queue
faster than they can be processed.