### PR TITLE
fixes bug 1436537 - fixes sha to tag with in deploy_bug.py

### DIFF
--- a/scripts/deploy_bug.py
+++ b/scripts/deploy_bug.py
@@ -23,6 +23,7 @@ import requests
 
 
 GITHUB_API = 'https://api.github.com/'
+HOST = 'https://crash-stats.mozilla.com'
 
 
 def fetch(url, is_json=True):
@@ -41,9 +42,14 @@ def fetch_history_from_github(user, repo, from_sha):
     return fetch(GITHUB_API + 'repos/%s/%s/compare/%s...master' % (user, repo, from_sha))
 
 
-def print_row(*args):
-    row_template = '%-13s ' * len(args)
-    print(row_template % args)
+def fetch_current_revision(host):
+    # Try /__version__ and fall back to /api/Status/
+    resp = fetch(host + '/__version__')
+    if 'commit' in resp:
+        return resp['commit']
+
+    resp = fetch(host + '/api/Status/')
+    return resp['socorro_revision']
 
 
 def ref_to_tag(ref):
@@ -56,7 +62,7 @@ def ref_to_tag(ref):
     return ref.split('/')[-1]
 
 
-def main(argv):
+def get_tags():
     # Figure out and print the current tag and the next tag
     tag_data = fetch_tags_from_github('mozilla-services', 'socorro')
     tags = [ref_to_tag(item['ref']) for item in tag_data]
@@ -66,6 +72,12 @@ def main(argv):
 
     # Convert to int and drop any that don't
     tags = [int(tag) for tag in tags if tag.isdigit()]
+    return tags
+
+
+def main(argv):
+    # Fetch tags as numbers (e.g. 309)
+    tags = get_tags()
 
     # The current tag is the max of that
     current_tag = max(tags)
@@ -73,50 +85,50 @@ def main(argv):
     # The next tag is current_tag + 1
     next_tag = current_tag + 1
 
+    # Figure out the current version
+    sha = fetch_current_revision(HOST)
+
+    # Get the commits between the currently deployed version and what's in
+    # master tip and if there's nothing to deploy, then we're done!
+    resp = fetch_history_from_github('mozilla-services', 'socorro', sha)
+    if resp['status'] != 'ahead':
+        print('Nothing to deploy!')
+        return
+
+    commits = resp['commits']
+
     print('summary:')
     print('socorro deploy: %s' % next_tag)
     print()
-
     print('description:')
     print()
-
     print('We want to do a Socorro -prod deploy today tagged %s.' % next_tag)
     print()
-
     print('It consists of the following:')
     print()
-
-    # Figure out and print the version
-
-    # NOTE(willkg): This is the current infrastructure--the new infrastructure
-    # uses the /__version__ endpoint. We'll need to update this when we switch
-    # over.
-    resp = fetch('https://crash-stats.mozilla.com/api/Status/')
-    sha = resp['socorro_revision']
-
-    # Figure out and print everything that's going out
     print('(current tag: %s - %s)' % (current_tag, sha[:8]))
-    resp = fetch_history_from_github('mozilla-services', 'socorro', sha)
-    if resp['status'] == 'ahead':
-        # Drop all the merge commits
-        commits = [commit for commit in resp['commits'] if len(commit['parents']) == 1]
 
-        # Print the commits out
-        for commit in commits:
-            print_row(
-                commit['sha'][:8],
-                commit['commit']['message'].splitlines()[0][:80]
-            )
+    # Print the commits out skipping merge commits
+    for commit in commits:
+        if len(commit['parents']) > 1:
+            continue
+
+        print('%s: %s' % (
+            commit['sha'][:8],
+            commit['commit']['message'].splitlines()[0][:80]
+        ))
+
     print('(next tag: %s - %s)' % (next_tag, commits[-1]['sha'][:8]))
     print()
 
-    # Print post-deploy steps
+    # Print all possible post-deploy steps--we winnow the unnecessary ones when
+    # writing up the bug
     print('After deploy:')
     print()
     print('* update -prod admin node')
     print('* make configuration changes')
     print('* perform alembic migrations')
-    print('* perform django migrations')
+    print('* perform Django migrations')
     print('* verify webapp functionality')
     print()
 


### PR DESCRIPTION
Previously we removed the merge commits from the list of commits that got
displayed and then figured out the commit to tag by looking at the last commit
in that list. However, that's wrong--we really want the last commit and not
the last non-merge commit especially since the last commit is likely to be
a merge commit.

This fixes that. It also cleans up the code a bit.