### PR TITLE
bug 1442148 - tweak crontabber state page

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crontabber_state.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crontabber_state.js
@@ -135,9 +135,7 @@ d3.json('/api/CrontabberState/', function(data) {
         .append('path')
         .attr('class', 'link')
         .attr('d', path)
-        .style('stroke-width', function(d) {
-            return Math.max(1, (d.y1 - d.y0));
-        })
+        .style('stroke-width', 15)
         .style('stroke', function(d) {
             return d.color = color(d);
         })
@@ -245,7 +243,7 @@ d3.json('/api/CrontabberState/', function(data) {
             var isTime = (field === 'last_success' || field === 'next_run');
             if (isTime) {
                 if (d) {
-                    return moment(d).fromNow();
+                    return d + ' (' + moment(d).fromNow() + ')';
                 } else {
                     return '';
                 }


### PR DESCRIPTION
This fixes display of next run and last success so that it shows actual dates
and times rather than than a delta between then and now encoded in vague
English prose.

This also tweaks the sankey links so the lines have a fixed width making the
graph legible (at least, on my local machine). I think to fix this further
requires someone to really get to know sankey (which has no docs) or switch
libs or roll our own.