### PR TITLE
1442380: Fix image-paths

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/variables.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/variables.less
@@ -1,4 +1,4 @@
-@image-path: "/base/static/img";
+@image-path: "/static/img";
 
 @base-font: Arial, Helvetica, sans-serif;
 @base-font-size: 12px;

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/simplebox.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/simplebox.less
@@ -15,7 +15,7 @@
 }
 #close_simplebox {
     position:absolute;
-    background:transparent url("@{image-path}/img/icons/close_round.png") 0 0 no-repeat;
+    background:transparent url("@{image-path}/icons/close_round.png") 0 0 no-repeat;
     margin-top:-20px;
     border:0;
     width:30px;

--- a/webapp-django/crashstats/supersearch/static/supersearch/css/search.less
+++ b/webapp-django/crashstats/supersearch/static/supersearch/css/search.less
@@ -210,13 +210,13 @@
     }
 
     .external-link {
-        background: transparent url("@{image-path}/img/icons/external.png") left top no-repeat;
+        background: transparent url("@{image-path}/icons/external.png") left top no-repeat;
         display: inline-block;
         padding-left: 17px;
     }
 
     .term {
-        background: transparent url("@{image-path}/img/icons/add.png") left top no-repeat;
+        background: transparent url("@{image-path}/icons/add.png") left top no-repeat;
         display: inline-block;
         padding-left: 13px;
     }


### PR DESCRIPTION
Fixes [#1442380](https://bugzilla.mozilla.org/show_bug.cgi?id=1442380)

This corrects `/base` prefix on `image-path`, pretty simple. I've tested this locally, and confirmed on stage that the images are simply pointing to the wrong location. I've also updated the paths that use `image-path` as well to avoid multiple `/img`s in image paths.
