### PR TITLE
Make the string representation of PolyStorageError more robust.

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -459,9 +459,12 @@ class PolyStorageError(Exception, collections.MutableSequence):
         self.exceptions.__setitem__(index, value)
 
     def __str__(self):
-        return '%s %s' % (self.args[0],
-                          ','.join(repr(e[1]).encode('ascii', 'ignore')
-                                   for e in self.exceptions))
+        output = []
+        if self.args:
+            output.append(self.args[0])
+        for e in self.exceptions:
+            output.append(repr(e[1]).encode('ascii', 'ignore'))
+        return ','.join(output)
 
 
 class PolyCrashStorage(CrashStorageBase):

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -256,9 +256,27 @@ class TestBase(TestCase):
                 sample in str(x)
                 for sample in ['hell', 'NameError', 'KeyError', 'AttributeError']
             )
+            assert (
+                str(x) == "hell,NameError('dwight',),KeyError('wilma',),AttributeError('sarita',)"
+            )
 
             x[0] = x[1]
             assert x[0] == x[1]
+
+    def test_polyerror_str_missing_args(self):
+        p = PolyStorageError()
+        try:
+            try:
+                raise NameError('dwight')
+            except NameError:
+                p.gather_current_exception()
+            try:
+                raise KeyError('wilma')
+            except KeyError:
+                p.gather_current_exception()
+            raise p
+        except PolyStorageError as x:
+            assert str(x) == "NameError('dwight',),KeyError('wilma',)"
 
     def test_poly_crash_storage(self):
         n = Namespace()


### PR DESCRIPTION
While working on [bug 687630](https://bugzilla.mozilla.org/show_bug.cgi?id=687630) I ran into an issue while processing crashes, and the error couldn't be output properly because `PolyStorageError` had been called with no arguments, which `PolyStorageError.__str__` could not properly handle.

This makes the method more robust to weird arguments so that it will print out the errors that occurred even if there are no arguments given. It also slightly changes the format of what was output, but none of the tests were relying on this anyway.