### PR TITLE
Bug 1431167 - Add ReleaseData to the prefix list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -178,6 +178,7 @@ realloc
 recv
 .*ReentrantMonitor::Wait
 RefPtr
+ReleaseData
 _RTC_Terminate
 Rtl
 _Rtl


### PR DESCRIPTION
ReleaseData is a generic function used to destroy string data.