### PR TITLE
Bug 1460134 - [e2e-tests] Update Firefox in Docker image to 60.0

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -16,7 +16,7 @@ COPY pipenv.txt /src
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python2.7
 RUN pip install -r pipenv.txt
 
-ENV FIREFOX_VERSION=59.0
+ENV FIREFOX_VERSION=60.0
 
 RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
   && apt-get -y purge firefox \


### PR DESCRIPTION
This won't affect the Sauce-Labs run jobs in Jenkins, but will when run locally.

Build-log with previously-existing intermittent failure:

```
Stephens-MacBook-Pro:e2e-tests stephendonner$ docker run -it socorro-tests
=============================================== test session starts ===============================================
platform linux2 -- Python 2.7.12, pytest-3.5.1, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python2.7
cachedir: .pytest_cache
driver: Firefox
sensitiveurl: mozilla\.org
metadata: {'Python': '2.7.12', 'Driver': 'Firefox', 'Capabilities': {}, 'Base URL': 'https://crash-stats.allizom.org', 'Platform': 'Linux-4.9.87-linuxkit-aufs-x86_64-with-Ubuntu-16.04-xenial', 'Plugins': {'variables': '1.7.1', 'selenium': '1.12.0', 'xdist': '1.22.2', 'mozlog': '3.7', 'html': '1.17.0', 'forked': '0.2', 'base-url': '1.4.1', 'metadata': '1.7.0'}, 'Packages': {'py': '1.5.3', 'pytest': '3.5.1', 'pluggy': '0.6.0'}}
baseurl: https://crash-stats.allizom.org
rootdir: /src, inifile: setup.cfg
plugins: xdist-1.22.2, variables-1.7.1, selenium-1.12.0, metadata-1.7.0, html-1.17.0, forked-0.2, base-url-1.4.1, mozlog-3.7
collected 33 items                                                                                                

tests/test_api.py::TestAPI::test_public_api_navigation PASSED                                               [  3%]
tests/test_api.py::TestAPI::test_supersearch_fields PASSED                                                  [  6%]
tests/test_api.py::TestAPI::test_platforms PASSED                                                           [  9%]
tests/test_api.py::TestAPI::test_crontabber PASSED                                                          [ 12%]
tests/test_crash_reports.py::TestCrashReports::test_that_bugzilla_link_contain_current_site PASSED          [ 15%]
tests/test_crash_reports.py::TestCrashReports::test_that_exploitable_crash_report_is_not_displayed_for_logged_out_users PASSED [ 18%]
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Firefox] PASSED      [ 21%]
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Thunderbird] PASSED  [ 24%]
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[FennecAndroid] PASSED [ 27%]
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[SeaMonkey] PASSED    [ 30%]
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Firefox] PASSED [ 33%]
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Thunderbird] PASSED [ 36%]
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[FennecAndroid] PASSED [ 39%]
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[SeaMonkey] PASSED [ 42%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_all_return_results PASSED       [ 45%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_browser_return_results PASSED   [ 48%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_plugin_return_results PASSED    [ 51%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Firefox] PASSED    [ 54%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Thunderbird] PASSED [ 57%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[FennecAndroid] PASSED [ 60%]
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[SeaMonkey] PASSED  [ 63%]
tests/test_crash_reports.py::TestCrashReports::test_top_crasher_reports_tab_has_uuid_report PASSED          [ 66%]
tests/test_crash_reports.py::TestCrashReports::test_that_7_days_is_selected_default_for_nightlies PASSED    [ 69%]
tests/test_crash_reports.py::TestCrashReports::test_that_only_browser_reports_have_browser_icon PASSED      [ 72%]
tests/test_crash_reports.py::TestCrashReports::test_that_only_plugin_reports_have_plugin_icon PASSED        [ 75%]
tests/test_crash_reports.py::TestCrashReports::test_that_lowest_version_topcrashers_do_not_return_errors PASSED [ 78%]
tests/test_search.py::TestSuperSearch::test_super_search_page_is_loaded PASSED                              [ 81%]
tests/test_search.py::TestSuperSearch::test_search_change_facet PASSED                                      [ 84%]
tests/test_search.py::TestSuperSearch::test_search_change_column PASSED                                     [ 87%]
tests/test_search.py::TestSuperSearch::test_search_with_one_line PASSED                                     [ 90%]
tests/test_search.py::TestSuperSearch::test_search_with_multiple_lines PASSED                               [ 93%]
tests/test_search.py::TestSearchForSpecificResults::test_search_for_valid_signature FAILED                  [ 96%]
tests/test_search.py::TestSearchForSpecificResults::test_selecting_one_version_doesnt_show_other_versions PASSED [100%]

==================================================== FAILURES =====================================================
__________________________ TestSearchForSpecificResults.test_search_for_valid_signature ___________________________

self = <tests.test_search.TestSearchForSpecificResults instance at 0x7f463da731b8>
base_url = 'https://crash-stats.allizom.org'
selenium = <selenium.webdriver.firefox.webdriver.WebDriver (session="26029365-184f-4287-a1d5-6d6a81b1e490")>

    @pytest.mark.nondestructive
    def test_search_for_valid_signature(self, base_url, selenium):
        csp = CrashStatsHomePage(selenium, base_url).open()
        report_list = csp.release_channels[-1].click_top_crasher()
        signature = report_list.first_signature_title
        result = csp.header.search_for_crash(signature)
    
>       assert result.are_search_results_found
E       assert False
E        +  where False = <pages.super_search_page.CrashStatsSuperSearch object at 0x7f463d2d53d0>.are_search_results_found

tests/test_search.py:105: AssertionError
------------------------------------------------- pytest-selenium -------------------------------------------------
Driver log: /tmp/pytest-of-root/pytest-0/test_search_for_valid_signatur0/driver.log
URL: https://crash-stats.allizom.org/search/?signature=~OOM%20%7C%20small&date=%3E%3D2018-05-02T02%3A33%3A33.000Z&date=%3C2018-05-09T02%3A33%3A33.000Z&page=1&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform
WARNING: Failed to gather log types: Message: GET /session/26029365-184f-4287-a1d5-6d6a81b1e490/log/types did not match a known command
============================================= short test summary info =============================================
FAIL tests/test_search.py::TestSearchForSpecificResults::()::test_search_for_valid_signature
====================================== 1 failed, 32 passed in 293.81 seconds ======================================
```