### PR TITLE
Fix bug 1434902: Removes references to graph on the home page, which is no longer in use.

### DIFF
--- a/e2e-tests/pages/home_page.py
+++ b/e2e-tests/pages/home_page.py
@@ -13,12 +13,10 @@ class CrashStatsHomePage(CrashStatsBasePage):
 
     URL_TEMPLATE = '/'
 
-    _graph_loading_locator = (By.CSS_SELECTOR, '#homepage-graph .loading')
     _release_channels_locator = (By.CSS_SELECTOR, '.release_channel')
 
     def wait_for_page_to_load(self):
         super(CrashStatsHomePage, self).wait_for_page_to_load()
-        self.wait.until(lambda s: not self.is_element_present(*self._graph_loading_locator))
         return self
 
     @property

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -679,13 +679,6 @@ div.admin {
     height: 18px;
     vertical-align: middle;
 }
-#homepage-graph {
-    position: relative;
-}
-.homepage-graph-legend {
-    width: 100%;
-    text-align: center;
-}
 /* simplebox css */
 #simplebox {
     display:none;


### PR DESCRIPTION
Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1434902