### PR TITLE
bug 1436071 - Remove YUI copyright

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -1,11 +1,3 @@
-/*
-Copyright (c) 2009, Yahoo! Inc. All rights reserved.
-Code licensed under the BSD License:
-http://developer.yahoo.net/yui/license.txt
-version: 3.0.0
-build: 1549
-*/
-
 @import "base/reset.less";
 @import "base/variables.less";
 @import "base/mixins.less";


### PR DESCRIPTION
Fixes [#1436071](https://bugzilla.mozilla.org/show_bug.cgi?id=1436071)

Pretty simple. We don't use the YUI javascript library and most (if not all) UI styling is done through jQuery UI.