### PR TITLE
Fix bug 687630: Linkify Build ID in crash report to BuildHub.

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -181,7 +181,11 @@
                             </tr>
                             <tr title="{{ fields_desc['processed_crash.build'] }}">
                                 <th scope="row">Build ID</th>
-                                <td>{{ report.build }}</td>
+                                <td>
+                                    <a href="https://mozilla-services.github.io/buildhub/?{{ make_query_string(q=report.build) }}">
+                                        {{ report.build }}
+                                    </a>
+                                </td>
                             </tr>
 
                             {# OS #}


### PR DESCRIPTION
Given that the original reporter for the bug didn't have a strong opinion on where else to linkify build IDs, I figure we can do it in the easiest and most prominent spot it appears in, and let people reopen the bug if they want it elsewhere.