### PR TITLE
fix bug 1440233 - ignore rust hashes in signature generation

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -108,6 +108,7 @@ class CSignatureTool(SignatureTool):
 
         self.fixup_space = re.compile(r' (?=[\*&,])')
         self.fixup_comma = re.compile(r',(?! )')
+        self.fixup_hash = re.compile(r'::h[0-9a-fA-F]+$')
 
     @staticmethod
     def _is_exception(exception_list, remaining_original_line, line_up_to_current_position):
@@ -220,6 +221,8 @@ class CSignatureTool(SignatureTool):
             function = self.fixup_space.sub('', function)
             # Ensure a space after commas
             function = self.fixup_comma.sub(', ', function)
+            # Remove rust-generated uniqueness hashes
+            function = self.fixup_hash.sub('', function)
             return function
 
         # if source is not None and source_line is not None:

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -119,6 +119,10 @@ class TestCSignatureTool:
             (('module', '', '', '23', '0xFFF'), 'module@0xFFF'),
             (('module', '', '', '', '0xFFF'), 'module@0xFFF'),
             ((None, '', '', '', '0xFFF'), '@0xFFF'),
+            (('module', 'expect_failed::h7f635057bfba806a', '', '', ''),
+             'expect_failed'),
+            (('module', 'expect_failed::h7f6350::blah', '', '', ''),
+             'expect_failed::h7f6350::blah'),
         ]
         for args, e in a:
             r = s.normalize_signature(*args)


### PR DESCRIPTION
The rust compiler generates a hash/fingerprint at the end of the
function names in order to distinguish between different versions of a
crate built together into the final product. This hash also changes
frequently between builds of Firefox, so it's better to strip it out
when generating signatures.