### PR TITLE
Fix bug 1438915: Set cache entry limit higher during tests.

### DIFF
--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -26,7 +26,10 @@ DATABASES = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'crashstats'
+        'LOCATION': 'crashstats',
+        'OPTIONS': {
+            'MAX_ENTRIES': 2000,  # Avoid culling during tests
+        },
     }
 }
 


### PR DESCRIPTION
Certain built-in cache backends in Django, such as the local memory cache, have
a maximum number of cache entries they can hold at any given time. By default,
this is 300.

During the intermittently-failing test, requests to the report_index view would
cause not only model fetches for raw and unredacted crashes to be cached, but
also hashed names of processed static files (thanks to PipelineCachedStorage).
The amount of cache entries would grow beyond the max cache size, causing the
cache to be culled.

The local memory cache culls by removing a fraction of cache entries in a
non-deterministic way that relies on the ordering of entries in a dictionary.
The result is that sometimes, but not all the time, the cache entries being
tested were culled, and the test failed. Increasing the cache entry limit avoids
culling keys during the test.

A more permanent fix that avoids culling during the test completely would be
nice, but also a lot more work.