### PR TITLE
Bug 1468435: circle config: switch base image to docker:stable, install compose via pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,23 @@ version: 2
 jobs:
   build:
     docker:
-      # base image
-      - image: ubuntu:16.04
+      - image: docker:stable
     working_directory: /
     steps:
       - run:
           name: Install essential packages
           command: |
-            apt-get update
-            apt-get install -y ca-certificates curl build-essential make git
+            apk update
+            apk add --update --no-cache \
+                    ca-certificates \
+                    build-base \
+                    bash \
+                    make \
+                    git \
+                    openssh \
+                    docker \
+                    py-pip
+            pip install docker-compose
 
       - checkout:
           path: /socorro
@@ -29,23 +37,6 @@ jobs:
 
       - store_artifacts:
           path: /socorro/version.json
-
-      # FIXME: should use an image w/ docker installed by default
-      - run:
-          name: Install Docker
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-
-      - run:
-          name: Install Docker Compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
 
       - setup_remote_docker
 


### PR DESCRIPTION
`docker:stable` is based on alpine, hence changing package manager invocations.

`curl` is no longer needed.