### PR TITLE
fix bug 1469978: nix all the admin links

### DIFF
--- a/webapp-django/crashstats/profile/jinja2/profile/profile.html
+++ b/webapp-django/crashstats/profile/jinja2/profile/profile.html
@@ -18,11 +18,6 @@
     <div class="panel">
         <div class="body">
             <ul class="links left">
-                {% if request.user.is_superuser %}
-                <li>
-                    <a href="{{ url('manage:home') }}">Admin</a>
-                </li>
-                {% endif %}
                 <li>
                     <a href="{{ url('tokens:home') }}">API Tokens</a>
                 </li>
@@ -88,7 +83,7 @@
         <div class="body">
         {% if request.user.is_superuser %}
             <p>
-                You are a <b>superuser</b>. You have <b>unrestricted access to everything</b>. <a href="{{ url('manage:home') }}">Visit the admin page</a>
+                You are a <b>superuser</b> with access to everything.
             </p>
         {% else %}
         <table class="data-table">


### PR DESCRIPTION
All the pages on crash stats have a link to the admin in the footer. There's
no need to have admin links sprinkled around the site. They're not chocolate
chips.

This removes some from the profile page which were erroring out after I
nixed the "manage:home" view.