### PR TITLE
[WIP] fix bug 1344864: add startup icons signature page

### DIFF
--- a/webapp-django/crashstats/base/jinja2/macros/signature_startup_stats_icons.html
+++ b/webapp-django/crashstats/base/jinja2/macros/signature_startup_stats_icons.html
@@ -1,0 +1,40 @@
+{% macro signature_startup_stats_icons(startup_stats) %}
+{% if startup_stats %}
+<div class="signature-icons">
+    {% if startup_stats.startup_count > 0 %}
+    {% if startup_stats.startup_count == startup_stats.crash_count %}
+    <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
+        alt="red flag"
+        title="Startup Crash, all crashes happened during startup"
+        class="startup" height="16" width="16"
+    />
+    {% else %}
+    <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
+        alt="yellow flag"
+        title="Potential Startup Crash, {{ startup_stats.startup_count }} out of {{ startup_stats.count }} crashes happened during startup"
+        class="startup" height="16" width="16"
+    />
+    {% endif %}
+    {% endif %}
+
+    {% if startup_stats.startup_crash %}
+    <img
+        src="{{ static('img/icons/rocket_fly.png') }}"
+        alt="rocket"
+        title="Potential Startup Crash, more than half of the crashes happened during the first minute after launch"
+        class="startup" height="16" width="16"
+    />
+    {% endif %}
+
+    {% if startup_stats.hang_count > 0 %}
+    <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}" alt="stop sign" title="Hanged Crash" class="hang" height="16" width="16">
+    {% endif %}
+
+    {% if startup_stats.plugin_count > 0 %}
+    <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}" alt="brick" title="Plugin Crash" class="plugin" height="16" width="16">
+    {% else %}
+    <img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}" width="16" height="16" alt="application" title="Browser Crash" class="browser" />
+    {% endif %}
+</div>
+{% endif %}
+{%- endmacro %}

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -1,4 +1,5 @@
 {% from "supersearch/macros/date_filters.html" import date_filters %}
+{% from "macros/signature_startup_stats_icons.html" import signature_startup_stats_icons %}
 
 {% extends "crashstats_base.html" %}
 {% block page_title %}{{ signature }} - Signature report - Mozilla Crash Reports{% endblock %}
@@ -32,6 +33,7 @@
 >
     <div class="page-heading">
         <h2>Signature report for <em>{{ signature }}</em></h2>
+        {{ signature_startup_stats_icons(startup_stats) }}
         <p>
             <a
                 href="#"

--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -2,6 +2,7 @@
 
 .page-heading {
     p {
+        margin-left: 20px;
         font-style: italic;
 
         time {


### PR DESCRIPTION
fixes bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1344864
This patch is a work in progress.

## what
- added icons to the signature report page that indicate startup crash statistics
  - these are the same icons found on the topcrashers page

## why
- being able to distinguish startup crashes is useful

## notes
I would love to hear thoughts on the following:
- the bug mentions adding a red banner, but I opted to try adding the icons from the top crashers page first because
  - having the same indicators everywhere leads to a more consistent experience
  - these icons theoretically reveal more information that just one banner
  - these icons could also be added to Super Search results, which has the similar space requirements to the top crashers page

- The template macro and part of startup statistics computation code was copied from top crashers files. I plan to modify the top crashers files to instead use the code I extracted in order to promote reusability.

## visuals
One can see the added icons by looking for the red rocket icon:
![screen shot 2018-06-27 at 2 07 30 pm](https://user-images.githubusercontent.com/12681350/42000011-33b969e0-7a14-11e8-9851-608e17e738f0.png)