### PR TITLE
bug 1460447: fix errant glom call

### DIFF
--- a/socorro/signature/__main__.py
+++ b/socorro/signature/__main__.py
@@ -260,7 +260,11 @@ def main(argv=None):
                 # NOTE(willkg): Classifications aren't available via the public API.
                 'classifications': {
                     'jit': {
-                        'category': glom(processed_crash, 'classifications.jit.category', default=''),
+                        'category': glom(
+                            processed_crash,
+                            'classifications.jit.category',
+                            default=''
+                        ),
                     },
                 },
                 'mdsw_status_string': processed_crash.get('mdsw_status_string', None),

--- a/socorro/signature/__main__.py
+++ b/socorro/signature/__main__.py
@@ -260,7 +260,7 @@ def main(argv=None):
                 # NOTE(willkg): Classifications aren't available via the public API.
                 'classifications': {
                     'jit': {
-                        'category': glom(processed_crash, 'classifications.jit.category', ''),
+                        'category': glom(processed_crash, 'classifications.jit.category', default=''),
                     },
                 },
                 'mdsw_status_string': processed_crash.get('mdsw_status_string', None),


### PR DESCRIPTION
This fixes a bug created when I switched the code from `tree_get` to
`glom`. `glom` requires the default to be a keyword argument.