### PR TITLE
fix bug 1448957 - ignore specifiers and return types in signature generation

### DIFF
--- a/socorro/signature/__main__.py
+++ b/socorro/signature/__main__.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('socorro.signature')
 
 
 # FIXME(willkg): This hits production. We might want it configurable.
-API_URL = 'https://crash-stats.mozilla.com/api/'
+API_URL = 'https://crash-stats.mozilla.com/api'
 
 
 def setup_logging(logging_level):

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -221,6 +221,22 @@ class TestCSignatureTool:
         sig, notes = s.generate(a)
         assert sig == 'f | e | d | i'
 
+    def test_specifiers_and_return_types(self):
+        """prefix and irrelevant should match ignoring specifiers and return types"""
+        generator = self.setup_config_c_sig_tool(
+            # irrelevant
+            ig=['ignored'],
+            # prefix
+            pr=['pre1', 'pre2'],
+        )
+        source_list = (
+            'static void ignored',
+            'pre1',
+            'static bool pre2',
+        )
+        sig, notes = generator.generate(source_list)
+        assert sig == 'pre1 | static bool pre2'
+
     def test_generate_with_merged_dll(self):
         generator = self.setup_config_c_sig_tool(
             ['a', 'b', 'c'],

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -233,9 +233,10 @@ class TestCSignatureTool:
             'static void ignored',
             'pre1',
             'static bool pre2',
+            'foo'
         )
         sig, notes = generator.generate(source_list)
-        assert sig == 'pre1 | static bool pre2'
+        assert sig == 'pre1 | static bool pre2 | foo'
 
     def test_generate_with_merged_dll(self):
         generator = self.setup_config_c_sig_tool(


### PR DESCRIPTION
This fixes signature generation to ignore specifiers and return types when matching against the signature list.