### PR TITLE
Bug 1452667 - change number of threads to 4

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -111,7 +111,7 @@ CONFIG_DEFAULTS = {
 
     'producer_consumer': {
         'maximum_queue_size': 32,
-        'number_of_threads': 16,
+        'number_of_threads': 4,
     },
 
     'resource': {


### PR DESCRIPTION
We're running processor nodes with 4 virtual CPUs. Since worker threads
are in Python, they run on the same CPU. However, they run stackwalker
which is a separate process, so the number of threads dictates the
number of simultaneous stackwalker processes. Stackwalker is CPU-heavy.

This sets the number of threads equal to the number of CPUs by default.