### PR TITLE
fixes bug 1371428 - nix quotes

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -15,7 +15,6 @@ from socorro.lib.util import drop_unicode
 
 SIGNATURE_MAX_LENGTH = 255
 MAXIMUM_FRAMES_TO_CONSIDER = 40
-SIGNATURE_ESCAPE_SINGLE_QUOTE = True
 
 
 logger = logging.getLogger(__name__)
@@ -69,8 +68,6 @@ class SignatureTool(object):
             crashed_thread,
             delimiter
         )
-        if SIGNATURE_ESCAPE_SINGLE_QUOTE:
-            signature = signature.replace("'", "''")
 
         return signature, signature_notes
 


### PR DESCRIPTION
The change was pretty minor.

Then I went looking for related tests and in the process of doing that, decided to change the test case names to something related to what they were testing so I didn't have to do so much work reading them next time around.

In the process of doing that, I found a couple of tests that were identical duplicates and one test that was testing the same thing as another test and so I removed those.

There are < 4000 crashes in the current corpus that are affected by this change. We could reprocess them after landing and deploying this, but I don't think that's necessary.