### PR TITLE
Update to latest geckodriver, 0.20.1

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
-ENV GECKODRIVER_VERSION=0.20.0
+ENV GECKODRIVER_VERSION=0.20.1
 RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \


### PR DESCRIPTION
Full, passing ad-hoc build here: https://pastebin.com/qvb4dG5J

Just bumps us to the latest point release (which we've done on our other web-automation projects, now).

@willkg r?