### PR TITLE
Switch to 7 character sha prefixes

### DIFF
--- a/scripts/deploy_bug.py
+++ b/scripts/deploy_bug.py
@@ -106,7 +106,7 @@ def main(argv):
     print()
     print('It consists of the following:')
     print()
-    print('(current tag: %s - %s)' % (current_tag, sha[:8]))
+    print('(current tag: %s - %s)' % (current_tag, sha[:7]))
 
     # Print the commits out skipping merge commits
     for commit in commits:
@@ -114,11 +114,11 @@ def main(argv):
             continue
 
         print('%s: %s' % (
-            commit['sha'][:8],
+            commit['sha'][:7],
             commit['commit']['message'].splitlines()[0][:80]
         ))
 
-    print('(next tag: %s - %s)' % (next_tag, commits[-1]['sha'][:8]))
+    print('(next tag: %s - %s)' % (next_tag, commits[-1]['sha'][:7]))
     print()
 
     # Print all possible post-deploy steps--we winnow the unnecessary ones when


### PR DESCRIPTION
This switches to 7 character sha prefixes in deploy_bug.py script so
it matches github's partial sha in the "recent commit" section when
tagging a release.