### PR TITLE
fix bug 1146030 - improve missing product page

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -510,8 +510,7 @@ class TestViews(BaseTestViews):
         url = reverse('home:home', args=('Unknown',))
         response = self.client.get(url)
         assert response.status_code == 404
-        assert 'Page Not Found' in response.content
-        assert 'id="products_select"' not in response.content
+        assert 'Missing product' in response.content
 
     def test_handler404_json(self):
         # Just need any view that has the json_view decorator on it.

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -507,10 +507,9 @@ class TestViews(BaseTestViews):
             assert result['query_string'] is None
 
     def test_handler404(self):
-        url = reverse('home:home', args=('Unknown',))
-        response = self.client.get(url)
+        response = self.client.get('/fillbert/mcpicklepants')
         assert response.status_code == 404
-        assert 'Missing product' in response.content
+        assert 'The requested page could not be found.' in response.content
 
     def test_handler404_json(self):
         # Just need any view that has the json_view decorator on it.

--- a/webapp-django/crashstats/home/jinja2/home/missing_product.html
+++ b/webapp-django/crashstats/home/jinja2/home/missing_product.html
@@ -1,0 +1,24 @@
+{% extends "crashstats_base.html" %}
+{% stylesheet 'home' %}
+
+{% block page_title %}
+Missing product: {{ product }}
+{% endblock %}
+
+{% block content %}
+<div id="mainbody">
+    <div class="page-heading">
+        <h2 id="homepage-heading">Missing product: {{ product }}</h2>
+    </div>
+
+    <div class="panel">
+        <div class="body">
+            <p>
+                The "{{ product }}" product doesn't exist. If you think this is
+                an error, please contact an admin to add the product to Crash
+                Stats.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/webapp-django/crashstats/home/jinja2/home/missing_product.html
+++ b/webapp-django/crashstats/home/jinja2/home/missing_product.html
@@ -1,5 +1,4 @@
 {% extends "crashstats_base.html" %}
-{% stylesheet 'home' %}
 
 {% block page_title %}
 Missing product: {{ product }}
@@ -8,7 +7,7 @@ Missing product: {{ product }}
 {% block content %}
 <div id="mainbody">
     <div class="page-heading">
-        <h2 id="homepage-heading">Missing product: {{ product }}</h2>
+        <h2>Missing product: {{ product }}</h2>
     </div>
 
     <div class="panel">
@@ -18,6 +17,16 @@ Missing product: {{ product }}
                 an error, please contact an admin to add the product to Crash
                 Stats.
             </p>
+            {% if DEBUG %}
+                <p>
+                    Seems like you might be seeing this page in a local
+                    development environment. If so, you should run:
+                </p>
+                <pre>make dockerupdatedata</pre>
+                <p>
+                    That'll create some products in the database.
+                </p>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/webapp-django/crashstats/home/tests/test_views.py
+++ b/webapp-django/crashstats/home/tests/test_views.py
@@ -13,6 +13,12 @@ class TestViews(BaseTestViews):
         assert 'WaterWolf Crash Data' in response.content
         assert 'WaterWolf 19.0' in response.content
 
+    def test_home_product_missing(self):
+        url = reverse('home:home', args=('PickleParty',))
+        response = self.client.get(url)
+        assert response.status_code == 404
+        assert 'Missing product: PickleParty' in response.content
+
     def test_home_product_without_featured_versions(self):
         url = reverse('home:home', args=('SeaMonkey',))
         response = self.client.get(url)


### PR DESCRIPTION
If you go to `/home/product/<PRODUCTNAME>` and that product doesn't exist, it
would kick up an unhelpful 404. Now it kicks up a 404, but with a bit more
text.