### PR TITLE
[wip] fixes bug 1425245 - adds crash_verify/ url endpoint

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -6,6 +6,7 @@ from socorro.lib import external_common, MissingArgumentError, BadArgumentError
 from socorro.external.boto.crashstorage import (
     BotoS3CrashStorage,
     CrashIDNotFound,
+    TelemetryBotoS3CrashStorage,
 )
 from socorro.external.crash_data_base import CrashDataBase
 
@@ -74,6 +75,43 @@ class SimplifiedCrashData(BotoS3CrashStorage):
                 return get(params.uuid)
         except CrashIDNotFound as cidnf:
             self.config.logger.error('%s not found: %s' % (params.datatype, cidnf))
+            # The CrashIDNotFound exception that happens inside the
+            # crashstorage is too revealing as exception message
+            # contains information about buckets and prefix keys.
+            # Re-wrap it here so the message is just the crash ID.
+            raise CrashIDNotFound(params.uuid)
+
+
+class TelemetryCrashData(TelemetryBotoS3CrashStorage):
+    """The difference between this and the base CrashData class is that
+    this one only makes the get() and if it fails it does NOT
+    try to put the crash ID back into the priority jobs queue.
+    Also, it returns a python dict instead of a DotDict which
+    makes this easier to work with from the webapp's model bridge.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TelemetryCrashData, self).__init__(*args, **kwargs)
+        # Forcibly set this to override the default in the base
+        # crash storage class for boto. We're confident that at this
+        # leaf point we want to NOT return a DotDict but just a plain
+        # python dict.
+        self.config.json_object_hook = dict
+
+    def get(self, **kwargs):
+        """Return JSON data of a crash report, given its uuid."""
+        filters = [
+            ('uuid', None, str),
+        ]
+        params = external_common.parse_arguments(filters, kwargs, modern=True)
+
+        if not params.uuid:
+            raise MissingArgumentError('uuid')
+
+        try:
+            return self.get_unredacted_processed(params.uuid)
+        except CrashIDNotFound as cidnf:
+            self.config.logger.error('telemetry crash not found: %s' % cidnf)
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message
             # contains information about buckets and prefix keys.

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -402,8 +402,9 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
 
     @staticmethod
     def _do_save_processed(boto_connection, processed_crash):
-        """Overriding this method so we can control the "name of thing"
-        prefix used to upload to S3."""
+        """Overriding this so we can change "name of thing" to "crash_report"
+
+        """
         crash_id = processed_crash['uuid']
         processed_crash_as_string = boto_connection._convert_mapping_to_string(
             processed_crash
@@ -413,6 +414,22 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
             "crash_report",
             processed_crash_as_string
         )
+
+    @staticmethod
+    def _do_get_unredacted_processed(boto_connection, crash_id, json_object_hook):
+        """Overriding this so we can change "name of thing" to "crash_report"
+
+        """
+        try:
+            processed_crash_as_string = boto_connection.fetch(crash_id, 'crash_report')
+            return json.loads(
+                processed_crash_as_string,
+                object_hook=json_object_hook,
+            )
+        except boto_connection.ResponseError as x:
+            raise CrashIDNotFound(
+                '%s not found: %s' % (crash_id, x)
+            )
 
 
 class SupportReasonAPIStorage(BotoS3CrashStorage):

--- a/socorro/external/postgresql/crash_data.py
+++ b/socorro/external/postgresql/crash_data.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from socorro.external.crash_data_base import CrashDataBase
+from socorro.external.postgresql.base import PostgreSQLBase
+from socorro.lib import external_common, MissingArgumentError
 
 
 class CrashData(CrashDataBase):
@@ -11,3 +13,51 @@ class CrashData(CrashDataBase):
     """
     def get_storage(self):
         return self.config.database.crashstorage_class(self.config.database)
+
+
+class RawCrash(PostgreSQLBase):
+    """Implement RawCrash data service with PostgreSQL"""
+    def get(self, **kwargs):
+        filters = [
+            ('uuid', None, str)
+        ]
+        params = external_common.parse_arguments(filters, kwargs, modern=True)
+        if not params.uuid:
+            raise MissingArgumentError('uuid')
+
+        sql_query = """
+            SELECT
+                uuid
+            FROM raw_crashes
+            WHERE uuid=%(uuid)s
+        """
+        results = self.query(sql_query, params)
+        hits = results.zipped()
+
+        return {
+            'hits': hits
+        }
+
+
+class ProcessedCrash(PostgreSQLBase):
+    """Implement ProcessedCrash  data service with PostgreSQL"""
+    def get(self, **kwargs):
+        filters = [
+            ('uuid', None, str)
+        ]
+        params = external_common.parse_arguments(filters, kwargs, modern=True)
+        if not params.uuid:
+            raise MissingArgumentError('uuid')
+
+        sql_query = """
+            SELECT
+                uuid
+            FROM processed_crashes
+            WHERE uuid=%(uuid)s
+        """
+        results = self.query(sql_query, params)
+        hits = results.zipped()
+
+        return {
+            'hits': hits
+        }

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -128,7 +128,10 @@ BLACKLIST = (
     'Query',
     # because it's an internal thing only
     'GraphicsReport',
+    'PostgresProcessedCrash',
+    'PostgresRawCrash',
     'Priorityjob',
+    'TelemetryCrash',
 )
 
 

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -29,6 +29,10 @@ urlpatterns = [
     url(r'^crontabber-state/$',
         views.crontabber_state,
         name='crontabber_state'),
+    url(r'^crash-verify/(?P<crash_id>[\w-]+)$',
+        views.crash_verify,
+        name='crash_verify'),
+
     url('^crashes-per-day/$',
         views.crashes_per_day,
         name='crashes_per_day'),

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -655,6 +655,10 @@ SOCORRO_IMPLEMENTATIONS_CONFIG = {
         'boto': {
             'access_key': config('resource.boto.access_key', None),
             'bucket_name': config('resource.boto.bucket_name', 'crashstats'),
+            'telemetry_bucket_name': config(
+                'resource.boto.telemetry_bucket_name',
+                'telemetry_bucket'
+            ),
             'region': config('resource.boto.region', 'us-west-2'),
             'prefix': config('resource.boto.prefix', ''),
             'keybuilder_class': config(


### PR DESCRIPTION
This url endpoint takes a crash id and tells you whether the data for that
crash exists in all the appropriate crash stores.

We can use this for end-to-end integration testing as well as debugging
system oddities.