### PR TITLE
fix bug 1375434: fix build_id storage

### DIFF
--- a/socorro/cron/jobs/update_signatures.py
+++ b/socorro/cron/jobs/update_signatures.py
@@ -114,6 +114,10 @@ class UpdateSignaturesCronApp(BaseCronApp):
         # Save signature data to the db
         signature_first_date_api = SignatureFirstDate(config=self.config)
         for item in signature_data:
+            # Convert the build_id to an int because that's how it's stored in
+            # the db
+            item['build_id'] = int(item['build_id'])
+
             if self.config.dry_run:
                 self.config.logger.info(
                     'Inserting/updating signature (%s, %s, %s)',

--- a/socorro/unittest/cron/jobs/test_update_signatures.py
+++ b/socorro/unittest/cron/jobs/test_update_signatures.py
@@ -204,7 +204,7 @@ class UpdateSignaturesCronAppTestCase(IntegrationTestBase):
         # Two signatures got inserted
         data = self.fetch_signatures_data()
         assert (
-            sorted(data) ==
+            sorted(data, key=lambda item: item['first_build']) ==
             [
                 {
                     'first_build': '20180322000000',


### PR DESCRIPTION
`build_id` is stored as a numeric in the db, so we need to convert it
before saving it.

I'm puzzled as to why it worked locally and doesn't work on -stage. Maybe they're different versions of postgres? Maybe they're configured differently in some way I'm not aware of?

Anyhow, pretty sure this should fix it. It's trivial to verify on -stage.