### PR TITLE
fixes bug 1424659 - nix consecutive spaces in signatures

### DIFF
--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -18,8 +18,8 @@ from socorro.signature.rules import (
     SignatureRunWatchDog,
     SignatureIPCChannelError,
     SignatureIPCMessageName,
-    SigTrim,
-    SigTrunc,
+    SigFixWhitespace,
+    SigTruncate,
     SignatureJitCategory,
     SignatureParentIDNotEqualsChildID,
 )
@@ -38,8 +38,8 @@ DEFAULT_PIPELINE = [
     SignatureJitCategory(),
 
     # NOTE(willkg): These should always come last and in this order
-    SigTrim(),
-    SigTrunc(),
+    SigFixWhitespace(),
+    SigTruncate(),
 ]
 
 

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -558,19 +558,40 @@ class AbortSignature(Rule):
         return True
 
 
-class SigTrim(Rule):
-    """ensure that the signature never has any leading or trailing white
-    spaces"""
+class SigFixWhitespace(Rule):
+    """Fix whitespace in signatures
+
+    This does the following:
+
+    * trims leading and trailing whitespace
+    * converts all non-space whitespace characters to space
+    * reduce consecutive spaces to a single space
+
+    """
+
+    WHITESPACE_RE = re.compile('\s')
+    CONSECUTIVE_WHITESPACE_RE = re.compile('\s\s+')
 
     def predicate(self, raw_crash, processed_crash):
         return isinstance(processed_crash.get('signature'), basestring)
 
     def action(self, raw_crash, processed_crash, notes):
-        processed_crash['signature'] = processed_crash['signature'].strip()
+        sig = processed_crash['signature']
+
+        # Trim leading and trailing whitespace
+        sig = sig.strip()
+
+        # Convert all non-space whitespace characters into spaces
+        sig = self.WHITESPACE_RE.sub(' ', sig)
+
+        # Reduce consecutive spaces to a single space
+        sig = self.CONSECUTIVE_WHITESPACE_RE.sub(' ', sig)
+
+        processed_crash['signature'] = sig
         return True
 
 
-class SigTrunc(Rule):
+class SigTruncate(Rule):
     """Truncates signatures down to SIGNATURE_MAX_LENGTH characters"""
 
     def predicate(self, raw_crash, processed_crash):

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -21,8 +21,8 @@ from socorro.signature.rules import (
     SignatureGenerationRule,
     SignatureJitCategory,
     SignatureRunWatchDog,
-    SigTrim,
-    SigTrunc,
+    SigFixWhitespace,
+    SigTruncate,
     SignatureShutdownTimeout,
     SignatureIPCMessageName,
     SignatureParentIDNotEqualsChildID,
@@ -1277,10 +1277,10 @@ class TestAbortSignature:
         assert processed_crash['signature'] == 'Abort | unknown | hello'
 
 
-class TestSigTrim:
+class TestSigFixWhitespace:
 
     def test_predicate_no_match(self):
-        rule = SigTrim()
+        rule = SigFixWhitespace()
 
         processed_crash = {}
         predicate_result = rule.predicate({}, processed_crash)
@@ -1291,7 +1291,7 @@ class TestSigTrim:
         assert predicate_result is False
 
     def test_predicate(self):
-        rule = SigTrim()
+        rule = SigFixWhitespace()
         processed_crash = {
             'signature': 'fooo::baar'
         }
@@ -1299,12 +1299,38 @@ class TestSigTrim:
         assert predicate_result is True
 
     @pytest.mark.parametrize('signature, expected', [
-        ('all   good', 'all   good'),
-        ('all   good     ', 'all   good'),
-        ('    all   good  ', 'all   good'),
+        ('all   good', 'all good'),
+        ('all   good     ', 'all good'),
+        ('    all   good  ', 'all good'),
     ])
-    def test_action_success(self, signature, expected):
-        rule = SigTrim()
+    def test_leading_trailing_whitespace(self, signature, expected):
+        rule = SigFixWhitespace()
+        processed_crash = {
+            'signature': signature
+        }
+        action_result = rule.action({}, processed_crash, [])
+        assert action_result is True
+        assert processed_crash['signature'] == expected
+
+    @pytest.mark.parametrize('signature, expected', [
+        ('all\tgood', 'all good'),
+        ('all\n\ngood', 'all good'),
+    ])
+    def test_non_space_whitespace(self, signature, expected):
+        rule = SigFixWhitespace()
+        processed_crash = {
+            'signature': signature
+        }
+        action_result = rule.action({}, processed_crash, [])
+        assert action_result is True
+        assert processed_crash['signature'] == expected
+
+    @pytest.mark.parametrize('signature, expected', [
+        ('all   good', 'all good'),
+        ('all  |  good', 'all | good'),
+    ])
+    def test_consecutive_spaces(self, signature, expected):
+        rule = SigFixWhitespace()
         processed_crash = {
             'signature': signature
         }
@@ -1313,10 +1339,10 @@ class TestSigTrim:
         assert processed_crash['signature'] == expected
 
 
-class TestSigTrunc:
+class TestSigTruncate:
 
     def test_predicate_no_match(self):
-        rule = SigTrunc()
+        rule = SigTruncate()
         processed_crash = {
             'signature': '0' * 100
         }
@@ -1324,7 +1350,7 @@ class TestSigTrunc:
         assert predicate_result is False
 
     def test_predicate(self):
-        rule = SigTrunc()
+        rule = SigTruncate()
         processed_crash = {
             'signature': '9' * 256
         }
@@ -1332,7 +1358,7 @@ class TestSigTrunc:
         assert predicate_result is True
 
     def test_action_success(self):
-        rule = SigTrunc()
+        rule = SigTruncate()
         processed_crash = {
             'signature': '9' * 256
         }

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -1299,37 +1299,20 @@ class TestSigFixWhitespace:
         assert predicate_result is True
 
     @pytest.mark.parametrize('signature, expected', [
+        # Leading and trailing whitespace are removed
         ('all   good', 'all good'),
         ('all   good     ', 'all good'),
         ('    all   good  ', 'all good'),
-    ])
-    def test_leading_trailing_whitespace(self, signature, expected):
-        rule = SigFixWhitespace()
-        processed_crash = {
-            'signature': signature
-        }
-        action_result = rule.action({}, processed_crash, [])
-        assert action_result is True
-        assert processed_crash['signature'] == expected
 
-    @pytest.mark.parametrize('signature, expected', [
+        # Non-space whitespace is converted to spaces
         ('all\tgood', 'all good'),
         ('all\n\ngood', 'all good'),
-    ])
-    def test_non_space_whitespace(self, signature, expected):
-        rule = SigFixWhitespace()
-        processed_crash = {
-            'signature': signature
-        }
-        action_result = rule.action({}, processed_crash, [])
-        assert action_result is True
-        assert processed_crash['signature'] == expected
 
-    @pytest.mark.parametrize('signature, expected', [
+        # Multiple consecutive spaces are converted to a single space
         ('all   good', 'all good'),
         ('all  |  good', 'all | good'),
     ])
-    def test_consecutive_spaces(self, signature, expected):
+    def test_whitespace_fixing(self, signature, expected):
         rule = SigFixWhitespace()
         processed_crash = {
             'signature': signature


### PR DESCRIPTION
Prior to this, it was possible (though rare) to have two spaces in a row
in signatures. That's tough because the webui shows that as a single
space and if you search for the single-space version, you won't get any
results.

This fixes that by establishing that signatures can't have more than 1
consecutive whitespace character. Further, this makes sure that all
non-space whitespace characters are converted to space and this
happens all before we truncate the signature.

I also changed SigTrunc to SigTruncate because "trunc" is an unnecessary
abbreviation.