### PR TITLE
Fix bug 1450286: re-add deploy-dockerhub.sh script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,10 @@ jobs:
             # set DOCKER_DEPLOY=true in Circle UI to push to Dockerhub
             DOCKER_DEPLOY="${DOCKER_DEPLOY:-false}"
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              bin/ci/deploy-dockerhub.sh latest
+              scripts/deploy-dockerhub.sh latest
             fi
             if [ -n "${CIRCLE_TAG}" ]; then
-              bin/ci/deploy-dockerhub.sh "$CIRCLE_TAG"
+              scripts/deploy-dockerhub.sh "$CIRCLE_TAG"
             fi
 
 workflows:

--- a/scripts/deploy-dockerhub.sh
+++ b/scripts/deploy-dockerhub.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Pushes Docker images to mozilla/ on dockerhub.
+#
+# This is intended to be run by CI.
+
+set -e
+set +x
+
+# Usage: retry MAX CMD...
+# Retry CMD up to MAX times. If it fails MAX times, returns failure.
+# Example: retry 3 docker push "mozilla/socorro:$TAG"
+function retry() {
+    max=$1
+    shift
+    count=1
+    until "$@"; do
+        count=$((count + 1))
+        if [[ $count -gt $max ]]; then
+            return 1
+        fi
+        echo "$count / $max"
+    done
+    return 0
+}
+
+if [[ "$DOCKER_DEPLOY" == "true" ]]; then
+    # configure docker creds
+    retry 3 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+    # docker tag and push git branch to dockerhub
+    if [ -n "$1" ]; then
+        [ "$1" == master ] && TAG=latest || TAG="$1"
+        for image in "socorro_processor" "socorro_webapp" "socorro_crontabber"; do
+            docker tag "local/$image:latest" "mozilla/$image:$TAG" ||
+                (echo "Couldn't tag local/$image:latest as mozilla/$image:$TAG" && false)
+            retry 3 docker push "mozilla/$image:$TAG" ||
+                (echo "Couldn't push mozilla/$image:$TAG" && false)
+            echo "Pushed mozilla/$image:$TAG"
+        done
+    fi
+fi


### PR DESCRIPTION
This re-adds the `deploy-dockerhub.sh` script which Circle needs to push the images it built to Dockerhub.

I looked to see if we were using it, but because the thing that mentions it is in `.circleci/config.yml`, and that starts with a `.`, it got skipped by ripgrep. Oops.