### PR TITLE
Started showing the user's Google Sign-In email address on every page.

### DIFF
--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -155,6 +155,8 @@
             <ul>
                 <li>
                 {% if request.user and request.user.is_active %}
+                    <span>{{ request.user.email }}</span>
+                    |
                     <a href="{{ url('profile:profile') }}"
                       title="You are signed in as {{ request.user.email }}"
                     >


### PR DESCRIPTION
Fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1461464

### Why
Crash Stats uses Google Sign-In, so it is helpful to know which account is signed in on every page.

### Changes
- Added the user email on bottom right of every page if the user is logged in

### Notes
- Should the tooltip on the `Your Profile` link be removed? It says `You are signed in as {{ request.user.email }}`, so it seems slightly redundant now.
- Should the placement or wording around the address be changed? For example, it could be: `Your are signed as {{ request.user.email }}` instead of just the email address.

### Screenshots
<img width="463" alt="screen shot 2018-05-21 at 4 39 44 pm" src="https://user-images.githubusercontent.com/12681350/40335303-c7554f94-5d17-11e8-9835-f3c6889af7da.png">
