### PR TITLE
fixes bug 1434678 - add message about rates to crashes-per-day graph

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
@@ -124,32 +124,6 @@ Crashes per Day for {{ product }}
                         </td>
                     </tr>
 
-                    {#
-
-                      This is deliberately commented out because the numbers
-                      we get are so different from the numbers you get in the
-                      old legacy PG-based "Crashes per ADI" (aka. daily report)
-
-                    <tr>
-                        <th>Date Range</th>
-                        <td>
-                          <fieldset>
-                              <legend class="visually-hidden">Date Range Type</legend>
-                              <span class="radio-item">
-                                  <label for="by_build">
-                                      <input type="radio" name="date_range_type" id="by_build" value="build" {% if date_range_type == 'build' %} checked="checked" {% endif %}/> Build Date
-                                  </label>
-                              </span>
-                              <span class="radio-item">
-                                  <label for="crash">
-                                      <input type="radio" name="date_range_type" id="crash" value="report" {% if date_range_type == 'report' %} checked="checked" {% endif %}/> Crash Date
-                                  </label>
-                              </span>
-                            </fieldset>
-                          </td>
-                    </tr>
-                    #}
-
                     <tr class="datepicker-daily">
                         <th>Date</th>
                         <td>
@@ -174,10 +148,14 @@ Crashes per Day for {{ product }}
         </div>
 
         <div class="body">
-                <div id="crashes-per-adi-graph"></div>
-                <div id="crashes-per-adi-legend" class="crashes-per-adi-legend"></div>
-            <p class="adu-chart-help">This graph uses an approximate <a href="https://wiki.mozilla.org/Socorro/SocorroUI/Branches_Admin#Throttle">throttle value</a> for each version, which may not be completely accurate for the entire time period.</p>
-            </div>
+            <div id="crashes-per-adi-graph"></div>
+            <div id="crashes-per-adi-legend" class="crashes-per-adi-legend"></div>
+            <p class="adu-charg-help">
+                Please note: We're changing throttling amounts for crash processing. Because of that, rates in this graph
+                are wrong. Please refer to <a href="https://data-missioncontrol.dev.mozaws.net/">Mission Control</a>
+                for better crash rates.
+            </p>
+        </div>
     </div>
 
 


### PR DESCRIPTION
This adds a message about rates to the crashes-per-day graph with a link to Mission Control which has better crash rate data.

This also deletes some dead code.