### PR TITLE
fix bug 1464107: add script to run migrations

### DIFF
--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This script runs migrations for Socorro. Run this in a crontabber docker
+# container.
+
+# Get a datestamp
+date
+
+# Run Django migrations
+python webapp-django/manage.py migrate --no-input
+
+# Run Alembic migrations
+alembic -c docker/config/alembic.ini upgrade head


### PR DESCRIPTION
This is pretty basic. To test:

```
$ docker-compose run crontabber ./scripts/run_migrations.sh
```

It runs in the crontabber container because that's how we do post-deploy steps right now.

After this lands, we need to update the cloudops repo. I'll take that on.