### PR TITLE
Fix bug 1442677: Disable wheel binary packages for psycopg2.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -49,6 +49,7 @@ pika==0.11.2 \
     --hash=sha256:15f485eb68ec56b5a2673c01d518d16f7c371809ca42c72a2da42d4d8190fa4f \
     --hash=sha256:ded1cf12810f909099a3a698cc5adf495b73fd2da1d8f669f8b267664653122d
 psycopg2==2.7.4 \
+    --no-binary psycopg2\
     --hash=sha256:aeaba399254ca79c299d9fe6aa811d3c3eac61458dee10270de7f4e71c624998 \
     --hash=sha256:1d90379d01d0dc50ae9b40c863933d87ff82d51dd7d52cea5d1cb7019afd72cd \
     --hash=sha256:36030ca7f4b4519ee4f52a74edc4ec73c75abfb6ea1d80ac7480953d1c0aa3c3 \


### PR DESCRIPTION
I tested with a `make dockerbuild`. I checked the docker build output and saw it downloading the `.tar.gz` file for the package, along with lines confirming it ran `setup.py install` for the package. That's different from the output when it was using a binary.

I also ran `docker-compose up webapp` and confirmed the `UserWarning` is gone now.

I also processed some crashes to ensure the app is still Postgres-ing correctly. Seems to work fine.

I humbly suggest we do not include this in [deploy 310](https://bugzilla.mozilla.org/show_bug.cgi?id=1442031). I can merge it afterwards.