### PR TITLE
fixes bug 1430786 - remove /api/GraphicsDevices/ endpoint

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -127,6 +127,7 @@ BLACKLIST = (
     # because it's very sensitive and we don't want to expose it
     'Query',
     # because it's an internal thing only
+    'GraphicsDevices',
     'GraphicsReport',
     'Priorityjob',
 )


### PR DESCRIPTION
This PR is pretty benign. Essentially, we drop the GraphicsDevices API endpoint without affecting any of the internal stuff which the signature report still uses.

Why bother with this now? It means that going forward it's not a publicly supported API endpoint, so it's not the case that someone could start using it between now and when we want to take all that code out.

I'd do more and take the rest of the code out, but the signature report still relies on it. I think we'd have to convert the model to use Elasticsearch before we could take out all the postgres-related bits. I'll write up a bug for that.