### PR TITLE
fix bug 1460035: implement python 3 test scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ e2e-tests/.cache/
 
 # docker things
 .docker-build
+.docker-build3
 .cache/
 docker-compose.override.yml
 my.env

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ dockerbuild: my.env
 dockersetup: my.env .docker-build
 	${DC} run webapp /app/docker/run_setup.sh
 
-dockertest: my.env
+dockertest: my.env .docker-build
 	./docker/run_tests_in_docker.sh ${ARGS}
 
-dockertestshell: my.env
+dockertestshell: my.env .docker-build
 	./docker/run_tests_in_docker.sh --shell
 
 dockerupdatedata: my.env
@@ -79,3 +79,20 @@ dockerstop: my.env
 
 dockerdependencycheck: my.env
 	${DC} run crontabber ./docker/run_dependency_checks.sh
+
+# Python 3 transition related things
+
+.PHONY: dockerbuild3 dockertest3 dockertestshell3
+
+.docker-build3:
+	make dockerbuild3
+
+dockerbuild3: my.env
+	${DC} build testpython3
+	touch .docker-build3
+
+dockertest3: my.env .docker-build3
+	USEPYTHON=3 ./docker/run_tests_in_docker.sh ${ARGS}
+
+dockertestshell3: my.env .docker-build3
+	USEPYTHON=3 ./docker/run_tests_in_docker.sh --shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,26 @@ services:
     volumes:
       - .:/app
 
+  # For running tests in as we transition to Python 3
+  testpython3:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.python3
+    image: local/socorro_python3
+    env_file:
+      - docker/config/local_dev.env
+      - docker/config/never_on_a_server.env
+      - my.env
+    depends_on:
+      - statsd
+      - localstack-s3
+      - postgresql
+      - elasticsearch
+      - rabbitmq
+      - memcached
+    volumes:
+      - .:/app
+
   # -----------------------------
   # External services
   # -----------------------------

--- a/docker/Dockerfile.python3
+++ b/docker/Dockerfile.python3
@@ -1,0 +1,40 @@
+# From Dockerfile
+FROM python:3.6.5-slim
+
+WORKDIR /app/
+RUN groupadd --gid 10001 app && useradd -g app --uid 10001 --shell /usr/sbin/nologin app
+
+# Install OS-level things
+COPY ./docker/set_up_ubuntu.sh /tmp/
+RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
+
+# Install Socorro Python requirements
+COPY ./requirements /app/requirements
+RUN pip install -U 'pip>=8' && \
+    pip install --no-cache-dir -r requirements/default.txt -c requirements/constraints.txt
+
+# From webapp
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONPATH /app
+
+# Install nodejs and npm from Nodesource's 8.x branch
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo 'deb https://deb.nodesource.com/node_8.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
+    echo 'deb-src https://deb.nodesource.com/node_8.x jessie main' >> /etc/apt/sources.list.d/nodesource.list
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+
+COPY ./webapp-django/package.json /webapp-frontend-deps/package.json
+COPY ./webapp-django/package-lock.json /webapp-frontend-deps/package-lock.json
+RUN cd /webapp-frontend-deps/ && npm install
+
+COPY . /app/
+
+ENV LESS_BINARY /webapp-frontend-deps/node_modules/.bin/lessc
+ENV UGLIFYJS_BINARY /webapp-frontend-deps/node_modules/.bin/uglifyjs
+ENV CSSMIN_BINARY /webapp-frontend-deps/node_modules/.bin/cssmin
+ENV NPM_ROOT_PATH /webapp-frontend-deps/
+
+USER app

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -6,8 +6,8 @@ alembic_config=/app/docker/config/alembic.ini
 # put filesystem crashstorage stuff in /tmp/test_crashes
 resource.fs.fs_root=/tmp/test_crashes
 
-# use socorro_integration_test for postgres and alembic
-database_url=postgres://postgres:aPassword@postgresql:5432/socorro_integration_test
+# use socorro_test for postgres and alembic
+database_url=postgres://postgres:aPassword@postgresql:5432/socorro_test
 sqlalchemy.url=postgresql://postgres:aPassword@postgresql:5432/socorro_migration_test
 
 # used for PostgresSQLTestCase derivatives

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -27,51 +27,37 @@ ELASTICSEARCH_URL=${elasticsearch_url:-"http://elasticsearch:9200"}
 export PYTHONPATH=/app/:$PYTHONPATH
 FLAKE8="$(which flake8)"
 PYTEST="$(which pytest)"
+PYTHON="$(which python)"
 ALEMBIC="$(which alembic)"
-SETUPDB="$(which python) /app/socorro/external/postgresql/setupdb_app.py"
+SETUPDB="/app/socorro/external/postgresql/setupdb_app.py"
 
-# Verify we have __init__.py files everywhere we need them
-errors=0
-while read d; do
-    if [ ! -f "$d/__init__.py" ]; then
-        if [ "$(ls -A "$d/test*py")" ]; then
-            echo "$d is missing an __init__.py file, tests will not run"
-            errors=$((errors+1))
-        else
-            echo "$d has no tests - ignoring it"
-        fi
-    fi
-done < <(find socorro/unittest/* -not -name logs -type d)
-
-if [ $errors != 0 ]; then
-    exit 1
-fi
-
-# Wait for postgres in the postgres container to be ready
+# Wait for postgres and elasticsearch services to be ready
 urlwait "${DATABASE_URL}" 10
-
-# Wait for elasticsearch in the elasticsearch container to be ready
 urlwait "${ELASTICSEARCH_URL}" 10
 
-# Set up database for alembic migrations
-#
-# Set up socorro_migration_test db
-$SETUPDB --database_name=socorro_migration_test --dropdb --logging.level=40 --unlogged --createdb
+# Set up socorro_migration_test db for migration testing
+"${PYTHON}" "${SETUPDB}" --database_name=socorro_migration_test --dropdb --logging.level=40 --unlogged --createdb
 
 # Set up socorro_test db for unittests
-$SETUPDB --database_name=socorro_test --dropdb --logging.level=40 --unlogged --no_staticdata --createdb
+"${PYTHON}" "${SETUPDB}" --database_name=socorro_test --dropdb --logging.level=40 --unlogged --no_staticdata --createdb
 
-$ALEMBIC -c "${alembic_config}" downgrade -1
-$ALEMBIC -c "${alembic_config}" upgrade heads
+# Test the last migration
+"${ALEMBIC}" -c "${alembic_config}" downgrade -1
+"${ALEMBIC}" -c "${alembic_config}" upgrade heads
 
 # Run linting
-$FLAKE8
+"${FLAKE8}"
 
-# Run tests
-$PYTEST
+if [ "${USEPYTHON:-2}" == "2" ]; then
+    # Run tests
+    "${PYTEST}"
 
-# Collect static and then run py.test in the webapp
-pushd webapp-django
-python manage.py collectstatic --noinput
-$PYTEST
-popd
+    # Collect static and then run py.test in the webapp
+    pushd webapp-django
+    python manage.py collectstatic --noinput
+    "${PYTEST}"
+    popd
+else
+    # Run the tests we know work in Python 3
+    ./docker/run_tests_python3.sh
+fi

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -19,7 +19,7 @@ set -v -e -x
 # Set up environment variables
 
 # NOTE(willkg): This has to be "database_url" all lowercase because configman.
-DATABASE_URL=${database_url:-"postgres://postgres:aPassword@postgresql:5432/socorro_integration_test"}
+DATABASE_URL=${database_url:-"postgres://postgres:aPassword@postgresql:5432/socorro_test"}
 
 # NOTE(willkg): This has to be "elasticsearch_url" all lowercase because configman.
 ELASTICSEARCH_URL=${elasticsearch_url:-"http://elasticsearch:9200"}
@@ -55,17 +55,11 @@ urlwait "${ELASTICSEARCH_URL}" 10
 
 # Set up database for alembic migrations
 #
-# FIXME(willkg): For some reason, this has to go first because setting up
-# socorro_integration_test needs it. Does it mean that alembic is doing
-# migrations in the wrong db?
+# Set up socorro_migration_test db
 $SETUPDB --database_name=socorro_migration_test --dropdb --logging.level=40 --unlogged --createdb
 
-# Set up database for unittests
-$SETUPDB --database_name=socorro_integration_test --dropdb --logging.level=40 --unlogged --no_staticdata --createdb
-
-# FIXME(willkg): What's this one for? It's got crontabber stuff in it and that's
-# it. Maybe we don't need it?
-$SETUPDB --database_name=socorro_test --dropdb --no_schema --logging.level=40 --unlogged --no_staticdata --createdb
+# Set up socorro_test db for unittests
+$SETUPDB --database_name=socorro_test --dropdb --logging.level=40 --unlogged --no_staticdata --createdb
 
 $ALEMBIC -c "${alembic_config}" downgrade -1
 $ALEMBIC -c "${alembic_config}" upgrade heads

--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script marks all the tests we know work in Python 3.
+#
+# Usage: ./docker/run_tests_python3.sh
+
+# This is the list of known working tests by directory/filename. When you
+# have tests in a directory/file working, add it to this list as a new line.
+WORKING_TESTS=(
+    socorro/unittest/lib/test_ooid.py
+)
+
+pytest ${WORKING_TESTS[@]}

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,9 +8,6 @@ configobj==5.0.6 \
     --hash=sha256:a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902
 simplejson==3.1.3 \
     --hash=sha256:941a25bbb00b021dbe026b94278d9fab9f4655e11ab76eb3f022a9ee097f0478 # pyup:ignore
-six==1.11.0 \
-    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
-    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
 thrift==0.10.0 \
     --hash=sha256:b7f6c09155321169af03f9fb20dc15a4a0c7481e7c334a5ba8f7f0d864633209
 cssselect==1.0.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -155,7 +155,7 @@ humanfriendly==4.12 \
 jsonschema==2.6.0 \
     --hash=sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08 \
     --hash=sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02
-functools32==3.2.3-2 \
+functools32==3.2.3-2 ; python_version < '3.2' \
     --hash=sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d \
     --hash=sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0
 requests-mock==1.4.0 \
@@ -213,3 +213,6 @@ flake8-isort==2.5 \
 moto==1.3.3 \
     --hash=sha256:ee71b515ba34d64c5f625950fc995594040f793a4a106614ff108ae02c1a2896 \
     --hash=sha256:45d14aca2b06b0083d5e82cfd770ebca0ba77b5070aec6928670240939a78681
+six==1.11.0 \
+    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
+    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -9,12 +9,13 @@ from collections import defaultdict
 
 from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch_dsl import A, F, Q, Search
+import six
+
 from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
     datetimeutil,
 )
-
 from socorro.lib.search_common import SearchBase
 
 
@@ -500,11 +501,9 @@ class SuperSearch(SearchBase):
                 except IndexError:
                     # Not an ElasticsearchParseException exception
                     pass
-                # Why not just do `raise exception`?
-                # Because if we don't do it this way, the eventual traceback
-                # is going to point to *this* line (right after this comment)
-                # rather than the actual error where it originally happened.
-                raise exc_type, exc_value, exc_tb
+
+                # Re-raise the original exception with the correct traceback
+                six.reraise(exc_type, exc_value, exc_tb)
 
         if shards and shards.failed:
             # Some shards failed. We want to explain what happened in the

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -7,9 +7,9 @@ import socket
 import contextlib
 import psycopg2
 import psycopg2.extensions
-from urlparse import urlparse
 
 from configman import RequiredConfig, Namespace
+from six.moves.urllib.parse import urlparse
 
 
 def get_field_from_pg_database_url(field, default):

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -8,7 +8,6 @@ Create, prepare and load schema for Socorro PostgreSQL database.
 """
 from __future__ import unicode_literals
 
-import cStringIO
 import os
 import re
 import sys
@@ -18,6 +17,7 @@ from alembic.config import Config
 from configman import Namespace, class_converter
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import CreateTable
+from six.moves import cStringIO
 
 from socorro.app.socorro_app import App
 from socorro.external.postgresql import staticdata
@@ -145,7 +145,7 @@ class SocorroDBApp(App):
     )
 
     def bulk_load_table(self, db, table):
-        io = cStringIO.StringIO()
+        io = cStringIO()
         for line in table.generate_rows():
             io.write('\t'.join([str(x) for x in line]))
             io.write('\n')

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -5,16 +5,14 @@
 import pika
 from random import randint
 
-from Queue import (
-    Queue,
-    Empty
-)
 
 from configman import (
     Namespace,
     class_converter
 )
 from configman.dotdict import DotDict
+from six.moves.queue import Queue, Empty
+
 from socorro.lib.converters import change_default
 from socorro.external.rabbitmq.connection_context import (
     ConnectionContext,

--- a/webapp-django/crashstats/crashstats/form_fields.py
+++ b/webapp-django/crashstats/crashstats/form_fields.py
@@ -18,7 +18,7 @@ class CarefulFieldBase(object):
     def strptime(self, value, format):
         try:
             return datetime.datetime.strptime(value, format)
-        except TypeError, e:
+        except TypeError as e:
             raise ValueError(e)
 
 

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -1,12 +1,13 @@
 import csv
 import codecs
-import cStringIO
 import datetime
 import isodate
 import functools
 import json
 import re
 from collections import OrderedDict
+
+from six.moves import cStringIO
 
 from django import http
 from django.conf import settings
@@ -311,7 +312,7 @@ class UnicodeWriter:
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
+        self.queue = StringIO()
         self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
         self.stream = f
         self.encoder = codecs.getincrementalencoder(encoding)()

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -312,7 +312,7 @@ class UnicodeWriter:
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         # Redirect output to a queue
-        self.queue = StringIO()
+        self.queue = cStringIO()
         self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
         self.stream = f
         self.encoder = codecs.getincrementalencoder(encoding)()

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -8,7 +8,7 @@ from pkg_resources import resource_string
 import dj_database_url
 from decouple import config, Csv
 
-from bundles import NPM_FILE_PATTERNS, PIPELINE_CSS, PIPELINE_JS  # noqa
+from .bundles import NPM_FILE_PATTERNS, PIPELINE_CSS, PIPELINE_JS  # noqa
 
 
 ROOT = os.path.abspath(

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
 
+import six
+
+
 # This determines what files are copied from npm libraries into the
 # static root when collectstatic runs.
 # The keys are library names (from webapp-django/package.json) and the
@@ -529,10 +532,10 @@ _used = {}
 for config in PIPELINE_JS, PIPELINE_CSS:  # NOQA
     _trouble = set()
     for k, v in config.items():
-        assert isinstance(k, basestring), k
+        assert isinstance(k, six.string_types), k
         out = v['output_filename']
         assert isinstance(v['source_filenames'], tuple), v
-        assert isinstance(out, basestring), v
+        assert isinstance(out, six.string_types), v
         assert not out.split('/')[-1].startswith('.'), k
         assert '_' not in out
         assert out.endswith('.min.css') or out.endswith('.min.js')


### PR DESCRIPTION
This adds a couple of make rules and shell scripts to give us scaffolding
with which we can iterate over fixing code to make it work in both
Python 2 and Python 3.

In order to get the tests to run at all, I had to fix a bunch of Python
3 issues. I also hoisted six to first-class dependency status.

This doesn't connect that with CI because linting fails epically. We'll do
that later.