### PR TITLE
bug 1458886: Show UTC on clicking the time shortcut

### DIFF
--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
@@ -26,6 +26,11 @@ $(function () {
             }),
         };
 
+	$("#search-button").on('click', function() {
+	    filters.from.input.value = filters.from.selectedDates[0].toUTCString();
+	    filters.to.input.value = filters.to.selectedDates[0].toUTCString();
+	});
+
         function setDate(key, value) {
             filters[key].setDate(value, true);
         }


### PR DESCRIPTION
1. super search time "shortcut" From and To are incorrectly adjusted by timezone, cutting off most recent results
2. Display UTC after clicking the time shortcut (24hours, 3days, 7days,,,)
3. Click the time shortcut on "Super Search page".
4. I didn't add or update any test since it's UI issue.
