### PR TITLE
fix bug 1471379: updated signature lists

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -14,7 +14,9 @@ app_process@0x
 AppleIntelHD3000GraphicsGLDriver@
 core\.odex@0x
 core::panicking::
+CrashReporter::TerminateHandler
 CrashStatsLogForwarder::CrashAction
+__cxa_throw
 _CxxThrowException
 dalvik-heap
 dalvik-jit-code-cache
@@ -67,6 +69,7 @@ NS_ProcessNextEvent
 (Nt|Zw)?WaitForMultipleObjects(Ex)?
 NtWaitForAlertByThreadId
 nvmap@0x
+objc_begin_catch
 org\.mozilla\.f.*-\d\.apk@0x
 PR_WaitCondVar
 RaiseException
@@ -80,6 +83,7 @@ SleepConditionVariableCS
 SleepConditionVariableSRW
 std::_Atomic_fetch_add_4
 std::panicking::
+std::__terminate
 system@framework@.*\.jar@classes\.dex@0x
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
 WaitForSingleObjectExImplementation

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -29,7 +29,6 @@ core::option::expect_failed
 core::result::unwrap_failed<T>
 core::str::slice_error_fail
 CrashInJS
-CrashReporter::TerminateHandler
 CreateFileMappingA
 __delayLoadHelper2
 dlmalloc


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1471379

# what
- moved `CrashReporter::TerminateHandler` from the prefix to the irrelevant list
- added 3 new signatures to the irrelevant list

# why
When looking at the crashes for the signature https://crash-stats.mozilla.com/report/index/4943e3d5-4e4a-4c83-b627-a41330180606, users indicated that they wished that the crashes could be better differentiated in https://bugzilla.mozilla.org/show_bug.cgi?id=1467582.

## examples
Here are example signature differences:
https://crash-stats.mozilla.com/report/index/4943e3d5-4e4a-4c83-b627-a41330180606
```
Crash id: 4943e3d5-4e4a-4c83-b627-a41330180606
Original: CrashReporter::TerminateHandler | std::__terminate
New:      CFPasteboardPromiseDataUsingBlock
Same?:    False
```

https://crash-stats.mozilla.com/report/index/6bc014b5-0799-47c5-8e1f-4fd3c0180620
```
Crash id: 6bc014b5-0799-47c5-8e1f-4fd3c0180620
Original: CrashReporter::TerminateHandler | std::__terminate
New:      CFPasteboardPromiseDataUsingBlock
Same?:    False
```

https://crash-stats.mozilla.com/report/index/f88469be-860d-4688-aff2-ff0330180626
```
Crash id: f88469be-860d-4688-aff2-ff0330180626
Original: CrashReporter::TerminateHandler | std::__terminate
New:      -[NSMutableArray replaceObjectsInRange:withObjectsFromSet:]
Same?:    False
```