### PR TITLE
fix bug 1468763: fix lint and test rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
             make build
 
       - run:
-          name: Run eslint
+          name: Lint
           working_directory: /socorro
-          command: docker run --workdir="/app/webapp-django" local/socorro_webapp /webapp-frontend-deps/node_modules/.bin/eslint /app/webapp-django
+          command: docker run local/socorro_webapp ./docker/run_lint.sh
 
       - run:
           name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ docs: my.env
 	./docker/as_me.sh --container docs ./docker/run_build_docs.sh
 
 lint: my.env
-	${DC} run processor flake8
-
-eslint: my.env
-	${DC} run --workdir="/app/webapp-django" webapp /webapp-frontend-deps/node_modules/.bin/eslint /app/webapp-django
+	${DC} run webapp ./docker/run_lint.sh
 
 .PHONY: build setup test testshell run dependencycheck stop
 

--- a/docker/run_lint.sh
+++ b/docker/run_lint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Runs linting.
+
+# This should be called from inside a container.
+
+set -e
+
+# Run flake8 to lint Python tests
+echo ">>> flake8 (python)"
+cd /app
+flake8
+
+echo ">>> eslint (js)"
+cd /app/webapp-django
+/webapp-frontend-deps/node_modules/.bin/eslint .

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -25,7 +25,6 @@ DATABASE_URL=${database_url:-"postgres://postgres:aPassword@postgresql:5432/soco
 ELASTICSEARCH_URL=${elasticsearch_url:-"http://elasticsearch:9200"}
 
 export PYTHONPATH=/app/:$PYTHONPATH
-FLAKE8="$(which flake8)"
 PYTEST="$(which pytest)"
 PYTHON="$(which python)"
 ALEMBIC="$(which alembic)"
@@ -44,9 +43,6 @@ urlwait "${ELASTICSEARCH_URL}" 10
 # Test the last migration
 "${ALEMBIC}" -c "${alembic_config}" downgrade -1
 "${ALEMBIC}" -c "${alembic_config}" upgrade heads
-
-# Run linting
-"${FLAKE8}"
 
 if [ "${USEPYTHON:-2}" == "2" ]; then
     # Run tests


### PR DESCRIPTION
This fixes linting and testing so there's a single make rule for linting and
one for testing. This fixes Circle configuration so it runs both.

To test:

1. run `make lint`
2. run `make test`
3. make sure Circle ran both lint and test