### PR TITLE
fixes bug 1406025 - switch to mozilla ES image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
   # https://hub.docker.com/_/elasticsearch/
   # Note: This image is deprecated, but the new one requires fiddling.
   elasticsearch:
-    image: elasticsearch:1.4.5
+    image: mozilla/socorro_elasticsearch:1.4.5
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
This switches the local development environment to use the Mozilla
Elasticsearch 1.4.5 image. This is what we're using in the new infra
so it behooves us to use it locally, too.

If Circle is fine with it, then it should work fine.