### PR TITLE
Fix path to e2e-tests' requirements.txt file for Pyup

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,6 +7,6 @@ requirements:
   - docs/requirements.txt:
       update: all
       pin: true
-  - e2e-tests/requirements/default.txt:
+  - e2e-tests/requirements/requirements.txt:
        update: all
        pin: true


### PR DESCRIPTION
@chartjes @willkg r?

I accidentally broke this by renaming "default.txt" to "requirements.txt" while following other conventions, in https://github.com/mozilla-services/socorro/pull/4305/files#diff-a7ef0f98e17ba791a95fa5364e74d1a2

This fixes that; sorry!

https://github.com/mozilla-services/socorro/blob/52ba35616ccd86b3674a251a3574b88f6ae0260f/e2e-tests/requirements/requirements.txt