### PR TITLE
fixes bug 1407625 - truncate values in Elasticsearch

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -12,10 +12,9 @@ import elasticsearch
 from configman import Namespace
 from configman.converters import class_converter, list_converter
 
-from socorro.external.crashstorage_base import CrashStorageBase
+from socorro.external.crashstorage_base import CrashStorageBase, Redactor
 from socorro.lib.converters import change_default
 from socorro.lib.datetimeutil import JsonDTEncoder, string_to_datetime
-from socorro.external.crashstorage_base import Redactor
 
 
 class RawCrashRedactor(Redactor):
@@ -51,6 +50,31 @@ def is_valid_key(key):
 
     """
     return bool(VALID_KEY.match(key))
+
+
+def remove_bad_keys(data):
+    """Removes keys from the top-level of the dict that are bad
+
+    Good keys satisfy the following properties:
+
+    * have one or more characters
+    * are composed of a-zA-Z0-9_-
+
+    Anything else is a bad key and needs to be removed.
+
+    Note: This modifies the data dict in-place and only looks at the top level.
+
+    :arg dict data: the data to remove bad keys from
+
+    """
+    if not data:
+        return
+
+    # Copy the list of things we're iterating over because we're mutating
+    # the dict in place.
+    for key in list(data.keys()):
+        if not is_valid_key(key):
+            del data[key]
 
 
 class ESCrashStorage(CrashStorageBase):
@@ -124,11 +148,25 @@ class ESCrashStorage(CrashStorageBase):
 
         return index
 
-    def save_raw_and_processed(self, raw_crash, dumps, processed_crash,
-                               crash_id):
-        """This is the only write mechanism that is actually employed in normal
-        usage.
+    def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
+        """Save raw and processed crash data to Elasticsearch
+
+        Note: This is the only write mechanism that is actually employed in
+        normal usage.
+
         """
+
+        # Massage the crash such that the date_processed field is formatted
+        # in the fashion of our established mapping.
+        self.reconstitute_datetimes(processed_crash)
+
+        # Remove bad keys from the raw crash--these keys are essentially
+        # user-provided and can contain junk data
+        remove_bad_keys(raw_crash)
+
+        # Capture crash data size metrics--do this only after we've cleaned up
+        # the crash data
+        self._capture_crash_metrics(raw_crash, processed_crash)
 
         crash_document = {
             'crash_id': crash_id,
@@ -136,6 +174,32 @@ class ESCrashStorage(CrashStorageBase):
             'raw_crash': raw_crash
         }
 
+        self.transaction(
+            self._submit_crash_to_elasticsearch,
+            crash_document=crash_document
+        )
+
+    @staticmethod
+    def reconstitute_datetimes(processed_crash):
+        # FIXME(willkg): These should be specified in super_search_fields.py
+        # and not hard-coded
+        datetime_fields = [
+            'submitted_timestamp',
+            'date_processed',
+            'client_crash_date',
+            'started_datetime',
+            'startedDateTime',
+            'completed_datetime',
+            'completeddatetime',
+        ]
+        for a_key in datetime_fields:
+            if a_key not in processed_crash:
+                continue
+
+            processed_crash[a_key] = string_to_datetime(processed_crash[a_key])
+
+    def _capture_crash_metrics(self, raw_crash, processed_crash):
+        """Capture metrics about crash data being saved to Elasticsearch"""
         # NOTE(willkg): this is a hard-coded keyname to match what the statsdbenchmarkingwrapper
         # produces for processor crashstorage classes. This is only used in that context, so we're
         # hard-coding this now rather than figuring out a better way to carry that name through.
@@ -157,69 +221,10 @@ class ESCrashStorage(CrashStorageBase):
         except Exception:
             # NOTE(willkg): An error here shouldn't screw up saving data. Log it so we can fix it
             # later.
-            self.config.logger.exception('something went wrong when capturing raw_crash_size')
-
-        self.transaction(
-            self._submit_crash_to_elasticsearch,
-            crash_document=crash_document
-        )
-
-    @staticmethod
-    def reconstitute_datetimes(processed_crash):
-        datetime_fields = [
-            'submitted_timestamp',
-            'date_processed',
-            'client_crash_date',
-            'started_datetime',
-            'startedDateTime',
-            'completed_datetime',
-            'completeddatetime',
-        ]
-        for a_key in datetime_fields:
-            try:
-                processed_crash[a_key] = string_to_datetime(
-                    processed_crash[a_key]
-                )
-            except KeyError:
-                # not there? we don't care
-                pass
-
-    @staticmethod
-    def remove_bad_keys(data):
-        """Removes keys from the top-level of the dict that are bad
-
-        Good keys satisfy the following properties:
-
-        * have one or more characters
-        * are composed of a-zA-Z0-9_-
-
-        Anything else is a bad key and needs to be removed.
-
-        This modifies the data dict in-place and only looks at the top level.
-
-        :arg dict data: the data to remove bad keys from
-
-        """
-        if not data:
-            return
-
-        # Copy the list of things we're iterating over because we're mutating
-        # the dict in place.
-        for key in list(data.keys()):
-            if not is_valid_key(key):
-                del data[key]
+            self.config.logger.exception('something went wrong when capturing processed_crash_size')
 
     def _submit_crash_to_elasticsearch(self, connection, crash_document):
-        """Submit a crash report to elasticsearch.
-        """
-        # Massage the crash such that the date_processed field is formatted
-        # in the fashion of our established mapping.
-        self.reconstitute_datetimes(crash_document['processed_crash'])
-
-        # Remove bad keys from the raw crash.
-        self.remove_bad_keys(crash_document['raw_crash'])
-
-        # Obtain the index name.
+        """Submit a crash report to elasticsearch"""
         es_index = self.get_index_for_crash(
             crash_document['processed_crash']['date_processed']
         )

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -83,7 +83,8 @@ def remove_bad_keys(data):
 
 
 def truncate_keyword_field_values(fields, data):
-    """Truncates values of keyword fields greater than 10,000 characters
+    """Truncates values of keyword fields greater than MAX_KEYWORD_FIELD_VALUE_SIZE
+    characters
 
     Note: This modifies the data dict in-place and only looks at the top level.
 
@@ -94,7 +95,7 @@ def truncate_keyword_field_values(fields, data):
     # Go through all the fields marked as keyword and truncate values
     # if they're too large
 
-    for name, properties in fields.items():
+    for properties in fields.values():
         field_name = properties.get('in_database_name')
         storage = properties.get('storage_mapping')
         if not field_name or not storage:
@@ -205,7 +206,7 @@ class ESCrashStorage(CrashStorageBase):
 
         # Capture crash data size metrics--do this only after we've cleaned up
         # the crash data
-        self._capture_crash_metrics(raw_crash, processed_crash)
+        self.capture_crash_metrics(raw_crash, processed_crash)
 
         crash_document = {
             'crash_id': crash_id,
@@ -237,7 +238,7 @@ class ESCrashStorage(CrashStorageBase):
 
             processed_crash[a_key] = string_to_datetime(processed_crash[a_key])
 
-    def _capture_crash_metrics(self, raw_crash, processed_crash):
+    def capture_crash_metrics(self, raw_crash, processed_crash):
         """Capture metrics about crash data being saved to Elasticsearch"""
         # NOTE(willkg): this is a hard-coded keyname to match what the statsdbenchmarkingwrapper
         # produces for processor crashstorage classes. This is only used in that context, so we're

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -19,7 +19,6 @@ from socorro.external.es.crashstorage import (
     RawCrashRedactor,
     truncate_keyword_field_values,
 )
-# from socorro.external.es.super_search_fields import FIELDS
 from socorro.lib.datetimeutil import string_to_datetime
 from socorro.unittest.external.es.base import (
     ElasticsearchTestCase,

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -11,13 +11,15 @@ import pytest
 
 from socorro.external.crashstorage_base import Redactor
 from socorro.external.es.crashstorage import (
-    is_valid_key,
     ESCrashStorage,
     ESCrashStorageRedactedSave,
     ESCrashStorageRedactedJsonDump,
     ESBulkCrashStorage,
+    is_valid_key,
     RawCrashRedactor,
+    truncate_keyword_field_values,
 )
+# from socorro.external.es.super_search_fields import FIELDS
 from socorro.lib.datetimeutil import string_to_datetime
 from socorro.unittest.external.es.base import (
     ElasticsearchTestCase,
@@ -941,3 +943,99 @@ class TestESCrashStorage(ElasticsearchTestCase):
         # a_processed_crash and a_raw_crash, then these numbers will change.
         assert 'call.histogram(\'processor.es.raw_crash_size\', 27)' in mock_calls
         assert 'call.histogram(\'processor.es.processed_crash_size\', 1785)' in mock_calls
+
+
+class Test_truncate_keyword_field_values:
+    @pytest.mark.parametrize('data, expected', [
+        # Top-level, non-basestring values are left alone
+        ({'key': None}, {'key': None}),
+        ({'key': 1}, {'key': 1}),
+
+        # Second-level values are left alone
+        ({'key': {'key': 'a' * 10001}}, {'key': {'key': 'a' * 10001}}),
+
+        # Top-level, basestring values are truncated if > 10,000 characters
+        ({'key': 'a' * 9999}, {'key': 'a' * 9999}),
+        ({'key': 'a' * 10000}, {'key': 'a' * 10000}),
+        ({'key': 'a' * 10001}, {'key': 'a' * 10000}),
+    ])
+    def test_truncate_keyword_field_values(self, data, expected):
+        fields = {
+            'key': {
+                'in_database_name': 'key',
+                'storage_mapping': {
+                    'analyzer': 'keyword',
+                    'type': 'string'
+                }
+            }
+        }
+
+        # Note: data is modified in place
+        truncate_keyword_field_values(fields, data)
+        assert data == expected
+
+    @pytest.mark.parametrize('fields', [
+        # Empty fields leaves data unchanged
+        {},
+
+        # No in_database_name leaves data unchanged
+        {
+            'key': {
+                'storage_mapping': {
+                    'analyzer': 'keyword',
+                    'type': 'string'
+                }
+            }
+        },
+
+        # No storage_mapping leaves data unchanged
+        {
+            'key': {
+                'in_database_name': 'key',
+            }
+        },
+
+        # Wrong in_database_name leaves data unchanged
+        {
+            'key': {
+                'in_database_name': 'different_key',
+                'storage_mapping': {
+                    'analyzer': 'keyword',
+                    'type': 'string'
+                }
+            }
+        },
+
+        # Wrong or missing analyzer leaves data unchanged
+        {
+            'key': {
+                'in_database_name': 'key',
+                'storage_mapping': {
+                    'type': 'string'
+                }
+            }
+        },
+        {
+            'key': {
+                'in_database_name': 'key',
+                'storage_mapping': {
+                    'analyzer': 'semicolon_keywords',
+                    'type': 'string'
+                }
+            }
+        },
+    ])
+    def test_fields_handling(self, fields):
+        """Verify truncation only occurs if all requirements are true
+
+        This also verifies that access of FIELDS handles edge cases like
+        missing data.
+
+        """
+        original_data = {
+            'key': 'a' * 10001
+        }
+        data = deepcopy(original_data)
+
+        truncate_keyword_field_values(fields, data)
+        assert original_data == data


### PR DESCRIPTION
This does three things:

1. clean up a bit of Elasticsearch code in a fundamental way
2. update the documentation because that helped figure out how I needed to do things
3. implement truncating values for fields analyzed with the "keyword" analyzer

I did some analysis on our data before implementing value truncating. That's covered in comment 4 and comment 5 in bug 1407625 (https://bugzilla.mozilla.org/show_bug.cgi?id=1407625). I can expand on that if that's helpful.

The unit tests cover testing the scenarios pretty well. I don't think I'd bother with manual testing.

The one thing the changes don't do is emit any kind of signal that a value was truncated, so we'll never really know. There's no way to add post-processing notes to crash data like we do in the processor rules. We can log something, but logs aren't a great way for normal people to answer questions like, "I'm looking at crash XYZ--were values truncated?". The person would have to ask one of us and we'd have to log into the logs host and grep the logs for the text to figure it out. That's ... rough. However, I don't think we have better options for signals in the Elasticsearch crashstorage.

We could do it as a processor rule, but I'm really hesitant to do that. This relies on `super_search_fields.py` to tell us what's up and that's Elasticsearch centric. If we convert that to a "processed crash schema" (which is probably a good idea to do some day), then we could use that and make a processor rule. Maybe some day in the future.

My data diving suggested we don't hit this situation very often--I wasn't able to find a problematic crash for the days I looked at. We do know it's happened in the past as evidenced by our problems migrating data over the summer. Maybe it happens less often now?

That's everything I can think of here.