### PR TITLE
fix bug 1441318 - fix crontabber status error

### DIFF
--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -27,6 +27,7 @@ def crontabber_status(request):
     all_apps = api.get()['state']
     last_runs = [
         x['last_run'] for x in all_apps.values()
+        if x['last_run']
     ]
     if last_runs:
         ancient_times = timezone.now() - datetime.timedelta(


### PR DESCRIPTION
If one of the jobs has a `last_run` of `null` (it was running for the first time), then `/monitoring/crontabber` would error out with a `TypeError`. This fixes that by changing that code to only look at non-None `last_run`.