### PR TITLE
Replace StorageNamespaceList.to_str with __repr__.

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -496,8 +496,8 @@ class StorageNamespaceList(collections.Sequence):
     def __getitem__(self, key):
         return self.storage_namespaces[key]
 
-    def to_str(self):
-        return ','.join(self.storage_namespaces)
+    def __repr__(self):
+        return 'StorageNamespaceList(%s)' % repr(self.storage_namespaces)
 
     @classmethod
     def converter(cls, storage_namespace_list_str):


### PR DESCRIPTION
This fixes the config value output when running SocorroApps to have a readable value for options using this class.

To test:

1. Checkout latest master.
2. Run `docker-compose up processor`. Confirm the output for the `destination.storage_namespaces` config value looks like this:

   ```
   destination.storage_namespaces: <socorro.external.crashstorage_base.StorageNamespaceList object at 0x7fc27787ff50>
   ```

3. Checkout this branch.
4. Run `docker-compose up processor`. The config value output should look like this now:

   ```
   destination.storage_namespaces: StorageNamespaceList(['postgres', 's3', 'elasticsearch', 'statsd', 'telemetry'])
   ```

I couldn't find where `to_str` was used so I didn't bother keeping it around.