### PR TITLE
webapp: configure csp report uri

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -691,6 +691,9 @@ CSP_CONNECT_SRC = (
     "'self'",
 )
 
+CSP_REPORT_URI = (
+    '/__cspreport__',   
+)
 
 # This is the number of versions to display if a particular product
 # has no 'featured versions'. Then we use the active versions, but capped

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -692,7 +692,7 @@ CSP_CONNECT_SRC = (
 )
 
 CSP_REPORT_URI = (
-    '/__cspreport__',   
+    '/__cspreport__',
 )
 
 # This is the number of versions to display if a particular product


### PR DESCRIPTION
see: https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/socorro/puppet/modules/socorro/templates/http_webapp.conf.erb#L35-L39 for uri