### PR TITLE
fixes bug 1432884 - upload_crash_report_json_schema s3 fix

### DIFF
--- a/docker/run_recreate_s3_buckets.sh
+++ b/docker/run_recreate_s3_buckets.sh
@@ -8,8 +8,16 @@ set -e
 
 # Deletes and recreates S3 bucket used for crash storage
 
+# FIXME(willkg): Pull bucket names from environment
+# resource.boto.bucket_name
+# resource.boto.telemetry_bucket_name
+
 cd /app
 
-echo "Dropping and recreating S3 bucket..."
+echo "Dropping and recreating S3 crash bucket..."
 (./scripts/socorro_aws_s3.sh rb s3://dev_bucket/ --force || true) 2> /dev/null # Ignore if it doesn't exist
 ./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+
+echo "Dropping and recreating S3 telemetry bucket..."
+(./scripts/socorro_aws_s3.sh rb s3://telemetry_bucket/ --force || true) 2> /dev/null # Ignore if it doesn't exist
+./scripts/socorro_aws_s3.sh mb s3://telemetry_bucket/

--- a/socorro/cron/jobs/upload_crash_report_json_schema.py
+++ b/socorro/cron/jobs/upload_crash_report_json_schema.py
@@ -30,7 +30,7 @@ class UploadCrashReportJSONSchemaCronApp(BaseCronApp):
     required_config.add_option(
         'resource_class',
         default=(
-            'socorro.external.boto.connection_context.S3ConnectionContext'
+            'socorro.external.boto.connection_context.RegionalS3ConnectionContext'
         ),
         doc=(
             'fully qualified dotted Python classname to handle Boto '

--- a/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
+++ b/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
@@ -7,6 +7,7 @@ import mock
 
 from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs.upload_crash_report_json_schema import UploadCrashReportJSONSchemaCronApp
+from socorro.external.boto.connection_context import S3ConnectionContext
 from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
@@ -16,7 +17,10 @@ class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
 
     def _setup_config_manager(self):
         return super(TestUploadCrashReportJSONSchemaCronApp, self)._setup_config_manager(
-            jobs_string=self.job
+            jobs_string=self.job,
+            extra_value_source=DotDict({
+                'resource.boto.resource_class': S3ConnectionContext
+            })
         )
 
     @mock.patch('boto.connect_s3')
@@ -44,7 +48,8 @@ class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
     def test_override_telemetry_bucket_name(self, connect_s3):
         config = DotDict({
             'telemetry_bucket_name': '',
-            'bucket_name': 'dev_bucket'
+            'bucket_name': 'dev_bucket',
+            'resource_class': S3ConnectionContext
         })
         app = UploadCrashReportJSONSchemaCronApp(config, job_information=None)
         assert app.get_bucket_name() == 'dev_bucket'


### PR DESCRIPTION
This fixes the `upload_crash_report_json_schema` [1] to have the same `resource_class` default as `TelemetryBotoS3CrashStorage` which it's related to. This should fix the problem we have in the new infra where something something cross regions something something.

This also fixes that job running in the local dev environment. So you can now do:

```
$ make dockersetup
$ make dockerupdatedata
$ docker-compose up crontabber
```

and watch crontabber do some stuff and run the ... well, run *that* job without failing.

[1] Typing this 10 times a day burns 100 calories and should be part of a daily health regimen.