### PR TITLE
fix bug 1447416 - JSON responses should have application/json mimetype

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -526,4 +526,4 @@ def crash_verify(request):
     # NOTE(willkg): This doesn't check postgres because that's being phased
     # out.
 
-    return http.HttpResponse(json.dumps(data), content_type='text/json')
+    return http.HttpResponse(json.dumps(data), content_type='application/json')

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -2766,7 +2766,7 @@ class TestDockerflow:
             client = Client()
             resp = client.get(reverse('crashstats:dockerflow_version'))
             assert resp.status_code == 200
-            assert resp['Content-Type'] == 'text/json'
+            assert resp['Content-Type'] == 'application/json'
             assert resp.content == '{}'
 
     def test_version_with_file(self, tmpdir):
@@ -2781,5 +2781,5 @@ class TestDockerflow:
             client = Client()
             resp = client.get(reverse('crashstats:dockerflow_version'))
             assert resp.status_code == 200
-            assert resp['Content-Type'] == 'text/json'
+            assert resp['Content-Type'] == 'application/json'
             assert resp.content == text

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1023,7 +1023,7 @@ def dockerflow_version(requst):
             data = fp.read()
     else:
         data = '{}'
-    return http.HttpResponse(data, content_type='text/json')
+    return http.HttpResponse(data, content_type='application/json')
 
 
 @pass_default_context


### PR DESCRIPTION
This fixes the `/__version__` and new `/api/CrashVerify/` endpoints to return `application/json` as the mimetype.