### PR TITLE
fix bug 1465908: add wcsrtombs to prefix list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -241,6 +241,7 @@ _VEC_memcpy
 _VEC_memzero
 .*WaitFor
 wcslen
+wcsrtombs
 __wrap_realloc
 WSARecv
 WSASend


### PR DESCRIPTION
This adds wcsrtombs to the prefix list so signature generation continues.

Example output:

```
you@processor:/app$ python -m socorro.signature 129cbcd4-248a-45c9-9b89-3a4460180604
Crash id: 129cbcd4-248a-45c9-9b89-3a4460180604
Original: wcsrtombs
New:      wcsrtombs | wcsrtombs | wcsrtombs | js::CloneFunctionReuseScript
Same?:    False
```