### PR TITLE
Fix bug 1469443 [e2e-tests] - Update geckodriver to latest, 0.21.0

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
-ENV GECKODRIVER_VERSION=0.20.1
+ENV GECKODRIVER_VERSION=0.21.0
 RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \


### PR DESCRIPTION
Here's a local build, with the same, pre-existing single failure (in the Docker run) testsuite: https://gist.github.com/stephendonner/fe911ccddec03da386cd61a8767a6e62

Sauce Labs (which is what Jenkins uses, currently) is fine: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/socorro.adhoc/267/console (https://gist.github.com/stephendonner/65dd3fb88e125354f2838776f43125a5)

@Osmose @davehunt r?