### PR TITLE
fix bug 1467280: started returning 404 on RawCrash API requests with malformed crash IDs

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorro.lib import external_common, MissingArgumentError, BadArgumentError
+from socorro.lib import external_common, MissingArgumentError, BadArgumentError, ooid
 from socorro.external.boto.crashstorage import (
     BotoS3CrashStorage,
     CrashIDNotFound,
@@ -58,6 +58,9 @@ class SimplifiedCrashData(BotoS3CrashStorage):
 
         if not params.uuid:
             raise MissingArgumentError('uuid')
+
+        if not ooid.is_crash_id_valid(params.uuid):
+            raise BadArgumentError('uuid')
 
         if not params.datatype:
             raise MissingArgumentError('datatype')

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -445,6 +445,16 @@ class TestViews(BaseTestViews):
         assert response['Content-Disposition'] == 'attachment; filename="abc.dmp"'
         assert response['Content-Type'] == 'application/octet-stream'
 
+    def test_RawCrash_invalid_crash_id(self):
+        # NOTE(alexisdeschamps): this undoes the mocking of the implementation so we can test
+        # the implementation code.
+        RawCrash.implementation = self._mockeries[RawCrash]
+        url = reverse('api:model_wrapper', args=('RawCrash',))
+        response = self.client.get(url, {
+            'crash_id': '821fcd0c-d925-4900-85b6-687250180607docker/as_me.sh'
+        })
+        assert response.status_code == 400
+
     def test_Bugs(self):
         url = reverse('api:model_wrapper', args=('Bugs',))
         response = self.client.get(url)

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 
 from crashstats.base.tests.testbase import DjangoTestCase
 from crashstats.crashstats import models
+from socorro.lib import BadArgumentError
 
 
 class Response(object):
@@ -334,6 +335,16 @@ class TestModels(DjangoTestCase):
         r = api.get(crash_id='some-crash-id')
         assert r['Vendor'] == 'Mozilla'
         assert 'Email' in r  # no filtering at this level
+
+    def test_raw_crash_invalid_id(self):
+        # NOTE(alexisdeschamps): this undoes the mocking of the implementation so we can test
+        # the implementation code.
+        models.RawCrash.implementation = self._mockeries[models.RawCrash]
+        model = models.RawCrash
+        api = model()
+
+        with pytest.raises(BadArgumentError):
+            api.get(crash_id='821fcd0c-d925-4900-85b6-687250180607docker/as_me.sh')
 
     def test_raw_crash_raw_data(self):
 


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1467280

## why 
- RawCrash API does not handle malformed crash IDs well. It does extra work and returns `500`

## what
- started returning 404 on RawCrash API requests with malformed crash IDs