### PR TITLE
added --service-ports to webapp docs on how to debug

### DIFF
--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -18,7 +18,7 @@ configuration.
 
 To ease debugging, you can run a shell in the container::
 
-  $ docker-compose run webapp /bin/bash
+  $ docker-compose run --service-ports webapp /bin/bash
 
 
 Then you can start and stop the webapp, adjust files, and debug.


### PR DESCRIPTION
## what
- added --service-ports to webapp docs on how to debug

# why
- `--service-ports` allows ports to be exposed, so the website can be visited
- this should be more intuitive for people reading the documentation