### PR TITLE
fix bug 1460708: added Python 3 test running to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,11 @@ jobs:
           command: make test
 
       - run:
+          name: Run tests in Python 3
+          working_directory: /socorro
+          command: make dockertest3
+
+      - run:
           name: Push to Dockerhub
           working_directory: /socorro
           command: |


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1460708

## what
- added one step in the CI to run the tests in Python 3
  - only some tests have been set as passing Python 3 through `https://github.com/mozilla-services/socorro/blob/master/docker/run_tests_python3.sh`

## why
- we are in the process of transitioning from Python 2 to 3
- we want to make sure that things currently working stay that way
  - thus, we want to run the tests in Python 3 in addition to what we currently have

## notes
It seems that `make dockertest3` automatically builds the `socorro_python3` image since `.docker-build3` is set as a prerequisite.  I guess `make dockerbuild3` could be added instead explicitly to the `Build Docker images` CI step instead, or as a command in the `Run tests in Python 3` step.