### PR TITLE
Fix bug 1460517: [e2e-tests] Update to Firefox 60.0 in Sauce Labs

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -3,7 +3,7 @@
 /** Desired capabilities */
 def capabilities = [
   browserName: 'Firefox',
-  version: '59.0',
+  version: '60.0',
   platform: 'Windows 10'
 ]
 


### PR DESCRIPTION
Bumps us up to Firefox 60.0 in Sauce Labs.

@davehunt @willkg @Osmose r?

Passing adhoc build against prod, here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/socorro.adhoc/237/