### PR TITLE
Add 5-minute SCM polling; run daily via cron

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -10,6 +10,10 @@ pipeline {
   libraries {
     lib('fxtest@1.10')
   }
+  triggers {
+    pollSCM('H/5 * * * *')
+    cron('H H * * *')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
Filed https://bugzilla.mozilla.org/show_bug.cgi?id=1439028 after chatting in IRC.

This would add 5-minute SCM polling + a daily run, via cron, of our e2e-tests, only (currently) in our Jenkins instance, here: https://qa-master.fxtest.jenkins.stage.mozaws.net/

These values are in the job configs, manually, but I'd like to move them here for better visibility + consistency.

Passing ad-hoc, here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/socorro.adhoc/129/console