### PR TITLE
fix bug 1275374, 1409427 - add minidump_sha256_hash to telemetry crash data

### DIFF
--- a/docker/config/local_dev_submitter.env
+++ b/docker/config/local_dev_submitter.env
@@ -13,7 +13,6 @@ destination.urls=http://antenna:8000/submit
 
 source.crashstorage_class=socorro.external.boto.crashstorage.BotoS3CrashStorage
 source.temporary_file_system_storage_path=/tmp
-resource.boto.keybuilder_class=socorro.external.boto.connection_context.DatePrefixKeyBuilder
 
 new_crash_source.crashstorage_class=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
 new_crash_source.new_crash_source_class=socorro.external.rabbitmq.rmq_new_crash_source.RMQNewCrashSource

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -25,10 +25,11 @@ APP_GID="10001"
 BASEIMAGENAME="python:2.7.14-slim"
 
 # Start services in background (this is idempotent)
-echo "Starting services in the background..."
+echo "Starting services needed by tests in the background..."
 ${DC} up -d elasticsearch
 ${DC} up -d postgresql
 ${DC} up -d rabbitmq
+${DC} up -d statsd
 
 # If we're running a shell, then we start up a test container with . mounted
 # to /app.

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -22,99 +22,15 @@ class KeyNotFound(Exception):
     pass
 
 
+class CrashidMissingDatestamp(Exception):
+    pass
+
+
 class JSONISOEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime.date):
             return obj.isoformat()
         raise NotImplementedError("Don't know about {0!r}".format(obj))
-
-
-class KeyBuilderBase(object):
-    """Base key builder for s3 pseudo-filenames"""
-    def build_keys(self, prefix, name_of_thing, id):
-        """
-        Use S3 pseudo-directories to make it easier to list/expire later
-        {prefix}/v1/{name_of_thing}/{id}
-        """
-        return [
-            '%s/v1/%s/%s' % (prefix, name_of_thing, id)
-        ]
-
-
-class DatePrefixKeyBuilder(KeyBuilderBase):
-    """s3 pseudo-filename key builder with date prefixes
-
-    This adds the date to the prefix for raw_crash objects making it easier to
-    list all the raw_crash objects for a specific date.
-
-    """
-    def build_keys(self, prefix, name_of_thing, id):
-        """Use S3 pseudo-directories to make it easier to list/expire.
-
-        For "raw_crash" things, the id is an ooid/crash_id. This uses the
-        first three characters of the ooid for entropy and extracts the
-        crash submission date from the last 6 charactes. Then it mooshes
-        that all together into this structure::
-
-            {prefix}/v2/{name_of_thing}/{entropy}/{date}/{id}
-
-        This makes it possible to list all the raw_crashes submitted on a
-        given date.
-
-        It also returns the keys that KeyBuilderBase builds so that we can
-        fetch objects that were saved with older keys.
-
-        """
-        keys = []
-
-        if name_of_thing == 'raw_crash':
-            datestamp = dateFromOoid(id)
-
-            if datestamp is not None:
-                # We insert the first 3 chars of the ooid/crash_id providing
-                # some entropy earlier in the key so that consecutive s3
-                # requests get distributed across multiple s3 partitions.
-                first_chars = id[:3]
-                date = datestamp.strftime('%Y%m%d')
-                keys.append(
-                    '%s/v2/%s/%s/%s/%s' % (
-                        prefix, name_of_thing, first_chars, date, id
-                    )
-                )
-
-        keys.extend(
-            super(DatePrefixKeyBuilder, self).build_keys(
-                prefix, name_of_thing, id
-            )
-        )
-        return keys
-
-
-class SimpleDatePrefixKeyBuilder(KeyBuilderBase):
-    """s3 pseudo-filename key builder with simple date prefixes.
-
-    Simply the {prefix}/{name_of_thing}/{date}/{id}
-
-    This key builder is useful for the S3 upload of processed crashes
-    to go into Telemetry. It's important that the {date} is of the
-    format YYYYMMDD.
-    """
-
-    def build_keys(self, prefix, name_of_thing, id):
-        """return a list of one key. The reason for not returning more than
-        one is that this key builder class is going to be used for
-        something new so it has no legacy."""
-        datestamp = dateFromOoid(id)
-        if datestamp is None:
-            # the id did not have a date component in it
-            datestamp = datetime.datetime.utcnow()
-        date = datestamp.strftime('%Y%m%d')
-        keys = [
-            '%s/v1/%s/%s/%s' % (
-                prefix, name_of_thing, date, id
-            )
-        ]
-        return keys
 
 
 class ConnectionContextBase(RequiredConfig):
@@ -148,17 +64,6 @@ class ConnectionContextBase(RequiredConfig):
         reference_value_from='resource.boto',
         likely_to_be_changed=True,
     )
-    required_config.add_option(
-        'keybuilder_class',
-        default='socorro.external.boto.connection_context.KeyBuilderBase',
-        doc=(
-            'fully qualified dotted Python classname to handle building s3 '
-            'pseudo-filenames'
-        ),
-        from_string_converter=class_converter,
-        reference_value_from='resource.boto',
-        likely_to_be_changed=True,
-    )
 
     operational_exceptions = (
         socket.timeout,
@@ -189,7 +94,6 @@ class ConnectionContextBase(RequiredConfig):
             boto.exception.StorageResponseError,
             KeyNotFound
         )
-        self.keybuilder = config.keybuilder_class()
 
         self._bucket_cache = {}
 
@@ -207,11 +111,59 @@ class ConnectionContextBase(RequiredConfig):
         of credentials required for the type of connection"""
         raise NotImplementedError
 
-    def build_keys(self, prefix, name_of_thing, id):
-        """Builds an s3 pseudo-filename using the specified keybuilder class.
+    def _get_datestamp(self, crashid):
+        """Retrieves the datestamp from a crashid or raises an exception"""
+        datestamp = dateFromOoid(crashid)
+        if datestamp is None:
+            # We should never hit this situation unless the crashid is a bad crashid
+            raise CrashidMissingDatestamp('%s is missing datestamp' % crashid)
+        return datestamp
+
+    def build_keys(self, prefix, name_of_thing, crashid):
+        """Builds a list of s3 pseudo-filenames
+
+        When using keys for saving a crash, always use the first one given.
+
+        When using keys for loading a crash, try each key in order. This lets
+        us change our key scheme and continue to access things saved using the
+        old key.
+
+        :arg prefix: the prefix to use
+        :arg name_of_thing: the kind of thing we're building a filename for; e.g.
+            "raw_crash"
+        :arg crashid: the crash id for the thing being stored
+
+        :returns: list of keys to try in order
 
         """
-        return self.keybuilder.build_keys(prefix, name_of_thing, id)
+        if name_of_thing == 'raw_crash':
+            # {prefix}/v2/{name_of_thing}/{entropy}/{date}/{id}
+
+            # Insert the first 3 chars of the crashid providing some entropy
+            # earlier in the key so that consecutive s3 requests get
+            # distributed across multiple s3 partitions
+            first_chars = crashid[:3]
+            date = self._get_datestamp(crashid).strftime('%Y%m%d')
+            return [
+                '%s/v2/%s/%s/%s/%s' % (
+                    prefix, name_of_thing, first_chars, date, crashid
+                )
+            ]
+
+        elif name_of_thing == 'crash_report':
+            # Crash data from the TelemetryBotoS3CrashStorage
+
+            # {prefix}/v1/{name_of_thing}/{date}/{id}
+            date = self._get_datestamp(crashid).strftime('%Y%m%d')
+            return [
+                '%s/v1/%s/%s/%s' % (
+                    prefix, name_of_thing, date, crashid
+                )
+            ]
+
+        return [
+            '%s/v1/%s/%s' % (prefix, name_of_thing, crashid)
+        ]
 
     def _get_bucket(self, conn, bucket_name):
         try:

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -137,32 +137,39 @@ class ConnectionContextBase(RequiredConfig):
 
         """
         if name_of_thing == 'raw_crash':
-            # {prefix}/v2/{name_of_thing}/{entropy}/{date}/{id}
-
             # Insert the first 3 chars of the crashid providing some entropy
             # earlier in the key so that consecutive s3 requests get
             # distributed across multiple s3 partitions
-            first_chars = crashid[:3]
+            entropy = crashid[:3]
             date = self._get_datestamp(crashid).strftime('%Y%m%d')
             return [
-                '%s/v2/%s/%s/%s/%s' % (
-                    prefix, name_of_thing, first_chars, date, crashid
-                )
+                '%(prefix)s/v2/%(nameofthing)s/%(entropy)s/%(date)s/%(crashid)s' % {
+                    'prefix': prefix,
+                    'nameofthing': name_of_thing,
+                    'entropy': entropy,
+                    'date': date,
+                    'crashid': crashid
+                }
             ]
 
         elif name_of_thing == 'crash_report':
             # Crash data from the TelemetryBotoS3CrashStorage
-
-            # {prefix}/v1/{name_of_thing}/{date}/{id}
             date = self._get_datestamp(crashid).strftime('%Y%m%d')
             return [
-                '%s/v1/%s/%s/%s' % (
-                    prefix, name_of_thing, date, crashid
-                )
+                '%(prefix)s/v1/%(nameofthing)s/%(date)s/%(crashid)s' % {
+                    'prefix': prefix,
+                    'nameofthing': name_of_thing,
+                    'date': date,
+                    'crashid': crashid
+                }
             ]
 
         return [
-            '%s/v1/%s/%s' % (prefix, name_of_thing, crashid)
+            '%(prefix)s/v1/%(nameofthing)s/%(crashid)s' % {
+                'prefix': prefix,
+                'nameofthing': name_of_thing,
+                'crashid': crashid
+            }
         ]
 
     def _get_bucket(self, conn, bucket_name):

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -15,9 +15,6 @@ from socorro.external.crashstorage_base import (
     CrashIDNotFound,
     MemoryDumpsMapping,
 )
-from socorro.external.boto.connection_context import (
-    SimpleDatePrefixKeyBuilder
-)
 from socorro.external.es.super_search_fields import SuperSearchFields
 from socorro.schemas import CRASH_REPORT_JSON_SCHEMA
 
@@ -314,10 +311,6 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
     )
 
     def __init__(self, config, *args, **kwargs):
-        # This class requires that we use
-        # SimpleDatePrefixKeyBuilder, so we stomp on the configuration
-        # to make absolutely sure it gets set that way.
-        config.keybuilder_class = SimpleDatePrefixKeyBuilder
         super(TelemetryBotoS3CrashStorage, self).__init__(
             config, *args, **kwargs
         )

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3056,6 +3056,24 @@ FIELDS = {
             'type': 'string'
         }
     },
+    'minidump_sha256_hash': {
+        'data_validation_type': 'str',
+        'default_value': None,
+        'description': 'SHA256 hash of the minidump if there was one.',
+        'form_field_choices': [],
+        'has_full_version': False,
+        'in_database_name': 'minidump_sha256_hash',
+        'is_exposed': True,
+        'is_mandatory': False,
+        'is_returned': True,
+        'name': 'minidump_sha256_hash',
+        'namespace': 'processed_crash',
+        'permissions_needed': [],
+        'query_type': 'string',
+        'storage_mapping': {
+            'type': 'string'
+        }
+    },
     'moz_crash_reason': {
         'data_validation_type': 'str',
         'default_value': None,

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -60,6 +60,18 @@ class CrashingThreadRule(Rule):
         return True
 
 
+class MinidumpSha256Rule(Rule):
+    """Copy over MinidumpSha256Hash value if there is one"""
+    def version(self):
+        return '1.0'
+
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return 'MinidumpSha256Hash' in raw_crash
+
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        processed_crash['minidump_sha256_hash'] = raw_crash['MinidumpSha256Hash']
+
+
 class ExternalProcessRule(Rule):
     # FIXME(willkg): command_line and command_pathname are referenced in the
     # uplifted versions in Processor2015. The rest of these config values have

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -26,6 +26,7 @@ from socorro.processor.breakpad_transform_rules import (
     CrashingThreadRule,
     ExternalProcessRule,  # imported to override config, not instantiated
     JitCrashCategorizeRule,
+    MinidumpSha256Rule,
 )
 
 from socorro.processor.general_transform_rules import (
@@ -70,6 +71,7 @@ DEFAULT_RULES = [
     PluginUserComment,
     # rules to transform a raw crash into a processed crash
     IdentifierRule,
+    MinidumpSha256Rule,
     BreakpadStackwalkerRule2015,
     ProductRule,
     UserDataRule,

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -116,7 +116,6 @@ CONFIG_DEFAULTS = {
 
     'resource': {
         'boto': {
-            'keybuilder_class': 'socorro.external.boto.connection_context.DatePrefixKeyBuilder',
             'prefix': '',
         },
 

--- a/socorro/schemas/crash_report.json
+++ b/socorro/schemas/crash_report.json
@@ -573,6 +573,10 @@
                 }
             }
         },
+        "minidump_sha256_hash": {
+            "type": ["string", "null"],
+            "description": "SHA256 hash of the minidump if there was one."
+        },
         "moz_crash_reason": {
             "type": ["string", "null"],
             "description": "For aborts caused by MOZ_CRASH, MOZ_RELEASE_ASSERT and related macros, this is the accompanying description."

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -18,16 +18,11 @@ class MockedTelemetryBotoS3CrashStorage(TelemetryBotoS3CrashStorage):
 
     def __init__(self):
         # Deliberately not doing anything fancy with config. So no super call.
-        # Prep the self._all_fields so it's available when
-        # self.save_raw_and_processed() is called.
         r = requests.get(
             API_BASE.format('SuperSearchFields'),
         )
         print(r.url)
         self._all_fields = r.json()
-
-    def _get_all_fields(self):
-        return self._all_fields
 
     def save_processed(self, crash):
         self.combined = crash

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -133,7 +133,7 @@ class TestBotoS3CrashStorage:
         # contents
         raw_crash = boto_helper.get_contents_as_string(
             bucket_name='crash_storage',
-            key='dev/v1/raw_crash/0bba929f-8721-460c-dead-a43c20071027'
+            key='dev/v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027'
         )
 
         assert (
@@ -170,7 +170,7 @@ class TestBotoS3CrashStorage:
         # contents
         raw_crash = boto_helper.get_contents_as_string(
             bucket_name='crash_storage',
-            key='dev/v1/raw_crash/0bba929f-8721-460c-dead-a43c20071027'
+            key='dev/v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027'
         )
 
         assert (
@@ -205,7 +205,7 @@ class TestBotoS3CrashStorage:
         # contents
         raw_crash = boto_helper.get_contents_as_string(
             bucket_name='crash_storage',
-            key='dev/v1/raw_crash/0bba929f-8721-460c-dead-a43c20071027'
+            key='dev/v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027'
         )
 
         assert (
@@ -303,7 +303,7 @@ class TestBotoS3CrashStorage:
     def test_get_raw_crash(self, boto_helper):
         boto_helper.set_contents_from_string(
             bucket_name='crash_storage',
-            key='dev/v1/raw_crash/936ce666-ff3b-4c7a-9674-367fe2120408',
+            key='dev/v2/raw_crash/936/20120408/936ce666-ff3b-4c7a-9674-367fe2120408',
             value=a_raw_crash_as_string
         )
 

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -930,10 +930,11 @@ class TestCrashVerify(object):
         }
 
         boto_helper = BotoHelper()
+        raw_crash_key = '/v2/raw_crash/%s/20%s/%s' % (uuid[0:3], uuid[-6:], uuid)
         boto_helper.get_or_create_bucket('crashstats-test')
         boto_helper.set_contents_from_string(
             bucket_name='crashstats-test',
-            key='/v1/raw_crash/%s' % uuid,
+            key=raw_crash_key,
             value=json.dumps(crash_data)
         )
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -598,10 +598,6 @@ SOCORRO_IMPLEMENTATIONS_CONFIG = {
             'bucket_name': config('resource.boto.bucket_name', 'crashstats'),
             'region': config('resource.boto.region', 'us-west-2'),
             'prefix': config('resource.boto.prefix', ''),
-            'keybuilder_class': config(
-                'resource.boto.keybuilder_class',
-                'socorro.external.boto.connection_context.DatePrefixKeyBuilder'
-            ),
 
             # NOTE(willkg): In the local dev environment, we need to use a
             # HostPortS3ConnectionContext which requires these additional configuration bits. The


### PR DESCRIPTION
This does two things:

1. remove all the keybuilder nonsense since it got in my way
2. add a processing rule for `MinidumpSha256Hash` and the bits required to make sure that field is indexed correctly in Elasticsearch, available for searching in super search, and in the telemetry crash report