### PR TITLE
fix bug 1438921 - remove hacky telemetry bucket_name configuration

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -54,7 +54,6 @@ resource.boto.port=5000
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
 resource.boto.bucket_name=dev_bucket
-resource.boto.telemetry_bucket_name=telemetry_bucket
 resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.calling_format=boto.s3.connection.OrdinaryCallingFormat
 resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3ConnectionContext
@@ -68,6 +67,9 @@ resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3
 companion_process.symbol_cache_path=/tmp/symbols/cache
 processor.symbol_cache_path=/tmp/symbols/cache
 processor.symbol_tmp_path=/tmp/symbols/tmp
+
+# Set the telemetry bucket name explicitly
+destination.telemetry.bucket_name=telemetry_bucket
 
 # webapp
 # ------
@@ -100,3 +102,4 @@ crontabber.jobs=socorro.cron.crontabber_app.STAGE_JOBS
 crontabber.class-DependencySecurityCheckCronApp.nsp_path=/webapp-frontend-deps/node_modules/.bin/nsp
 crontabber.class-DependencySecurityCheckCronApp.safety_path=/usr/local/bin/safety
 crontabber.class-DependencySecurityCheckCronApp.package_json_path=/app/webapp-django/package.json
+crontabber.class-UploadCrashReportJSONSchemaCronApp.bucket_name=telemetry_bucket

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -6,10 +6,6 @@ alembic_config=/app/docker/config/alembic.ini
 # put filesystem crashstorage stuff in /tmp/test_crashes
 resource.fs.fs_root=/tmp/test_crashes
 
-# unset telemetry_bucket_name so that TelemetryS3CrashStorage configuration
-# tests work correctly
-resource.boto.telemetry_bucket_name=
-
 # use socorro_integration_test for postgres and alembic
 database_url=postgres://postgres:aPassword@postgresql:5432/socorro_integration_test
 sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test

--- a/socorro/cron/jobs/upload_crash_report_json_schema.py
+++ b/socorro/cron/jobs/upload_crash_report_json_schema.py
@@ -44,34 +44,12 @@ class UploadCrashReportJSONSchemaCronApp(BaseCronApp):
         default='crash_report.json',
         doc="Name of the file/key we're going to upload to"
     )
-    required_config.add_option(
-        'telemetry_bucket_name',
-        default='',
-        reference_value_from='resource.boto',
-        doc='if set, overrides resource_class bucket name'
-    )
-
-    def get_bucket_name(self):
-        if self.config.telemetry_bucket_name:
-            # If we have a telemetry.bucket_name set, then stomp on it with
-            # config.telemetry_bucket_name.
-
-            # FIXME(willkg): It'd be better if we could detect whether the
-            # connection context bucket_name was set at all (it's a default
-            # value, or the value of resource.boto.bucket_name).
-            return self.config.telemetry_bucket_name
-        else:
-            return self.config.bucket_name
 
     def run(self):
         connection_context = self.config.resource_class(self.config)
 
         connection = connection_context._connect()
-        bucket_name = self.get_bucket_name()
-        self.config.logger.info(
-            'Using %s for S3 bucket', bucket_name
-        )
-        bucket = connection_context._get_bucket(connection, bucket_name)
+        bucket = connection_context._get_bucket(connection, self.config.bucket_name)
         key = bucket.get_key(self.config.json_filename)
         if not key:
             key = bucket.new_key(self.config.json_filename)

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -297,9 +297,6 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
     The subset of the processed crash is based on the JSON Schema which is
     derived from "socorro/external/es/super_search_fields.py".
 
-    This uses a boto connection context with one twist: if you set
-    "resource.boto.telemetry_bucket_name", then that will override the value.
-
     """
 
     required_config = Namespace()
@@ -308,13 +305,6 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
         'resource_class',
         'socorro.external.boto.connection_context.RegionalS3ConnectionContext'
     )
-    required_config.add_option(
-        'telemetry_bucket_name',
-        default='',
-        reference_value_from='resource.boto',
-        doc='if set, overrides resource_class bucket name'
-    )
-
     required_config.elasticsearch = Namespace()
     required_config.elasticsearch.add_option(
         'elasticsearch_class',
@@ -331,18 +321,6 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
         super(TelemetryBotoS3CrashStorage, self).__init__(
             config, *args, **kwargs
         )
-
-        if config.telemetry_bucket_name:
-            # If we have a telemetry.bucket_name set, then stomp on it with
-            # config.telemetry_bucket_name.
-
-            # FIXME(willkg): It'd be better if we could detect whether the
-            # connection context bucket_name was set at all (it's a default
-            # value, or the value of resource.boto.bucket_name).
-            config.logger.info(
-                'Using %s for TelemetryBotoS3CrashStorage bucket', config.telemetry_bucket_name
-            )
-            self.connection_source.config.bucket_name = config.telemetry_bucket_name
 
     def _get_all_fields(self):
         if (

--- a/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
+++ b/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
@@ -6,7 +6,6 @@ from configman.dotdict import DotDict
 import mock
 
 from socorro.cron.crontabber_app import CronTabberApp
-from socorro.cron.jobs.upload_crash_report_json_schema import UploadCrashReportJSONSchemaCronApp
 from socorro.external.boto.connection_context import S3ConnectionContext
 from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
@@ -43,20 +42,3 @@ class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
         key.set_contents_from_string.assert_called_with(
             CRASH_REPORT_JSON_SCHEMA_AS_STRING
         )
-
-    @mock.patch('boto.connect_s3')
-    def test_override_telemetry_bucket_name(self, connect_s3):
-        config = DotDict({
-            'telemetry_bucket_name': '',
-            'bucket_name': 'dev_bucket',
-            'resource_class': S3ConnectionContext
-        })
-        app = UploadCrashReportJSONSchemaCronApp(config, job_information=None)
-        assert app.get_bucket_name() == 'dev_bucket'
-
-        config = DotDict({
-            'telemetry_bucket_name': 'telemetry_bucket',
-            'bucket_name': 'dev_bucket'
-        })
-        app = UploadCrashReportJSONSchemaCronApp(config, job_information=None)
-        assert app.get_bucket_name() == 'telemetry_bucket'

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -1053,36 +1053,6 @@ class TelemetryTestCase(ElasticsearchTestCase, BaseTestCase):
 
         return s3
 
-    def test_bucket_name_override(self):
-        """Verify that setting "resource.boto.telemetry_bucket_name" stomps on whatever
-        value bucket_name picked up.
-
-        """
-        tcs = TelemetryBotoS3CrashStorage(
-            config=self.get_tuned_config(
-                TelemetryBotoS3CrashStorage,
-                extra_values={
-                    'resource_class': S3ConnectionContext,
-                    'logger': mock.Mock(),
-                    'bucket_name': 'telemetry_crashes',
-                }
-            )
-        )
-        assert tcs.connection_source.config.bucket_name == 'telemetry_crashes'
-
-        tcs = TelemetryBotoS3CrashStorage(
-            config=self.get_tuned_config(
-                TelemetryBotoS3CrashStorage,
-                extra_values={
-                    'resource_class': S3ConnectionContext,
-                    'logger': mock.Mock(),
-                    'bucket_name': 'telemetry_crashes',
-                    'resource.boto.telemetry_bucket_name': 'override_bucket'
-                }
-            )
-        )
-        assert tcs.connection_source.config.bucket_name == 'override_bucket'
-
     def test_save_raw_and_processed(self):
         boto_s3_store = self.get_s3_store()
 


### PR DESCRIPTION
After the settings overhaul where we now store behavior configuration in
Python files and the `PolyCrashStorage` doesn't namespace using indexes, we
no longer need the hack to set the telemetry `bucket_name`.

This removes that code.