### PR TITLE
fix bug 1453476 - add "today" and "now" to fetch_crashids

### DIFF
--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import argparse
 import datetime
 from functools import total_ordering
-import random
 import sys
 from urlparse import urlparse, parse_qs
 


### PR DESCRIPTION
* add "today" as a valid value for `--date`
* add "now" as a valid value for `--date` that is like "today", but
  sets sort order to `-date` and adds cache-busting bits