### PR TITLE
Fix bug 1467567, by adding 'future' to our requirements for Python 2

### DIFF
--- a/e2e-tests/Pipfile
+++ b/e2e-tests/Pipfile
@@ -1,16 +1,11 @@
 [[source]]
-
 url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
 
-
-
 [packages]
-
 mozlog = "*"
 PyPOM = "*"
 pytest = "*"
@@ -22,3 +17,4 @@ pytest-variables = "*"
 pytest-xdist = "*"
 selenium = "*"
 requests = "*"
+future = "*"

--- a/e2e-tests/Pipfile.lock
+++ b/e2e-tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "51b343fba36d775e99216f998d06cc49b2644914a4af9d79e4f95e315b451ad5"
+            "sha256": "e9d365d66e2fffd530613f69c6ac7fd2dac4a40b2a8c440e39b60cd6b9269aaa"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -72,6 +72,13 @@
             "markers": "python_version < '3.0'",
             "version": "==1.0.2"
         },
+        "future": {
+            "hashes": [
+                "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
+            ],
+            "index": "pypi",
+            "version": "==0.16.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
@@ -127,11 +134,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:39555d023af3200d004d09e51b4dd9fdd828baa863cded3fd6ba2f29f757ae2d",
-                "sha256:c76e93f3145a44812955e8d46cdd302d8a45fbfc7bf22be24fe231f9d8d8853a"
+                "sha256:26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591",
+                "sha256:32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
+            "version": "==3.6.1"
         },
         "pytest-base-url": {
             "hashes": [


### PR DESCRIPTION
Ad-hoc build here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/socorro.adhoc/255/console

And sorry, not (really) sorry; a point release to pytest snuck in too - but IMHO we might as well take it, here?

@Osmose @willkg @davehunt r?