### PR TITLE
[e2e-tests] Hard-code -n=1 to mitigate test crashes with multiple Firefox processes/concurrency

### DIFF
--- a/e2e-tests/setup.cfg
+++ b/e2e-tests/setup.cfg
@@ -4,6 +4,7 @@ known_first_party = pages
 
 [tool:pytest]
 addopts = -n=1 --verbose -r=a --driver=Firefox
+# we set -n=1 to help mitigate crashes running tests
 testpaths = .
 xfail_strict = true
 base_url = https://crash-stats.allizom.org

--- a/e2e-tests/setup.cfg
+++ b/e2e-tests/setup.cfg
@@ -3,7 +3,7 @@ default_section = THIRDPARTY
 known_first_party = pages
 
 [tool:pytest]
-addopts = -n=auto --verbose -r=a --driver=Firefox
+addopts = -n=1 --verbose -r=a --driver=Firefox
 testpaths = .
 xfail_strict = true
 base_url = https://crash-stats.allizom.org


### PR DESCRIPTION
"Fixes" https://bugzilla.mozilla.org/show_bug.cgi?id=1456286 - limit concurrent Firefox test sessions to 1, by hard-coding "-n=1".

Passing ad-hoc here, run against prod: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/socorro.adhoc/207/console and here: https://gist.github.com/stephendonner/488d8ebc7bfa7abe96fee042afc99161

Locally, we still hit a failure, but it's much-reduced, compare to with concurrency:

```
======================== 1 failed, 32 passed in 281.94 seconds ========================
Stephens-MacBook-Pro:e2e-tests stephendonner$ docker run -t socorro-tests pytest -n=1 \
                                              --base-url=https://crash-stats.mozilla.com

vs.

=========================== 3 failed, 29 passed, 3 error in 95.54 seconds ===========================
Stephens-MacBook-Pro:e2e-tests stephendonner$ docker run -t socorro-tests pytest --base-url=https://crash-stats.mozilla.com
```

@davehunt @willkg can I get both of your reviews here, please?  I'd like to ensure I'm making the right first set of forthcoming changes; cheers!