### PR TITLE
Fix bug 1429829: Use functions for `interpolate` param of metricsgraphics.js

### DIFF
--- a/docs/tests/system_checklist.rst
+++ b/docs/tests/system_checklist.rst
@@ -153,6 +153,11 @@ Checklist
       stage: In IRC: "webqatestbot build socorro.stage.saucelabs"
       prod: In IRC: "webqatestbot build socorro.prod.saucelabs"
 
+    Are there JavaScript errors in the webapp?
+
+    * While checking individual pages below, open the DevTools console and watch
+      for JavaScript errors.
+
     Can we log into the webapp?
 
     * Log in and check the profile page.

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
@@ -35,7 +35,7 @@ $(function() {
             y_accessor: 'ratio',
             axes_not_compact: true,
             utc_time: true,
-            interpolate: 'basic',
+            interpolate: d3.curveLinear,
             area: false,
             legend: legend,
             legend_target: '#crashes-per-adi-legend',

--- a/webapp-django/crashstats/home/static/home/js/home.js
+++ b/webapp-django/crashstats/home/static/home/js/home.js
@@ -462,7 +462,7 @@ $(function () {
             y_accessor: 'count',
             axes_not_compact: true,
             utc_time: true,
-            interpolate: 'basic',
+            interpolate: d3.curveLinear,
             area: false,
             legend: versions,
             legend_target: '#homepage-graph-legend',

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -215,7 +215,7 @@ PIPELINE_JS = {
     },
     'd3': {
         'source_filenames': (
-            'd3/build/d3.min.js',
+            'd3/build/d3.js',
         ),
         'output_filename': 'js/d3.min.js',
     },
@@ -249,7 +249,7 @@ PIPELINE_JS = {
     },
     'metricsgraphics': {
         'source_filenames': (
-            'metrics-graphics/dist/metricsgraphics.min.js',
+            'metrics-graphics/dist/metricsgraphics.js',
         ),
         'output_filename': 'js/metricsgraphics.min.js',
     },
@@ -279,7 +279,7 @@ PIPELINE_JS = {
     },
     'crashstats_base': {
         'source_filenames': (
-            'jquery/dist/jquery.min.js',
+            'jquery/dist/jquery.js',
             'crashstats/js/jquery/plugins/jquery.cookies.2.2.0.js',
             'qs/dist/qs.js',
             'moment/moment.js',

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -152,7 +152,7 @@ SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElem
         y_accessor: 'count',
         axes_not_compact: true,
         utc_time: true,
-        interpolate: 'basic',
+        interpolate: d3.curveLinear,
         area: false,
         legend: graphData.legend,
         legend_target: '.new-legend',


### PR DESCRIPTION
This should fix the JS errors on the home, crashes-per-day, and signature graphs pages. It also makes debugging JS a bit easier by not using some minified files in development, and updates the system checklist docs to remind people (mostly me) to check the JS console while testing the webapp.