### PR TITLE
fix bug 1460707: fixed python 3 lint errors

### DIFF
--- a/e2e-tests/pages/version.py
+++ b/e2e-tests/pages/version.py
@@ -6,6 +6,8 @@
 import re
 from distutils.version import Version
 
+from past.builtins import basestring, cmp
+
 
 class FirefoxVersion(Version):
     """Version numbering for Firefox.

--- a/scripts/hive_adi_test.py
+++ b/scripts/hive_adi_test.py
@@ -8,6 +8,8 @@ import pyhs2
 import tempfile
 import unicodedata
 import urllib2
+from past.builtins import basestring
+from builtins import str
 
 # Example command-line usage:
 # $ . /etc/socorro/socorrorc
@@ -77,7 +79,7 @@ def main():
 
     def remove_control_characters(s):
         if isinstance(s, str):
-            s = unicode(s, 'utf-8', errors='replace')
+            s = str(s, 'utf-8', errors='replace')
         return ''.join(c for c in s if unicodedata.category(c)[0] != "C")
 
     with codecs.open(options.output_filename, 'w', 'utf-8') as f:

--- a/socorro/cron/jobs/fetch_adi_from_hive.py
+++ b/socorro/cron/jobs/fetch_adi_from_hive.py
@@ -32,6 +32,8 @@ import os
 import tempfile
 import unicodedata
 import urllib2
+from past.builtins import basestring
+from past.builtins import str
 
 import pyhs2
 
@@ -238,7 +240,7 @@ class FetchADIFromHiveCronApp(BaseCronApp):
     @staticmethod
     def remove_control_characters(s):
         if isinstance(s, str):
-            s = unicode(s, 'utf-8', errors='replace')
+            s = str(s, 'utf-8', errors='replace')
         return ''.join(c for c in s if unicodedata.category(c)[0] != "C")
 
     def _database_transaction(

--- a/socorro/cron/jobs/fetch_adi_from_hive.py
+++ b/socorro/cron/jobs/fetch_adi_from_hive.py
@@ -36,6 +36,7 @@ from past.builtins import basestring
 from past.builtins import str
 
 import pyhs2
+from six import text_type
 
 from configman import Namespace, class_converter
 from crontabber.base import BaseCronApp
@@ -240,7 +241,7 @@ class FetchADIFromHiveCronApp(BaseCronApp):
     @staticmethod
     def remove_control_characters(s):
         if isinstance(s, str):
-            s = str(s, 'utf-8', errors='replace')
+            s = text_type(s, 'utf-8', errors='replace')
         return ''.join(c for c in s if unicodedata.category(c)[0] != "C")
 
     def _database_transaction(

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -6,6 +6,7 @@ import json
 import socket
 import datetime
 import contextlib
+from past.builtins import basestring
 
 import boto
 import boto.s3.connection

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -11,6 +11,7 @@ import sys
 import os
 import collections
 import datetime
+from past.builtins import basestring
 
 from socorro.lib.util import DotDict as SocorroDotDict
 

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -4,6 +4,7 @@
 
 import json
 import re
+from past.builtins import basestring
 from threading import Thread
 from Queue import Queue
 from contextlib import contextmanager

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -5,6 +5,7 @@
 import datetime
 import sys
 import re
+from past.builtins import basestring
 from collections import defaultdict
 
 from elasticsearch.exceptions import NotFoundError, RequestError

--- a/socorro/external/fs/filesystem.py
+++ b/socorro/external/fs/filesystem.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from past.builtins import cmp
 import errno
 import os
 from os.path import curdir
@@ -69,7 +70,7 @@ def visitPath(rootDir, fullPath, visit, osModule=os):
             raise OSError(errno.ENOENT, '%s does not exist' % (root))
 
 
-def makedirs(name, mode=0777, osModule=os):
+def makedirs(name, mode=777, osModule=os):
     """makedirs(path [, mode=0777])
 
     Super-mkdir; create a leaf directory and all intermediate ones.

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -200,7 +200,7 @@ class SocorroDBApp(App):
                 autocommit=False
         ) as db:
             if 'test' not in database_name and not self.config.force:
-                confirm = raw_input(
+                confirm = input(
                     'drop database %s [y/N]: ' % database_name
                 )
                 if not confirm == "y":

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -12,12 +12,13 @@ import os
 import re
 import sys
 
+import six
 from alembic import command
 from alembic.config import Config
 from configman import Namespace, class_converter
+from six.moves import cStringIO
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import CreateTable
-from six.moves import cStringIO
 
 from socorro.app.socorro_app import App
 from socorro.external.postgresql import staticdata
@@ -200,7 +201,7 @@ class SocorroDBApp(App):
                 autocommit=False
         ) as db:
             if 'test' not in database_name and not self.config.force:
-                confirm = input(
+                confirm = six.moves.input(
                     'drop database %s [y/N]: ' % database_name
                 )
                 if not confirm == "y":

--- a/socorro/lib/converters.py
+++ b/socorro/lib/converters.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 from configman import RequiredConfig, Namespace, class_converter
 
 

--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -6,6 +6,7 @@ import re
 import datetime
 import isodate  # 3rd party
 import json
+from past.builtins import basestring
 
 UTC = isodate.UTC
 

--- a/socorro/lib/external_common.py
+++ b/socorro/lib/external_common.py
@@ -8,6 +8,7 @@ Common functions for external modules.
 
 import json
 import datetime
+from past.builtins import basestring
 
 from socorro.lib import BadArgumentError
 from socorro.lib.util import DotDict

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -8,6 +8,7 @@ Common functions for search-related external modules.
 
 import datetime
 import json
+from past.builtins import basestring
 
 from socorro.lib import (
     BadArgumentError,

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -7,6 +7,7 @@ import gzip
 import re
 from sys import maxint
 import time
+from past.builtins import basestring
 from urllib import unquote_plus
 
 import ujson

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -6,10 +6,10 @@
 """the processor_app converts raw_crashes into processed_crashes"""
 
 import os
-import six
 import sys
 import collections
 
+from six import reraise
 from configman import Namespace
 from configman.converters import class_converter
 
@@ -285,7 +285,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
             self._capture_error(crash_id, exc_type, exc_value, exc_tb)
 
             # Re-raise the original exception with the correct traceback
-            six.reraise(exc_type, exc_value, exc_tb)
+            reraise(exc_type, exc_value, exc_tb)
         finally:
             # earlier, we created the dumps as files on the file system,
             # we need to clean up after ourselves.

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -6,6 +6,7 @@
 """the processor_app converts raw_crashes into processed_crashes"""
 
 import os
+import six
 import sys
 import collections
 
@@ -283,11 +284,8 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
             # Capture the error
             self._capture_error(crash_id, exc_type, exc_value, exc_tb)
 
-            # Why not just do `raise exception`?
-            # Because if we don't do it this way, the eventual traceback
-            # is going to point to *this* line (right after this comment)
-            # rather than the actual error where it originally happened.
-            raise exc_type, exc_value, exc_tb
+            # Re-raise the original exception with the correct traceback
+            six.reraise(exc_type, exc_value, exc_tb)
         finally:
             # earlier, we created the dumps as files on the file system,
             # we need to clean up after ourselves.

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import tempfile
+from past.builtins import basestring
 from collections import OrderedDict
 
 from configman import Namespace, RequiredConfig

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -5,6 +5,7 @@
 from itertools import islice
 import logging
 import re
+from past.builtins import basestring
 
 import ujson
 

--- a/socorro/unittest/cron/crontabber_tests_base.py
+++ b/socorro/unittest/cron/crontabber_tests_base.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from past.builtins import basestring
 from collections import Sequence, Mapping, defaultdict
 
 import mock

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from past.builtins import basestring
 
 import mock
 

--- a/socorro/unittest/external/postgresql/test_adi.py
+++ b/socorro/unittest/external/postgresql/test_adi.py
@@ -169,7 +169,7 @@ class IntegrationTestADI(PostgreSQLTestCase):
 
         hit, = stats['hits']
         expected = {
-            'adi_count': 64L + 16L,
+            'adi_count': 64 + 16,
             'date': start.date(),
             'version': '40.0',
             'build_type': 'release'
@@ -186,7 +186,7 @@ class IntegrationTestADI(PostgreSQLTestCase):
         assert stats['total'] == 1
         hit, = stats['hits']
         expected = {
-            'adi_count': 4 + 1L,
+            'adi_count': 4 + 1,
             'date': start.date(),
             'version': '39.0b1',
             'build_type': 'release'

--- a/socorro/unittest/lib/test_external_common.py
+++ b/socorro/unittest/lib/test_external_common.py
@@ -36,7 +36,7 @@ class TestExternalCommon(TestCase):
         assert res == 12
 
         # Test 4: string
-        param = datetime.datetime(2012, 01, 01)
+        param = datetime.datetime(2012, 1, 1)
         datatype = "str"
         res = external_common.check_type(param, datatype)
 

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -4,6 +4,7 @@
 
 import logging
 import time
+from past.builtins import xrange
 
 from mock import Mock
 

--- a/socorro/unittest/siglists/test_siglists.py
+++ b/socorro/unittest/siglists/test_siglists.py
@@ -5,6 +5,7 @@
 import mock
 from pkg_resources import resource_stream
 import pytest
+from past.builtins import basestring
 
 from socorro import siglists
 from socorro.unittest.testbase import TestCase

--- a/webapp-django/crashstats/api/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/api/templatetags/jinja_helpers.py
@@ -2,7 +2,7 @@ import urllib
 import warnings
 import datetime
 from past.builtins import basestring
-from builtins import str
+from six import text_type
 
 from django_jinja import library
 import jinja2
@@ -59,7 +59,7 @@ def make_test_input(parameter, defaults):
     if parameter['type'] is not basestring:
         classes.append('validate-%s' % parameter['type'].__name__)
     if defaults.get(parameter['name']):
-        data['value'] = urllib.quote(str(defaults.get(parameter['name'])))
+        data['value'] = urllib.quote(text_type(defaults.get(parameter['name'])))
     else:
         data['value'] = ''
 

--- a/webapp-django/crashstats/api/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/api/templatetags/jinja_helpers.py
@@ -1,6 +1,8 @@
 import urllib
 import warnings
 import datetime
+from past.builtins import basestring
+from builtins import str
 
 from django_jinja import library
 import jinja2
@@ -57,7 +59,7 @@ def make_test_input(parameter, defaults):
     if parameter['type'] is not basestring:
         classes.append('validate-%s' % parameter['type'].__name__)
     if defaults.get(parameter['name']):
-        data['value'] = urllib.quote(unicode(defaults.get(parameter['name'])))
+        data['value'] = urllib.quote(str(defaults.get(parameter['name'])))
     else:
         data['value'] = ''
 

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -2,6 +2,8 @@ import json
 import re
 import datetime
 import inspect
+from past.builtins import basestring
+from builtins import str
 
 from django import http
 from django.shortcuts import render
@@ -246,12 +248,12 @@ def model_wrapper(request, model_name):
             raise
         except NOT_FOUND_EXCEPTIONS as exception:
             return http.HttpResponseNotFound(
-                json.dumps({'error': unicode(exception)}),
+                json.dumps({'error': str(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
         except BAD_REQUEST_EXCEPTIONS as exception:
             return http.HttpResponseBadRequest(
-                json.dumps({'error': unicode(exception)}),
+                json.dumps({'error': str(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
 

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -3,7 +3,6 @@ import re
 import datetime
 import inspect
 from past.builtins import basestring
-from builtins import str
 
 from django import http
 from django.shortcuts import render
@@ -13,6 +12,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django import forms
 from django.views.decorators.csrf import csrf_exempt
+from six import text_type
 # explicit import because django.forms has an __all__
 from django.forms.forms import DeclarativeFieldsMetaclass
 
@@ -248,12 +248,12 @@ def model_wrapper(request, model_name):
             raise
         except NOT_FOUND_EXCEPTIONS as exception:
             return http.HttpResponseNotFound(
-                json.dumps({'error': str(exception)}),
+                json.dumps({'error': text_type(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
         except BAD_REQUEST_EXCEPTIONS as exception:
             return http.HttpResponseBadRequest(
-                json.dumps({'error': str(exception)}),
+                json.dumps({'error': text_type(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
 

--- a/webapp-django/crashstats/base/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/base/templatetags/jinja_helpers.py
@@ -1,5 +1,6 @@
 import urlparse
 import urllib
+from past.builtins import basestring
 
 import jinja2
 from django_jinja import library

--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -1,4 +1,5 @@
 import datetime
+from past.builtins import basestring
 
 from django import forms
 from . import form_fields

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -8,9 +8,9 @@ import hashlib
 import logging
 import time
 from past.builtins import basestring
-from builtins import str
 
 from configman import configuration, Namespace
+from six import text_type
 
 from socorro.lib import BadArgumentError
 from socorro.external.es.base import ElasticsearchConfig
@@ -257,7 +257,7 @@ class SocorroCommon(object):
         ):
             name = implementation.__class__.__name__
             cache_key = hashlib.md5(
-                name + str(params)
+                name + text_type(params)
             ).hexdigest()
 
             if not refresh_cache:

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -7,6 +7,8 @@ import functools
 import hashlib
 import logging
 import time
+from past.builtins import basestring
+from builtins import str
 
 from configman import configuration, Namespace
 
@@ -255,7 +257,7 @@ class SocorroCommon(object):
         ):
             name = implementation.__class__.__name__
             cache_key = hashlib.md5(
-                name + unicode(params)
+                name + str(params)
             ).hexdigest()
 
             if not refresh_cache:

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -2,6 +2,9 @@ import datetime
 import json
 import re
 import urllib
+from past.builtins import basestring
+from builtins import str
+from past.builtins import long
 
 import isodate
 import jinja2
@@ -41,7 +44,7 @@ def urlencode(txt):
     if not isinstance(txt, basestring):
         # Do nothing on non-strings.
         return txt
-    if isinstance(txt, unicode):
+    if isinstance(txt, str):
         txt = txt.encode('utf-8')
     return urllib.quote_plus(txt).replace('+', '%20')
 

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -3,13 +3,13 @@ import json
 import re
 import urllib
 from past.builtins import basestring
-from builtins import str
 from past.builtins import long
 
 import isodate
 import jinja2
 import humanfriendly
 from django_jinja import library
+from six import text_type
 
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -44,7 +44,7 @@ def urlencode(txt):
     if not isinstance(txt, basestring):
         # Do nothing on non-strings.
         return txt
-    if isinstance(txt, str):
+    if isinstance(txt, text_type):
         txt = txt.encode('utf-8')
     return urllib.quote_plus(txt).replace('+', '%20')
 

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -459,7 +459,7 @@ class TesDigitGroupSeparator(TestCase):
         assert digitgroupseparator(None) is None
         assert digitgroupseparator(1000) == '1,000'
         assert digitgroupseparator(-1000) == '-1,000'
-        assert digitgroupseparator(1000000L) == '1,000,000'
+        assert digitgroupseparator(1000000) == '1,000,000'
 
 
 class TestHumanizers(TestCase):

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -3,10 +3,10 @@ import datetime
 import random
 import urlparse
 from past.builtins import basestring
-from builtins import str
 
 import mock
 import pytest
+from six import text_type
 
 from django.core.cache import cache
 from django.conf import settings
@@ -27,7 +27,7 @@ class Response(object):
     @property
     def text(self):
         # similar to content but with the right encoding
-        return str(self.content, 'utf-8')
+        return text_type(self.content, 'utf-8')
 
     def json(self):
         return self.raw

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -2,6 +2,8 @@ import json
 import datetime
 import random
 import urlparse
+from past.builtins import basestring
+from builtins import str
 
 import mock
 import pytest
@@ -25,7 +27,7 @@ class Response(object):
     @property
     def text(self):
         # similar to content but with the right encoding
-        return unicode(self.content, 'utf-8')
+        return str(self.content, 'utf-8')
 
     def json(self):
         return self.raw
@@ -425,14 +427,14 @@ class TestModels(DjangoTestCase):
                     {
 
                         'build_type': 'aurora',
-                        'adi_count': 12327L,
+                        'adi_count': 12327,
                         'version': '2.0',
                         'date': datetime.date(2015, 8, 12),
 
                     },
                     {
                         'build_type': 'release',
-                        'adi_count': 4L,
+                        'adi_count': 4,
                         'version': '2.0',
                         'date': datetime.date(2016, 8, 12),
 

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -1,13 +1,12 @@
 import copy
 import datetime
-from builtins import str
 from cStringIO import StringIO
 from unittest import TestCase
 import json
 
 from django.http import HttpResponse
 from django.test.client import RequestFactory
-from six import string_types
+from six import string_types, text_type
 
 from crashstats.crashstats import utils
 
@@ -526,7 +525,7 @@ class TestUtils(TestCase):
 
         result = out.getvalue()
         assert isinstance(result, string_types)
-        u_result = str(result, 'utf-8')
+        u_result = text_type(result, 'utf-8')
         assert 'abc,' in u_result
         assert u'\xe4\xc3,' in u_result
         assert '123,' in u_result

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -6,7 +6,7 @@ import json
 
 from django.http import HttpResponse
 from django.test.client import RequestFactory
-from six import string_types, text_type
+from six import text_type, binary_type
 
 from crashstats.crashstats import utils
 
@@ -522,9 +522,11 @@ class TestUtils(TestCase):
             123,
             1.23,
         ])
-
+        #NOTE: This probably needs to be a StringIO in Python 2 and a BytesIO in Python 3
+        # assuming UnicodeWriter even works in Python 3. I made change to binary_type for
+        # a simple fix until we run python 3 harness test in future.
         result = out.getvalue()
-        assert isinstance(result, string_types)
+        assert isinstance(result, binary_type)
         u_result = text_type(result, 'utf-8')
         assert 'abc,' in u_result
         assert u'\xe4\xc3,' in u_result

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -1,11 +1,13 @@
 import copy
 import datetime
+from builtins import str
 from cStringIO import StringIO
 from unittest import TestCase
 import json
 
 from django.http import HttpResponse
 from django.test.client import RequestFactory
+from six import string_types
 
 from crashstats.crashstats import utils
 
@@ -523,8 +525,8 @@ class TestUtils(TestCase):
         ])
 
         result = out.getvalue()
-        assert isinstance(result, str)
-        u_result = unicode(result, 'utf-8')
+        assert isinstance(result, string_types)
+        u_result = str(result, 'utf-8')
         assert 'abc,' in u_result
         assert u'\xe4\xc3,' in u_result
         assert '123,' in u_result

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -7,7 +7,6 @@ import datetime
 import json
 import random
 import urlparse
-from builtins import int
 from cStringIO import StringIO
 
 import pyquery
@@ -765,7 +764,7 @@ class TestViews(BaseTestViews):
                 for version in ['20.0', '19.0']:
                     for build_type in ['beta', 'release']:
                         response['hits'].append({
-                            'adi_count': int(random.randint(100, 1000)),
+                            'adi_count': random.randint(100, 1000),
                             'build_type': build_type,
                             'date': start_date,
                             'version': version
@@ -1102,7 +1101,7 @@ class TestViews(BaseTestViews):
                 for version in ['18.0b1', '18.0b2', '19.0']:
                     for build_type in ['beta', 'release']:
                         response['hits'].append({
-                            'adi_count': int(random.randint(100, 1000)),
+                            'adi_count': random.randint(100, 1000),
                             'build_type': build_type,
                             'date': start_date,
                             'version': version

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import random
 import urlparse
+from builtins import int
 from cStringIO import StringIO
 
 import pyquery
@@ -764,7 +765,7 @@ class TestViews(BaseTestViews):
                 for version in ['20.0', '19.0']:
                     for build_type in ['beta', 'release']:
                         response['hits'].append({
-                            'adi_count': long(random.randint(100, 1000)),
+                            'adi_count': int(random.randint(100, 1000)),
                             'build_type': build_type,
                             'date': start_date,
                             'version': version
@@ -1101,7 +1102,7 @@ class TestViews(BaseTestViews):
                 for version in ['18.0b1', '18.0b2', '19.0']:
                     for build_type in ['beta', 'release']:
                         response['hits'].append({
-                            'adi_count': long(random.randint(100, 1000)),
+                            'adi_count': int(random.randint(100, 1000)),
                             'build_type': build_type,
                             'date': start_date,
                             'version': version

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -6,10 +6,10 @@ import functools
 import json
 import re
 from past.builtins import basestring
-from builtins import str
 from collections import OrderedDict
 
 from six.moves import cStringIO
+from six import text_type
 
 from django import http
 from django.conf import settings
@@ -29,7 +29,7 @@ def parse_isodate(ds):
     """
     return a datetime object from a date string
     """
-    if isinstance(ds, str):
+    if isinstance(ds, text_type):
         # isodate struggles to convert unicode strings with
         # its parse_datetime() if the input string is unicode.
         ds = ds.encode('ascii')
@@ -320,7 +320,7 @@ class UnicodeWriter:
         self.encoder = codecs.getincrementalencoder(encoding)()
 
     def writerow(self, row):
-        self.writer.writerow([str(s).encode("utf-8") for s in row])
+        self.writer.writerow([text_type(s).encode("utf-8") for s in row])
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode("utf-8")

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -5,6 +5,8 @@ import isodate
 import functools
 import json
 import re
+from past.builtins import basestring
+from builtins import str
 from collections import OrderedDict
 
 from six.moves import cStringIO
@@ -27,7 +29,7 @@ def parse_isodate(ds):
     """
     return a datetime object from a date string
     """
-    if isinstance(ds, unicode):
+    if isinstance(ds, str):
         # isodate struggles to convert unicode strings with
         # its parse_datetime() if the input string is unicode.
         ds = ds.encode('ascii')
@@ -318,7 +320,7 @@ class UnicodeWriter:
         self.encoder = codecs.getincrementalencoder(encoding)()
 
     def writerow(self, row):
-        self.writer.writerow([unicode(s).encode("utf-8") for s in row])
+        self.writer.writerow([str(s).encode("utf-8") for s in row])
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode("utf-8")

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -4,12 +4,12 @@ import json
 import datetime
 import os
 import urllib
-from builtins import str
 from collections import defaultdict
 from operator import itemgetter
 from io import BytesIO
 
 import isoweek
+from six import text_type
 
 from django import http
 from django.conf import settings
@@ -565,7 +565,7 @@ def crashes_per_day(request, default_context=None):
             _date_range_type
         )
     except BadArgumentError as exception:
-        return http.HttpResponseBadRequest(str(exception))
+        return http.HttpResponseBadRequest(text_type(exception))
 
     render_csv = request.GET.get('format') == 'csv'
     data_table = {

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -4,6 +4,7 @@ import json
 import datetime
 import os
 import urllib
+from builtins import str
 from collections import defaultdict
 from operator import itemgetter
 from io import BytesIO
@@ -564,7 +565,7 @@ def crashes_per_day(request, default_context=None):
             _date_range_type
         )
     except BadArgumentError as exception:
-        return http.HttpResponseBadRequest(unicode(exception))
+        return http.HttpResponseBadRequest(str(exception))
 
     render_csv = request.GET.get('format') == 'csv'
     data_table = {

--- a/webapp-django/crashstats/manage/utils.py
+++ b/webapp-django/crashstats/manage/utils.py
@@ -1,3 +1,7 @@
+from past.builtins import basestring
+from builtins import str
+
+
 def string_hex_to_hex_string(snippet):
     """The PCIDatabase.com uses shortened hex strings (e.g. '919A')
     whereas in Socorro we use the full represenation, but still as a
@@ -35,11 +39,11 @@ def pcidatabase__parse_graphics_devices_iterable(iterable, delimiter='\t'):
         if line.startswith(';'):
             continue
         try:
-            line = unicode(line, 'utf-8')
+            line = str(line, 'utf-8')
         except UnicodeDecodeError:
             try:
                 # the PCIDatabase.com's CSV file uses this
-                line = unicode(line, 'cp1252')
+                line = str(line, 'cp1252')
             except UnicodeDecodeError:
                 continue
         split = [x.strip() for x in line.rstrip().split(delimiter)]

--- a/webapp-django/crashstats/manage/utils.py
+++ b/webapp-django/crashstats/manage/utils.py
@@ -1,5 +1,6 @@
 from past.builtins import basestring
-from builtins import str
+
+from six import text_type
 
 
 def string_hex_to_hex_string(snippet):
@@ -39,11 +40,11 @@ def pcidatabase__parse_graphics_devices_iterable(iterable, delimiter='\t'):
         if line.startswith(';'):
             continue
         try:
-            line = str(line, 'utf-8')
+            line = text_type(line, 'utf-8')
         except UnicodeDecodeError:
             try:
                 # the PCIDatabase.com's CSV file uses this
-                line = str(line, 'cp1252')
+                line = text_type(line, 'cp1252')
             except UnicodeDecodeError:
                 continue
         split = [x.strip() for x in line.rstrip().split(delimiter)]

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -1,4 +1,5 @@
 import hashlib
+from builtins import str
 
 from django import http
 from django.conf import settings

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -1,7 +1,7 @@
 import operator
 
 import isodate
-from six import string_types
+from six import string_types, text_type
 
 from django import forms
 from django.utils.timezone import utc
@@ -65,7 +65,7 @@ class PrefixedField(object):
         """Return the value as a string. """
         if value is None:
             return None
-        return str(value)
+        return text_type(value)
 
 
 class MultipleValueField(forms.MultipleChoiceField):

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -1,6 +1,7 @@
 import operator
 
 import isodate
+from six import string_types
 
 from django import forms
 from django.utils.timezone import utc
@@ -46,7 +47,7 @@ class PrefixedField(object):
     prefixed_value = None
 
     def to_python(self, value):
-        if isinstance(value, str):
+        if isinstance(value, string_types):
             self.operator, value = split_on_operator(value)
 
         return super(PrefixedField, self).to_python(value)

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -46,7 +46,7 @@ class PrefixedField(object):
     prefixed_value = None
 
     def to_python(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             self.operator, value = split_on_operator(value)
 
         return super(PrefixedField, self).to_python(value)
@@ -64,7 +64,7 @@ class PrefixedField(object):
         """Return the value as a string. """
         if value is None:
             return None
-        return unicode(value)
+        return str(value)
 
 
 class MultipleValueField(forms.MultipleChoiceField):

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+from past.builtins import basestring
 
 from socorro.external.es import query
 from socorro.external.es import supersearch

--- a/webapp-django/crashstats/supersearch/tests/common.py
+++ b/webapp-django/crashstats/supersearch/tests/common.py
@@ -1,4 +1,5 @@
 import ujson
+from past.builtins import basestring
 
 from crashstats.crashstats.tests.test_models import Response
 

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -1,4 +1,5 @@
 import datetime
+from builtins import str
 from collections import defaultdict
 
 from django import http
@@ -183,7 +184,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
 
     form = TopCrashersForm(request.GET)
     if not form.is_valid():
-        return http.HttpResponseBadRequest(unicode(form.errors))
+        return http.HttpResponseBadRequest(str(form.errors))
 
     product = form.cleaned_data['product']
     versions = form.cleaned_data['version']
@@ -277,7 +278,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         'versions': versions,
         'crash_type': crash_type,
         'os_name': os_name,
-        'result_count': unicode(result_count),
+        'result_count': str(result_count),
         'mode': tcbs_mode,
         'range_type': range_type,
         'end_date': end_date,

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -1,5 +1,4 @@
 import datetime
-from builtins import str
 from collections import defaultdict
 
 from django import http
@@ -7,6 +6,7 @@ from django.conf import settings
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.utils.http import urlquote
+from six import text_type
 
 from session_csrf import anonymous_csrf
 
@@ -184,7 +184,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
 
     form = TopCrashersForm(request.GET)
     if not form.is_valid():
-        return http.HttpResponseBadRequest(str(form.errors))
+        return http.HttpResponseBadRequest(text_type(form.errors))
 
     product = form.cleaned_data['product']
     versions = form.cleaned_data['version']
@@ -278,7 +278,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         'versions': versions,
         'crash_type': crash_type,
         'os_name': os_name,
-        'result_count': str(result_count),
+        'result_count': text_type(result_count),
         'mode': tcbs_mode,
         'range_type': range_type,
         'end_date': end_date,


### PR DESCRIPTION
Fixed linting errors via flake8. Modified code so that test pass in both
python 2 & 3. Most modifications for flake errors were done using find
and replace. New imports were added according to pep8 import
conventions. After linting errors were fixed another crontabber test
failed because explicit type checking wanted 'unicode' type. Unicode
type is only in python 2. A string was passed instead.Checked 2/3 cheat
sheet. Cheat sheet suggested to import from builtins library and use
str. But this failed because the str function doesnt provide the casting
behavior needed. So instead I coerced the string to unicode using its
own decode method. Lastly there was an error of types being used.
Buildin library types vs actual native language types. I used the six
library to import string_types which is a compatibility package for both
python 2 & 3.