### PR TITLE
bug 997272: applied Prettier to all .js files that are not downloaded libs

### DIFF
--- a/webapp-django/crashstats/api/static/api/js/testdrive.js
+++ b/webapp-django/crashstats/api/static/api/js/testdrive.js
@@ -1,4 +1,4 @@
-(function ($, document) {
+(function($, document) {
     'use strict';
 
     var _submission_locked = false;
@@ -12,11 +12,9 @@
                 if (!o[this.name].push) {
                     o[this.name] = [o[this.name]];
                 }
-                if (this.value)
-                  o[this.name].push(this.value || '');
+                if (this.value) o[this.name].push(this.value || '');
             } else {
-                if (this.value)
-                  o[this.name] = this.value || '';
+                if (this.value) o[this.name] = this.value || '';
             }
         });
         return o;
@@ -43,11 +41,10 @@
     }
 
     function validate_form(form) {
-
         function is_int(x) {
             var y = parseInt(x, 10);
             if (isNaN(y)) return false;
-            return x==y && x.toString() == y.toString();
+            return x == y && x.toString() == y.toString();
         }
         var all_valid = true;
         $('input', form).each(function() {
@@ -56,7 +53,11 @@
             var value = element.val();
             if (element.hasClass('required') && !value) {
                 valid = false;
-            } else if (element.hasClass('required') && element.hasClass('validate-int') && !is_int(value)) {
+            } else if (
+                element.hasClass('required') &&
+                element.hasClass('validate-int') &&
+                !is_int(value)
+            ) {
                 valid = false;
             } else {
                 // we can do more validation but let's not go too crazy yet
@@ -85,7 +86,9 @@
             // The second parameter (`true`) is so that things like
             // `{products: ["Firefox", "Thunderbird"]}`
             // becomes: `products=Firefox&products=Thunderbird`
-            var qs = Qs.stringify(form.serializeExclusive(), { indices: false });
+            var qs = Qs.stringify(form.serializeExclusive(), {
+                indices: false,
+            });
             if (qs) {
                 url += '?' + qs;
             }
@@ -103,84 +106,94 @@
 
         var container = $('.test-drive', form);
         $.ajax({
-           url: ajax_url,
-           method: method,
-           // Only send the `data` if it's a POST. For get the params are
-           // in the `ajax_url` already.
-           data: method === 'POST' ? form.serializeArray() : null,
-           dataType: 'text',
-           success: function(response, textStatus, jqXHR) {
-               $('pre', container).text(response);
-               $('.status code', container).hide();
-               $('.status-error', container).hide();
-               $('.response-size code', container).text(filesize(response.length));
-               $('.response-size').show();
-           },
-           error: function(jqXHR, textStatus, errorThrown) {
-               $('pre', container).text(jqXHR.responseText);
-               $('.status code', container).text(jqXHR.status).show();
-               $('.status-error', container).show();
-               $('.response-size').hide();
-               // in case it was binary before this run
-               $('pre', container).show();
-               $('.binary-response-warning', container).hide();
-           },
-           complete: function(jqXHR, textStatus) {
-               $('.used-url code', container).text(url);
-               $('.used-url a', container).attr('href', url);
-               if (method === 'POST') {
-                   $('.used-data code')
-                   .text(JSON.stringify(form.serializeExclusive()));
-                   $('.used-data').show();
-               } else {
-                   $('.used-data').hide();
-               }
-               if (jqXHR.getResponseHeader('Content-Type') === 'application/octet-stream') {
+            url: ajax_url,
+            method: method,
+            // Only send the `data` if it's a POST. For get the params are
+            // in the `ajax_url` already.
+            data: method === 'POST' ? form.serializeArray() : null,
+            dataType: 'text',
+            success: function(response, textStatus, jqXHR) {
+                $('pre', container).text(response);
+                $('.status code', container).hide();
+                $('.status-error', container).hide();
+                $('.response-size code', container).text(
+                    filesize(response.length)
+                );
+                $('.response-size').show();
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                $('pre', container).text(jqXHR.responseText);
+                $('.status code', container)
+                    .text(jqXHR.status)
+                    .show();
+                $('.status-error', container).show();
+                $('.response-size').hide();
+                // in case it was binary before this run
+                $('pre', container).show();
+                $('.binary-response-warning', container).hide();
+            },
+            complete: function(jqXHR, textStatus) {
+                $('.used-url code', container).text(url);
+                $('.used-url a', container).attr('href', url);
+                if (method === 'POST') {
+                    $('.used-data code').text(
+                        JSON.stringify(form.serializeExclusive())
+                    );
+                    $('.used-data').show();
+                } else {
+                    $('.used-data').hide();
+                }
+                if (
+                    jqXHR.getResponseHeader('Content-Type') ===
+                    'application/octet-stream'
+                ) {
                     $('pre', container).hide();
                     $('.binary-response-warning', container).show();
-               } else {
+                } else {
                     // in case it was binary *before* this run, reset it
                     $('pre', container).show();
                     $('.binary-response-warning', container).hide();
-               }
-               container.show();
-               setTimeout(function() {
-                   // add a slight delay so it feels smoother for endpoints
-                   // that complete in milliseconds
-                   $('img.loading-ajax', form).hide();
-                   $('button.close', form).show();
-               }, 500);
-               _submission_locked = false;
-           }
+                }
+                container.show();
+                setTimeout(function() {
+                    // add a slight delay so it feels smoother for endpoints
+                    // that complete in milliseconds
+                    $('img.loading-ajax', form).hide();
+                    $('button.close', form).show();
+                }, 500);
+                _submission_locked = false;
+            },
         });
     }
 
-    $(document).ready(function () {
+    $(document).ready(function() {
         $('input.validate-list').each(function() {
             $('<a href="#">-</a>')
-              .hide()
-              .addClass('collapse-list')
-              .attr('title', 'Click to remove the last added input field')
-              .click(function(e) {
-                  e.preventDefault();
-                  one_less(this);
-              })
-              .insertAfter($(this));
+                .hide()
+                .addClass('collapse-list')
+                .attr('title', 'Click to remove the last added input field')
+                .click(function(e) {
+                    e.preventDefault();
+                    one_less(this);
+                })
+                .insertAfter($(this));
             $('<a href="#">+</a>')
-              .addClass('expand-list')
-              .attr('title', 'Click to create another input field')
-              .click(function(e) {
-                  e.preventDefault();
-                  one_more(this);
-              })
-              .insertAfter($(this));
+                .addClass('expand-list')
+                .attr('title', 'Click to create another input field')
+                .click(function(e) {
+                    e.preventDefault();
+                    one_more(this);
+                })
+                .insertAfter($(this));
         });
 
         $('form.testdrive').submit(function(event) {
             var $form = $(this);
             event.preventDefault();
             if (_submission_locked) {
-                alert('Currently processing an existing query. Please be patient.');
+                alert(
+                    'Currently processing an existing query. Please be patient.'
+                );
             } else {
                 _submission_locked = true;
                 if (validate_form($form)) {
@@ -215,8 +228,5 @@
             location.href = url;
             // window.open(url);
         });
-
     });
-
-
-}($, document));
+})($, document);

--- a/webapp-django/crashstats/authentication/static/auth/js/debug_login.js
+++ b/webapp-django/crashstats/authentication/static/auth/js/debug_login.js
@@ -18,7 +18,10 @@ $(function() {
 
     function addVerdict(container, msg, color) {
         container.append(
-            $('<p>').addClass('verdict').html(msg).addClass(color)
+            $('<p>')
+                .addClass('verdict')
+                .html(msg)
+                .addClass(color)
         );
     }
 
@@ -58,56 +61,59 @@ $(function() {
             );
         }
     }
-    $.getJSON(location.pathname, {'test-cookie': true})
-    .done(function(r) {
-        if (r.cookie_value === cookie_secure.data('cookie-value')) {
-            addVerdict(
-                cookie_secure,
-                "Happily able to set a cookie and retrieving it again.",
-                'good'
-            );
-        } else {
-            addVerdict(
-                cookie_secure,
-                "Unable to set a cookie and retrieving it again.",
-                'bad'
-            );
-        }
-    }).fail(function() {
-        console.warn('Unable to make an AJAX request to test cookies');
-        console.error(arguments);
-        $('#check-console').show();
-    }).always(function() {
-        $('.loading', cookie_secure).hide();
-        drawConclusionSoon();
-    });
+    $.getJSON(location.pathname, { 'test-cookie': true })
+        .done(function(r) {
+            if (r.cookie_value === cookie_secure.data('cookie-value')) {
+                addVerdict(
+                    cookie_secure,
+                    'Happily able to set a cookie and retrieving it again.',
+                    'good'
+                );
+            } else {
+                addVerdict(
+                    cookie_secure,
+                    'Unable to set a cookie and retrieving it again.',
+                    'bad'
+                );
+            }
+        })
+        .fail(function() {
+            console.warn('Unable to make an AJAX request to test cookies');
+            console.error(arguments);
+            $('#check-console').show();
+        })
+        .always(function() {
+            $('.loading', cookie_secure).hide();
+            drawConclusionSoon();
+        });
 
     /* Check that caching works */
     var caching = $('#caching');
-    $.getJSON(location.pathname, {'test-caching': true})
-    .done(function(r) {
-        if (r.cache_value === caching.data('cache-value')) {
-            // seems to work
-            addVerdict(
-                caching,
-                'Setting and retrieving from cache seems to work.',
-                'good'
-            );
-        } else {
-            addVerdict(
-                caching,
-                'Unable to set a value in cache that sticks! ' +
-                'Check your <code>settings.CACHES</code> settings.',
-                'bad'
-            );
-        }
-    }).fail(function() {
-        console.warn('Unable to make an AJAX request');
-        console.error(arguments);
-        $('#check-console').show();
-    }).always(function() {
-        $('.loading', caching).hide();
-        drawConclusionSoon();
-    });
-
+    $.getJSON(location.pathname, { 'test-caching': true })
+        .done(function(r) {
+            if (r.cache_value === caching.data('cache-value')) {
+                // seems to work
+                addVerdict(
+                    caching,
+                    'Setting and retrieving from cache seems to work.',
+                    'good'
+                );
+            } else {
+                addVerdict(
+                    caching,
+                    'Unable to set a value in cache that sticks! ' +
+                        'Check your <code>settings.CACHES</code> settings.',
+                    'bad'
+                );
+            }
+        })
+        .fail(function() {
+            console.warn('Unable to make an AJAX request');
+            console.error(arguments);
+            $('#check-console').show();
+        })
+        .always(function() {
+            $('.loading', caching).hide();
+            drawConclusionSoon();
+        });
 });

--- a/webapp-django/crashstats/base/static/js/error.js
+++ b/webapp-django/crashstats/base/static/js/error.js
@@ -3,14 +3,13 @@
     Remember, there's no jQuery available in this context.
  */
 
-
 // If the page as a bugzilla link, because we can't rely on the server
 // to figure out the current full URL, we have to use JavaScript to
 // append the current full URL to the bug_file_loc parameter link.
 window.onload = function() {
     var link = document.querySelector('a.bugzilla-link');
     if (link) {
-        link.href += '&bug_file_loc=' + encodeURIComponent(document.location.href);
+        link.href +=
+            '&bug_file_loc=' + encodeURIComponent(document.location.href);
     }
-
 };

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/lib/accordions.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/lib/accordions.js
@@ -1,12 +1,10 @@
 (function(window, undefined) {
-
     'use strict';
 
     var Accordion = function(accordionContainer) {
         // var self = this;
 
         this.container = accordionContainer;
-
 
         /**
          * Hides all content panes in current accordion container.
@@ -16,7 +14,9 @@
             var panesLength = contentPanes.length;
 
             for (var i = 0; i < panesLength; i++) {
-                var classArray = contentPanes[i].getAttribute('class').split(/\s/);
+                var classArray = contentPanes[i]
+                    .getAttribute('class')
+                    .split(/\s/);
                 var index = classArray.indexOf('show');
 
                 if (index > -1) {
@@ -24,7 +24,10 @@
                     // we are collapsing so, update aria-expanded
                     contentPanes[i].setAttribute('aria-hidden', 'true');
                     // @see https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode.previousElementSibling
-                    contentPanes[i].previousElementSibling.setAttribute('aria-expanded', 'false');
+                    contentPanes[i].previousElementSibling.setAttribute(
+                        'aria-expanded',
+                        'false'
+                    );
                 }
                 contentPanes[i].setAttribute('class', classArray.join(' '));
             }
@@ -47,7 +50,6 @@
          * @params {object} event - The event that was fired.
          */
         this.handleEvent = function(event) {
-
             var anchor = event.target;
             var contentPanelId = anchor.getAttribute('href');
 
@@ -65,7 +67,9 @@
                 parent.setAttribute('aria-selected', 'false');
 
                 // hide all the panes
-                this.hidePanes(this.container.querySelectorAll('.content-pane'));
+                this.hidePanes(
+                    this.container.querySelectorAll('.content-pane')
+                );
             } else if (parentRole === 'tab') {
                 event.preventDefault();
 
@@ -74,7 +78,9 @@
                 parent.setAttribute('aria-selected', 'true');
 
                 // hide all the panes
-                this.hidePanes(this.container.querySelectorAll('.content-pane'));
+                this.hidePanes(
+                    this.container.querySelectorAll('.content-pane')
+                );
 
                 // show the selected pane
                 this.showPane(document.querySelector(contentPanelId));
@@ -90,8 +96,11 @@
             var key = event.key ? event.key : event.keyCode;
 
             // handle enter and spacebar keys.
-            if ((key === 13 || key === 32) ||
-                (key === 'Enter' || key === 'Spacebar')) {
+            if (
+                key === 13 ||
+                key === 32 ||
+                (key === 'Enter' || key === 'Spacebar')
+            ) {
                 this.handleEvent(event);
             }
         }.bind(this);
@@ -117,34 +126,43 @@
         }.bind(this);
 
         this.init = function() {
-
             // this.container = accordionContainer;
 
-            this.container.addEventListener('click', function(event) {
-                // handle edge cases where the original event.targer is removed
-                // riht after the event was trigered causing event.target.parentNode
-                // in handleEvent to be null.
-                if (event.target.parentNode) {
-                    this.handleEvent(event);
-                }
-            }.bind(this), false);
+            this.container.addEventListener(
+                'click',
+                function(event) {
+                    // handle edge cases where the original event.targer is removed
+                    // riht after the event was trigered causing event.target.parentNode
+                    // in handleEvent to be null.
+                    if (event.target.parentNode) {
+                        this.handleEvent(event);
+                    }
+                }.bind(this),
+                false
+            );
 
-            this.container.addEventListener('keyup', function(event) {
-                if (event.target.parentNode) {
-                    this.delegateKeyEvents(event);
-                }
-            }.bind(this), false);
+            this.container.addEventListener(
+                'keyup',
+                function(event) {
+                    if (event.target.parentNode) {
+                        this.delegateKeyEvents(event);
+                    }
+                }.bind(this),
+                false
+            );
 
-            this.container.addEventListener('keydown', function(event) {
-                if (event.target.parentNode) {
-                    this.delegateKeyEvents(event);
-                }
-            }.bind(this), false);
+            this.container.addEventListener(
+                'keydown',
+                function(event) {
+                    if (event.target.parentNode) {
+                        this.delegateKeyEvents(event);
+                    }
+                }.bind(this),
+                false
+            );
         }.bind(this);
-
     };
 
     // Expose accordion to the global object
     window.Accordion = Accordion;
-
 })(window);

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/polyfill/fetch.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/polyfill/fetch.js
@@ -1,433 +1,475 @@
 (function(self) {
-  'use strict';
+    'use strict';
 
-  if (self.fetch) {
-    return
-  }
-
-  var support = {
-    searchParams: 'URLSearchParams' in self,
-    iterable: 'Symbol' in self && 'iterator' in Symbol,
-    blob: 'FileReader' in self && 'Blob' in self && (function() {
-      try {
-        new Blob()
-        return true
-      } catch(e) {
-        return false
-      }
-    })(),
-    formData: 'FormData' in self,
-    arrayBuffer: 'ArrayBuffer' in self
-  }
-
-  function normalizeName(name) {
-    if (typeof name !== 'string') {
-      name = String(name)
+    if (self.fetch) {
+        return;
     }
-    if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
-      throw new TypeError('Invalid character in header field name')
-    }
-    return name.toLowerCase()
-  }
 
-  function normalizeValue(value) {
-    if (typeof value !== 'string') {
-      value = String(value)
-    }
-    return value
-  }
+    var support = {
+        searchParams: 'URLSearchParams' in self,
+        iterable: 'Symbol' in self && 'iterator' in Symbol,
+        blob:
+            'FileReader' in self &&
+            'Blob' in self &&
+            (function() {
+                try {
+                    new Blob();
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            })(),
+        formData: 'FormData' in self,
+        arrayBuffer: 'ArrayBuffer' in self,
+    };
 
-  // Build a destructive iterator for the value list
-  function iteratorFor(items) {
-    var iterator = {
-      next: function() {
-        var value = items.shift()
-        return {done: value === undefined, value: value}
-      }
+    function normalizeName(name) {
+        if (typeof name !== 'string') {
+            name = String(name);
+        }
+        if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
+            throw new TypeError('Invalid character in header field name');
+        }
+        return name.toLowerCase();
     }
+
+    function normalizeValue(value) {
+        if (typeof value !== 'string') {
+            value = String(value);
+        }
+        return value;
+    }
+
+    // Build a destructive iterator for the value list
+    function iteratorFor(items) {
+        var iterator = {
+            next: function() {
+                var value = items.shift();
+                return { done: value === undefined, value: value };
+            },
+        };
+
+        if (support.iterable) {
+            iterator[Symbol.iterator] = function() {
+                return iterator;
+            };
+        }
+
+        return iterator;
+    }
+
+    function Headers(headers) {
+        this.map = {};
+
+        if (headers instanceof Headers) {
+            headers.forEach(function(value, name) {
+                this.append(name, value);
+            }, this);
+        } else if (headers) {
+            Object.getOwnPropertyNames(headers).forEach(function(name) {
+                this.append(name, headers[name]);
+            }, this);
+        }
+    }
+
+    Headers.prototype.append = function(name, value) {
+        name = normalizeName(name);
+        value = normalizeValue(value);
+        var list = this.map[name];
+        if (!list) {
+            list = [];
+            this.map[name] = list;
+        }
+        list.push(value);
+    };
+
+    Headers.prototype['delete'] = function(name) {
+        delete this.map[normalizeName(name)];
+    };
+
+    Headers.prototype.get = function(name) {
+        var values = this.map[normalizeName(name)];
+        return values ? values[0] : null;
+    };
+
+    Headers.prototype.getAll = function(name) {
+        return this.map[normalizeName(name)] || [];
+    };
+
+    Headers.prototype.has = function(name) {
+        return this.map.hasOwnProperty(normalizeName(name));
+    };
+
+    Headers.prototype.set = function(name, value) {
+        this.map[normalizeName(name)] = [normalizeValue(value)];
+    };
+
+    Headers.prototype.forEach = function(callback, thisArg) {
+        Object.getOwnPropertyNames(this.map).forEach(function(name) {
+            this.map[name].forEach(function(value) {
+                callback.call(thisArg, value, name, this);
+            }, this);
+        }, this);
+    };
+
+    Headers.prototype.keys = function() {
+        var items = [];
+        this.forEach(function(value, name) {
+            items.push(name);
+        });
+        return iteratorFor(items);
+    };
+
+    Headers.prototype.values = function() {
+        var items = [];
+        this.forEach(function(value) {
+            items.push(value);
+        });
+        return iteratorFor(items);
+    };
+
+    Headers.prototype.entries = function() {
+        var items = [];
+        this.forEach(function(value, name) {
+            items.push([name, value]);
+        });
+        return iteratorFor(items);
+    };
 
     if (support.iterable) {
-      iterator[Symbol.iterator] = function() {
-        return iterator
-      }
+        Headers.prototype[Symbol.iterator] = Headers.prototype.entries;
     }
 
-    return iterator
-  }
-
-  function Headers(headers) {
-    this.map = {}
-
-    if (headers instanceof Headers) {
-      headers.forEach(function(value, name) {
-        this.append(name, value)
-      }, this)
-
-    } else if (headers) {
-      Object.getOwnPropertyNames(headers).forEach(function(name) {
-        this.append(name, headers[name])
-      }, this)
-    }
-  }
-
-  Headers.prototype.append = function(name, value) {
-    name = normalizeName(name)
-    value = normalizeValue(value)
-    var list = this.map[name]
-    if (!list) {
-      list = []
-      this.map[name] = list
-    }
-    list.push(value)
-  }
-
-  Headers.prototype['delete'] = function(name) {
-    delete this.map[normalizeName(name)]
-  }
-
-  Headers.prototype.get = function(name) {
-    var values = this.map[normalizeName(name)]
-    return values ? values[0] : null
-  }
-
-  Headers.prototype.getAll = function(name) {
-    return this.map[normalizeName(name)] || []
-  }
-
-  Headers.prototype.has = function(name) {
-    return this.map.hasOwnProperty(normalizeName(name))
-  }
-
-  Headers.prototype.set = function(name, value) {
-    this.map[normalizeName(name)] = [normalizeValue(value)]
-  }
-
-  Headers.prototype.forEach = function(callback, thisArg) {
-    Object.getOwnPropertyNames(this.map).forEach(function(name) {
-      this.map[name].forEach(function(value) {
-        callback.call(thisArg, value, name, this)
-      }, this)
-    }, this)
-  }
-
-  Headers.prototype.keys = function() {
-    var items = []
-    this.forEach(function(value, name) { items.push(name) })
-    return iteratorFor(items)
-  }
-
-  Headers.prototype.values = function() {
-    var items = []
-    this.forEach(function(value) { items.push(value) })
-    return iteratorFor(items)
-  }
-
-  Headers.prototype.entries = function() {
-    var items = []
-    this.forEach(function(value, name) { items.push([name, value]) })
-    return iteratorFor(items)
-  }
-
-  if (support.iterable) {
-    Headers.prototype[Symbol.iterator] = Headers.prototype.entries
-  }
-
-  function consumed(body) {
-    if (body.bodyUsed) {
-      return Promise.reject(new TypeError('Already read'))
-    }
-    body.bodyUsed = true
-  }
-
-  function fileReaderReady(reader) {
-    return new Promise(function(resolve, reject) {
-      reader.onload = function() {
-        resolve(reader.result)
-      }
-      reader.onerror = function() {
-        reject(reader.error)
-      }
-    })
-  }
-
-  function readBlobAsArrayBuffer(blob) {
-    var reader = new FileReader()
-    reader.readAsArrayBuffer(blob)
-    return fileReaderReady(reader)
-  }
-
-  function readBlobAsText(blob) {
-    var reader = new FileReader()
-    reader.readAsText(blob)
-    return fileReaderReady(reader)
-  }
-
-  function Body() {
-    this.bodyUsed = false
-
-    this._initBody = function(body) {
-      this._bodyInit = body
-      if (typeof body === 'string') {
-        this._bodyText = body
-      } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
-        this._bodyBlob = body
-      } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
-        this._bodyFormData = body
-      } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-        this._bodyText = body.toString()
-      } else if (!body) {
-        this._bodyText = ''
-      } else if (support.arrayBuffer && ArrayBuffer.prototype.isPrototypeOf(body)) {
-        // Only support ArrayBuffers for POST method.
-        // Receiving ArrayBuffers happens via Blobs, instead.
-      } else {
-        throw new Error('unsupported BodyInit type')
-      }
-
-      if (!this.headers.get('content-type')) {
-        if (typeof body === 'string') {
-          this.headers.set('content-type', 'text/plain;charset=UTF-8')
-        } else if (this._bodyBlob && this._bodyBlob.type) {
-          this.headers.set('content-type', this._bodyBlob.type)
-        } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-          this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
+    function consumed(body) {
+        if (body.bodyUsed) {
+            return Promise.reject(new TypeError('Already read'));
         }
-      }
+        body.bodyUsed = true;
     }
 
-    if (support.blob) {
-      this.blob = function() {
-        var rejected = consumed(this)
-        if (rejected) {
-          return rejected
-        }
+    function fileReaderReady(reader) {
+        return new Promise(function(resolve, reject) {
+            reader.onload = function() {
+                resolve(reader.result);
+            };
+            reader.onerror = function() {
+                reject(reader.error);
+            };
+        });
+    }
 
-        if (this._bodyBlob) {
-          return Promise.resolve(this._bodyBlob)
-        } else if (this._bodyFormData) {
-          throw new Error('could not read FormData body as blob')
+    function readBlobAsArrayBuffer(blob) {
+        var reader = new FileReader();
+        reader.readAsArrayBuffer(blob);
+        return fileReaderReady(reader);
+    }
+
+    function readBlobAsText(blob) {
+        var reader = new FileReader();
+        reader.readAsText(blob);
+        return fileReaderReady(reader);
+    }
+
+    function Body() {
+        this.bodyUsed = false;
+
+        this._initBody = function(body) {
+            this._bodyInit = body;
+            if (typeof body === 'string') {
+                this._bodyText = body;
+            } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
+                this._bodyBlob = body;
+            } else if (
+                support.formData &&
+                FormData.prototype.isPrototypeOf(body)
+            ) {
+                this._bodyFormData = body;
+            } else if (
+                support.searchParams &&
+                URLSearchParams.prototype.isPrototypeOf(body)
+            ) {
+                this._bodyText = body.toString();
+            } else if (!body) {
+                this._bodyText = '';
+            } else if (
+                support.arrayBuffer &&
+                ArrayBuffer.prototype.isPrototypeOf(body)
+            ) {
+                // Only support ArrayBuffers for POST method.
+                // Receiving ArrayBuffers happens via Blobs, instead.
+            } else {
+                throw new Error('unsupported BodyInit type');
+            }
+
+            if (!this.headers.get('content-type')) {
+                if (typeof body === 'string') {
+                    this.headers.set(
+                        'content-type',
+                        'text/plain;charset=UTF-8'
+                    );
+                } else if (this._bodyBlob && this._bodyBlob.type) {
+                    this.headers.set('content-type', this._bodyBlob.type);
+                } else if (
+                    support.searchParams &&
+                    URLSearchParams.prototype.isPrototypeOf(body)
+                ) {
+                    this.headers.set(
+                        'content-type',
+                        'application/x-www-form-urlencoded;charset=UTF-8'
+                    );
+                }
+            }
+        };
+
+        if (support.blob) {
+            this.blob = function() {
+                var rejected = consumed(this);
+                if (rejected) {
+                    return rejected;
+                }
+
+                if (this._bodyBlob) {
+                    return Promise.resolve(this._bodyBlob);
+                } else if (this._bodyFormData) {
+                    throw new Error('could not read FormData body as blob');
+                } else {
+                    return Promise.resolve(new Blob([this._bodyText]));
+                }
+            };
+
+            this.arrayBuffer = function() {
+                return this.blob().then(readBlobAsArrayBuffer);
+            };
+
+            this.text = function() {
+                var rejected = consumed(this);
+                if (rejected) {
+                    return rejected;
+                }
+
+                if (this._bodyBlob) {
+                    return readBlobAsText(this._bodyBlob);
+                } else if (this._bodyFormData) {
+                    throw new Error('could not read FormData body as text');
+                } else {
+                    return Promise.resolve(this._bodyText);
+                }
+            };
         } else {
-          return Promise.resolve(new Blob([this._bodyText]))
-        }
-      }
-
-      this.arrayBuffer = function() {
-        return this.blob().then(readBlobAsArrayBuffer)
-      }
-
-      this.text = function() {
-        var rejected = consumed(this)
-        if (rejected) {
-          return rejected
+            this.text = function() {
+                var rejected = consumed(this);
+                return rejected ? rejected : Promise.resolve(this._bodyText);
+            };
         }
 
-        if (this._bodyBlob) {
-          return readBlobAsText(this._bodyBlob)
-        } else if (this._bodyFormData) {
-          throw new Error('could not read FormData body as text')
+        if (support.formData) {
+            this.formData = function() {
+                return this.text().then(decode);
+            };
+        }
+
+        this.json = function() {
+            return this.text().then(JSON.parse);
+        };
+
+        return this;
+    }
+
+    // HTTP methods whose capitalization should be normalized
+    var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT'];
+
+    function normalizeMethod(method) {
+        var upcased = method.toUpperCase();
+        return methods.indexOf(upcased) > -1 ? upcased : method;
+    }
+
+    function Request(input, options) {
+        options = options || {};
+        var body = options.body;
+        if (Request.prototype.isPrototypeOf(input)) {
+            if (input.bodyUsed) {
+                throw new TypeError('Already read');
+            }
+            this.url = input.url;
+            this.credentials = input.credentials;
+            if (!options.headers) {
+                this.headers = new Headers(input.headers);
+            }
+            this.method = input.method;
+            this.mode = input.mode;
+            if (!body) {
+                body = input._bodyInit;
+                input.bodyUsed = true;
+            }
         } else {
-          return Promise.resolve(this._bodyText)
-        }
-      }
-    } else {
-      this.text = function() {
-        var rejected = consumed(this)
-        return rejected ? rejected : Promise.resolve(this._bodyText)
-      }
-    }
-
-    if (support.formData) {
-      this.formData = function() {
-        return this.text().then(decode)
-      }
-    }
-
-    this.json = function() {
-      return this.text().then(JSON.parse)
-    }
-
-    return this
-  }
-
-  // HTTP methods whose capitalization should be normalized
-  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
-
-  function normalizeMethod(method) {
-    var upcased = method.toUpperCase()
-    return (methods.indexOf(upcased) > -1) ? upcased : method
-  }
-
-  function Request(input, options) {
-    options = options || {}
-    var body = options.body
-    if (Request.prototype.isPrototypeOf(input)) {
-      if (input.bodyUsed) {
-        throw new TypeError('Already read')
-      }
-      this.url = input.url
-      this.credentials = input.credentials
-      if (!options.headers) {
-        this.headers = new Headers(input.headers)
-      }
-      this.method = input.method
-      this.mode = input.mode
-      if (!body) {
-        body = input._bodyInit
-        input.bodyUsed = true
-      }
-    } else {
-      this.url = input
-    }
-
-    this.credentials = options.credentials || this.credentials || 'omit'
-    if (options.headers || !this.headers) {
-      this.headers = new Headers(options.headers)
-    }
-    this.method = normalizeMethod(options.method || this.method || 'GET')
-    this.mode = options.mode || this.mode || null
-    this.referrer = null
-
-    if ((this.method === 'GET' || this.method === 'HEAD') && body) {
-      throw new TypeError('Body not allowed for GET or HEAD requests')
-    }
-    this._initBody(body)
-  }
-
-  Request.prototype.clone = function() {
-    return new Request(this)
-  }
-
-  function decode(body) {
-    var form = new FormData()
-    body.trim().split('&').forEach(function(bytes) {
-      if (bytes) {
-        var split = bytes.split('=')
-        var name = split.shift().replace(/\+/g, ' ')
-        var value = split.join('=').replace(/\+/g, ' ')
-        form.append(decodeURIComponent(name), decodeURIComponent(value))
-      }
-    })
-    return form
-  }
-
-  function headers(xhr) {
-    var head = new Headers()
-    var pairs = (xhr.getAllResponseHeaders() || '').trim().split('\n')
-    pairs.forEach(function(header) {
-      var split = header.trim().split(':')
-      var key = split.shift().trim()
-      var value = split.join(':').trim()
-      head.append(key, value)
-    })
-    return head
-  }
-
-  Body.call(Request.prototype)
-
-  function Response(bodyInit, options) {
-    if (!options) {
-      options = {}
-    }
-
-    this.type = 'default'
-    this.status = options.status
-    this.ok = this.status >= 200 && this.status < 300
-    this.statusText = options.statusText
-    this.headers = options.headers instanceof Headers ? options.headers : new Headers(options.headers)
-    this.url = options.url || ''
-    this._initBody(bodyInit)
-  }
-
-  Body.call(Response.prototype)
-
-  Response.prototype.clone = function() {
-    return new Response(this._bodyInit, {
-      status: this.status,
-      statusText: this.statusText,
-      headers: new Headers(this.headers),
-      url: this.url
-    })
-  }
-
-  Response.error = function() {
-    var response = new Response(null, {status: 0, statusText: ''})
-    response.type = 'error'
-    return response
-  }
-
-  var redirectStatuses = [301, 302, 303, 307, 308]
-
-  Response.redirect = function(url, status) {
-    if (redirectStatuses.indexOf(status) === -1) {
-      throw new RangeError('Invalid status code')
-    }
-
-    return new Response(null, {status: status, headers: {location: url}})
-  }
-
-  self.Headers = Headers
-  self.Request = Request
-  self.Response = Response
-
-  self.fetch = function(input, init) {
-    return new Promise(function(resolve, reject) {
-      var request
-      if (Request.prototype.isPrototypeOf(input) && !init) {
-        request = input
-      } else {
-        request = new Request(input, init)
-      }
-
-      var xhr = new XMLHttpRequest()
-
-      function responseURL() {
-        if ('responseURL' in xhr) {
-          return xhr.responseURL
+            this.url = input;
         }
 
-        // Avoid security warnings on getResponseHeader when not allowed by CORS
-        if (/^X-Request-URL:/mi.test(xhr.getAllResponseHeaders())) {
-          return xhr.getResponseHeader('X-Request-URL')
+        this.credentials = options.credentials || this.credentials || 'omit';
+        if (options.headers || !this.headers) {
+            this.headers = new Headers(options.headers);
+        }
+        this.method = normalizeMethod(options.method || this.method || 'GET');
+        this.mode = options.mode || this.mode || null;
+        this.referrer = null;
+
+        if ((this.method === 'GET' || this.method === 'HEAD') && body) {
+            throw new TypeError('Body not allowed for GET or HEAD requests');
+        }
+        this._initBody(body);
+    }
+
+    Request.prototype.clone = function() {
+        return new Request(this);
+    };
+
+    function decode(body) {
+        var form = new FormData();
+        body
+            .trim()
+            .split('&')
+            .forEach(function(bytes) {
+                if (bytes) {
+                    var split = bytes.split('=');
+                    var name = split.shift().replace(/\+/g, ' ');
+                    var value = split.join('=').replace(/\+/g, ' ');
+                    form.append(
+                        decodeURIComponent(name),
+                        decodeURIComponent(value)
+                    );
+                }
+            });
+        return form;
+    }
+
+    function headers(xhr) {
+        var head = new Headers();
+        var pairs = (xhr.getAllResponseHeaders() || '').trim().split('\n');
+        pairs.forEach(function(header) {
+            var split = header.trim().split(':');
+            var key = split.shift().trim();
+            var value = split.join(':').trim();
+            head.append(key, value);
+        });
+        return head;
+    }
+
+    Body.call(Request.prototype);
+
+    function Response(bodyInit, options) {
+        if (!options) {
+            options = {};
         }
 
-        return
-      }
+        this.type = 'default';
+        this.status = options.status;
+        this.ok = this.status >= 200 && this.status < 300;
+        this.statusText = options.statusText;
+        this.headers =
+            options.headers instanceof Headers
+                ? options.headers
+                : new Headers(options.headers);
+        this.url = options.url || '';
+        this._initBody(bodyInit);
+    }
 
-      xhr.onload = function() {
-        var options = {
-          status: xhr.status,
-          statusText: xhr.statusText,
-          headers: headers(xhr),
-          url: responseURL()
+    Body.call(Response.prototype);
+
+    Response.prototype.clone = function() {
+        return new Response(this._bodyInit, {
+            status: this.status,
+            statusText: this.statusText,
+            headers: new Headers(this.headers),
+            url: this.url,
+        });
+    };
+
+    Response.error = function() {
+        var response = new Response(null, { status: 0, statusText: '' });
+        response.type = 'error';
+        return response;
+    };
+
+    var redirectStatuses = [301, 302, 303, 307, 308];
+
+    Response.redirect = function(url, status) {
+        if (redirectStatuses.indexOf(status) === -1) {
+            throw new RangeError('Invalid status code');
         }
-        var body = 'response' in xhr ? xhr.response : xhr.responseText
-        resolve(new Response(body, options))
-      }
 
-      xhr.onerror = function() {
-        reject(new TypeError('Network request failed'))
-      }
+        return new Response(null, {
+            status: status,
+            headers: { location: url },
+        });
+    };
 
-      xhr.ontimeout = function() {
-        reject(new TypeError('Network request failed'))
-      }
+    self.Headers = Headers;
+    self.Request = Request;
+    self.Response = Response;
 
-      xhr.open(request.method, request.url, true)
+    self.fetch = function(input, init) {
+        return new Promise(function(resolve, reject) {
+            var request;
+            if (Request.prototype.isPrototypeOf(input) && !init) {
+                request = input;
+            } else {
+                request = new Request(input, init);
+            }
 
-      if (request.credentials === 'include') {
-        xhr.withCredentials = true
-      }
+            var xhr = new XMLHttpRequest();
 
-      if ('responseType' in xhr && support.blob) {
-        xhr.responseType = 'blob'
-      }
+            function responseURL() {
+                if ('responseURL' in xhr) {
+                    return xhr.responseURL;
+                }
 
-      request.headers.forEach(function(value, name) {
-        xhr.setRequestHeader(name, value)
-      })
+                // Avoid security warnings on getResponseHeader when not allowed by CORS
+                if (/^X-Request-URL:/im.test(xhr.getAllResponseHeaders())) {
+                    return xhr.getResponseHeader('X-Request-URL');
+                }
 
-      xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
-    })
-  }
-  self.fetch.polyfill = true
+                return;
+            }
+
+            xhr.onload = function() {
+                var options = {
+                    status: xhr.status,
+                    statusText: xhr.statusText,
+                    headers: headers(xhr),
+                    url: responseURL(),
+                };
+                var body = 'response' in xhr ? xhr.response : xhr.responseText;
+                resolve(new Response(body, options));
+            };
+
+            xhr.onerror = function() {
+                reject(new TypeError('Network request failed'));
+            };
+
+            xhr.ontimeout = function() {
+                reject(new TypeError('Network request failed'));
+            };
+
+            xhr.open(request.method, request.url, true);
+
+            if (request.credentials === 'include') {
+                xhr.withCredentials = true;
+            }
+
+            if ('responseType' in xhr && support.blob) {
+                xhr.responseType = 'blob';
+            }
+
+            request.headers.forEach(function(value, name) {
+                xhr.setRequestHeader(name, value);
+            });
+
+            xhr.send(
+                typeof request._bodyInit === 'undefined'
+                    ? null
+                    : request._bodyInit
+            );
+        });
+    };
+    self.fetch.polyfill = true;
 })(typeof self !== 'undefined' ? self : this);

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/admin.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/admin.js
@@ -1,58 +1,69 @@
 // Open the add product version form and fill the fields in with given input
 function branchAddProductVersionFill(product, version) {
-	$('#add_version').simplebox();
-	$('#product').val(product);
-	$('#version').val(version);
+    $('#add_version').simplebox();
+    $('#product').val(product);
+    $('#version').val(version);
 }
 
 // Replace the submit button with a progress icon
 function hideShow(hideId, showId) {
-	$('#'+hideId).hide();
-	$('#'+showId).show('fast');
+    $('#' + hideId).hide();
+    $('#' + showId).show('fast');
 }
 
-$(document).ready(function(){
-
+$(document).ready(function() {
     var dataSourcesTabs = $('#data_sources');
 
-	/* Emails */
-    $('input[name=email_start_date][type=text], input[name=email_end_date][type=text]').datepicker({
-		dateFormat: "dd/mm/yy"
-	});
-
-	/* Add new */
-	$("#start_date, #end_date").datepicker({
-		dateFormat: "yy/mm/dd"
-	});
-
-	/* Update */
-	$("#update_start_date, #update_end_date").datepicker({
-		dateFormat: "yy/mm/dd"
-	});
-
-    $('input[name=submit][type=submit][value="OK, Send Emails"]').click(function(){
-      postData = {token: $('input[name=token]').val(),
-                  campaign_id: $('input[name=campaign_id]').val(),
-                  submit: 'start'}
-      $.post('/admin/send_email', postData);
+    /* Emails */
+    $(
+        'input[name=email_start_date][type=text], input[name=email_end_date][type=text]'
+    ).datepicker({
+        dateFormat: 'dd/mm/yy',
     });
-    $('input[name=submit][type=submit][value="STOP Sending Emails"]').click(function(){
-      postData = {token: $('input[name=token]').val(),
-                  campaign_id: $('input[name=campaign_id]').val(),
-                  submit: 'stop'}
-      $.post('/admin/send_email', postData);
+
+    /* Add new */
+    $('#start_date, #end_date').datepicker({
+        dateFormat: 'yy/mm/dd',
     });
+
+    /* Update */
+    $('#update_start_date, #update_end_date').datepicker({
+        dateFormat: 'yy/mm/dd',
+    });
+
+    $('input[name=submit][type=submit][value="OK, Send Emails"]').click(
+        function() {
+            postData = {
+                token: $('input[name=token]').val(),
+                campaign_id: $('input[name=campaign_id]').val(),
+                submit: 'start',
+            };
+            $.post('/admin/send_email', postData);
+        }
+    );
+    $('input[name=submit][type=submit][value="STOP Sending Emails"]').click(
+        function() {
+            postData = {
+                token: $('input[name=token]').val(),
+                campaign_id: $('input[name=campaign_id]').val(),
+                submit: 'stop',
+            };
+            $.post('/admin/send_email', postData);
+        }
+    );
 
     $('.admin tbody tr:odd').css('background-color', '#efefef');
 
-    if(dataSourcesTabs.length) {
-        dataSourcesTabs.tabs({
-            cookie: {
-                expires: 1
-            }
-        }).show();
+    if (dataSourcesTabs.length) {
+        dataSourcesTabs
+            .tabs({
+                cookie: {
+                    expires: 1,
+                },
+            })
+            .show();
     }
 
     //hide the loader
-    $("#loading-bds").hide();
+    $('#loading-bds').hide();
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/analytics.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/analytics.js
@@ -15,6 +15,6 @@ var Analytics = (function() {
         },
         trackPageview: function(url) {
             wrap('send', 'pageview', url);
-        }
+        },
     };
 })();

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
@@ -4,26 +4,26 @@
 
 var BugLinks = (function() {
     var NOT_DONE_STATUSES = ['UNCONFIRMED', 'NEW', 'ASSIGNED', 'REOPENED'];
-    var URL = '/buginfo/bug';  // TODO move this outside
+    var URL = '/buginfo/bug'; // TODO move this outside
 
     // from https://github.com/janl/mustache.js/blob/master/mustache.js#L82
     var entityMap = {
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
         '"': '&quot;',
         "'": '&#39;',
-        "/": '&#x2F;'
+        '/': '&#x2F;',
     };
     function escapeHtml(string) {
-        return String(string).replace(/[&<>"'\/]/g, function (s) {
+        return String(string).replace(/[&<>"'\/]/g, function(s) {
             return entityMap[s];
         });
     }
 
     function fetch_remotely(bug_ids) {
         var deferred = $.Deferred();
-        var data = {bug_ids: bug_ids.join(',')};
+        var data = { bug_ids: bug_ids.join(',') };
         var req = $.getJSON(URL, data);
         req.done(function(response) {
             var table = {};
@@ -56,15 +56,15 @@ var BugLinks = (function() {
 
     function fetch(bug_ids) {
         var batch_size = 100;
-        var i = 0, j = 0;
+        var i = 0,
+            j = 0;
         while (i < bug_ids.length) {
             j += batch_size;
             // For each batch, do an XHR on the data
             // which also appends that fetched data to each link tag.
             // When the data has been downloaded and attached to
             // each link tag run this to update
-            fetch_remotely(bug_ids.slice(i, j))
-              .done(transform_with_data);
+            fetch_remotely(bug_ids.slice(i, j)).done(transform_with_data);
             i = j;
         }
     }
@@ -74,7 +74,7 @@ var BugLinks = (function() {
         // fetch_without_data() has fetched more data for the links
         $('.bug-link-with-data').each(function() {
             var $link = $(this);
-            if ($link.data('transformed')) return;  // already done
+            if ($link.data('transformed')) return; // already done
             var status = $link.data('status');
             var resolution = $link.data('resolution') || '---';
             var summary = $link.data('summary');
@@ -82,12 +82,10 @@ var BugLinks = (function() {
             var combined = status + ' ' + resolution + ' ' + summary;
             $link.attr('title', escapeHtml(combined));
             if ($link.parents('.bug_ids_expanded_list').length) {
-                $link.after(
-                    $('<span class="bug-summary">').text(combined)
-                );
+                $link.after($('<span class="bug-summary">').text(combined));
             }
             if (status && $.inArray(status, NOT_DONE_STATUSES) === -1) {
-                $link.addClass("strike");
+                $link.addClass('strike');
             }
             $link.data('transformed', true);
         });
@@ -116,7 +114,7 @@ var BugLinks = (function() {
             fetch_without_data();
         },
         /* Enhance bug links and expanded bug lists. */
-        enhanceExpanded: function () {
+        enhanceExpanded: function() {
             this.enhance();
 
             $('.bug_ids_more').hover(function() {
@@ -124,11 +122,13 @@ var BugLinks = (function() {
                 var inset = 10;
                 var $cell = $(this);
                 var bugList = $cell.find('.bug_ids_expanded_list');
-                bugList.css({
-                    top: $cell.position().top - inset,
-                    left: $cell.position().left - (bugList.width() + inset)
-                }).toggle();
+                bugList
+                    .css({
+                        top: $cell.position().top - inset,
+                        left: $cell.position().left - (bugList.width() + inset),
+                    })
+                    .toggle();
             });
-        }
+        },
     };
 })();

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
@@ -20,7 +20,7 @@ $(function() {
                 $.map(data.ratios[i], function(value) {
                     return {
                         date: new Date(value[0]),
-                        ratio: value[1]
+                        ratio: value[1],
                     };
                 })
             );
@@ -39,12 +39,10 @@ $(function() {
             area: false,
             legend: legend,
             legend_target: '#crashes-per-adi-legend',
-            show_secondary_x_label: false
+            show_secondary_x_label: false,
         });
-
     } else {
-        $('#crashes-per-adi-graph')
-            .text('No results were found.');
+        $('#crashes-per-adi-graph').text('No results were found.');
     }
 
     $('th.version').each(function() {
@@ -54,10 +52,12 @@ $(function() {
     // To avoid having to set `title="Bla bla throttle something bla bla"`
     // on every th and td element that is about the throttle we just do
     // it here once with javascript
-    $('th.throttle, td.throttle')
-        .attr('title', $('table#crash_data').data('throttle-title'));
+    $('th.throttle, td.throttle').attr(
+        'title',
+        $('table#crash_data').data('throttle-title')
+    );
 
     $('.datepicker-daily input').datepicker({
-        dateFormat: 'yy-mm-dd'
+        dateFormat: 'yy-mm-dd',
     });
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crontabber_state.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crontabber_state.js
@@ -1,6 +1,9 @@
 /*global moment, d3, _ */
-var margin = {top: 1, right: 20, bottom: 6, left: 10};
-var width = d3.select('#crontabber-chart').property('scrollWidth') - margin.left - margin.right;
+var margin = { top: 1, right: 20, bottom: 6, left: 10 };
+var width =
+    d3.select('#crontabber-chart').property('scrollWidth') -
+    margin.left -
+    margin.right;
 var height = 500 - margin.top - margin.bottom;
 // To be obsolete it means that your next_run was more than
 // 24 hours ago.
@@ -30,7 +33,7 @@ var format = d3.format(',.0f'),
         if (name === undefined) {
             name = d.source.name;
         }
-        if(errors > 0) {
+        if (errors > 0) {
             return name + ' has failed ' + format(errors) + ' times';
         }
         if (skips > 0) {
@@ -40,22 +43,25 @@ var format = d3.format(',.0f'),
             return name + ' is ongoing for ' + moment(d.ongoing).fromNow(true);
         }
         if (d._obsolete) {
-            return name + ' is obsolete. Last run ' + moment(d.last_run).fromNow(false);
+            return (
+                name +
+                ' is obsolete. Last run ' +
+                moment(d.last_run).fromNow(false)
+            );
         }
         return name + ' is working normally.';
     };
 
-var svg = d3.select('#crontabber-chart')
+var svg = d3
+    .select('#crontabber-chart')
     .append('svg')
     .attr('width', width + margin.left + margin.right)
     .attr('height', height + margin.top + margin.bottom)
     .append('g')
-    .attr(
-        'transform',
-        'translate(' + margin.left + ',' + margin.top + ')'
-    );
+    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-var sankey = d3.sankey()
+var sankey = d3
+    .sankey()
     .nodeWidth(15)
     .nodePadding(10)
     .size([width, height]);
@@ -72,7 +78,6 @@ function escapeHtml(unsafe) {
 }
 
 d3.json('/api/CrontabberState/').then(function(data) {
-
     /**
      * Reshape the data
      * Sankey wants the following:
@@ -110,7 +115,7 @@ d3.json('/api/CrontabberState/').then(function(data) {
     // reverse linked lists
     var links = [];
     _.each(nodes, function(element, index) {
-        _.each(element.depends_on, function (d) {
+        _.each(element.depends_on, function(d) {
             var dep = data.state[d];
             links.push({
                 source: dep.pos,
@@ -124,11 +129,12 @@ d3.json('/api/CrontabberState/').then(function(data) {
 
     var graph = {
         nodes: nodes,
-        links: links
+        links: links,
     };
     sankey(graph);
 
-    var link = svg.append('g')
+    var link = svg
+        .append('g')
         .selectAll('path')
         .data(links)
         .enter()
@@ -137,14 +143,16 @@ d3.json('/api/CrontabberState/').then(function(data) {
         .attr('d', path)
         .style('stroke-width', 15)
         .style('stroke', function(d) {
-            return d.color = color(d);
+            return (d.color = color(d));
         })
-        .sort(function(a, b) { return (b.y1 - b.y0) - (a.y1 - a.y0); });
+        .sort(function(a, b) {
+            return b.y1 - b.y0 - (a.y1 - a.y0);
+        });
 
-    link.append('title')
-        .text(title);
+    link.append('title').text(title);
 
-    var node = svg.append('g')
+    var node = svg
+        .append('g')
         .selectAll('g')
         .data(nodes)
         .enter()
@@ -153,21 +161,28 @@ d3.json('/api/CrontabberState/').then(function(data) {
         .attr('transform', function(d) {
             return 'translate(' + d.x0 + ',' + d.y0 + ')';
         })
-        .call(d3.drag()
-            .on('start', function() {
-                this.parentNode.appendChild(this);
-            })
-            .on('drag', dragmove)
+        .call(
+            d3
+                .drag()
+                .on('start', function() {
+                    this.parentNode.appendChild(this);
+                })
+                .on('drag', dragmove)
         );
 
-    node.append('rect')
-        .attr('height', function(d) { return d.y1 - d.y0; })
-        .attr('width', function(d) { return d.x1 - d.x0; })
+    node
+        .append('rect')
+        .attr('height', function(d) {
+            return d.y1 - d.y0;
+        })
+        .attr('width', function(d) {
+            return d.x1 - d.x0;
+        })
         .style('fill', function(d) {
-            return d.color = color(d);
+            return (d.color = color(d));
         })
         .style('opacity', function(d) {
-            return d.opacity = d._obsolete && 0.3 || 1.0;
+            return (d.opacity = (d._obsolete && 0.3) || 1.0);
         })
         .style('stroke', function(d) {
             return d3.rgb(d.color).darker(2);
@@ -176,22 +191,29 @@ d3.json('/api/CrontabberState/').then(function(data) {
         .text(title)
         .style(color);
 
-    node.append('text')
+    node
+        .append('text')
         .attr('x', -6)
-        .attr('y', function(d) { return (d.y1 - d.y0) / 2; })
+        .attr('y', function(d) {
+            return (d.y1 - d.y0) / 2;
+        })
         .attr('dy', '.35em')
         .attr('text-anchor', 'end')
         .attr('transform', null)
-        .text(function(d) { return d.name; })
-        .filter(function(d) { return d.x0 < width / 2;})
+        .text(function(d) {
+            return d.name;
+        })
+        .filter(function(d) {
+            return d.x0 < width / 2;
+        })
         .attr('x', 6 + sankey.nodeWidth())
         .attr('text-anchor', 'start');
 
     function dragmove(d) {
         d.y0 = Math.max(0, Math.min(height - (d.y1 - d.y0), d3.event.y));
-        d3.select(this).attr(
-            'transform',
-            'translate(' + d.x0 + ',' + d.y0 + ')');
+        d3
+            .select(this)
+            .attr('transform', 'translate(' + d.x0 + ',' + d.y0 + ')');
         sankey.update(graph);
         link.attr('d', path);
     }
@@ -215,17 +237,22 @@ d3.json('/api/CrontabberState/').then(function(data) {
 
     table.classed('data-table tablesorter', true);
 
-    thead.append('tr').selectAll('th')
+    thead
+        .append('tr')
+        .selectAll('th')
         .data(tableFields)
-        .enter().append('th')
+        .enter()
+        .append('th')
         .text(function capitalize(s) {
             return s[0].toUpperCase() + s.slice(1).replace('_', ' ');
         })
         .classed('header', true);
 
-    tbody.selectAll('tr')
+    tbody
+        .selectAll('tr')
         .data(nodes)
-        .enter().append('tr')
+        .enter()
+        .append('tr')
         .filter(function(node) {
             return !node._obsolete;
         })
@@ -237,10 +264,11 @@ d3.json('/api/CrontabberState/').then(function(data) {
             });
             return scrubbed;
         })
-        .enter().append('td')
+        .enter()
+        .append('td')
         .text(function(d, i) {
             var field = tableFields[i];
-            var isTime = (field === 'last_success' || field === 'next_run');
+            var isTime = field === 'last_success' || field === 'next_run';
             if (isTime) {
                 if (d) {
                     return d + ' (' + moment(d).fromNow() + ')';
@@ -248,10 +276,14 @@ d3.json('/api/CrontabberState/').then(function(data) {
                     return '';
                 }
             }
-            if (typeof(d) === 'object') {
-                var joined = _.reduce(d, function(m, i) {
-                    return m + i + ', ';
-                }, '');
+            if (typeof d === 'object') {
+                var joined = _.reduce(
+                    d,
+                    function(m, i) {
+                        return m + i + ', ';
+                    },
+                    ''
+                );
                 return joined.substring(0, joined.length - 2);
             }
             return d;
@@ -261,15 +293,14 @@ d3.json('/api/CrontabberState/').then(function(data) {
     table = d3.select('#ongoing-table').append('table');
     thead = table.append('thead');
     tbody = table.append('tbody');
-    tableFields = [
-        'name',
-        'ongoing',
-    ];
+    tableFields = ['name', 'ongoing'];
     var anyOngoing = false;
 
     table.classed('data-table tablesorter', true);
 
-    thead.append('tr').selectAll('th')
+    thead
+        .append('tr')
+        .selectAll('th')
         .data(tableFields)
         .enter()
         .append('th')
@@ -282,9 +313,11 @@ d3.json('/api/CrontabberState/').then(function(data) {
         })
         .classed('header', true);
 
-    tbody.selectAll('tr')
+    tbody
+        .selectAll('tr')
         .data(nodes)
-        .enter().append('tr')
+        .enter()
+        .append('tr')
         .filter(function(node) {
             if (node.ongoing) {
                 anyOngoing = true;
@@ -299,7 +332,8 @@ d3.json('/api/CrontabberState/').then(function(data) {
             });
             return scrubbed;
         })
-        .enter().append('td')
+        .enter()
+        .append('td')
         .text(function(d, i) {
             var field = tableFields[i];
             if (field === 'ongoing') {
@@ -317,14 +351,13 @@ d3.json('/api/CrontabberState/').then(function(data) {
     table = d3.select('.obsolete .body').append('table');
     thead = table.append('thead');
     tbody = table.append('tbody');
-    tableFields = [
-        'name',
-        'last_run',
-    ];
+    tableFields = ['name', 'last_run'];
     var anyObsolete = false;
 
     table.classed('data-table tablesorter', true);
-    thead.append('tr').selectAll('th')
+    thead
+        .append('tr')
+        .selectAll('th')
         .data(tableFields)
         .enter()
         .append('th')
@@ -333,9 +366,11 @@ d3.json('/api/CrontabberState/').then(function(data) {
         })
         .classed('header', true);
 
-    tbody.selectAll('tr')
+    tbody
+        .selectAll('tr')
         .data(nodes)
-        .enter().append('tr')
+        .enter()
+        .append('tr')
         .filter(function(node) {
             if (node._obsolete) {
                 anyObsolete = true;
@@ -351,7 +386,8 @@ d3.json('/api/CrontabberState/').then(function(data) {
             });
             return scrubbed;
         })
-        .enter().append('td')
+        .enter()
+        .append('td')
         .text(function(d, i) {
             var field = tableFields[i];
             if (field === 'last_run') {
@@ -368,14 +404,12 @@ d3.json('/api/CrontabberState/').then(function(data) {
     table = d3.select('#failing').append('table');
     thead = table.append('thead');
     tbody = table.append('tbody');
-    tableFields = [
-        'name',
-        'error_count',
-        'last_error',
-    ];
+    tableFields = ['name', 'error_count', 'last_error'];
     table.classed('data-table tablesorter', true); // worth doing?
 
-    thead.append('tr').selectAll('th')
+    thead
+        .append('tr')
+        .selectAll('th')
         .data(tableFields)
         .enter()
         .append('th')
@@ -385,7 +419,8 @@ d3.json('/api/CrontabberState/').then(function(data) {
         .classed('header', true);
 
     var anyErrors = false;
-    tbody.selectAll('tr')
+    tbody
+        .selectAll('tr')
         .data(nodes)
         .enter()
         .append('tr')
@@ -405,9 +440,11 @@ d3.json('/api/CrontabberState/').then(function(data) {
         .append('td')
         .html(function(d, i) {
             if (tableFields[i] === 'last_error') {
-                return '<pre>' +
+                return (
+                    '<pre>' +
                     escapeHtml(JSON.stringify(d, undefined, 4)) +
-                    '</pre>';
+                    '</pre>'
+                );
             }
             return escapeHtml('' + d);
         });
@@ -416,5 +453,4 @@ d3.json('/api/CrontabberState/').then(function(data) {
     }
 
     $('.tablesorter').tablesorter();
-
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
@@ -1,3 +1,8 @@
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+window.ga =
+    window.ga ||
+    function() {
+        (ga.q = ga.q || []).push(arguments);
+    };
+ga.l = +new Date();
 ga('create', document.documentElement.dataset.googleAnalyticsId, 'auto');
 ga('send', 'pageview');

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/hangreport.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/hangreport.js
@@ -1,16 +1,18 @@
 /*jslint browser:true, regexp:false, plusplus:false */
 /*global window, $, SocReport */
-$(document).ready(function () {
-    $("#signature-list").tablesorter({
+$(document).ready(function() {
+    $('#signature-list').tablesorter({
         headers: {
-            0: { sorter: 'text'  },
-            1: { sorter: 'text'  },
+            0: { sorter: 'text' },
+            1: { sorter: 'text' },
             2: { sorter: 'digit' },
-            3: { sorter: 'text'  },
-            4: { sorter: 'date'  }
-        }
+            3: { sorter: 'text' },
+            4: { sorter: 'date' },
+        },
     });
 
-    $('td a.signature').girdle({previewClass: 'signature-preview', fullviewClass: 'signature-popup'});
-
+    $('td a.signature').girdle({
+        previewClass: 'signature-preview',
+        fullviewClass: 'signature-popup',
+    });
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/nav.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/nav.js
@@ -1,17 +1,17 @@
-$(document).ready(function () {
-    var getReportsURLs = function () {
+$(document).ready(function() {
+    var getReportsURLs = function() {
         var urls = {};
         $('#report_select option').each(function(i, elem) {
             urls[elem.value] = {
-                'product': elem.dataset.urlProduct,
-                'version': elem.dataset.urlVersion,
+                product: elem.dataset.urlProduct,
+                version: elem.dataset.urlVersion,
             };
         });
 
         return urls;
     };
 
-    var getURL = function () {
+    var getURL = function() {
         var report = $('#report_select').val();
         var product = $('#products_select').val();
         var version = $('#product_version_select').val();
@@ -22,16 +22,17 @@ $(document).ready(function () {
         if (version === 'Current Versions') {
             // That means there is no version set, so we only set the product.
             url = reportsURLs[report].product.replace('__PRODUCT__', product);
-        }
-        else {
+        } else {
             // There is both a product and a version.
-            url = reportsURLs[report].version.replace('__PRODUCT__', product).replace('__VERSION__', version);
+            url = reportsURLs[report].version
+                .replace('__PRODUCT__', product)
+                .replace('__VERSION__', version);
         }
 
         return url;
     };
 
-    $('.version-nav').on('change', 'select', function () {
+    $('.version-nav').on('change', 'select', function() {
         window.location = getURL();
     });
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
@@ -27,35 +27,33 @@ var OAuth2 = (function() {
 
     var serverSignout = function() {
         var signoutURL = $('a.google-signout').attr('href');
-        var csrfmiddlewaretoken = $(
-            'input[name="csrfmiddlewaretoken"]'
-        ).val();
+        var csrfmiddlewaretoken = $('input[name="csrfmiddlewaretoken"]').val();
         var data = {
             csrfmiddlewaretoken: csrfmiddlewaretoken,
         };
         $.post(signoutURL, data)
-        .done(function() {
-            document.location.reload();
-        })
-        .fail(function() {
-            // XXX Need to understand what the conditions might be for
-            // failing.
-            console.warn('Failed to sign out on the server');
-            console.error.apply(console, arguments);
-        });
+            .done(function() {
+                document.location.reload();
+            })
+            .fail(function() {
+                // XXX Need to understand what the conditions might be for
+                // failing.
+                console.warn('Failed to sign out on the server');
+                console.error.apply(console, arguments);
+            });
     };
 
     var signOut = function() {
         loadGoogleAuth()
-        .then(function(auth2api) {
-            var auth2 = auth2api.getAuthInstance();
-            auth2.then(function() {
-                auth2.signOut().then(serverSignout);
+            .then(function(auth2api) {
+                var auth2 = auth2api.getAuthInstance();
+                auth2.then(function() {
+                    auth2.signOut().then(serverSignout);
+                });
+            })
+            .catch(function() {
+                console.error.apply(console, arguments);
             });
-        })
-        .catch(function() {
-            console.error.apply(console, arguments);
-        });
     };
 
     return {
@@ -63,9 +61,7 @@ var OAuth2 = (function() {
             // The "signin" meta tag, and its value being "signout"
             // means that the server thinks the user has been logged in
             // to be safe.
-            var signedin = document.head.querySelector(
-                'meta[name="signin"]'
-            );
+            var signedin = document.head.querySelector('meta[name="signin"]');
             if (signedin && signedin.content === 'signout') {
                 console.warn('Login session has to expire.');
                 // You have to sign out
@@ -89,14 +85,14 @@ var OAuth2 = (function() {
                 // commented out for the sake of showing what can be set.
                 gapi.signin2.render('signin2', {
                     // 'scope': 'profile email',
-                    'scope': 'email',
+                    scope: 'email',
                     // 'scope': 'openid',
                     // 'width': 240,
                     // 'height': 36,
-                    'height': 30,
+                    height: 30,
                     // 'longtitle': true,
                     // 'theme': 'dark',
-                    'onsuccess': function(googleUser) {
+                    onsuccess: function(googleUser) {
                         var id_token = googleUser.getAuthResponse().id_token;
 
                         var url = $('.google-signin').data('signin-url');
@@ -108,49 +104,48 @@ var OAuth2 = (function() {
                             csrfmiddlewaretoken: csrfmiddlewaretoken,
                         };
                         $.post(url, data)
-                        .done(function(response) {
-                            // It worked!
-                            var next = Qs.parse(
-                                document.location.search.slice(1)
-                            ).next;
-                            // only if ?next=/... exists on the current URL
-                            if (next) {
-                                // A specific URL exits.
-                                // This is most likely the case when you tried
-                                // to access a privileged URL whilst being
-                                // anonymous and being redirected.
-                                // Make sure it's on this server
-                                document.location.pathname = next;
-                            } else {
-                                document.location.reload();
-                            }
-                        })
-                        .fail(function(xhr) {
-                            console.error(xhr);
-                            var auth2 = gapi.auth2.getAuthInstance();
-                            auth2.signOut().then(function() {
-                                alert(
-                                    'Signed in to Google, but unable to ' +
-                                    'sign in on the server. (' +
-                                    xhr.responseText + ')'
-                                );
+                            .done(function(response) {
+                                // It worked!
+                                var next = Qs.parse(
+                                    document.location.search.slice(1)
+                                ).next;
+                                // only if ?next=/... exists on the current URL
+                                if (next) {
+                                    // A specific URL exits.
+                                    // This is most likely the case when you tried
+                                    // to access a privileged URL whilst being
+                                    // anonymous and being redirected.
+                                    // Make sure it's on this server
+                                    document.location.pathname = next;
+                                } else {
+                                    document.location.reload();
+                                }
+                            })
+                            .fail(function(xhr) {
+                                console.error(xhr);
+                                var auth2 = gapi.auth2.getAuthInstance();
+                                auth2.signOut().then(function() {
+                                    alert(
+                                        'Signed in to Google, but unable to ' +
+                                            'sign in on the server. (' +
+                                            xhr.responseText +
+                                            ')'
+                                    );
+                                });
                             });
-                        });
                     },
-                    'onfailure': function(error) {
+                    onfailure: function(error) {
                         // Happens if the user,
                         // for some reason presses the "Deny" button.
                         // If that happens, there's not much to do.
                         console.error(error);
                         console.warn.apply(console, arguments);
-                    }
+                    },
                 });
-
             }
         },
     };
 })();
-
 
 // This is how we load the google APIs, with a callback.
 window.googleAPILoaded = OAuth2.init;

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/pending.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/pending.js
@@ -7,28 +7,28 @@ $(function() {
         return {
             startChecking: function(crashID) {
                 checkInterval = setInterval(function() {
-                    $.get('/api/ProcessedCrash/', {crash_id: crashID})
-                    .then(function() {
-                        clearInterval(checkInterval);
-                        // If it exists, we can reload the page we're on.
-                        $('.pending .searching').hide();
-                        $('.pending .found').fadeIn(300, function() {
-                            document.location.reload();
-                        });
-                    })
-                    .fail(function(err) {
-                        // Perfectly expected.
-                        // We kind of expect the processed crash to not
-                        // exist for a while. Once it's been processed,
-                        // it should exist and yield a 200 error.
-                        if (err.status !== 404) {
-                            // But it's not a 404 error it's something unexpected.
+                    $.get('/api/ProcessedCrash/', { crash_id: crashID })
+                        .then(function() {
                             clearInterval(checkInterval);
-                            throw new Error(err);
-                        }
-                    });
+                            // If it exists, we can reload the page we're on.
+                            $('.pending .searching').hide();
+                            $('.pending .found').fadeIn(300, function() {
+                                document.location.reload();
+                            });
+                        })
+                        .fail(function(err) {
+                            // Perfectly expected.
+                            // We kind of expect the processed crash to not
+                            // exist for a while. Once it's been processed,
+                            // it should exist and yield a 200 error.
+                            if (err.status !== 404) {
+                                // But it's not a 404 error it's something unexpected.
+                                clearInterval(checkInterval);
+                                throw new Error(err);
+                            }
+                        });
                 }, intervalTime);
-            }
+            },
         };
     })();
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -1,7 +1,6 @@
 /* global window $ Analytics BugLinks */
 
-$(document).ready(function () {
-
+$(document).ready(function() {
     /* Idempotent function to display the TelemetryEnvironment with
      * jQuery JSONView */
     var displayTelemetryEnvironment = (function() {
@@ -19,7 +18,7 @@ $(document).ready(function () {
                     $('#telemetryenvironment-json').JSONView(jsonData);
                 } catch (ex) {
                     console.warn(
-                        "The data in the #telemetryenvironment-json dataset is not valid JSON"
+                        'The data in the #telemetryenvironment-json dataset is not valid JSON'
                     );
                     container.append(
                         $('<p>Invalid JSON in TelemetryEnvironment</p>')
@@ -60,7 +59,7 @@ $(document).ready(function () {
         },
     });
 
-    $('a[href="#allthreads"]').on('click', function () {
+    $('a[href="#allthreads"]').on('click', function() {
         var element = $(this);
         $('#allthreads').toggle(400);
         if (element.text() === element.data('show')) {
@@ -79,8 +78,10 @@ $(document).ready(function () {
         $('.expand').click(function(event) {
             event.preventDefault();
             // swap cell title into cell text for each cell in this column
-            $('td:nth-child(3)', $(this).parents('tbody')).each(function () {
-                $(this).text($(this).attr('title')).removeAttr('title');
+            $('td:nth-child(3)', $(this).parents('tbody')).each(function() {
+                $(this)
+                    .text($(this).attr('title'))
+                    .removeAttr('title');
             });
             $(this).remove();
         });
@@ -98,14 +99,24 @@ $(document).ready(function () {
         // This avoids adding multiple calls to addExpand which will add multiple links to the
         // same header.
         cells.each(function() {
-            if (($(this).attr('title').length !== $(this).text().length) && (!isExpandAdded)) {
-                addExpand($(this).parents('tbody').find('th.signature-column'));
+            if (
+                $(this).attr('title').length !== $(this).text().length &&
+                !isExpandAdded
+            ) {
+                addExpand(
+                    $(this)
+                        .parents('tbody')
+                        .find('th.signature-column')
+                );
                 isExpandAdded = true;
             }
         });
     });
 
-    $('#modules-list').tablesorter({sortList: [[1, 0]], headers: {1: {sorter : 'digit'}}});
+    $('#modules-list').tablesorter({
+        sortList: [[1, 0]],
+        headers: { 1: { sorter: 'digit' } },
+    });
 
     // Decide whether to show the Correlations tab if this product,
     // channel and signature has correlations.
@@ -114,18 +125,27 @@ $(document).ready(function () {
     var channel = container.data('channel');
     var product = container.data('product');
 
-    window.correlations.getCorrelations(signature, channel, product)
-    .then(function(results) {
-        if (!Array.isArray(results)) {
-            return;
-        }
+    window.correlations
+        .getCorrelations(signature, channel, product)
+        .then(function(results) {
+            if (!Array.isArray(results)) {
+                return;
+            }
 
-        var content = results.join('\n');
+            var content = results.join('\n');
 
-        $('li.correlations').show();
-        $('#correlation h3').text('Correlations for ' + product + ' ' + channel[0].toUpperCase() + channel.substr(1));
-        $('#correlation pre').empty().text(content);
-    });
+            $('li.correlations').show();
+            $('#correlation h3').text(
+                'Correlations for ' +
+                    product +
+                    ' ' +
+                    channel[0].toUpperCase() +
+                    channel.substr(1)
+            );
+            $('#correlation pre')
+                .empty()
+                .text(content);
+        });
 
     // Enhance bug links.
     BugLinks.enhance();

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
@@ -15,19 +15,18 @@ $(function() {
         // show a waiting message
         $('.waiting', parent).show();
 
-        $.post('/api/Reprocessing/', {crash_ids: crash_id})
-        .done(function(response) {
-            $('.reprocessing-success', parent).show();
-        })
-        .error(function(jqXHR, textStatus, errorThrown) {
-            $('.reprocessing-error .status', parent).text(jqXHR.status);
-            $('.reprocessing-error pre', parent).text(jqXHR.responseText);
-            $('.reprocessing-error', parent).show();
-        })
-        .complete(function() {
-            $('.waiting', parent).hide();
-            $('form button', parent).prop('disabled', false);
-        });
+        $.post('/api/Reprocessing/', { crash_ids: crash_id })
+            .done(function(response) {
+                $('.reprocessing-success', parent).show();
+            })
+            .error(function(jqXHR, textStatus, errorThrown) {
+                $('.reprocessing-error .status', parent).text(jqXHR.status);
+                $('.reprocessing-error pre', parent).text(jqXHR.responseText);
+                $('.reprocessing-error', parent).show();
+            })
+            .complete(function() {
+                $('.waiting', parent).hide();
+                $('form button', parent).prop('disabled', false);
+            });
     });
-
 });

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/timeutils.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/timeutils.js
@@ -2,10 +2,11 @@
 
 $(function() {
     function replaceTimeTag(inTheFuture) {
-        return function () {
+        return function() {
             var self = $(this);
             var date = self.attr('datetime') || self.data('date');
-            self.attr('title', self.text())
+            self
+                .attr('title', self.text())
                 .text(moment(date).fromNow(inTheFuture));
         };
     }

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/utils.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/utils.js
@@ -1,6 +1,6 @@
 /*global socorro:false, $:false */
-(function( window, undefined ) {
-    "use strict";
+(function(window, undefined) {
+    'use strict';
     var socorro = {
         ui: {
             /**
@@ -22,12 +22,15 @@
                     isLoaderSet = document.querySelector('.' + selector);
                 }
 
-                if(!isLoaderSet) {
+                if (!isLoaderSet) {
                     var loader = new Image();
                     //set the class, alt and src attributes of the loading image
-                    loader.setAttribute("class", classList);
-                    loader.setAttribute("alt", "loading...");
-                    loader.setAttribute("src", "/static/img/icons/ajax-loader.gif");
+                    loader.setAttribute('class', classList);
+                    loader.setAttribute('alt', 'loading...');
+                    loader.setAttribute(
+                        'src',
+                        '/static/img/icons/ajax-loader.gif'
+                    );
 
                     //append loader to it's container
                     $(container).append(loader);
@@ -59,18 +62,23 @@
                 }
             },
             setUserMsg: function(selector, response, position) {
-
                 // Remove any currently shown user messages in node.
                 socorro.ui.removeUserMsg(selector);
 
                 var domParentNode = document.querySelector(selector),
-                insertPos = position ? position : "afterbegin";
-                if(response.status === "success") {
-                    domParentNode.insertAdjacentHTML(insertPos, "<div class='success'>" + response.message + "</div>");
+                    insertPos = position ? position : 'afterbegin';
+                if (response.status === 'success') {
+                    domParentNode.insertAdjacentHTML(
+                        insertPos,
+                        "<div class='success'>" + response.message + '</div>'
+                    );
                 } else {
-                    domParentNode.insertAdjacentHTML(insertPos, "<div class='error'>" + response.message + "</div>");
+                    domParentNode.insertAdjacentHTML(
+                        insertPos,
+                        "<div class='error'>" + response.message + '</div>'
+                    );
                 }
-            }
+            },
         },
         date: {
             ONE_DAY: 1000 * 60 * 60 * 24,
@@ -85,7 +93,7 @@
             // @param dateString The string to convert to a Date object
             // @param form The date format of the string
             convertToDateObj: function(dateString, format) {
-                if(format === "ISO8601") {
+                if (format === 'ISO8601') {
                     var origin = dateString,
                         year = origin.substring(0, 4),
                         month = origin.substring(4, 6),
@@ -112,7 +120,7 @@
                 return inequality === 'less' ? adate < bdate : adate > bdate;
             },
             addLeadingZero: function(number) {
-                    return number > 9 ? number : "0" + number;
+                return number > 9 ? number : '0' + number;
             },
             // add one day to the passed date
             addDay: function(currentDate) {
@@ -125,33 +133,32 @@
              * ISO_STANDARD = "yyyy-mm-dd"
              */
             formatDate: function(date, format) {
-
                 var returnDate, day, month, full_year;
                 day = this.addLeadingZero(date.getDate());
                 //months are zero based so we need to add one
                 month = this.addLeadingZero(date.getMonth() + 1);
                 full_year = date.getFullYear();
 
-                if(format === "US_NUMERICAL") {
-                    returnDate = day + "/" + month + "/" + full_year;
-                } else if(format === "ISO") {
-                    returnDate = full_year + "/" + month + "/" + day;
-                } else if(format === "ISO_STANDARD") {
-                    returnDate = full_year + "-" + month + "-" + day;
+                if (format === 'US_NUMERICAL') {
+                    returnDate = day + '/' + month + '/' + full_year;
+                } else if (format === 'ISO') {
+                    returnDate = full_year + '/' + month + '/' + day;
+                } else if (format === 'ISO_STANDARD') {
+                    returnDate = full_year + '-' + month + '-' + day;
                 }
 
-               return returnDate;
+                return returnDate;
             },
             getAllDatesInRange: function(from, to, returnFormat) {
                 var fromDate = null,
-                toDate = null,
-                shouldFormat = returnFormat !== undefined,
-                dates = [];
+                    toDate = null,
+                    shouldFormat = returnFormat !== undefined,
+                    dates = [];
 
                 // if we received dates in the format dd/mm/yyyy then we need
                 // to massage the date a little in order for new Date to return
                 // the correct date.
-                if((typeof from !== "object") && from.indexOf("/") > -1) {
+                if (typeof from !== 'object' && from.indexOf('/') > -1) {
                     fromDate = this.convertToDateObj(from);
                     toDate = this.convertToDateObj(to);
                 }
@@ -167,7 +174,7 @@
 
                     //if a return format for the dates have been specified,
                     // format the date first before adding to the array.
-                    if(shouldFormat) {
+                    if (shouldFormat) {
                         fromDate = this.formatDate(fromDate, returnFormat);
                     }
                     dates.push(fromDate);
@@ -176,14 +183,16 @@
                     fromDate = this.addDay(currentDate);
                 }
                 // as a last step at the toDate to the end of the dates array
-                toDate = shouldFormat ? this.formatDate(toDate, returnFormat) : toDate;
+                toDate = shouldFormat
+                    ? this.formatDate(toDate, returnFormat)
+                    : toDate;
                 dates.push(toDate);
 
                 return dates;
-            }
+            },
         },
         search: {
-            parseQueryString: function (queryString) {
+            parseQueryString: function(queryString) {
                 var params = {};
                 var queries;
                 var temp;
@@ -191,7 +200,7 @@
                 var len;
 
                 // Split into key/value pairs
-                queries = queryString.split("&");
+                queries = queryString.split('&');
                 len = queries.length;
 
                 if (len === 1 && queries[0] === '') {
@@ -206,18 +215,16 @@
 
                     if (params[key] && Array.isArray(params[key])) {
                         params[key].push(value);
-                    }
-                    else if (params[key]) {
+                    } else if (params[key]) {
                         params[key] = [params[key], value];
-                    }
-                    else {
+                    } else {
                         params[key] = value;
                     }
                 }
 
                 return params;
             },
-            getFilteredParams: function (params) {
+            getFilteredParams: function(params) {
                 if ('page' in params) {
                     delete params.page;
                 }
@@ -231,16 +238,14 @@
 
                 return params;
             },
-            sortResults: function (results, container, query) {
+            sortResults: function(results, container, query) {
                 if (query.term) {
-                    return results.sort(function (a, b) {
+                    return results.sort(function(a, b) {
                         if (a.text.length > b.text.length) {
                             return 1;
-                        }
-                        else if (a.text.length < b.text.length) {
+                        } else if (a.text.length < b.text.length) {
                             return -1;
-                        }
-                        else {
+                        } else {
                             return 0;
                         }
                     });
@@ -249,14 +254,13 @@
             },
         },
         dateSupported: function() {
-            var inputElem = document.createElement("input");
-            inputElem.setAttribute("type", "date");
+            var inputElem = document.createElement('input');
+            inputElem.setAttribute('type', 'date');
 
-            return inputElem.type !== "text" ? true : false;
-        }
+            return inputElem.type !== 'text' ? true : false;
+        },
     };
 
     //expose socorro to the global object
     window.socorro = socorro;
-
 })(window);

--- a/webapp-django/crashstats/documentation/static/documentation/js/documentation.js
+++ b/webapp-django/crashstats/documentation/static/documentation/js/documentation.js
@@ -1,69 +1,78 @@
-$(function () {
+$(function() {
     'use strict';
 
     // Create the table of content.
     var tableOfContent = $('<ol>');
     var currentContainer = tableOfContent;
 
-    $('h1[id], h2[id]', '.body').map(function (i, elem) {
+    $('h1[id], h2[id]', '.body').map(function(i, elem) {
         var listItem = $('<li>');
-        listItem.append($('<a>', { href: '#' + elem.id, text: elem.innerText }));
+        listItem.append(
+            $('<a>', { href: '#' + elem.id, text: elem.innerText })
+        );
         if (elem.localName == 'h1') {
             tableOfContent.append(listItem);
             currentContainer = $('<ol>');
             listItem.append(currentContainer);
-        }
-        else {
+        } else {
             currentContainer.append(listItem);
         }
     });
 
-    $('#table-of-content').append(tableOfContent).show();
+    $('#table-of-content')
+        .append(tableOfContent)
+        .show();
 
     // Add a command to all examples.
-    $('.example pre code').prepend('"').prepend(
-        $('<span>', { text: 'curl ' }).addClass('http-verb')
-    ).append('"');
+    $('.example pre code')
+        .prepend('"')
+        .prepend($('<span>', { text: 'curl ' }).addClass('http-verb'))
+        .append('"');
 
     // JSON results viewers.
-    $('.example pre code').each(function () {
+    $('.example pre code').each(function() {
         var $code = $(this);
         var $example = $code.parent().parent();
         var url = $code.data('url');
 
         // Add a "try it" button to each individual example URL
         // (there can be several URLs per example).
-        $code.append($('<button>', { text: 'try it' })
-            .addClass('try')
-            .click(function () {
-                // Remove any previous results.
-                $('.results', $example).remove();
+        $code.append(
+            $('<button>', { text: 'try it' })
+                .addClass('try')
+                .click(function() {
+                    // Remove any previous results.
+                    $('.results', $example).remove();
 
-                // Create a new results container.
-                var resultsViewer = $('<div>').addClass('results');
-                $example.append(resultsViewer);
+                    // Create a new results container.
+                    var resultsViewer = $('<div>').addClass('results');
+                    $example.append(resultsViewer);
 
-                // Add a title and a hide button.
-                var hideBtn = $('<span>', { text: 'x' })
-                    .addClass('hide')
-                    .click(function () {
-                        $('.results', $example).remove();
+                    // Add a title and a hide button.
+                    var hideBtn = $('<span>', { text: 'x' })
+                        .addClass('hide')
+                        .click(function() {
+                            $('.results', $example).remove();
+                        });
+
+                    resultsViewer.append(
+                        $('<h2>', {
+                            text: 'Results',
+                            title: 'Results for ' + url,
+                        }).append(hideBtn)
+                    );
+
+                    // Add a container for the JSON data, and give it a loader.
+                    var jsonContent = $('<div>').append(
+                        $('<div>').addClass('loader')
+                    );
+                    resultsViewer.append(jsonContent);
+
+                    // Now load the data and we have it, show it nicely.
+                    $.getJSON(url, function(data) {
+                        jsonContent.JSONView(data);
                     });
-
-                resultsViewer.append(
-                    $('<h2>', { text: 'Results', title: 'Results for ' + url })
-                    .append(hideBtn)
-                );
-
-                // Add a container for the JSON data, and give it a loader.
-                var jsonContent = $('<div>').append($('<div>').addClass('loader'));
-                resultsViewer.append(jsonContent);
-
-                // Now load the data and we have it, show it nicely.
-                $.getJSON(url, function (data) {
-                    jsonContent.JSONView(data);
-                });
-            })
+                })
         );
     });
 });

--- a/webapp-django/crashstats/manage/static/manage/js/api_tokens.js
+++ b/webapp-django/crashstats/manage/static/manage/js/api_tokens.js
@@ -1,5 +1,5 @@
 /*global alert:true location:true PaginationUtils:true */
-(function ($, document) {
+(function($, document) {
     'use strict';
 
     function start_loading() {
@@ -11,29 +11,30 @@
     }
 
     function fetch() {
-
         function deleteToken(button) {
             var id = button.data('id');
             var row = button.parents('tr');
             var expired = button.data('expired');
-            if (expired || confirm("Are you sure you want to delete this?")) {
+            if (expired || confirm('Are you sure you want to delete this?')) {
                 button.text('Deleting');
                 var form = $('form#tokens');
                 var data = {
                     id: id,
-                    csrfmiddlewaretoken: $('input[name="csrfmiddlewaretoken"]').val()
+                    csrfmiddlewaretoken: $(
+                        'input[name="csrfmiddlewaretoken"]'
+                    ).val(),
                 };
                 $.post(form.data('delete-url'), data)
-                .then(function(response) {
-                    row.fadeOut(300, function() {
-                        row.remove();
+                    .then(function(response) {
+                        row.fadeOut(300, function() {
+                            row.remove();
+                        });
+                    })
+                    .fail(function() {
+                        console.warn('Unable to delete the token');
+                        console.error(arguments);
+                        $(this).text('Delete');
                     });
-                })
-                .fail(function() {
-                    console.warn('Unable to delete the token');
-                    console.error(arguments);
-                    $(this).text('Delete');
-                });
             }
         }
 
@@ -65,29 +66,37 @@
             var brief = text;
             if (brief.length > max_length) {
                 brief = brief.substr(0, max_length);
-                return $('<span>').addClass('redacted').append(
-                    $('<span>').addClass('_brief').text(brief + '...')
-                    .click(function() {
-                        var parent = $(this).parent('span');
-                        $('._full', parent).show();
-                        $(this).hide();
-                    })
-                ).append(
-                    $('<span>').addClass('_full').hide().html(
-                        text.replace('<', '&lt;')
-                            .replace('>', '&gt;')
-                            .replace('\n', '<br>')
+                return $('<span>')
+                    .addClass('redacted')
+                    .append(
+                        $('<span>')
+                            .addClass('_brief')
+                            .text(brief + '...')
+                            .click(function() {
+                                var parent = $(this).parent('span');
+                                $('._full', parent).show();
+                                $(this).hide();
+                            })
                     )
-                    .click(function() {
-                        var parent = $(this).parent('span');
-                        $('._brief', parent).show();
-                        $(this).hide();
-                    })
-                );
+                    .append(
+                        $('<span>')
+                            .addClass('_full')
+                            .hide()
+                            .html(
+                                text
+                                    .replace('<', '&lt;')
+                                    .replace('>', '&gt;')
+                                    .replace('\n', '<br>')
+                            )
+                            .click(function() {
+                                var parent = $(this).parent('span');
+                                $('._brief', parent).show();
+                                $(this).hide();
+                            })
+                    );
             } else {
                 return $('<span>').text(text);
             }
-
         }
 
         start_loading();
@@ -102,8 +111,8 @@
             var $tbody = $('tbody', $form);
             $('tr', $tbody).remove();
             $.each(response.tokens, function(i, token) {
-
-                var timestamp_text, timestamp = moment(token.expires);
+                var timestamp_text,
+                    timestamp = moment(token.expires);
                 if (token.expired) {
                     timestamp_text = timestamp.fromNow(false);
                 } else {
@@ -112,24 +121,30 @@
                 $('<tr>')
                     .append($('<td>').text(token.user))
                     .append($('<td>').append(displayKey(token.key)))
-                    .append($('<td>')
+                    .append(
+                        $('<td>')
                             .text(timestamp_text)
                             .addClass(token.expired ? 'expired' : '')
-                            .attr('title', timestamp.format('LLLL')))
-                    .append($('<td>')
-                            .html(token.permissions.join('<br>')))
-                    .append($('<td>')
+                            .attr('title', timestamp.format('LLLL'))
+                    )
+                    .append($('<td>').html(token.permissions.join('<br>')))
+                    .append(
+                        $('<td>')
                             .addClass('notes')
-                            .append(displayNotes(token.notes)))
-                    .append($('<td>')
-                            .append($('<button>')
-                                    .text('Delete')
-                                    .data('id', token.id)
-                                    .data('expired', token.expired)
-                                    .click(function(event) {
-                                        event.preventDefault();
-                                        deleteToken($(this));
-                                    })))
+                            .append(displayNotes(token.notes))
+                    )
+                    .append(
+                        $('<td>').append(
+                            $('<button>')
+                                .text('Delete')
+                                .data('id', token.id)
+                                .data('expired', token.expired)
+                                .click(function(event) {
+                                    event.preventDefault();
+                                    deleteToken($(this));
+                                })
+                        )
+                    )
                     .appendTo($tbody);
             });
             $('.page').text(response.page);
@@ -146,16 +161,16 @@
             if ($('form#create .errorlist').length) {
                 $('form#create')[0].scrollIntoView();
             }
-
         });
-    }  // end of function fetch()
+    } // end of function fetch()
 
     function reset_page() {
-        $('#tokens').find('[name="page"]').val('1');
+        $('#tokens')
+            .find('[name="page"]')
+            .val('1');
     }
 
     $(document).ready(function() {
-
         var $form = $('#tokens');
         $('input.reset', $form).click(function() {
             $form[0].reset();
@@ -190,7 +205,5 @@
         });
 
         fetch();
-
     });
-
-}($, document));
+})($, document);

--- a/webapp-django/crashstats/manage/static/manage/js/events.js
+++ b/webapp-django/crashstats/manage/static/manage/js/events.js
@@ -1,5 +1,5 @@
 /*global alert:true location:true PaginationUtils:true */
-(function ($, document) {
+(function($, document) {
     'use strict';
 
     function start_loading() {
@@ -11,11 +11,12 @@
     }
 
     function fetch_events() {
-
         function tdURLOrEmpty(url) {
             if (url) {
                 return $('<td>').append(
-                    $('<a>').text('Edit').attr('href', url)
+                    $('<a>')
+                        .text('Edit')
+                        .attr('href', url)
                 );
             } else {
                 return $('<td>').text('n/a');
@@ -51,15 +52,25 @@
                 $('<tr>')
                     .append($('<td>').text(event.user))
                     .append($('<td>').text(event.action))
-                    .append($('<td>')
+                    .append(
+                        $('<td>')
                             .text(timestamp.fromNow())
-                            .attr('title', timestamp.format('LLLL')))
+                            .attr('title', timestamp.format('LLLL'))
+                    )
                     .append(tdURLOrEmpty(event.url))
-                    .append($('<td>').append(
-                            $('<a href="#">').text('Expand').click(toggleExpandPre))
-                        .append(
-                            $('<pre>').text(JSON.stringify(event.extra, undefined, 4))
-                        ))
+                    .append(
+                        $('<td>')
+                            .append(
+                                $('<a href="#">')
+                                    .text('Expand')
+                                    .click(toggleExpandPre)
+                            )
+                            .append(
+                                $('<pre>').text(
+                                    JSON.stringify(event.extra, undefined, 4)
+                                )
+                            )
+                    )
                     .appendTo($tbody);
             });
             $('.page').text(response.page);
@@ -72,11 +83,12 @@
     }
 
     function reset_page() {
-        $('#filter').find('[name="page"]').val('1');
+        $('#filter')
+            .find('[name="page"]')
+            .val('1');
     }
 
     $(document).ready(function() {
-
         var $form = $('#filter');
         $('input.reset', $form).click(function() {
             $form[0].reset();
@@ -112,5 +124,4 @@
 
         fetch_events();
     });
-
-}($, document));
+})($, document);

--- a/webapp-django/crashstats/manage/static/manage/js/graphics_devices.js
+++ b/webapp-django/crashstats/manage/static/manage/js/graphics_devices.js
@@ -1,17 +1,21 @@
 function perform_lookup() {
-    var vendor_hex = $('#id_vendor_hex').val().trim();
-    var adapter_hex = $('#id_adapter_hex').val().trim();
+    var vendor_hex = $('#id_vendor_hex')
+        .val()
+        .trim();
+    var adapter_hex = $('#id_adapter_hex')
+        .val()
+        .trim();
     if (!vendor_hex) {
-        alert("Enter a Vendor hex first");
+        alert('Enter a Vendor hex first');
         return;
     }
     if (!adapter_hex) {
-        alert("Enter an Adapter hex first");
+        alert('Enter an Adapter hex first');
         return;
     }
     var url = $('form.edit').data('lookup-url');
     $('.lookup-result:visible').hide();
-    $.get(url, {vendor_hex: vendor_hex, adapter_hex: adapter_hex})
+    $.get(url, { vendor_hex: vendor_hex, adapter_hex: adapter_hex })
         .done(function(response) {
             if (response.total) {
                 $('#something-found').show();
@@ -28,7 +32,8 @@ function perform_lookup() {
         })
         .fail(function() {
             alert('Unable to perform lookup');
-        }).always(function() {
+        })
+        .always(function() {
             setTimeout(function() {
                 $('.lookup-result:visible').hide();
             }, 5 * 1000);

--- a/webapp-django/crashstats/manage/static/manage/js/pagination_utils.js
+++ b/webapp-django/crashstats/manage/static/manage/js/pagination_utils.js
@@ -26,5 +26,4 @@ var PaginationUtils = (function() {
     return {
         show_pagination_links: show_pagination_links,
     };
-
 })();

--- a/webapp-django/crashstats/manage/static/manage/js/supersearch_field.js
+++ b/webapp-django/crashstats/manage/static/manage/js/supersearch_field.js
@@ -1,34 +1,31 @@
 /*global: ALL_PERMISSIONS */
 
-$(function () {
+$(function() {
     'use strict';
 
     var formElt = $('#supersearch-field');
 
     $('input[name=name]', formElt).select2({
-        'tags': [],
-        'maximumSelectionSize': 1,
-        'width': 'element'
+        tags: [],
+        maximumSelectionSize: 1,
+        width: 'element',
     });
 
     $('input[name=namespace]', formElt).select2({
-        'tags': [
-            'processed_crash',
-            'raw_crash'
-        ],
-        'maximumSelectionSize': 1,
-        'width': 'element'
+        tags: ['processed_crash', 'raw_crash'],
+        maximumSelectionSize: 1,
+        width: 'element',
     });
 
     $('input[name=in_database_name]', formElt).select2({
-        'tags': [],
-        'maximumSelectionSize': 1,
-        'width': 'element'
+        tags: [],
+        maximumSelectionSize: 1,
+        width: 'element',
     });
 
     var queryTypeElt = $('select[name=query_type]', formElt);
     queryTypeElt.select2({
-        'width': 'element'
+        width: 'element',
     });
     if (queryTypeElt.data('selected')) {
         queryTypeElt.select2('val', queryTypeElt.data('selected'));
@@ -36,20 +33,22 @@ $(function () {
 
     var dataValidationTypeElt = $('select[name=data_validation_type]', formElt);
     dataValidationTypeElt.select2({
-        'width': 'element'
+        width: 'element',
     });
     if (dataValidationTypeElt.data('selected')) {
-        dataValidationTypeElt.select2('val', dataValidationTypeElt.data('selected'));
+        dataValidationTypeElt.select2(
+            'val',
+            dataValidationTypeElt.data('selected')
+        );
     }
 
     $('input[name=permissions_needed]', formElt).select2({
-        'tags': ALL_PERMISSIONS,
-        'width': 'element'
+        tags: ALL_PERMISSIONS,
+        width: 'element',
     });
 
     $('input[name=form_field_choices]', formElt).select2({
-        'tags': [],
-        'width': 'element'
+        tags: [],
+        width: 'element',
     });
-
 });

--- a/webapp-django/crashstats/manage/static/manage/js/supersearch_fields.js
+++ b/webapp-django/crashstats/manage/static/manage/js/supersearch_fields.js
@@ -1,7 +1,9 @@
-$(function () {
+$(function() {
     $('.tablesorter').tablesorter();
-    $('.delete').click(function (e) {
+    $('.delete').click(function(e) {
         var field_name = $(this).data('field-name');
-        return confirm('Do you really want to delete the "'+ field_name +'" field?');
+        return confirm(
+            'Do you really want to delete the "' + field_name + '" field?'
+        );
     });
 });

--- a/webapp-django/crashstats/manage/static/manage/js/users.js
+++ b/webapp-django/crashstats/manage/static/manage/js/users.js
@@ -1,5 +1,5 @@
 /*global alert:true location:true PaginationUtils:true */
-(function ($, document) {
+(function($, document) {
     'use strict';
 
     function start_loading() {
@@ -11,7 +11,6 @@
     }
 
     function fetch_users() {
-
         function show_groups(groups) {
             var names = $.map(groups, function(item) {
                 return item.name;
@@ -37,10 +36,13 @@
                     .append($('<td>').text(user.is_active))
                     .append($('<td>').text(show_groups(user.groups)))
                     .append($('<td>').text(moment(user.last_login).fromNow()))
-                    .append($('<td>')
-                            .append($('<a>')
-                                    .attr('href', location.pathname + user.id + '/')
-                                    .text('Edit')))
+                    .append(
+                        $('<td>').append(
+                            $('<a>')
+                                .attr('href', location.pathname + user.id + '/')
+                                .text('Edit')
+                        )
+                    )
                     .appendTo($tbody);
             });
             $('.page').text(response.page);
@@ -53,11 +55,12 @@
     }
 
     function reset_page() {
-        $('#filter').find('[name="page"]').val('1');
+        $('#filter')
+            .find('[name="page"]')
+            .val('1');
     }
 
     $(document).ready(function() {
-
         var $form = $('#filter');
         $('input.reset', $form).click(function() {
             $form[0].reset();
@@ -93,5 +96,4 @@
 
         fetch_users();
     });
-
-}($, document));
+})($, document);

--- a/webapp-django/crashstats/signature/static/signature/js/signature_panel.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_panel.js
@@ -1,23 +1,22 @@
-SignatureReport.Panel = function (panelName, onDelete) {
-
+SignatureReport.Panel = function(panelName, onDelete) {
     // For accessing this from inside functions.
     var that = this;
 
     // Make the HTML elements.
-    this.$panelElement = $('<div>', {'class': 'panel tab-inner-panel'});
-    var $headerElement = $('<div>', {'class': 'title'});
+    this.$panelElement = $('<div>', { class: 'panel tab-inner-panel' });
+    var $headerElement = $('<div>', { class: 'title' });
     var $headingElement = $('<h2>', {
-        'text': SignatureReport.capitalizeHeading(panelName)
+        text: SignatureReport.capitalizeHeading(panelName),
     });
     var $deleteButton = $('<div>', {
-        'class': 'options delete',
-        'text': 'X'
+        class: 'options delete',
+        text: 'X',
     });
-    var $bodyElement = $('<div>', {'class': 'body'});
-    this.$contentElement = $('<div>', {'class': 'content'});
+    var $bodyElement = $('<div>', { class: 'body' });
+    this.$contentElement = $('<div>', { class: 'content' });
 
     // Bind the delete function to the delet button.
-    $deleteButton.on('click', function (e) {
+    $deleteButton.on('click', function(e) {
         e.preventDefault();
         that.$panelElement.remove();
         // Check that onDelete is not undefined
@@ -29,13 +28,7 @@ SignatureReport.Panel = function (panelName, onDelete) {
     // Append everything.
     SignatureReport.addLoaderToElement(this.$contentElement);
     this.$panelElement.append(
-        $headerElement.append(
-            $headingElement,
-            $deleteButton
-        ),
-        $bodyElement.append(
-            this.$contentElement
-        )
+        $headerElement.append($headingElement, $deleteButton),
+        $bodyElement.append(this.$contentElement)
     );
-
 };

--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -2,19 +2,19 @@
 
 var SignatureReport = {
     // Function to help with inheritance.
-    'inherit': function (proto) {
-        var f = function () {};
+    inherit: function(proto) {
+        var f = function() {};
         f.prototype = proto;
-        return new f ();
+        return new f();
     },
 };
 
-SignatureReport.getURL = function (name) {
+SignatureReport.getURL = function(name) {
     'use strict';
     return $('#mainbody').data('urls-' + name);
 };
 
-SignatureReport.init = function () {
+SignatureReport.init = function() {
     'use strict';
 
     // parameters
@@ -27,21 +27,21 @@ SignatureReport.init = function () {
     var panelsNavSection = $('#panels-nav');
     var mainBodyElt = $('#mainbody');
 
-    SignatureReport.pageNum = 1;  // the page number as passed in the URL
+    SignatureReport.pageNum = 1; // the page number as passed in the URL
 
     // Define the tab names.
-    var tabNames = $('a', panelsNavSection).map(function () {
+    var tabNames = $('a', panelsNavSection).map(function() {
         return $(this).data('tab-name');
     });
     var tabs = {};
     var tabClasses = {
-        'summary': SignatureReport.SummaryTab,
-        'graphs': SignatureReport.GraphsTab,
-        'reports': SignatureReport.ReportsTab,
-        'aggregations': SignatureReport.AggregationsTab,
-        'bugzilla': SignatureReport.BugzillaTab,
-        'comments': SignatureReport.CommentsTab,
-        'correlations': SignatureReport.CorrelationsTab,
+        summary: SignatureReport.SummaryTab,
+        graphs: SignatureReport.GraphsTab,
+        reports: SignatureReport.ReportsTab,
+        aggregations: SignatureReport.AggregationsTab,
+        bugzilla: SignatureReport.BugzillaTab,
+        comments: SignatureReport.CommentsTab,
+        correlations: SignatureReport.CorrelationsTab,
     };
 
     // Set the current tab, either from location.hash or defaultTab.
@@ -50,7 +50,7 @@ SignatureReport.init = function () {
     var currentTab = hashString ? hashString : defaultTab;
 
     // Helper function for getting parameters.
-    SignatureReport.getParamsWithSignature = function () {
+    SignatureReport.getParamsWithSignature = function() {
         var params = form.dynamicForm('getParams');
         params.signature = SIGNATURE;
 
@@ -61,19 +61,26 @@ SignatureReport.init = function () {
     };
 
     // Helper function for capitalizing headings.
-    SignatureReport.capitalizeHeading = function (heading) {
-        return heading.charAt(0).toUpperCase() +
-            heading.slice(1).replace(/_/g, ' ');
+    SignatureReport.capitalizeHeading = function(heading) {
+        return (
+            heading.charAt(0).toUpperCase() +
+            heading.slice(1).replace(/_/g, ' ')
+        );
     };
 
     // Helper function for adding a loader.
-    SignatureReport.addLoaderToElement = function (elt) {
+    SignatureReport.addLoaderToElement = function(elt) {
         elt.empty();
-        elt.append($('<div>', {'class': 'loader'}));
+        elt.append($('<div>', { class: 'loader' }));
     };
 
-    SignatureReport.handleError = function (contentElt, jqXHR, textStatus, errorThrown) {
-        var errorContent = $('<div>', {class: 'error'});
+    SignatureReport.handleError = function(
+        contentElt,
+        jqXHR,
+        textStatus,
+        errorThrown
+    ) {
+        var errorContent = $('<div>', { class: 'error' });
         var errorDetails;
         var errorTitle;
         var errorMsg;
@@ -83,21 +90,21 @@ SignatureReport.init = function () {
             errorTitle = 'Oops, an error occured';
             errorMsg = 'Please fix the following issues: ';
 
-            errorContent.append($('<h3>', {text: errorTitle}));
-            errorContent.append($('<p>', {text: errorMsg}));
+            errorContent.append($('<h3>', { text: errorTitle }));
+            errorContent.append($('<p>', { text: errorMsg }));
             errorContent.append(errorDetails);
-        }
-        catch (e) {
+        } catch (e) {
             // If an exception occurs, that means jQuery wasn't able
             // to understand the status of the HTTP response. It is
             // probably a 500 error. We thus show a different error.
             errorDetails = textStatus + ' - ' + errorThrown;
             errorTitle = 'An unexpected error occured :(';
-            errorMsg = 'We have been automatically informed of that error, and are working on a solution. ';
+            errorMsg =
+                'We have been automatically informed of that error, and are working on a solution. ';
 
-            errorContent.append($('<h3>', {text: errorTitle}));
-            errorContent.append($('<p>', {text: errorMsg}));
-            errorContent.append($('<p>', {text: errorDetails}));
+            errorContent.append($('<h3>', { text: errorTitle }));
+            errorContent.append($('<p>', { text: errorMsg }));
+            errorContent.append($('<p>', { text: errorDetails }));
         }
 
         contentElt.empty().append(errorContent);
@@ -140,30 +147,34 @@ SignatureReport.init = function () {
             }
 
             initialParams = socorro.search.getFilteredParams(initialParams);
-        }
-        else {
+        } else {
             initialParams = {};
         }
 
-        form.dynamicForm(fieldsURL, initialParams, '#search-params-fieldset', function () {
-            $('.loader', searchSection).remove();
-            form.show();
-            // When the form has finished loading, we get sanitized parameters
-            // from it and show the results. This will avoid strange behaviors
-            // that can be caused by manually set parameters, for example.
-            callback();
-        });
+        form.dynamicForm(
+            fieldsURL,
+            initialParams,
+            '#search-params-fieldset',
+            function() {
+                $('.loader', searchSection).remove();
+                form.show();
+                // When the form has finished loading, we get sanitized parameters
+                // from it and show the results. This will avoid strange behaviors
+                // that can be caused by manually set parameters, for example.
+                callback();
+            }
+        );
 
         searchSection.hide();
     }
 
     function bindEvents() {
-        searchSection.on('click', '.new-line', function (e) {
+        searchSection.on('click', '.new-line', function(e) {
             e.preventDefault();
             form.dynamicForm('newLine');
         });
 
-        searchSection.on('click', 'button[type=submit]', function (e) {
+        searchSection.on('click', 'button[type=submit]', function(e) {
             e.preventDefault();
             var params = SignatureReport.getParamsWithSignature();
             var queryString = '?' + Qs.stringify(params, { indices: false });
@@ -171,7 +182,7 @@ SignatureReport.init = function () {
         });
 
         // Show or hide filters.
-        $('.toggle-filters').on('click', function (e) {
+        $('.toggle-filters').on('click', function(e) {
             e.preventDefault();
             searchSection.slideToggle(300);
 
@@ -184,13 +195,13 @@ SignatureReport.init = function () {
         });
 
         // Change tab using navigation links.
-        panelsNavSection.on('click', 'a', function () {
+        panelsNavSection.on('click', 'a', function() {
             showTab($(this).data('tab-name'));
         });
     }
 
     // Make the tabs.
-    $.each(tabNames, function (i, tabName) {
+    $.each(tabNames, function(i, tabName) {
         var TabClass = tabClasses[tabName];
         tabs[tabName] = new TabClass(tabName);
         mainBodyElt.append(tabs[tabName].$panelElement);

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
@@ -15,8 +15,7 @@
  * @cfg {boolean} pagination
  *      Should be true if the tab is displaying tables with pages
  */
-SignatureReport.Tab = function (tabName, config) {
-
+SignatureReport.Tab = function(tabName, config) {
     // Set the name of the tab.
     this.tabName = tabName;
 
@@ -33,28 +32,22 @@ SignatureReport.Tab = function (tabName, config) {
     this.dataUrl = SignatureReport.getURL(this.tabName);
 
     // Make the HTML elements.
-    this.$panelElement = $('<section>',
-        {'class': 'panel tab-panel ' + this.tabName + '-panel'}
-    );
-    var $headerElement = $('<header>', {'class': 'title'});
+    this.$panelElement = $('<section>', {
+        class: 'panel tab-panel ' + this.tabName + '-panel',
+    });
+    var $headerElement = $('<header>', { class: 'title' });
     var $headingElement = $('<h2>', {
-        'text': SignatureReport.capitalizeHeading(this.tabName)}
-    );
-    var $bodyElement = $('<div>', {'class': 'body'});
-    this.$controlsElement = $('<div>', {'class': 'controls'});
-    this.$contentElement = $('<div>', {'class': 'content'});
+        text: SignatureReport.capitalizeHeading(this.tabName),
+    });
+    var $bodyElement = $('<div>', { class: 'body' });
+    this.$controlsElement = $('<div>', { class: 'controls' });
+    this.$contentElement = $('<div>', { class: 'content' });
 
     // Append the elements.
     this.$panelElement.append(
-        $headerElement.append(
-            $headingElement
-        ),
-        $bodyElement.append(
-            this.$controlsElement,
-            this.$contentElement
-        )
+        $headerElement.append($headingElement),
+        $bodyElement.append(this.$controlsElement, this.$contentElement)
     );
-
 };
 
 /*
@@ -62,11 +55,9 @@ SignatureReport.Tab = function (tabName, config) {
  */
 
 // Shows the tab. Also loads it if it is not already loaded.
-SignatureReport.Tab.prototype.showTab = function () {
-
+SignatureReport.Tab.prototype.showTab = function() {
     // If tab hasn't been loaded, load it.
     if (!this.loaded) {
-
         // Load the controls.
         // (If there are no controls this won't do anything.)
         this.loadControls();
@@ -75,26 +66,24 @@ SignatureReport.Tab.prototype.showTab = function () {
         // If there are no panels, load the content directly.
         if (!this.panels) {
             this.loadContent(this.$contentElement);
-        // If there are panels, load the default panels.
-        // (loadContent will be called by loadPanel.)
+            // If there are panels, load the default panels.
+            // (loadContent will be called by loadPanel.)
         } else {
-            for (var i = 0; i < this.defaultOptions.length; i++ ) {
+            for (var i = 0; i < this.defaultOptions.length; i++) {
                 this.loadPanel(this.defaultOptions[i]);
             }
         }
 
         // Record that this tab has now been loaded.
         this.loaded = true;
-
     }
 
     // Show this tab.
     this.$panelElement.show();
-
 };
 
 // Hides the tab.
-SignatureReport.Tab.prototype.hideTab = function () {
+SignatureReport.Tab.prototype.hideTab = function() {
     this.$panelElement.hide();
 };
 
@@ -103,12 +92,12 @@ SignatureReport.Tab.prototype.hideTab = function () {
  */
 
 // Extend this to load any controls.
-SignatureReport.Tab.prototype.loadControls = function () {
+SignatureReport.Tab.prototype.loadControls = function() {
     // If there are no controls, nothing will happen.
 };
 
 // Extend this if any extra parameters need to be added.
-SignatureReport.Tab.prototype.getParamsForUrl = function () {
+SignatureReport.Tab.prototype.getParamsForUrl = function() {
     var params = SignatureReport.getParamsWithSignature();
     if (this.pagination) {
         params.page = this.page || SignatureReport.pageNum;
@@ -117,13 +106,15 @@ SignatureReport.Tab.prototype.getParamsForUrl = function () {
 };
 
 // Extend this if anything different needs to be added to the URL.
-SignatureReport.Tab.prototype.buildUrl = function (params, option) {
+SignatureReport.Tab.prototype.buildUrl = function(params, option) {
     option = option ? option + '/' : '';
-    return this.dataUrl + option + '?' + Qs.stringify(params, { indices: false });
+    return (
+        this.dataUrl + option + '?' + Qs.stringify(params, { indices: false })
+    );
 };
 
 // Extend this if anything different should be done with the returned data.
-SignatureReport.Tab.prototype.onAjaxSuccess = function (contentElement, data) {
+SignatureReport.Tab.prototype.onAjaxSuccess = function(contentElement, data) {
     contentElement.empty().append($(data));
     contentElement.addClass('loaded');
     if (this.dataDisplayType === 'table') {
@@ -136,13 +127,15 @@ SignatureReport.Tab.prototype.onAjaxSuccess = function (contentElement, data) {
 
 // This should not need to be extended.
 // NB if panels are present, the tab is assumed to have a select as its controls.
-SignatureReport.Tab.prototype.loadPanel = function (option) {
-
+SignatureReport.Tab.prototype.loadPanel = function(option) {
     // Initialize a new panel.
     var panel = new SignatureReport.Panel(
         option,
-        $.proxy(function () {
-            $('option[value=' + option + ']', this.$selectElement).prop('disabled', false);
+        $.proxy(function() {
+            $('option[value=' + option + ']', this.$selectElement).prop(
+                'disabled',
+                false
+            );
         }, this)
     );
 
@@ -151,29 +144,29 @@ SignatureReport.Tab.prototype.loadPanel = function (option) {
     this.$contentElement.addClass('loaded');
 
     // Disable the currently selected option.
-    $('option[value=' + option + ']', this.$selectElement).prop('disabled', true);
+    $('option[value=' + option + ']', this.$selectElement).prop(
+        'disabled',
+        true
+    );
 
     // Now load the panel's content.
     this.loadContent(panel.$contentElement, option);
-
 };
 
 // This should not need to be extended.
-SignatureReport.Tab.prototype.loadContent = function (contentElement, option) {
-
+SignatureReport.Tab.prototype.loadContent = function(contentElement, option) {
     // Get the parameters for the URL to get the data.
     var params = this.getParamsForUrl();
 
     if (params) {
-
         // Make the URL for getting the data.
         var url = this.buildUrl(params, option);
 
         // Define the returned data type according to whether we are getting a
         // table or a graph.
         var dataTypes = {
-            'table': 'html',
-            'graph': 'json',
+            table: 'html',
+            graph: 'json',
         };
 
         // Empty the content element and append a loader.
@@ -184,26 +177,27 @@ SignatureReport.Tab.prototype.loadContent = function (contentElement, option) {
             url: url,
             success: $.proxy(this.onAjaxSuccess, this, contentElement),
             error: function(jqXHR, textStatus, errorThrown) {
-                SignatureReport.handleError(contentElement, jqXHR, textStatus, errorThrown);
+                SignatureReport.handleError(
+                    contentElement,
+                    jqXHR,
+                    textStatus,
+                    errorThrown
+                );
             },
             dataType: dataTypes[this.dataDisplayType],
         });
-
     }
-
 };
 
 // This should not need to be extended.
-SignatureReport.Tab.prototype.bindPaginationLinks = function (contentElement) {
-
+SignatureReport.Tab.prototype.bindPaginationLinks = function(contentElement) {
     // For accessing this inside functions.
     var that = this;
 
-    $('.pagination a', contentElement).click(function (e) {
+    $('.pagination a', contentElement).click(function(e) {
         e.preventDefault();
 
         that.page = $(this).data('page');
         that.loadContent(contentElement);
     });
-
 };

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_aggregations.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_aggregations.js
@@ -9,38 +9,39 @@
  * @inheritdoc
  */
 SignatureReport.AggregationsTab = function(tabName) {
-
     var config = {
-        'panels': true,
-        'defaultOptions': ['product', 'platform', 'build_id', 'install_time'],
-        'dataDisplayType': 'table',
-        'pagination': false,
+        panels: true,
+        defaultOptions: ['product', 'platform', 'build_id', 'install_time'],
+        dataDisplayType: 'table',
+        pagination: false,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
-
 };
 
-SignatureReport.AggregationsTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.AggregationsTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
 // Extends loadControls to add a select and some options.
 SignatureReport.AggregationsTab.prototype.loadControls = function() {
-
     // For accessing this inside functions.
     var that = this;
 
     // Make the select element and one empty option element (for select2).
-    this.$selectElement = $('<select>', {'class': 'fields-list'});
+    this.$selectElement = $('<select>', { class: 'fields-list' });
     this.$selectElement.append($('<option>'));
 
     var fields = $('#mainbody').data('fields');
 
     // Append an option element for each field.
     $.each(fields, function(i, field) {
-        that.$selectElement.append($('<option>', {
-            'value': field.id,
-            'text': field.text,
-        }));
+        that.$selectElement.append(
+            $('<option>', {
+                value: field.id,
+                text: field.text,
+            })
+        );
     });
 
     // Append the control elements.
@@ -48,15 +49,14 @@ SignatureReport.AggregationsTab.prototype.loadControls = function() {
 
     // Set the placeholder.
     this.$selectElement.select2({
-        'placeholder': 'Aggregate on...',
-        'allowClear': true,
-        'sortResults': socorro.search.sortResults,
+        placeholder: 'Aggregate on...',
+        allowClear: true,
+        sortResults: socorro.search.sortResults,
     });
 
     // On changing the selected option, load a new panel.
-    this.$selectElement.on('change', function (e) {
+    this.$selectElement.on('change', function(e) {
         that.$selectElement.select2('val', '');
         that.loadPanel(e.val);
     });
-
 };

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_bugzilla.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_bugzilla.js
@@ -7,20 +7,23 @@
  * @inheritdoc
  */
 SignatureReport.BugzillaTab = function(tabName) {
-
-    var config  = {
-        'panels': false,
-        'dataDisplayType': 'table',
-        'pagination': false
+    var config = {
+        panels: false,
+        dataDisplayType: 'table',
+        pagination: false,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
-
 };
 
-SignatureReport.BugzillaTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.BugzillaTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
-SignatureReport.BugzillaTab.prototype.onAjaxSuccess = function (contentElement, data) {
+SignatureReport.BugzillaTab.prototype.onAjaxSuccess = function(
+    contentElement,
+    data
+) {
     SignatureReport.Tab.prototype.onAjaxSuccess.apply(this, arguments);
 
     // Enhance bug links.

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_comments.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_comments.js
@@ -7,15 +7,15 @@
  * @inheritdoc
  */
 SignatureReport.CommentsTab = function(tabName) {
-
-    var config  = {
-        'panels': false,
-        'dataDisplayType': 'table',
-        'pagination': true
+    var config = {
+        panels: false,
+        dataDisplayType: 'table',
+        pagination: true,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
-
 };
 
-SignatureReport.CommentsTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.CommentsTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_correlations.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_correlations.js
@@ -8,19 +8,19 @@
  * @extends {SignatureReport.Tab}
  * @inheritdoc
  */
-SignatureReport.CorrelationsTab = function (tabName) {
-
-    var config  = {
-        'panels': false,
-        'dataDisplayType': 'table',
-        'pagination': false,
+SignatureReport.CorrelationsTab = function(tabName) {
+    var config = {
+        panels: false,
+        dataDisplayType: 'table',
+        pagination: false,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
-
 };
 
-SignatureReport.CorrelationsTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.CorrelationsTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
 SignatureReport.CorrelationsTab.prototype.loadControls = function() {
     var self = this;
@@ -28,24 +28,36 @@ SignatureReport.CorrelationsTab.prototype.loadControls = function() {
     var channels = $('#mainbody').data('channels');
 
     // Create a select box for the product.
-    this.productSelect = $('<select>', {'class': 'products-list', id: 'correlations-products-list'});
-    this.productSelect.append($('<option>', { value: 'Firefox', text: 'Firefox'}));
-    this.productSelect.append($('<option>', { value: 'FennecAndroid', text: 'FennecAndroid'}));
+    this.productSelect = $('<select>', {
+        class: 'products-list',
+        id: 'correlations-products-list',
+    });
+    this.productSelect.append(
+        $('<option>', { value: 'Firefox', text: 'Firefox' })
+    );
+    this.productSelect.append(
+        $('<option>', { value: 'FennecAndroid', text: 'FennecAndroid' })
+    );
 
     // Create a select box for the channel.
-    this.channelSelect = $('<select>', {'class': 'channels-list', id: 'correlations-channels-list'});
-    channels.forEach(function (channel) {
-        self.channelSelect.append($('<option>', {
-            'value': channel,
-            'text': channel,
-        }));
+    this.channelSelect = $('<select>', {
+        class: 'channels-list',
+        id: 'correlations-channels-list',
+    });
+    channels.forEach(function(channel) {
+        self.channelSelect.append(
+            $('<option>', {
+                value: channel,
+                text: channel,
+            })
+        );
     });
 
     // Append the controls.
     this.$controlsElement.append(
-        $('<label>', {for: 'correlations-products-list', text: 'Product: '}),
+        $('<label>', { for: 'correlations-products-list', text: 'Product: ' }),
         this.productSelect,
-        $('<label>', {for: 'correlations-channels-list', text: 'Channel: '}),
+        $('<label>', { for: 'correlations-channels-list', text: 'Channel: ' }),
         this.channelSelect,
         $('<hr>')
     );
@@ -58,7 +70,7 @@ SignatureReport.CorrelationsTab.prototype.loadControls = function() {
     this.channelSelect.on('change', this.loadCorrelations.bind(this));
 };
 
-SignatureReport.CorrelationsTab.prototype.onAjaxSuccess = function () {
+SignatureReport.CorrelationsTab.prototype.onAjaxSuccess = function() {
     SignatureReport.Tab.prototype.onAjaxSuccess.apply(this, arguments);
 
     var defaultProduct = $('#correlations-wrapper').data('default-product');
@@ -71,21 +83,28 @@ SignatureReport.CorrelationsTab.prototype.onAjaxSuccess = function () {
     this.loadCorrelations();
 };
 
-SignatureReport.CorrelationsTab.prototype.loadCorrelations = function () {
+SignatureReport.CorrelationsTab.prototype.loadCorrelations = function() {
     var contentElt = $('#correlations-wrapper pre');
-    contentElt.empty().append($('<div>', {'class': 'loader'}));
+    contentElt.empty().append($('<div>', { class: 'loader' }));
 
     var product = this.productSelect.select2('val');
     var channel = this.channelSelect.select2('val');
 
-    $('#correlations-wrapper h3').text('Correlations for ' + product + ' ' + channel[0].toUpperCase() + channel.substr(1));
+    $('#correlations-wrapper h3').text(
+        'Correlations for ' +
+            product +
+            ' ' +
+            channel[0].toUpperCase() +
+            channel.substr(1)
+    );
 
-    window.correlations.getCorrelations(SignatureReport.signature, channel, product)
-    .then(function (results) {
-        var content = results;
-        if (Array.isArray(results)) {
-            content = results.join('\n');
-        }
-        contentElt.empty().text(content);
-    });
+    window.correlations
+        .getCorrelations(SignatureReport.signature, channel, product)
+        .then(function(results) {
+            var content = results;
+            if (Array.isArray(results)) {
+                content = results.join('\n');
+            }
+            contentElt.empty().text(content);
+        });
 };

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -7,27 +7,26 @@
  * @inheritdoc
  */
 SignatureReport.GraphsTab = function(tabName) {
-
-    var config  = {
-        'panels': true,
-        'dataDisplayType': 'graph',
-        'defaultOptions': ['product'],
-        'pagination': false
+    var config = {
+        panels: true,
+        dataDisplayType: 'graph',
+        defaultOptions: ['product'],
+        pagination: false,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
-
 };
 
-SignatureReport.GraphsTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.GraphsTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
-SignatureReport.GraphsTab.prototype.loadControls = function () {
-
+SignatureReport.GraphsTab.prototype.loadControls = function() {
     // For accessing this inside functions.
     var that = this;
 
     // Make the select element and one empty option element (for select2).
-    this.$selectElement = $('<select>', {'class': 'fields-list'});
+    this.$selectElement = $('<select>', { class: 'fields-list' });
     this.$selectElement.append($('<option>'));
 
     // Pick up necessary data from the DOM
@@ -35,10 +34,12 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
 
     // Append an option element for each field.
     $.each(fields, function(i, field) {
-        that.$selectElement.append($('<option>', {
-            'value': field.id,
-            'text': field.text
-        }));
+        that.$selectElement.append(
+            $('<option>', {
+                value: field.id,
+                text: field.text,
+            })
+        );
     });
 
     // Append the control elements.
@@ -46,22 +47,20 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
 
     // Set the placeholder.
     this.$selectElement.select2({
-        'placeholder': 'Crashes per day, by...',
-        'allowClear': true,
-        'sortResults': socorro.search.sortResults,
+        placeholder: 'Crashes per day, by...',
+        allowClear: true,
+        sortResults: socorro.search.sortResults,
     });
 
     // On changing the selected option, load a new panel.
-    this.$selectElement.on('change', function (e) {
+    this.$selectElement.on('change', function(e) {
         that.$selectElement.select2('val', '');
         that.loadPanel(e.val);
     });
-
 };
 
 // Format the data for the graph library.
-SignatureReport.GraphsTab.prototype.formatData = function (data) {
-
+SignatureReport.GraphsTab.prototype.formatData = function(data) {
     var option = data.aggregation;
 
     // Variables for the graph's data and legend. Metrics Graphics requires an
@@ -77,71 +76,68 @@ SignatureReport.GraphsTab.prototype.formatData = function (data) {
     // Splice out terms with the highest counts (up to the 4th highest) and:
     // 1) add an empty array for each one to lineDataObject
     // 2) add each one to the legend array
-    $.each(termCounts.splice(0, 4), function (i, element) {
+    $.each(termCounts.splice(0, 4), function(i, element) {
         lineDataObject[element.term] = [];
         legend.push(element.term);
     });
 
     // Each object in data.aggregates contains data for one date.
-    $.each(data.aggregates, function (i, dateData) {
-
+    $.each(data.aggregates, function(i, dateData) {
         // Each object in dateData.facets[option] contains data for one term
         // on this date.
-        $.each(dateData.facets[option], function (j, termData) {
-
+        $.each(dateData.facets[option], function(j, termData) {
             // If this term is one of the 4 with the highest counts...
             if (lineDataObject.hasOwnProperty(termData.term)) {
-
                 // ...Make a data object for a node on the graph...
                 var nodeData = {
-                    'count': termData.count,
-                    'date': new Date(dateData.term),
-                    'term': termData.term
+                    count: termData.count,
+                    date: new Date(dateData.term),
+                    term: termData.term,
                 };
 
                 // ... And add it to this term's data array.
                 lineDataObject[termData.term].push(nodeData);
             }
-
         });
-
     });
 
     // Make the data object into an array of arrays for Metrics Graphics.
-    $.each(lineDataObject, function (key, lineData) {
+    $.each(lineDataObject, function(key, lineData) {
         lineDataArray.push(lineData);
     });
 
     // Return the line data, the legend and also any remaining terms after the
     // top 4 were spliced out.
-    return {'data': lineDataArray, 'legend': legend, 'missingTerms': termCounts};
-
+    return { data: lineDataArray, legend: legend, missingTerms: termCounts };
 };
 
-SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElement) {
-
+SignatureReport.GraphsTab.prototype.drawGraph = function(
+    graphData,
+    contentElement
+) {
     var graphElement = $('<div>', {
-        'class': 'new-graph'
+        class: 'new-graph',
     });
 
     var legendElement = $('<div>', {
-        'class': 'legend new-legend'
+        class: 'legend new-legend',
     });
 
     // Remove the loader and append divs for graph and legend.
-    contentElement.empty().append(
-        graphElement,
-        legendElement
-    );
+    contentElement.empty().append(graphElement, legendElement);
 
     // If there are extra terms missing, let the user know.
     if (graphData.missingTerms.length) {
         var message = 'Showing the top 4 results. Not showing:';
-        $.each(graphData.missingTerms, function (i, term) {
-            message += ' ' + term.term + ' (' + term.count +
+        $.each(graphData.missingTerms, function(i, term) {
+            message +=
+                ' ' +
+                term.term +
+                ' (' +
+                term.count +
                 (term.count === 1 ? ' crash),' : ' crashes),');
         });
-        contentElement.append($('<p>', {'text': message.slice(0, -1)}));
+        contentElement.append($('<p>', { text: message.slice(0, -1) }));
     }
 
     MG.data_graphic({
@@ -158,33 +154,33 @@ SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElem
         legend_target: '.new-legend',
         show_secondary_x_label: false,
         mouseover: function(d, i) {
-            $('.mg-active-datapoint', contentElement)
-                .html(d.term +
+            $('.mg-active-datapoint', contentElement).html(
+                d.term +
                     ': ' +
                     d.count +
                     (d.count === 1 ? ' crash' : ' crashes')
-                );
-        }
+            );
+        },
     });
 
     // Ensure the next graph and legend don't get added to this panel.
     graphElement.removeClass('new-graph');
     legendElement.removeClass('new-legend');
-
 };
 
 // Extends onAjaxSuccess to process the data and draw a graph.
-SignatureReport.GraphsTab.prototype.onAjaxSuccess = function (contentElement, data) {
-
+SignatureReport.GraphsTab.prototype.onAjaxSuccess = function(
+    contentElement,
+    data
+) {
     // Data needs to be processed to determine if we can draw the graph.
     var graphData = this.formatData(data);
 
     // If data was returned, draw the graph.
     if (graphData.data.length) {
         this.drawGraph(graphData, contentElement);
-    // If no data was returned, let the user know.
+        // If no data was returned, let the user know.
     } else {
         contentElement.text('No results were found.');
     }
-
 };

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
@@ -7,21 +7,21 @@
  * @inheritdoc
  */
 SignatureReport.ReportsTab = function(tabName) {
-
     var config = {
-        'panels': false,
-        'dataDisplayType': 'table',
-        'pagination': true
+        panels: false,
+        dataDisplayType: 'table',
+        pagination: true,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
 };
 
-SignatureReport.ReportsTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.ReportsTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
 // Extends loadControls to add a text input and some default fields.
 SignatureReport.ReportsTab.prototype.loadControls = function() {
-
     // For accessing this inside functions.
     var that = this;
 
@@ -32,27 +32,27 @@ SignatureReport.ReportsTab.prototype.loadControls = function() {
 
     // Make the control elements: an input and an update button.
     // (The hidden input is for select2.)
-    var columnsInputHidden = $('<input>',  {
-        'type': 'hidden',
-        'name': '_columns',
-        'value': columns,
+    var columnsInputHidden = $('<input>', {
+        type: 'hidden',
+        name: '_columns',
+        value: columns,
     });
 
     this.$columnsInput = $('<input>', {
-        'type': 'text',
-        'name': '_columns_fake',
-        'value': columns,
+        type: 'text',
+        name: '_columns_fake',
+        value: columns,
     });
 
     this.$sortInputHidden = $('<input>', {
-        'type': 'hidden',
-        'name': '_sort',
-        'value': sort,
+        type: 'hidden',
+        name: '_sort',
+        value: sort,
     });
 
     var updateButton = $('<button>', {
-        'type': 'submit',
-        'text': 'Update'
+        type: 'submit',
+        text: 'Update',
     });
 
     // Append the controls.
@@ -66,28 +66,31 @@ SignatureReport.ReportsTab.prototype.loadControls = function() {
 
     // Make the columns input sortable.
     this.$columnsInput.select2({
-        'data': fields,
-        'multiple': true,
-        'width': 'element',
-        'sortResults': socorro.search.sortResults,
+        data: fields,
+        multiple: true,
+        width: 'element',
+        sortResults: socorro.search.sortResults,
     });
 
-    this.$columnsInput.on("change", function() {
+    this.$columnsInput.on('change', function() {
         columnsInputHidden.val(that.$columnsInput.val());
     });
 
-    this.$columnsInput.select2('container').find('ul.select2-choices').sortable({
-        containment: 'parent',
-        start: function() {
-            that.$columnsInput.select2('onSortStart');
-        },
-        update: function() {
-            that.$columnsInput.select2('onSortEnd');
-        }
-    });
+    this.$columnsInput
+        .select2('container')
+        .find('ul.select2-choices')
+        .sortable({
+            containment: 'parent',
+            start: function() {
+                that.$columnsInput.select2('onSortStart');
+            },
+            update: function() {
+                that.$columnsInput.select2('onSortEnd');
+            },
+        });
 
     // On clicking the update button, loadContent is called.
-    updateButton.on('click', function (e) {
+    updateButton.on('click', function(e) {
         e.preventDefault();
         that.loadContent(that.$contentElement);
     });
@@ -96,8 +99,7 @@ SignatureReport.ReportsTab.prototype.loadControls = function() {
 // Extends getParamsForUrl to do two extra things:
 // 1) add the columns parameters
 // 2) add the page parameter
-SignatureReport.ReportsTab.prototype.getParamsForUrl = function () {
-
+SignatureReport.ReportsTab.prototype.getParamsForUrl = function() {
     // Get the params as usual.
     var params = SignatureReport.getParamsWithSignature();
 
@@ -110,7 +112,11 @@ SignatureReport.ReportsTab.prototype.getParamsForUrl = function () {
     }
 
     // Get the sort for the input.
-    params._sort = this.$sortInputHidden.val().trim().split(',') || [];
+    params._sort =
+        this.$sortInputHidden
+            .val()
+            .trim()
+            .split(',') || [];
 
     // Get the page number.
     params.page = this.page || SignatureReport.pageNum;
@@ -119,8 +125,7 @@ SignatureReport.ReportsTab.prototype.getParamsForUrl = function () {
 };
 
 // Extends buildUrl to also replace the history.
-SignatureReport.ReportsTab.prototype.buildUrl = function (params) {
-
+SignatureReport.ReportsTab.prototype.buildUrl = function(params) {
     // Build the query string.
     var queryString = '?' + Qs.stringify(params, { indices: false });
 
@@ -131,16 +136,20 @@ SignatureReport.ReportsTab.prototype.buildUrl = function (params) {
     return this.dataUrl + queryString;
 };
 
-SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, data) {
+SignatureReport.ReportsTab.prototype.onAjaxSuccess = function(
+    contentElement,
+    data
+) {
     var tab = this;
 
     contentElement.empty().append($(data));
     $('#reports-list').tablesorter({
         headers: {
-            0: {  // disable the first column, `Crash ID`
-                sorter: false
-            }
-        }
+            0: {
+                // disable the first column, `Crash ID`
+                sorter: false,
+            },
+        },
     });
     this.bindPaginationLinks(contentElement);
 
@@ -148,7 +157,7 @@ SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, d
     // do not activate server-side sorting, rely on the
     // default client-side sorting.
     if ($('.pagination a', contentElement).length) {
-        $('.sort-header', contentElement).click(function (e) {
+        $('.sort-header', contentElement).click(function(e) {
             e.preventDefault();
 
             var thisElt = $(this);
@@ -158,7 +167,7 @@ SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, d
             var sortArr = tab.$sortInputHidden.val().split(',');
 
             // First remove all previous mentions of that field.
-            sortArr = sortArr.filter(function (item) {
+            sortArr = sortArr.filter(function(item) {
                 return item !== fieldName && item !== '-' + fieldName;
             });
 
@@ -166,8 +175,10 @@ SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, d
             // ascending -> descending -> none
             if (thisElt.hasClass('headerSortDown')) {
                 sortArr.unshift('-' + fieldName);
-            }
-            else if (!thisElt.hasClass('headerSortDown') && !thisElt.hasClass('headerSortUp')) {
+            } else if (
+                !thisElt.hasClass('headerSortDown') &&
+                !thisElt.hasClass('headerSortUp')
+            ) {
                 sortArr.unshift(fieldName);
             }
 

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_summary.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_summary.js
@@ -7,30 +7,36 @@
  * @inheritdoc
  */
 SignatureReport.SummaryTab = function(tabName) {
-
-    var config  = {
-        'panels': false,
-        'dataDisplayType': 'table',
-        'pagination': false
+    var config = {
+        panels: false,
+        dataDisplayType: 'table',
+        pagination: false,
     };
 
     SignatureReport.Tab.call(this, tabName, config);
 };
 
-SignatureReport.SummaryTab.prototype = SignatureReport.inherit(SignatureReport.Tab.prototype);
+SignatureReport.SummaryTab.prototype = SignatureReport.inherit(
+    SignatureReport.Tab.prototype
+);
 
-SignatureReport.SummaryTab.prototype.onAjaxSuccess = function (contentElement, data) {
+SignatureReport.SummaryTab.prototype.onAjaxSuccess = function(
+    contentElement,
+    data
+) {
     SignatureReport.Tab.prototype.onAjaxSuccess.apply(this, arguments);
 
     var localStorageKey = 'pref-opened-panels';
-    var prefOpenedPanels = JSON.parse(localStorage.getItem(localStorageKey) || '[]');
+    var prefOpenedPanels = JSON.parse(
+        localStorage.getItem(localStorageKey) || '[]'
+    );
     prefOpenedPanels.forEach(function(id, i) {
         var parent = $('#' + id + '.panel');
         $('.content', parent).toggle();
         $('.options', parent).toggleClass('hide');
     });
 
-    $(contentElement).on('click', '.panel header', function (e) {
+    $(contentElement).on('click', '.panel header', function(e) {
         e.preventDefault();
         var parent = $(this).parent();
         var panelId = parent.attr('id');

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
@@ -1,5 +1,5 @@
 /*jshint jquery: true */
-(function ($) {
+(function($) {
     'use strict';
 
     // String used to separate values in select2 fields.
@@ -7,7 +7,7 @@
 
     // All available operators.
     var OPERATORS = {
-        'has': 'has terms',
+        has: 'has terms',
         '!': 'does not have terms',
         '=': 'is',
         '!=': 'is not',
@@ -15,7 +15,7 @@
         '!~': 'does not contain',
         '^': 'starts with',
         '!^': 'does not start with',
-        '$': 'ends with',
+        $: 'ends with',
         '!$': 'does not end with',
         '@': 'matches regex',
         '!@': 'does not match regex',
@@ -23,9 +23,9 @@
         '>=': '>=',
         '<': '<',
         '<=': '<=',
-        '__null__': 'does not exist',
+        __null__: 'does not exist',
         '!__null__': 'exists',
-        '__true__': 'is true',
+        __true__: 'is true',
         '!__true__': 'is false',
     };
 
@@ -33,14 +33,27 @@
     // value when no operator is passed for a field.
     var OPERATORS_BASE = ['has', '!'];
     var OPERATORS_RANGE = ['>', '>=', '<', '<='];
-    var OPERATORS_REGEX = ['~', '=', '$', '^', '@', '!=', '!~', '!$', '!^', '!@'];
+    var OPERATORS_REGEX = [
+        '~',
+        '=',
+        '$',
+        '^',
+        '@',
+        '!=',
+        '!~',
+        '!$',
+        '!^',
+        '!@',
+    ];
     var OPERATORS_EXISTENCE = ['__null__', '!__null__'];
     var OPERATORS_BOOLEAN = ['__true__', '!__true__'];
 
     var OPERATORS_ENUM = OPERATORS_BASE;
     var OPERATORS_NUMBER = OPERATORS_BASE.concat(OPERATORS_RANGE);
     var OPERATORS_DATE = OPERATORS_RANGE;
-    var OPERATORS_STRING = OPERATORS_BASE.concat(OPERATORS_REGEX).concat(OPERATORS_EXISTENCE);
+    var OPERATORS_STRING = OPERATORS_BASE.concat(OPERATORS_REGEX).concat(
+        OPERATORS_EXISTENCE
+    );
 
     var OPERATORS_NO_VALUE = OPERATORS_EXISTENCE.concat(OPERATORS_BOOLEAN);
 
@@ -57,7 +70,13 @@
      * and the optional second argument is an object containing the initial
      * form values.
      */
-    function dynamicForm(action, initialParams, containerId, onReadyCallback, sortFuntion) {
+    function dynamicForm(
+        action,
+        initialParams,
+        containerId,
+        onReadyCallback,
+        sortFuntion
+    ) {
         var form = this;
         var dynamic = form.data('dynamic');
         var lines = [];
@@ -75,9 +94,17 @@
             return Object.keys(OPERATORS);
         }
 
-        if (action === 'newLine' || action === 'getParams' || action === 'setParams') {
+        if (
+            action === 'newLine' ||
+            action === 'getParams' ||
+            action === 'setParams'
+        ) {
             if (!dynamic) {
-                throw new Error('Impossible to call ' + action + ' on an object that was not initialized first');
+                throw new Error(
+                    'Impossible to call ' +
+                        action +
+                        ' on an object that was not initialized first'
+                );
             }
 
             if (action === 'newLine') {
@@ -90,11 +117,9 @@
                     );
                 }
                 return dynamic.newLine();
-            }
-            else if (action === 'getParams') {
+            } else if (action === 'getParams') {
                 return dynamic.getParams();
-            }
-            else if (action === 'setParams') {
+            } else if (action === 'setParams') {
                 return dynamic.setParams(initialParams);
             }
         }
@@ -108,20 +133,17 @@
             container = $(containerId, form);
         }
 
-        $.getJSON(
-            fieldsURL,
-            function(data) {
-                fields = data;
-                sortedFieldNames = Object.keys(fields).sort();
-                if (initialParams) {
-                    setParams(initialParams);
-                }
-
-                if (onReadyCallback) {
-                    onReadyCallback();
-                }
+        $.getJSON(fieldsURL, function(data) {
+            fields = data;
+            sortedFieldNames = Object.keys(fields).sort();
+            if (initialParams) {
+                setParams(initialParams);
             }
-        );
+
+            if (onReadyCallback) {
+                onReadyCallback();
+            }
+        });
 
         /**
          * Get the list of operators for a field.
@@ -134,20 +156,16 @@
 
             if (field.valueType === 'number') {
                 options = OPERATORS_NUMBER;
-            }
-            else if (field.valueType === 'date') {
+            } else if (field.valueType === 'date') {
                 options = OPERATORS_DATE;
-            }
-            else if (field.valueType === 'bool') {
+            } else if (field.valueType === 'bool') {
                 options = OPERATORS_BOOLEAN;
-            }
-            else if (field.valueType === 'flag') {
+            } else if (field.valueType === 'flag') {
                 options = OPERATORS_EXISTENCE;
-            }
-            else if (field.valueType === 'string') {
+            } else if (field.valueType === 'string') {
                 options = OPERATORS_STRING;
-            }
-            else {  // type 'enum' or unknown type
+            } else {
+                // type 'enum' or unknown type
                 options = OPERATORS_ENUM;
             }
 
@@ -167,8 +185,7 @@
 
                 if (filter.operator === OPERATORS_BASE[0]) {
                     value = filter.value.split(VALUES_SEPARATOR);
-                }
-                else {
+                } else {
                     value = filter.value.split(VALUES_SEPARATOR);
                     for (var i = value.length - 1; i >= 0; i--) {
                         value[i] = filter.operator + value[i];
@@ -180,8 +197,7 @@
                         params[filter.field] = [params[filter.field]];
                     }
                     params[filter.field].push(value);
-                }
-                else {
+                } else {
                     params[filter.field] = value;
                 }
             }
@@ -242,7 +258,7 @@
 
                 if (Array.isArray(param)) {
                     var valuesWithoutOperator = [];
-                    param.forEach(function (value) {
+                    param.forEach(function(value) {
                         if (!value) {
                             return;
                         }
@@ -251,16 +267,18 @@
                         value = value.slice(operator.length);
                         if (operator) {
                             createLine(p, operator, value);
-                        }
-                        else {
+                        } else {
                             valuesWithoutOperator.push(value);
                         }
                     });
                     if (valuesWithoutOperator.length > 0) {
-                        createLine(p, allowed_operators[0], valuesWithoutOperator);
+                        createLine(
+                            p,
+                            allowed_operators[0],
+                            valuesWithoutOperator
+                        );
                     }
-                }
-                else {
+                } else {
                     setParamLine(p, param);
                 }
             }
@@ -271,7 +289,20 @@
          */
         function getOperatorFromValue(value) {
             // These operators need to be sorted by decreasing size.
-            var operators = ['__true__', '__null__', '<=', '>=', '~', '$', '^', '=', '@', '<', '>', '!'];
+            var operators = [
+                '__true__',
+                '__null__',
+                '<=',
+                '>=',
+                '~',
+                '$',
+                '^',
+                '=',
+                '@',
+                '<',
+                '>',
+                '!',
+            ];
             var prefix = '!';
 
             for (var i = 0, l = operators.length; i < l; i++) {
@@ -329,7 +360,7 @@
         /**
          * A line of the form. Handles DOM creation, events, and data.
          */
-        var FormLine = function (container) {
+        var FormLine = function(container) {
             this.id = lastFieldLineId++;
             this.container = container;
         };
@@ -337,19 +368,21 @@
         /**
          * Create the new line.
          */
-        FormLine.prototype.createLine = function (noField) {
-            this.line = $('<fieldset>', { 'id': this.id });
+        FormLine.prototype.createLine = function(noField) {
+            this.line = $('<fieldset>', { id: this.id });
             this.container.append(this.line);
 
             // Create an option to remove the line
             var deleteOption = $('<a>', {
-                'class': 'dynamic-line-delete',
-                'href': '#',
-                'text': 'x',
-            }).click(function (e) {
-                e.preventDefault();
-                this.remove();
-            }.bind(this));
+                class: 'dynamic-line-delete',
+                href: '#',
+                text: 'x',
+            }).click(
+                function(e) {
+                    e.preventDefault();
+                    this.remove();
+                }.bind(this)
+            );
             this.line.append(deleteOption);
 
             if (!noField) {
@@ -360,18 +393,20 @@
         /**
          * Create the field input.
          */
-        FormLine.prototype.createFieldInput = function (field) {
+        FormLine.prototype.createFieldInput = function(field) {
             this.fieldInput = $('<select>', {
-                'class': 'field',
+                class: 'field',
                 'data-placeholder': 'Choose a field',
             });
             this.fieldInput.append($('<option>'));
 
             sortedFieldNames.forEach(function(f) {
-                this.fieldInput.append($('<option>', {
-                    'value': f,
-                    'text': fields[f].name,
-                }));
+                this.fieldInput.append(
+                    $('<option>', {
+                        value: f,
+                        text: fields[f].name,
+                    })
+                );
             }, this);
             this.line.append(this.fieldInput);
 
@@ -384,8 +419,7 @@
 
             if (field) {
                 this.fieldInput.select2('val', field);
-            }
-            else {
+            } else {
                 this.fieldInput.select2('open');
             }
         };
@@ -393,21 +427,23 @@
         /**
          * Create the operator input.
          */
-        FormLine.prototype.createOperatorInput = function (event, operator) {
+        FormLine.prototype.createOperatorInput = function(event, operator) {
             this.remove(['operatorInput', 'valueInput']);
 
             this.operatorInput = $('<select>', {
-                'class': 'operator',
-                'placeholder': 'Choose an operator',
+                class: 'operator',
+                placeholder: 'Choose an operator',
             });
             this.operatorInput.append($('<option>'));
 
             var options = getOperatorsForField(fields[this.fieldInput.val()]);
             for (var i = 0, l = options.length; i < l; i++) {
-                this.operatorInput.append($('<option>', {
-                    'value': options[i],
-                    'text': OPERATORS[options[i]],
-                }));
+                this.operatorInput.append(
+                    $('<option>', {
+                        value: options[i],
+                        text: OPERATORS[options[i]],
+                    })
+                );
             }
 
             this.line.append(this.operatorInput);
@@ -415,31 +451,31 @@
             this.operatorInput.select2({
                 width: 'element',
             });
-            this.operatorInput.on('change', function (e) {
-                // We should create the value input only if there was no value
-                // yet or the previous operator was a "no-value" one, and
-                // the new operator accepts values.
-                if (
-                    OPERATORS_NO_VALUE.indexOf(e.added.id) === -1 && (
-                        !e.removed ||
-                        OPERATORS_NO_VALUE.indexOf(e.removed.id) > -1
-                    )
-                ) {
-                    this.createValueInput();
-                }
-                else if (OPERATORS_NO_VALUE.indexOf(e.added.id) > -1) {
-                    this.remove(['valueInput']);
-                    newLine();
-                }
-            }.bind(this));
+            this.operatorInput.on(
+                'change',
+                function(e) {
+                    // We should create the value input only if there was no value
+                    // yet or the previous operator was a "no-value" one, and
+                    // the new operator accepts values.
+                    if (
+                        OPERATORS_NO_VALUE.indexOf(e.added.id) === -1 &&
+                        (!e.removed ||
+                            OPERATORS_NO_VALUE.indexOf(e.removed.id) > -1)
+                    ) {
+                        this.createValueInput();
+                    } else if (OPERATORS_NO_VALUE.indexOf(e.added.id) > -1) {
+                        this.remove(['valueInput']);
+                        newLine();
+                    }
+                }.bind(this)
+            );
 
             if (operator) {
                 if ($.inArray(operator, options) == -1) {
                     operator = options[0];
                 }
                 this.operatorInput.select2('val', operator);
-            }
-            else {
+            } else {
                 this.operatorInput.select2('open');
             }
         };
@@ -447,7 +483,7 @@
         /**
          * Create the value input.
          */
-        FormLine.prototype.createValueInput = function (event, value) {
+        FormLine.prototype.createValueInput = function(event, value) {
             var field = fields[this.fieldInput.val()];
             var operator = this.operatorInput.val();
             var values = field.values || [];
@@ -456,29 +492,30 @@
 
             if (field.valueType === 'enum' && field.extendable === false) {
                 this.valueInput = $('<select>', {
-                    'class': 'value',
+                    class: 'value',
                 });
                 if (operator === 'in') {
                     this.valueInput.attr('multiple', 'multiple');
                 }
                 for (var i in values) {
-                    this.valueInput.append($('<option>', {
-                        'value': values[i],
-                        'text': values[i],
-                    }));
+                    this.valueInput.append(
+                        $('<option>', {
+                            value: values[i],
+                            text: values[i],
+                        })
+                    );
                 }
-            }
-            else {
+            } else {
                 this.valueInput = $('<input>', {
-                    'type': 'text',
-                    'class': 'value',
+                    type: 'text',
+                    class: 'value',
                 });
             }
             this.line.append(this.valueInput);
 
             var selectParams = {
-                'separator': VALUES_SEPARATOR,
-                'width': 'element',
+                separator: VALUES_SEPARATOR,
+                width: 'element',
             };
             if (field.extendable !== false) {
                 selectParams.tags = values;
@@ -494,24 +531,27 @@
                 if (Array.isArray(value)) {
                     data = [];
                     for (var j = 0, l = value.length; j < l; j++) {
-                        data.push({'id': value[j], 'text': value[j]});
+                        data.push({ id: value[j], text: value[j] });
                     }
-                }
-                else {
-                    data = {'id': value, 'text': value};
+                } else {
+                    data = { id: value, text: value };
                 }
                 this.valueInput.select2('data', data);
-            }
-            else if (typeof value === 'undefined') {
+            } else if (typeof value === 'undefined') {
                 // open only if value was not passed, which means only when
                 // this field is created after a user selected an operator
                 this.valueInput.select2('open');
             }
 
             // bind TAB key to create new line
-            $('.select2-search-field input').on('keypress', function (e) {
+            $('.select2-search-field input').on('keypress', function(e) {
                 var TAB_KEY = 9;
-                if (e.keyCode === TAB_KEY && !e.shiftKey && !e.ctrlKey && !e.altKey) {
+                if (
+                    e.keyCode === TAB_KEY &&
+                    !e.shiftKey &&
+                    !e.ctrlKey &&
+                    !e.altKey
+                ) {
                     newLine();
                 }
             });
@@ -520,7 +560,7 @@
         /**
          * Remove this line from the DOM, and delete its values.
          */
-        FormLine.prototype.remove = function (inputs) {
+        FormLine.prototype.remove = function(inputs) {
             // If no parameter is passed, default to the list of all inputs
             if (!inputs) {
                 inputs = ['fieldInput', 'operatorInput', 'valueInput'];
@@ -543,7 +583,7 @@
         /**
          * Return the values of this line, if the line is complete.
          */
-        FormLine.prototype.get = function () {
+        FormLine.prototype.get = function() {
             if (this.fieldInput && this.operatorInput) {
                 var field = this.fieldInput.val();
                 var operator = this.operatorInput.val();
@@ -553,16 +593,15 @@
 
                 if (isValueNeeded && !this.valueInput) {
                     return null;
-                }
-                else if (isValueNeeded && this.valueInput) {
+                } else if (isValueNeeded && this.valueInput) {
                     value = this.valueInput.val();
                 }
 
                 if (field && operator && (value || !isValueNeeded)) {
                     return {
-                        'field': field,
-                        'operator': operator,
-                        'value': value,
+                        field: field,
+                        operator: operator,
+                        value: value,
                     };
                 }
             }

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
@@ -1,6 +1,6 @@
 /*global $ window moment */
 
-$(function () {
+$(function() {
     /**
      * Interface to deal with the date filters in the Search form.
      *
@@ -10,16 +10,16 @@ $(function () {
      *  - setDates(dates = Array of strings) -> void
      *  - getDates() -> Array of strings
      */
-    window.DateFilters = (function () {
+    window.DateFilters = (function() {
         var filters = {
             from: $('.datetime-picker.date_from').flatpickr({
-                onChange: function (dateObjs) {
+                onChange: function(dateObjs) {
                     removeSelectedShortcut();
                     filters.to.set('minDate', dateObjs[0]);
                 },
             }),
             to: $('.datetime-picker.date_to').flatpickr({
-                onChange: function (dateObjs) {
+                onChange: function(dateObjs) {
                     removeSelectedShortcut();
                     filters.from.set('maxDate', dateObjs[0]);
                 },
@@ -31,7 +31,9 @@ $(function () {
         }
 
         function getDate(key) {
-            return moment(filters[key].input.value).utc().toDate();
+            return moment(filters[key].input.value)
+                .utc()
+                .toDate();
         }
 
         function removeSelectedShortcut() {
@@ -43,15 +45,20 @@ $(function () {
         filters.from.set('maxDate', getDate('to'));
 
         // Enable the date filters range shortcuts.
-        $('.date-shortcuts').on('click', 'a', function (e) {
+        $('.date-shortcuts').on('click', 'a', function(e) {
             e.preventDefault();
             var thisElt = $(this);
 
             var range = thisElt.data('range');
             var value = parseInt(range.slice(0, -1));
             var unit = range.slice(-1);
-            var toDate = moment().utc().toDate();
-            var fromDate = moment().utc().subtract(value, unit).toDate();
+            var toDate = moment()
+                .utc()
+                .toDate();
+            var fromDate = moment()
+                .utc()
+                .subtract(value, unit)
+                .toDate();
 
             setDate('to', toDate);
             setDate('from', fromDate);
@@ -65,7 +72,7 @@ $(function () {
         return {
             set: setDate,
             get: getDate,
-            setDates: function (dates) {
+            setDates: function(dates) {
                 // Remove any previously selected date shortcut because it
                 // will most likely be wrong now.
                 $('.date-shortcuts a').removeClass('selected');
@@ -75,29 +82,38 @@ $(function () {
                 }
 
                 // Set date filters values.
-                dates.forEach(function (value) {
+                dates.forEach(function(value) {
                     var date;
                     if (value.indexOf('>') === 0) {
                         if (value.indexOf('>=') === 0) {
                             date = value.slice(2);
-                        }
-                        else {
+                        } else {
                             date = value.slice(1);
                         }
-                        setDate('from', moment.utc(date).utcOffset(date).toDate());
-                    }
-                    else if (value.indexOf('<') === 0) {
+                        setDate(
+                            'from',
+                            moment
+                                .utc(date)
+                                .utcOffset(date)
+                                .toDate()
+                        );
+                    } else if (value.indexOf('<') === 0) {
                         if (value.indexOf('<=') === 0) {
                             date = value.slice(2);
-                        }
-                        else {
+                        } else {
                             date = value.slice(1);
                         }
-                        setDate('to', moment.utc(date).utcOffset(date).toDate());
+                        setDate(
+                            'to',
+                            moment
+                                .utc(date)
+                                .utcOffset(date)
+                                .toDate()
+                        );
                     }
                 });
             },
-            getDates: function () {
+            getDates: function() {
                 var dateFrom = getDate('from');
                 var dateTo = getDate('to');
                 var dates = [];

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -1,6 +1,6 @@
 /*global $ window Analytics socorro Qs BugLinks DateFilters */
 
-$(function () {
+$(function() {
     'use strict';
 
     var searchContainer = $('#search-form');
@@ -63,12 +63,12 @@ $(function () {
 
         contentElt.tabs({
             active: activeTab,
-            activate: function (event, ui) {
+            activate: function(event, ui) {
                 // Make sure the hash is changed when switching tabs.
                 var hash = '#' + ui.newPanel.attr('id');
                 pushHistoryState(params, url, hash);
             },
-            create: function (event, ui) {
+            create: function(event, ui) {
                 // Put the first tab's id in the hash of the URL.
                 var hash = '#' + ui.panel.attr('id');
                 pushHistoryState(params, url, hash, true);
@@ -79,7 +79,8 @@ $(function () {
         $('.tablesorter.facet').tablesorter();
         $('#reports-list').tablesorter({
             headers: {
-                0: {  // disable the first column, `Crash ID`
+                0: {
+                    // disable the first column, `Crash ID`
                     sorter: false,
                 },
             },
@@ -89,7 +90,7 @@ $(function () {
         // do not activate server-side sorting, rely on the
         // default client-side sorting.
         if ($('.pagination a', contentElt).length) {
-            $('.sort-header', contentElt).click(function (e) {
+            $('.sort-header', contentElt).click(function(e) {
                 e.preventDefault();
 
                 var thisElt = $(this);
@@ -99,7 +100,7 @@ $(function () {
                 var sortArr = sortInput.select2('val');
 
                 // First remove all previous mentions of that field.
-                sortArr = sortArr.filter(function (item) {
+                sortArr = sortArr.filter(function(item) {
                     return item !== fieldName && item !== '-' + fieldName;
                 });
 
@@ -107,8 +108,10 @@ $(function () {
                 // ascending -> descending -> none
                 if (thisElt.hasClass('headerSortDown')) {
                     sortArr.unshift('-' + fieldName);
-                }
-                else if (!thisElt.hasClass('headerSortDown') && !thisElt.hasClass('headerSortUp')) {
+                } else if (
+                    !thisElt.hasClass('headerSortDown') &&
+                    !thisElt.hasClass('headerSortUp')
+                ) {
                     sortArr.unshift(fieldName);
                 }
 
@@ -128,11 +131,10 @@ $(function () {
         // Show loader.
         try {
             contentElt.tabs('destroy');
-        }
-        catch (e) {
+        } catch (e) {
             // It is possible that no tabs existed before, and that is fine.
         }
-        contentElt.empty().append($('<div>', {'class': 'loader'}));
+        contentElt.empty().append($('<div>', { class: 'loader' }));
 
         // If a tracker is available, track that AJAX call.
         Analytics.trackPageview(url);
@@ -140,29 +142,36 @@ $(function () {
         $.ajax({
             url: url,
             success: showResults,
-            error: function (jqXHR) {
-                var errorContent = $('<div>', {class: 'error'});
+            error: function(jqXHR) {
+                var errorContent = $('<div>', { class: 'error' });
 
                 if (jqXHR.status >= 400 && jqXHR.status < 500) {
-                    errorContent.append(
-                        $('<h3>', {text: 'Oops, an error occured'})
-                    ).append(
-                        $('<p>', {text: 'Please fix the following issues:'})
-                    ).append($(jqXHR.responseText));
-                }
-                else {
+                    errorContent
+                        .append($('<h3>', { text: 'Oops, an error occured' }))
+                        .append(
+                            $('<p>', {
+                                text: 'Please fix the following issues:',
+                            })
+                        )
+                        .append($(jqXHR.responseText));
+                } else {
                     // We have no interest data to display as a constructive
                     // error message to the user. So we'll have to show a
                     // generic error message.
-                    errorContent.append(
-                        $('<h3>', {text: 'An unexpected error occured :('})
-                    ).append(
-                        $('<p>', {
-                            text: 'We have been automatically informed ' +
-                                  'of that error, and are working on a ' +
-                                  'solution. ',
-                        })
-                    );
+                    errorContent
+                        .append(
+                            $('<h3>', {
+                                text: 'An unexpected error occured :(',
+                            })
+                        )
+                        .append(
+                            $('<p>', {
+                                text:
+                                    'We have been automatically informed ' +
+                                    'of that error, and are working on a ' +
+                                    'solution. ',
+                            })
+                        );
                 }
 
                 contentElt.empty().append(errorContent);
@@ -177,16 +186,22 @@ $(function () {
      */
     function prepareResultsQueryString(params) {
         var sortArr = sortInput.select2('data');
-        params._sort = sortArr.map(function (x) { return x.id; });
+        params._sort = sortArr.map(function(x) {
+            return x.id;
+        });
 
         var facets = facetsInput.select2('data');
         if (facets) {
-            params._facets = facets.map(function (x) { return x.id; });
+            params._facets = facets.map(function(x) {
+                return x.id;
+            });
         }
 
         var columns = columnsInput.select2('data');
         if (columns) {
-            params._columns = columns.map(function (x) { return x.id; });
+            params._columns = columns.map(function(x) {
+                return x.id;
+            });
         }
 
         var queryString = Qs.stringify(params, { indices: false });
@@ -210,7 +225,9 @@ $(function () {
      * Push a new browser history state.
      */
     function pushHistoryState(params, url, hash, replace) {
-        var func = replace && window.history.replaceState || window.history.pushState;
+        var func =
+            (replace && window.history.replaceState) ||
+            window.history.pushState;
         if (!hash) {
             hash = location.hash;
         }
@@ -224,14 +241,16 @@ $(function () {
         var params = form.dynamicForm('getParams');
 
         // Add Simple Search parameters.
-        $('input.simple-search-input', simpleSearchContainer).each(function (i, item) {
+        $('input.simple-search-input', simpleSearchContainer).each(function(
+            i,
+            item
+        ) {
             var name = item.name;
             var value = $(item).select2('val');
             if (value.length) {
                 if (params[name]) {
                     params[name] = params[name].concat(value);
-                }
-                else {
+                } else {
                     params[name] = value;
                 }
             }
@@ -248,7 +267,7 @@ $(function () {
      */
     function hasOperator(value) {
         var operators = form.dynamicForm('getOperatorsList');
-        return operators.some(function (operator) {
+        return operators.some(function(operator) {
             if (operator === 'has') {
                 return false; // we don't care about that one
             }
@@ -261,7 +280,7 @@ $(function () {
      */
     function setParams(params) {
         // Set Simple Search parameters.
-        $('input', simpleSearchContainer).each(function (i, item) {
+        $('input', simpleSearchContainer).each(function(i, item) {
             if (item.name in params) {
                 var values = params[item.name];
                 if (!Array.isArray(values)) {
@@ -271,11 +290,10 @@ $(function () {
                 // will go into the simple search select tags, while others
                 // will stay in `params` and end up in the advanced form.
                 var simpleValues = [];
-                params[item.name] = values.map(function (value) {
+                params[item.name] = values.map(function(value) {
                     if (!hasOperator(value)) {
                         simpleValues.push(value);
-                    }
-                    else {
+                    } else {
                         return value;
                     }
                 });
@@ -307,7 +325,7 @@ $(function () {
     /**
      * Handler for browser history state changes.
      */
-    window.onpopstate = function (e) {
+    window.onpopstate = function(e) {
         var queryString;
         var params = e.state;
 
@@ -322,13 +340,16 @@ $(function () {
             // and run the search and show results
             setParams(params);
             search(true);
-        }
-        else {
+        } else {
             // If there are no parameters, empty the form and show the default content
             form.dynamicForm('setParams', {});
             form.dynamicForm('newLine');
             $('select', simpleSearchContainer).select2('val', null);
-            contentElt.empty().append($('<p>', {'text': 'Run a search to get some results. '}));
+            contentElt
+                .empty()
+                .append(
+                    $('<p>', { text: 'Run a search to get some results. ' })
+                );
         }
     };
 
@@ -356,7 +377,7 @@ $(function () {
         var queryString = window.location.search.substring(1);
         var initialParams = socorro.search.parseQueryString(queryString);
 
-        var formCallback = function () {
+        var formCallback = function() {
             showForm();
 
             // By default, we simply create a new line in the form.
@@ -380,7 +401,7 @@ $(function () {
             // a regular search, which will use the sane parameters from
             // the dynamicForm library. This will avoid strange behaviors
             // that can be caused by manually set parameters, for example.
-            formCallback = function () {
+            formCallback = function() {
                 showForm();
 
                 setParams(initialParams);
@@ -403,11 +424,11 @@ $(function () {
      * Initialize the simplified search form.
      */
     function initSimpleSearch() {
-        $('input[type=text]', simpleSearchContainer).each(function () {
+        $('input[type=text]', simpleSearchContainer).each(function() {
             var elt = $(this);
             elt.select2({
-                'width': 'element',
-                'tags': elt.data('choices'),
+                width: 'element',
+                tags: elt.data('choices'),
             });
         });
     }
@@ -416,17 +437,17 @@ $(function () {
      * Bind the search buttons' events.
      */
     function initFormButtons() {
-        $('button[type=submit]', form).click(function (e) {
+        $('button[type=submit]', form).click(function(e) {
             e.preventDefault();
             search();
         });
 
-        $('.new-line', form).click(function (e) {
+        $('.new-line', form).click(function(e) {
             e.preventDefault();
             form.dynamicForm('newLine');
         });
 
-        $('.customize', form).click(function (e) {
+        $('.customize', form).click(function(e) {
             e.preventDefault();
             var params = getParams();
             var url = prepareResultsQueryString(params);
@@ -442,7 +463,7 @@ $(function () {
         var COLUMNS = $('#mainbody').data('columns');
         var FACETS = $('#mainbody').data('facets');
         var sortFields = [];
-        COLUMNS.forEach(function (item) {
+        COLUMNS.forEach(function(item) {
             sortFields.push(item);
             sortFields.push({
                 id: '-' + item.id,
@@ -451,42 +472,45 @@ $(function () {
         });
 
         sortInput.select2({
-            'data': sortFields,
-            'multiple': true,
-            'width': 'element',
-            'sortResults': socorro.search.sortResults,
+            data: sortFields,
+            multiple: true,
+            width: 'element',
+            sortResults: socorro.search.sortResults,
         });
         facetsInput.select2({
-            'data': FACETS,
-            'multiple': true,
-            'width': 'element',
-            'sortResults': socorro.search.sortResults,
+            data: FACETS,
+            multiple: true,
+            width: 'element',
+            sortResults: socorro.search.sortResults,
         });
         columnsInput.select2({
-            'data': COLUMNS,
-            'multiple': true,
-            'width': 'element',
-            'sortResults': socorro.search.sortResults,
+            data: COLUMNS,
+            multiple: true,
+            width: 'element',
+            sortResults: socorro.search.sortResults,
         });
 
         // Make the columns input sortable
-        columnsInput.on('change', function () {
+        columnsInput.on('change', function() {
             $('input[name=_columns]').val(columnsInput.val());
         });
 
-        columnsInput.select2('container').find('ul.select2-choices').sortable({
-            containment: 'parent',
-            start: function () {
-                columnsInput.select2('onSortStart');
-            },
-            update: function () {
-                columnsInput.select2('onSortEnd');
-            },
-        });
+        columnsInput
+            .select2('container')
+            .find('ul.select2-choices')
+            .sortable({
+                containment: 'parent',
+                start: function() {
+                    columnsInput.select2('onSortStart');
+                },
+                update: function() {
+                    columnsInput.select2('onSortEnd');
+                },
+            });
 
         // Show or hide advanced options.
         var optionsElt = $('fieldset.options', form);
-        $('h4', optionsElt).on('click', function () {
+        $('h4', optionsElt).on('click', function() {
             $('h4 + div', optionsElt).toggle();
             $('span', this).toggleClass('hide');
         });
@@ -498,13 +522,10 @@ $(function () {
      */
     function initContentBinding() {
         // Make every value a link that adds a new line to the form.
-        contentElt.on('click', '.term', function (e) {
+        contentElt.on('click', '.term', function(e) {
             e.preventDefault();
 
-            addTerm(
-                $(this).data('field'),
-                $(this).data('content')
-            );
+            addTerm($(this).data('field'), $(this).data('content'));
 
             // And then run the new, corresponding search.
             search();

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search_custom.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search_custom.js
@@ -1,6 +1,6 @@
 /* globals ace */
 
-$(function () {
+$(function() {
     'use strict';
 
     // parameters
@@ -10,17 +10,14 @@ $(function () {
     var submitButton = $('#search-button');
     var contentElt = $('#search_results');
     var indicesElt = $('#search_indices');
-    var textareaElt = $('<textarea>', {'class': 'json-results'});
+    var textareaElt = $('<textarea>', { class: 'json-results' });
     var editorElt = $('#editor');
     var editor = null;
 
     // Default UI data.
     var defaultQuery = '{"query": {"match_all": {}}}';
     var possibleIndices = $('#mainbody').data('elasticsearch-indices');
-    var defaultIndices = [
-        possibleIndices[0],
-        possibleIndices[1],
-    ];
+    var defaultIndices = [possibleIndices[0], possibleIndices[1]];
 
     // Django CSRF protection
     var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
@@ -31,7 +28,7 @@ $(function () {
 
     function csrfSafeMethod(method) {
         // these HTTP methods do not require CSRF protection
-        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+        return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
     }
     $.ajaxSetup({
         crossDomain: false, // obviates need for sameOrigin test
@@ -44,11 +41,11 @@ $(function () {
 
     function showResults(query, indices) {
         // show loader
-        contentElt.empty().append($('<div>', {'class': 'loader'}));
+        contentElt.empty().append($('<div>', { class: 'loader' }));
 
         $.ajax({
             url: resultsURL,
-            data: {'query': query, 'indices': indices},
+            data: { query: query, indices: indices },
             type: 'POST',
             traditional: true,
             success: function(data) {
@@ -61,31 +58,35 @@ $(function () {
                 var errorTitle = 'Oops, an error occured';
                 var errorMsg = 'Please fix the following issues: ';
 
-                var errorContent = $('<div>', {class: 'error'});
-                errorContent.append($('<h3>', {text: errorTitle}));
-                errorContent.append($('<p>', {text: errorMsg}));
-                errorContent.append($('<p>', {text: jqXHR.responseText}));
+                var errorContent = $('<div>', { class: 'error' });
+                errorContent.append($('<h3>', { text: errorTitle }));
+                errorContent.append($('<p>', { text: errorMsg }));
+                errorContent.append($('<p>', { text: jqXHR.responseText }));
 
                 contentElt.empty().append(errorContent);
             },
         });
     }
 
-    submitButton.click(function (e) {
+    submitButton.click(function(e) {
         e.preventDefault();
 
         var query = editor.getValue();
         var indices = indicesElt.select2('val');
         var state = {
-            'query': query,
-            'indices': indices,
+            query: query,
+            indices: indices,
         };
 
-        window.history.pushState(state, 'Search results', window.location.pathname);
+        window.history.pushState(
+            state,
+            'Search results',
+            window.location.pathname
+        );
         showResults(query, indices);
     });
 
-    window.onpopstate = function (e) {
+    window.onpopstate = function(e) {
         if (e.state) {
             // If there is a query, run the search and show results
             var query = e.state.query;
@@ -94,12 +95,15 @@ $(function () {
             showResults(query, indices);
             editor.setValue(query);
             indicesElt.select2('data', indices);
-        }
-        else {
+        } else {
             // If there are no parameters, empty the form and show the default content
             editor.setValue(defaultQuery);
             indicesElt.select2('data', defaultIndices);
-            contentElt.empty().append($('<p>', {'text': 'Run a search to get some results. '}));
+            contentElt
+                .empty()
+                .append(
+                    $('<p>', { text: 'Run a search to get some results. ' })
+                );
         }
     };
 
@@ -119,10 +123,10 @@ $(function () {
     form.show();
 
     indicesElt.select2({
-        'data': possibleIndices,
-        'closeOnSelect': false,
-        'multiple': true,
-        'width': 'element',
+        data: possibleIndices,
+        closeOnSelect: false,
+        multiple: true,
+        width: 'element',
     });
     if (!indicesElt.val()) {
         indicesElt.select2('data', defaultIndices);

--- a/webapp-django/crashstats/tokens/static/tokens/js/home.js
+++ b/webapp-django/crashstats/tokens/static/tokens/js/home.js
@@ -1,19 +1,20 @@
 $(function() {
-
     'use strict';
 
     $('.token p.code[data-key]').each(function() {
         var p = $(this);
-        p.prepend(
-            $('<code>')
-            .addClass('truncated')
-            .text(p.data('key').substr(0, 12) + '…')
-        ).prepend(
-            $('<code>')
-            .addClass('whole')
-            .text(p.data('key'))
-            .hide()
-        );
+        p
+            .prepend(
+                $('<code>')
+                    .addClass('truncated')
+                    .text(p.data('key').substr(0, 12) + '…')
+            )
+            .prepend(
+                $('<code>')
+                    .addClass('whole')
+                    .text(p.data('key'))
+                    .hide()
+            );
     });
 
     $('.token').on('click', 'p.code button', function(event) {
@@ -31,6 +32,5 @@ $(function() {
         } else {
             return confirm('Are you sure you want to delete this API Token?');
         }
-
     });
 });

--- a/webapp-django/crashstats/topcrashers/static/topcrashers/js/topcrashers.js
+++ b/webapp-django/crashstats/topcrashers/static/topcrashers/js/topcrashers.js
@@ -5,7 +5,7 @@
 /*jslint browser:true, jQuery:false */
 /*global window, $, BugLinks */
 
-$(document).ready(function () {
+$(document).ready(function() {
     var perosTbl = $('#peros-tbl');
 
     $('#signature-list').tablesorter({
@@ -17,8 +17,8 @@ $(document).ready(function () {
             6: { sorter: 'digit' },
             7: { sorter: 'digit' },
             8: { sorter: 'digit' },
-            9: { sorter: 'date' },  // First Appearance
-            11: { sorter: false },  // Bugzilla IDs
+            9: { sorter: 'date' }, // First Appearance
+            11: { sorter: false }, // Bugzilla IDs
         },
     });
 


### PR DESCRIPTION
Issue: https://bugzilla.mozilla.org/show_bug.cgi?id=997272

### Changes
* Applied eslint with Prettier to all .js files that are not downloaded libs

### Why
* jshint has been used in the past but not mandated
* this commit makes the code Prettier compliant in order to later add Prettier to the CI

### Notes
The changes were done by executing the following command: `prettier --tab-width 4 --single-quote --trailing-comma es5 --write socorro/**/*.js`

With the following files excluded:
`webapp-django/crashstats/api/static/api/js/lib/filesize.min.js`
`webapp-django/crashstats/crashstats/static/crashstats/js/jquery/plugins/jquery.cookies.2.2.0.js`
`webapp-django/crashstats/crashstats/static/crashstats/js/underscore-min.js`

The Prettier options were chosen according to the following: 
* 4-space indentation: https://socorro.readthedocs.io/en/latest/contributing.html
* single quote: the project was already using single quotes
* trailing comma (ES5): seems better according to conversation with Osmose
* the rest is default
