### PR TITLE
bug 1459276: fix migration problem with reports_user_info

### DIFF
--- a/alembic/versions/fd76c8bb0d78_bug_1459276_reports.py
+++ b/alembic/versions/fd76c8bb0d78_bug_1459276_reports.py
@@ -42,7 +42,6 @@ def upgrade():
 
     op.execute('DROP TABLE IF EXISTS reports_bad')
     op.execute('DROP TABLE IF EXISTS reports_duplicates')
-    op.execute('DROP TABLE IF EXISTS reports_user_info')
 
     # Get rid of all tables that start with 'reports_clean'
     connection = op.get_bind()
@@ -66,6 +65,30 @@ def upgrade():
     # doesn't try to create a new partition
     op.execute("""
         DELETE FROM report_partition_info WHERE table_name = 'reports_clean'
+    """)
+
+    # Get rid of all the tables that start with 'reports_user_info'
+    connection = op.get_bind()
+    cursor = connection.connection.cursor()
+    cursor.execute("""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_name like 'reports_user_info%'
+    """)
+    all_table_names = []
+    for records in cursor.fetchall():
+        all_table_names.append(records[0])
+
+    # Sort table names so 'reports_user_info' is last since the others depend on it and
+    # delete them in that order
+    all_table_names.sort(reverse=True)
+    for table_name in all_table_names:
+        op.execute('DROP TABLE IF EXISTS {}'.format(table_name))
+
+    # Now remove the entry from report_partition_info so the crontabber job
+    # doesn't try to create a new partition
+    op.execute("""
+        DELETE FROM report_partition_info WHERE table_name = 'reports_user_info'
     """)
 
     # Get rid of all tables that start with 'reports'


### PR DESCRIPTION
This fixes the migration to account for `reports_user_info` being a partitioned
table.

Second verse, same as the first.