### PR TITLE
Fix deprecation warning raised during tests.

### DIFF
--- a/webapp-django/crashstats/api/urls.py
+++ b/webapp-django/crashstats/api/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'api'
 urlpatterns = [
     url('^$', views.documentation, name='documentation'),
     url('^(?P<model_name>\w+)/$',

--- a/webapp-django/crashstats/authentication/urls.py
+++ b/webapp-django/crashstats/authentication/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'auth'
 urlpatterns = [
     url(
         '^_debug_login/$',

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -12,6 +12,7 @@ version = r'/versions/(?P<version>[;\w\.()]+)'
 perm_legacy_redirect = settings.PERMANENT_LEGACY_REDIRECTS
 
 
+app_name = 'crashstats'
 urlpatterns = [
     url('^robots\.txt$',
         views.robots_txt,

--- a/webapp-django/crashstats/documentation/urls.py
+++ b/webapp-django/crashstats/documentation/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'documentation'
 urlpatterns = [
     url(
         r'^supersearch/$',

--- a/webapp-django/crashstats/home/urls.py
+++ b/webapp-django/crashstats/home/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'home'
 urlpatterns = [
     url(
         r'^product/(?P<product>\w+)$',

--- a/webapp-django/crashstats/manage/urls.py
+++ b/webapp-django/crashstats/manage/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'manage'
 urlpatterns = [
     url('^$',
         views.home,

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'monitoring'
 urlpatterns = [
     url(r'^$',
         views.index,

--- a/webapp-django/crashstats/profile/urls.py
+++ b/webapp-django/crashstats/profile/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'profile'
 urlpatterns = [
     url(
         r'^$',

--- a/webapp-django/crashstats/signature/urls.py
+++ b/webapp-django/crashstats/signature/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'signature'
 urlpatterns = [
     url(
         r'^reports/$',

--- a/webapp-django/crashstats/sources/urls.py
+++ b/webapp-django/crashstats/sources/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'sources'
 urlpatterns = [
     url(r'^highlight/$',
         views.highlight_url,

--- a/webapp-django/crashstats/tokens/urls.py
+++ b/webapp-django/crashstats/tokens/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'tokens'
 urlpatterns = [
     url('^$', views.home, name='home'),
     url('^delete/(?P<pk>\d+)/$', views.delete_token, name='delete_token'),

--- a/webapp-django/crashstats/topcrashers/urls.py
+++ b/webapp-django/crashstats/topcrashers/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 from . import views
 
+
+app_name = 'topcrashers'
 urlpatterns = [
     url(r'^$',
         views.topcrashers,


### PR DESCRIPTION
Setting a namespace for an included URLConf without an app_name attribute was
deprecated in 1.9:

https://docs.djangoproject.com/en/dev/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include