### PR TITLE
Remove link to deprecated infra code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,5 +74,3 @@ Development
 ===========
 
 Current deployment status: https://whatsdeployed.io/s-7M7
-
-Mozilla-centric Infrastructure (AWS) code: https://github.com/mozilla/socorro-infra


### PR DESCRIPTION
After the AWS account migration, the code in this repo is no longer
being used.  Since it is going to rot, stop directing people to it.