### PR TITLE
fix bug 1467308 update socorro.lib

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -16,11 +16,11 @@ WORKING_TESTS=(
     socorro/unittest/lib/test_external_common.py
     socorro/unittest/lib/test_ooid.py
     socorro/unittest/lib/test_search_common.py
-    # socorro/unittest/lib/test_task_manager.py
-    # socorro/unittest/lib/test_threaded_task_manager.py
+    socorro/unittest/lib/test_task_manager.py
+    socorro/unittest/lib/test_threaded_task_manager.py
     socorro/unittest/lib/test_transform_rules.py
     socorro/unittest/lib/test_treelib.py
-    # socorro/unittest/lib/test_util.py
+    socorro/unittest/lib/test_util.py
     socorro/unittest/lib/test_vertools.py
 )
 

--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -11,7 +11,17 @@
 # This is the list of known working tests by directory/filename. When you
 # have tests in a directory/file working, add it to this list as a new line.
 WORKING_TESTS=(
+    socorro/unittest/lib/test_converters.py
+    socorro/unittest/lib/test_datetimeutil.py
+    socorro/unittest/lib/test_external_common.py
     socorro/unittest/lib/test_ooid.py
+    socorro/unittest/lib/test_search_common.py
+    # socorro/unittest/lib/test_task_manager.py
+    # socorro/unittest/lib/test_threaded_task_manager.py
+    socorro/unittest/lib/test_transform_rules.py
+    socorro/unittest/lib/test_treelib.py
+    # socorro/unittest/lib/test_util.py
+    socorro/unittest/lib/test_vertools.py
 )
 
 pytest ${WORKING_TESTS[@]}

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -5,10 +5,10 @@ consists of a function and the data applied to the function."""
 
 import time
 import threading
-import Queue
 
 from configman import Namespace
 from configman.converters import class_converter
+from six.moves import queue
 
 from socorro.lib.task_manager import (
     default_task_func,
@@ -76,7 +76,7 @@ class ThreadedTaskManager(TaskManager):
         )
         self.thread_list = []  # the thread object storage
         self.number_of_threads = config.number_of_threads
-        self.task_queue = Queue.Queue(config.maximum_queue_size)
+        self.task_queue = queue.Queue(config.maximum_queue_size)
 
     def start(self):
         """this function will start the queing thread that executes the

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function
+import sys
 
 from itertools import islice
 
@@ -40,12 +41,15 @@ def drop_unicode(text):
     :returns: text with all unicode characters dropped
 
     """
-    if isinstance(text, str):
-        # Convert any str to a unicode so that we can convert it back and drop any non-ascii
-        # characters
-        text = text.decode('unicode_escape')
+    if sys.version_info < (3,):
+        if isinstance(text, str):
+            # Convert ascii to unicode in python 2
+            text = text.decode('unicode_escape')
+        # Convert it back to a acsii string and drop any non-ascii characters
+        return text.encode('ascii', 'ignore')
 
-    return text.encode('ascii', 'ignore')
+    # Python 3 ONLY, python 3 needs unicode string to return
+    return text.encode('ascii', 'ignore').decode('unicode_escape')
 
 
 # utilities

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function
-import sys
+import six
 
 from itertools import islice
 
@@ -41,15 +41,18 @@ def drop_unicode(text):
     :returns: text with all unicode characters dropped
 
     """
-    if sys.version_info < (3,):
+    if six.PY2:
         if isinstance(text, str):
             # Convert ascii to unicode in python 2
             text = text.decode('unicode_escape')
         # Convert it back to a acsii string and drop any non-ascii characters
         return text.encode('ascii', 'ignore')
 
-    # Python 3 ONLY, python 3 needs unicode string to return
-    return text.encode('ascii', 'ignore').decode('unicode_escape')
+    # Python 3 ONLY, strip non ascii characters
+    ALLOWED_CHARS = [chr(c) for c in range(32, 127)]
+    text = ''.join([c for c in text if c in ALLOWED_CHARS])
+
+    return text
 
 
 # utilities

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -48,7 +48,7 @@ class TestTaskManager(TestCase):
             config,
             job_source_iterator=range(1),
         )
-        assert tm._get_iterator() == [0]
+        assert list(tm._get_iterator()) == [0]
 
         def an_iter(self):
             for i in range(5):

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -73,7 +73,7 @@ class TestThreadedTaskManager(TestCase):
             ttm.start()
             time.sleep(0.2)
             assert len(my_list) == 10
-            assert my_list == range(10)
+            assert my_list == list(range(10))
             ttm.stop()
         except Exception:
             # we got threads to join
@@ -100,7 +100,7 @@ class TestThreadedTaskManager(TestCase):
             time.sleep(0.2)
             assert len(ttm.thread_list) == 2
             assert len(my_list) == 10
-            assert sorted(my_list) == range(10)
+            assert sorted(my_list) == list(range(10))
         except Exception:
             # we got threads to join
             ttm.wait_for_completion()
@@ -128,7 +128,7 @@ class TestThreadedTaskManager(TestCase):
             time.sleep(0.2)
             assert len(ttm.thread_list) == 2
             assert len(my_list) == 5
-            assert sorted(my_list) == range(5)
+            assert sorted(my_list) == list(range(5))
         except Exception:
             # we got threads to join
             ttm.wait_for_completion()

--- a/socorro/unittest/lib/test_treelib.py
+++ b/socorro/unittest/lib/test_treelib.py
@@ -28,33 +28,33 @@ class TestParsePath:
         with pytest.raises(treelib.MalformedPath) as exc_info:
             treelib.parse_path('')
 
-        exc_str = str(exc_info.exconly())
-        expected = "MalformedPath: '' is a malformed path: empty edge"
+        exc_str = str(exc_info.value)
+        expected = "'' is a malformed path: empty edge"
         assert exc_str == expected
 
     def test_bad_path_empty_edge(self):
         with pytest.raises(treelib.MalformedPath) as exc_info:
             treelib.parse_path('a..b')
 
-        exc_str = str(exc_info.exconly())
-        expected = "MalformedPath: 'a..b' is a malformed path: empty edge"
+        exc_str = str(exc_info.value)
+        expected = "'a..b' is a malformed path: empty edge"
         assert exc_str == expected
 
     def test_bad_path_mismatched_brackets(self):
         with pytest.raises(treelib.MalformedPath) as exc_info:
             treelib.parse_path('a.[10')
 
-        exc_str = str(exc_info.exconly())
-        expected = "MalformedPath: 'a.[10' is a malformed path: [ without ]"
+        exc_str = str(exc_info.value)
+        expected = "'a.[10' is a malformed path: [ without ]"
         assert exc_str == expected
 
     def test_bad_path_index_is_not_int(self):
         with pytest.raises(treelib.MalformedPath) as exc_info:
             treelib.parse_path('a.[a]')
 
-        exc_str = str(exc_info.exconly())
+        exc_str = str(exc_info.value)
         expected = (
-            "MalformedPath: 'a.[a]' is a malformed path: "
+            "'a.[a]' is a malformed path: "
             "invalid literal for int() with base 10: 'a'"
         )
         assert exc_str == expected


### PR DESCRIPTION
Modified socorro.lib folder to pass python 3 testing. 
Errors fixed: 
* An error occurred when reporting class names and descriptions of expected results in test functions. This changed from python 2 to 3. Python 2 returned the class name and the value of the error. Python 3 returned a qualified class name(absolute reference) and the value of the error. So we modified test expectation to just return its value and removed a redundant verification of the error type. 
* We then resolved implementation difference of range() function between python 2 and 3 by converting the iterator generated in python 3 to a list for value comparison. 
* Fixed import changes in python 2 to 3 using the six lib. 
* Lastly we fixed a function that sanitized strings to return as the default type of string in the testing environment of either python 2 or 3. 