### PR TITLE
bug 1431442 - add "mark-success" to crontabber app

### DIFF
--- a/docker/run_setup.sh
+++ b/docker/run_setup.sh
@@ -9,6 +9,15 @@ set -e
 # Run scripts for setting up data sources for the local development environment.
 # This assumes that it is running in the webapp docker container.
 
+# Drop and re-create the breakpad database with tables, stored procedures,
+# types, indexes, and keys; also bulk-loads static data for some lookup tables
 /app/docker/run_setup_postgres.sh
+
+# Drop and re-create local S3 buckets
 /app/docker/run_recreate_s3_buckets.sh
+
+# Delete all Elasticsearch indices
 /app/scripts/socorro clear_es_indices
+
+# Initialize the crontabber bookkeeping for all configured jobs to success
+/app/scripts/socorro crontabber --mark-success=all

--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -16,7 +16,9 @@ PRODUCTS="firefox,mobile"
 CRONTABBERCMD="./scripts/socorro crontabber"
 
 
-# Fetch release data -- do it as the user so it can cache things
+# Fetch release data -- do it as the user so it can cache things, but reset
+# the ftpscraper job first
+docker-compose run crontabber ${CRONTABBERCMD} --reset-job=ftpscraper
 docker-compose run -u "${HOSTUSER}" crontabber ${CRONTABBERCMD} \
                --job=ftpscraper \
                --crontabber.class-FTPScraperCronApp.cachedir=${CACHEDIR} \

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -3,14 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 import sys
 
 from configman import Namespace, class_converter
 from crontabber.app import (
     classes_in_namespaces_converter_with_compression,
     CronTabberBase,
-    database_transaction,
     get_extra_as_options,
     JobNotFoundError,
     line_splitter,


### PR DESCRIPTION
This makes it easier to set up initial crontabber bookkeeping state in
the local development environment without having to run all the crontabber
jobs.

Mike: Do you think this helps? Is it good enough for a first pass? We can also do one for marking jobs as failed. I think that covers basic cases and after that it's probably easier to drop into psql and edit the db manually.