### PR TITLE
fix bug 1467412: updated crash reprocessing jQuery notation

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
@@ -19,12 +19,12 @@ $(function() {
       .done(function() {
         $('.reprocessing-success', parent).show();
       })
-      .error(function(jqXHR) {
+      .fail(function(jqXHR) {
         $('.reprocessing-error .status', parent).text(jqXHR.status);
         $('.reprocessing-error pre', parent).text(jqXHR.responseText);
         $('.reprocessing-error', parent).show();
       })
-      .complete(function() {
+      .always(function() {
         $('.waiting', parent).hide();
         $('form button', parent).prop('disabled', false);
       });


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1467412

## what
- updated crash reprocessing jQuery notation in `reprocessing.js`

## why
- when doing a crash reprocess, JavaScript type errors could appear in the console because:
  - as of jQuery 3.0, `jqXHR.error()`, and `jqXHR.complete()` callback methods were replaced by `jqXHR.fail()`, and `jqXHR.always()`
  - documentation: https://api.jquery.com/jquery.post/
![screen shot 2018-06-08 at 8 44 31 am](https://user-images.githubusercontent.com/12681350/41167593-3b0ef078-6af8-11e8-9b23-c26c8ba77cd4.png)

## test
1. do the whole socorro setup and process some crashes: https://socorro.readthedocs.io/en/latest/service/processor.html#example-using-all-the-scripts
2. give your user `crashstats.reprocess_crashes` permission or change instances of the string `request.user.has_perm('crashstats.reprocess_crashes')` to the string `True` in `report_index.html`
3. press the `Reprocess this crash` button
4. see that the following JavaScript errors are not printed to the Dev console:
    - `TypeError: $.post(...).done(...).error is not a function`
    - `TypeError: $.post(...).done(...).fail(...).complete is not a function`