### PR TITLE
Tweak contributor docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,6 +26,25 @@ If you're not familiar with `Docker <https://docs.docker.com/>`_ and
 reading up on.
 
 
+Preparing to contribute changes to Socorro
+==========================================
+
+If you're interested in helping out and taking a bug to work on, you
+need to do the following first:
+
+1. `Set up a working local development environment
+   <https://socorro.readthedocs.io/en/latest/gettingstarted.html>`_.
+
+2. Read through the `overview of Socorro
+   <https://socorro.readthedocs.io/en/latest/overview.html>`_.
+
+We can't assign bugs to you until you've done at least those two
+steps.
+
+If you need help, let us know by `asking on IRC or sending an email to the
+mailing list <https://socorro.readthedocs.io/en/latest/#project-info>`_.
+
+
 Python code conventions
 =======================
 
@@ -79,7 +98,11 @@ notes that future readers should know for context or be aware of.
 Pull requests
 =============
 
-Pull request summary should indicate the bug the pull request addresses.
+Pull request summary should indicate the bug the pull request addresses. For
+example::
+
+  fix bug nnnnnnn: removed frob from tree class
+
 
 Pull request descriptions should cover at least some of the following:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,8 @@ Project info
 :Documentation: https://socorro.readthedocs.io/
 :Mailing list: https://lists.mozilla.org/listinfo/tools-socorro
 :IRC: `<irc://irc.mozilla.org/breakpad>`_
-:Bugs: https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro
+:New bugs: https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro
+:Bugs: https://bugzilla.mozilla.org/buglist.cgi?quicksearch=product%3Asocorro
 
 
 Contents


### PR DESCRIPTION
I need a place I can point new contributors to that makes sure they're
ready to contribute. This adds that.