### PR TITLE
fix bug 1375434: handle crashes with no build id

### DIFF
--- a/socorro/cron/jobs/update_signatures.py
+++ b/socorro/cron/jobs/update_signatures.py
@@ -82,6 +82,10 @@ class UpdateSignaturesCronApp(BaseCronApp):
             for hit in hits:
                 crashids_count += 1
 
+                if not hit['build_id']:
+                    # Not all crashes have a build id, so skip the ones that don't.
+                    continue
+
                 if hit['signature'] in results:
                     data = results[hit['signature']]
                     data['build_id'] = min(data['build_id'], hit['build_id'])
@@ -114,10 +118,6 @@ class UpdateSignaturesCronApp(BaseCronApp):
         # Save signature data to the db
         signature_first_date_api = SignatureFirstDate(config=self.config)
         for item in signature_data:
-            # Convert the build_id to an int because that's how it's stored in
-            # the db
-            item['build_id'] = int(item['build_id'])
-
             if self.config.dry_run:
                 self.config.logger.info(
                     'Inserting/updating signature (%s, %s, %s)',

--- a/socorro/unittest/cron/jobs/test_update_signatures.py
+++ b/socorro/unittest/cron/jobs/test_update_signatures.py
@@ -225,7 +225,7 @@ class UpdateSignaturesCronAppTestCase(IntegrationTestBase):
         supersearch = FakeModel()
         mock_supersearch.return_value = supersearch
 
-        # Mock SuperSearch to return 4 crashes covering two signatures
+        # Mock SuperSearch to return 1 crash with no build id
         supersearch.add_get_step({
             'errors': [],
             'hits': [
@@ -242,6 +242,7 @@ class UpdateSignaturesCronAppTestCase(IntegrationTestBase):
         # Run crontabber
         self.run_job_and_assert_success()
 
-        # Two signatures got inserted
+        # The crash has no build id, so it gets ignored and nothing gets
+        # inserted
         data = self.fetch_signatures_data()
         assert data == []


### PR DESCRIPTION
Some crashes don't have a build id which is why they don't "intify" well.
This skips those because we don't consider them when figuring out
first build and first date.