### PR TITLE
fix bug 1436702: made the Signature Summary tab Product table respect the selected filters 

### DIFF
--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -55,10 +55,6 @@
                 {% endfor %}
             </tbody>
         </table>
-        <p class="footnote">
-            <sup>*</sup> This summary does not use any of the filters defined above except the signature.
-            The date range is from 7 days ago to now.
-        </p>
     </div>
 </div>
 

--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -211,15 +211,6 @@ section.correlations-panel {
     }
 }
 
-.footnote {
-    font-style: italic;
-    line-height: 1.3;
-    margin: 0;
-    font-weight: bold;
-    color: @red;
-    padding: 2px 4px;
-}
-
 .bugzilla-panel {
     .bug_ids_expanded_list {
         border: none;

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -579,13 +579,6 @@ class TestViews(BaseTestViews):
             assert 'signature' in params
             assert params['signature'] == ['=' + DUMB_SIGNATURE]
 
-            if '_aggs.product.version' in params:
-                assert 'product' not in params
-                assert 'version' not in params
-            else:
-                assert '_histogram.uptime' in params
-                assert '_facets' in params
-
             res = {
                 "hits": [],
                 "total": 4,


### PR DESCRIPTION
fixes bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1436702

## what
- made the Signature Summary tab Product table respect the selected filters for the signature report

## why
Previously, this table had behavior different from the other tables to make it display data from the last 7 days instead of the data range specified in the filters.
- this was a specific request of a crash investigator that is no longer here
- this created confusion for users

## test

1. process the following crashes:
```
99ead0d8-891f-443e-839a-fd2410180619
237d327b-6ef5-4d7c-bf54-77f040180619
59533cca-a632-4b24-8390-336830180619
b0e81e01-edd3-4db0-81fe-369ee0180618
a98fb7fd-44a1-435a-9a54-03eae0180618
ee829ff0-330f-4fbf-8637-fef9d0180618
f7d0972b-1973-4c11-9498-21ee50180618
```
here are the dates associated with these crashes:
```
237d327b-6ef5-4d7c-bf54-77f040180619 2018-06-08 15:23:57
59533cca-a632-4b24-8390-336830180619 2018-05-21 10:54:55
a98fb7fd-44a1-435a-9a54-03eae0180618 2018-04-06 18:27:58
f7d0972b-1973-4c11-9498-21ee50180618 2018-03-30 08:16:26
ee829ff0-330f-4fbf-8637-fef9d0180618 2018-03-29 22:23:05
b0e81e01-edd3-4db0-81fe-369ee0180618 2017-11-01 20:05:53
99ead0d8-891f-443e-839a-fd2410180619 2018-02-15 13:26:05
```
2. go to the signature page for these crashes
    1. go to the crash page for any of these crashes (`/report/index/<crash id>/`)
    2. click `More Reports`
3. click `Show Filters`
4. observe the `Product *` table under the Summary tab to expect different results based on the data range selected (instead of the same results regardless of the data range selected)
    1. example: compare `last 3 days` to `last 7 days`
    2. there should be a different number of results based on the date range

## visual
<details>
<summary>images</summary>
before: last 3 days
![before last 3 days](https://user-images.githubusercontent.com/12681350/41790488-93c6895a-7607-11e8-84df-6466f104b011.png)

before: last 7 days
![before last 7 days](https://user-images.githubusercontent.com/12681350/41790376-42dfdbae-7607-11e8-94d8-f4653a704c38.png)

after: last 3 days
![after last 3 days](https://user-images.githubusercontent.com/12681350/41790382-45e68aaa-7607-11e8-937b-7c75f177fd89.png)

after: last 7 days
![after last 7 days](https://user-images.githubusercontent.com/12681350/41790387-4945f000-7607-11e8-9832-2302c74480c6.png)
<details>