### PR TITLE
fixes bug 1438969 - fix processor service

### DIFF
--- a/config/package/usr/lib/systemd/system/socorro-processor.service
+++ b/config/package/usr/lib/systemd/system/socorro-processor.service
@@ -4,7 +4,7 @@ Description=Socorro Processor
 [Service]
 WorkingDirectory=/home/socorro
 Environment=VENV=/data/socorro/socorro-virtualenv
-ExecStart=/bin/bash -c "envconsul -upcase=false -prefix socorro/common -prefix socorro/processor $VENV/bin/socorro processor"
+ExecStart=/bin/bash -c "envconsul -upcase=false -prefix socorro/common -prefix socorro/processor $VENV/bin/python /data/socorro/application/socorro/processor/processor_app.py"
 Restart=always
 
 [Install]


### PR DESCRIPTION
The processor service was still using the "socorro" script, but we nixed that.
This updates the service file to run the processor app directly.