### PR TITLE
Fix deploy_bug.py to show authors

### DIFF
--- a/scripts/deploy_bug.py
+++ b/scripts/deploy_bug.py
@@ -108,9 +108,10 @@ def main(argv):
         if len(commit['parents']) > 1:
             continue
 
-        print('%s: %s' % (
+        print('%s: %s (%s)' % (
             commit['sha'][:7],
-            commit['commit']['message'].splitlines()[0][:80]
+            commit['commit']['message'].splitlines()[0][:80],
+            (commit['author'] or {}).get('login', '?')
         ))
 
     print('(next tag: %s - %s)' % (next_tag, commits[-1]['sha'][:7]))


### PR DESCRIPTION
The `deploy_bug.py` script spits out all the commits that will get deployed.
This adjusts that output to also specify the authors. The hope is that
this makes it easier to figure out who needs to verify what before a
prod deploy.

Example of old output:

```
323c77c: bug 1462749: move graphics devices to django admin
f24fa3c: fix bug 1462749: remove last vestiges of old admin
d820f11: Fix create_recent_indices_app to create last 2 weeks
```

Example of new output:

```
323c77c: bug 1462749: move graphics devices to django admin (willkg)
f24fa3c: fix bug 1462749: remove last vestiges of old admin (willkg)
d820f11: Fix create_recent_indices_app to create last 2 weeks (willkg)
```

It's showing the github username of the person. For us, I think that will generally work. We could show something else if we wanted.

@Osmose What do you think?