### PR TITLE
bug 1439928 - fix mdsw config values

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -68,6 +68,16 @@ companion_process.symbol_cache_path=/tmp/symbols/cache
 processor.symbol_cache_path=/tmp/symbols/cache
 processor.symbol_tmp_path=/tmp/symbols/tmp
 
+# Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
+# a long time
+processor.kill_timeout=30
+
+# Set symbols_urls to something helpful for local dev
+processor.symbols_urls=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1
+
+# Stackwalker is in a different place in the new infra and local dev
+processor.command_pathname=/stackwalk/stackwalker
+
 # Set the telemetry bucket name explicitly
 destination.telemetry.bucket_name=telemetry_bucket
 

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -109,17 +109,6 @@ CONFIG_DEFAULTS = {
         ),
     },
 
-    'processor': {
-        'processor_class': 'socorro.processor.processor_2015.Processor2015',
-
-        # These are for the minidump-stackwalker command line
-        'command_pathname': '/stackwalk/stackwalker',
-        'kill_timeout': 30,
-        'symbols_urls': ','.join([
-            'https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1',
-        ]),
-    },
-
     'producer_consumer': {
         'maximum_queue_size': 32,
         'number_of_threads': 16,
@@ -143,10 +132,6 @@ CONFIG_DEFAULTS = {
         'rabbitmq': {
             'filter_on_legacy_processing': True,
             'routing_key': 'socorro.normal',
-        },
-
-        'signature': {
-            'collapse_arguments': True,
         },
     },
 }


### PR DESCRIPTION
The default should be what we use in server environments--not what we use
in local dev environments. This fixes the various values scattered around
so there are fewer of them and they're correct in defaulty ways.

Also, we don't need `resource.signature.*` anything anymore.