### PR TITLE
fixes bug 1132858 - remove the extensions table

### DIFF
--- a/alembic/versions/0193b4725f32_bug_1132858_remove_extensions.py
+++ b/alembic/versions/0193b4725f32_bug_1132858_remove_extensions.py
@@ -1,0 +1,51 @@
+"""bug 1132858 remove extensions table
+
+Revision ID: 0193b4725f32
+Revises: bb8cdbb8a6bd
+Create Date: 2018-01-31 14:21:41.032179
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0193b4725f32'
+down_revision = 'bb8cdbb8a6bd'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+
+def upgrade():
+    # Get a list of ALL tables that start with 'extensions_*' and drop them
+    connection = op.get_bind()
+    cursor = connection.connection.cursor()
+    cursor.execute("""
+        SELECT c.relname FROM pg_catalog.pg_class c
+        WHERE c.relkind = 'r' AND c.relname LIKE 'extensions_%'
+    """)
+    all_table_names = []
+    for records in cursor.fetchall():
+        table_name, = records
+        all_table_names.append(table_name)
+
+    all_table_names.sort(reverse=True)
+    for table_name in all_table_names:
+        op.execute('DROP TABLE IF EXISTS {}'.format(table_name))
+
+    # Now drop the extensions table itself
+    op.execute('DROP TABLE IF EXISTS extensions')
+
+    # Now remove the entry from report_partition_info so the crontabber job
+    # doesn't try to create a new partition
+    op.execute("""
+        DELETE FROM report_partition_info WHERE table_name = 'extensions'
+    """)
+
+def downgrade():
+    # There is no going back.
+    pass

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -313,21 +313,6 @@ class Module(DeclarativeBase):
     version = Column(u'version', TEXT(), nullable=False, primary_key=True)
 
 
-class Extension(DeclarativeBase):
-    __tablename__ = 'extensions'
-
-    # column definitions
-    report_id = Column(u'report_id', INTEGER(), nullable=False)
-    date_processed = Column(u'date_processed', TIMESTAMP(timezone=True))
-    extension_key = Column(u'extension_key', INTEGER(), nullable=False)
-    extension_id = Column(u'extension_id', TEXT(), nullable=False)
-    extension_version = Column(u'extension_version', TEXT())
-    uuid = Column(u'uuid', UUID())
-
-    __mapper_args__ = {"primary_key": (
-        report_id, date_processed, extension_key, extension_id, extension_version)}
-
-
 class ExploitabilityReport(DeclarativeBase):
     __tablename__ = 'exploitability_reports'
 

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -164,15 +164,6 @@ class ReportPartitionInfo(BaseTable):
             'TIMESTAMPTZ'
         ),
         (
-            'extensions',
-            '3',
-            '{"report_id,extension_key"}',
-            '{"report_id,date_processed"}',
-            '{"(report_id) REFERENCES reports_WEEKNUM(id)"}',
-            'date_processed',
-            'TIMESTAMPTZ'
-        ),
-        (
             'raw_crashes',
             '4',
             '{uuid}',


### PR DESCRIPTION
The extensions table was a partitioned table, so this creates a migration
to remove the table, all the partitions, and the `report_partition_info` record.
It also removes the model in the code.