### PR TITLE
Bug 1393037 Catch ValueError on raw_crash.OOMAllocationSize conversion

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -508,7 +508,7 @@ class OOMSignature(Rule):
         processed_crash['original_signature'] = processed_crash['signature']
         try:
             size = int(raw_crash['OOMAllocationSize'])
-        except (TypeError, AttributeError, KeyError):
+        except (TypeError, AttributeError, KeyError, ValueError):
             processed_crash['signature'] = "OOM | unknown | " + processed_crash['signature']
             return True
 

--- a/socorro/unittest/signature/test_rules.py
+++ b/socorro/unittest/signature/test_rules.py
@@ -1157,6 +1157,21 @@ class TestOOMSignature:
         assert processed_crash['original_signature'] == 'hello'
         assert processed_crash['signature'] == 'OOM | large | hello'
 
+    def test_action_invalid_value(self):
+        processed_crash = {
+            'signature': 'hello'
+        }
+        raw_crash = {
+            'OOMAllocationSize': 'BOWWOWOW'
+        }
+
+        rule = OOMSignature()
+        action_result = rule.action(raw_crash, processed_crash, [])
+
+        assert action_result is True
+        assert processed_crash['original_signature'] == 'hello'
+        assert processed_crash['signature'] == 'OOM | unknown | hello'
+
 
 class TestAbortSignature:
 


### PR DESCRIPTION
I fixed `OOMSignature#action` to catch `ValueError`.
I added a test in `test_rules.py`. Could you check it? Thanks.