### PR TITLE
fixes bug 1437414 - clarify crash data situation in getting started

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -82,17 +82,18 @@ Quickstart
 
 
 At this point, you should have a basic functional Socorro development
-environment.
+environment that has no crash data in it.
+
+If you need crash data, see :ref:`processor-chapter` for additional setup,
+fetching crash data, and running the processor.
 
 See :ref:`gettingstarted-chapter-updating` for how to maintain and update your
-environment.
+local development environment.
 
 See :ref:`gettingstarted-chapter-configuration` for how configuration works and
 about ``my.env``.
 
 See :ref:`webapp-chapter` for additional setup and running the webapp.
-
-See :ref:`processor-chapter` for additional setup and running the processor.
 
 See :ref:`crontabber-chapter` for additional setup and running crontabber.
 


### PR DESCRIPTION
This clarifies that you have a local development environment with no crash
data in it and that you need to process some crashes to add some. It also
moves the link to the processor chapter up a bit so it's clearer where those
docs are.

@lonnen Does this help at all with bug 1437414?