### PR TITLE
bug 1454482: add timing captures for ES

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -88,7 +88,7 @@ class BotoCrashStorage(CrashStorageBase):
             quit_check_callback=quit_check_callback
         )
 
-        self.connection_source = config.resource_class(config)
+        self.connection_source = config.resource_class(config, namespace=namespace)
         self.transaction = config.transaction_executor_class(
             config,
             self.connection_source,


### PR DESCRIPTION
bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1454482
This patch is a work in progress.
This patch is based off #4391.

## what
- added metric for the time to index a crash
  - successes and failures have a different metric


## why
- provide better timing data for document indexing in elasticsearch


## notes
@sciurus I can make other changes within this patch. Does this patch still make sense? What other things would it be helpful to have timings on?
