### PR TITLE
fix bug 1344864: added startup stats to the signature summary

### DIFF
--- a/webapp-django/crashstats/base/jinja2/macros/signature_startup_icons.html
+++ b/webapp-django/crashstats/base/jinja2/macros/signature_startup_icons.html
@@ -1,0 +1,60 @@
+{% macro startup_crash_icon() %}
+<img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
+    alt="red flag"
+    title="Startup Crash, all crashes happened during startup"
+    class="startup"
+    height="16"
+    width="16"
+/>
+{%- endmacro %}
+
+{% macro potential_startup_crash_icon(num_startup_crashes, num_crashes) %}
+<img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
+    alt="yellow flag"
+    title="Potential Startup Crash, {{ num_startup_crashes }} out of {{ num_crashes }} crashes happened during startup"
+    class="startup"
+    height="16"
+    width="16"
+/>
+{%- endmacro %}
+
+{% macro potential_startup_window_crash_icon() %}
+<img
+    src="{{ static('img/icons/rocket_fly.png') }}"
+    alt="rocket"
+    title="Potential Startup Crash, more than half of the crashes happened during the first minute after launch"
+    class="startup"
+    height="16"
+    width="16"
+/>
+{%- endmacro %}
+
+{% macro hang_crash_icon() %}
+<img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}"
+    alt="stop sign"
+    title="Hanged Crash"
+    class="hang"
+    height="16"
+    width="16"
+/>
+{%- endmacro %}
+
+{% macro plugin_crash_icon() %}
+<img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}"
+    alt="brick"
+    title="Plugin Crash"
+    class="plugin"
+    height="16"
+    width="16"
+/>
+{%- endmacro %}
+
+{% macro browser_crash_icon() %}
+<img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}"
+    alt="application"
+    title="Browser Crash"
+    class="browser"
+    width="16"
+    height="16"
+/>
+{%- endmacro %}

--- a/webapp-django/crashstats/base/tests/test_utils.py
+++ b/webapp-django/crashstats/base/tests/test_utils.py
@@ -1,5 +1,5 @@
 from crashstats.base.tests.testbase import TestCase
-from crashstats.base.utils import render_exception
+from crashstats.base.utils import render_exception, SignatureStats
 
 
 class TestRenderException(TestCase):
@@ -18,3 +18,63 @@ class TestRenderException(TestCase):
         except NameError as exc:
             html = render_exception(exc)
         assert html == '<ul><li>&lt;hack&gt;</li></ul>'
+
+
+class TestUtils(TestCase):
+    def test_SignatureStats(self):
+        signature = {
+            'count': 2,
+            'term': 'EMPTY: no crashing thread identified; ERROR_NO_MINIDUMP_HEADER',
+            'facets': {
+                'histogram_uptime': [{
+                    'count': 2,
+                    'term': 0
+                }],
+                'startup_crash': [{
+                    'count': 2,
+                    'term': 'F'
+                }],
+                'cardinality_install_time': {
+                    'value': 1
+                },
+                'is_garbage_collecting': [],
+                'process_type': [],
+                'platform': [{
+                    'count': 2,
+                    'term': ''
+                }],
+                'hang_type': [{
+                    'count': 2,
+                    'term': 0
+                }]
+            }
+        }
+        platforms = [
+            {'code': 'win', 'name': 'Windows'},
+            {'code': 'mac', 'name': 'Mac OS X'},
+            {'code': 'lin', 'name': 'Linux'},
+            {'code': 'unknown', 'name': 'Unknown'}]
+        signature_stats = SignatureStats(
+            signature=signature,
+            rank=1,
+            num_total_crashes=2,
+            platforms=platforms,
+            previous_signature=None,
+        )
+
+        assert signature_stats.rank == 1
+        assert signature_stats.signature_term \
+            == 'EMPTY: no crashing thread identified; ERROR_NO_MINIDUMP_HEADER'
+        assert signature_stats.percent_of_total_crashes == 100.0
+        assert signature_stats.num_crashes == 2
+        assert signature_stats.num_crashes_per_platform \
+            == {'mac_count': 0, 'lin_count': 0, 'win_count': 0}
+        assert signature_stats.num_crashes_in_garbage_collection == 0
+        assert signature_stats.num_installs == 1
+        assert signature_stats.num_crashes == 2
+        assert signature_stats.num_startup_crashes == 0
+        assert signature_stats.is_startup_crash == 0
+        assert signature_stats.is_potential_startup_crash == 0
+        assert signature_stats.is_startup_window_crash is True
+        assert signature_stats.is_hang_crash is False
+        assert signature_stats.is_plugin_crash is False

--- a/webapp-django/crashstats/base/utils.py
+++ b/webapp-django/crashstats/base/utils.py
@@ -77,3 +77,121 @@ def requests_retry_session(
     session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
+
+
+def get_signatures_stats(results, previous_range_results, platforms):
+    signatures = results['facets']['signature']
+    num_signatures = results['total']
+    platform_codes = [x['code'] for x in platforms if x['code'] != 'unknown']
+
+    signatures_stats = []
+    for i, signature in enumerate(signatures):
+        signatures_stats.append(SignatureStats(signature, i, num_signatures, platform_codes))
+
+    if num_signatures > 0 and 'signature' in previous_range_results['facets']:
+        previous_signatures = get_comparison_signatures(previous_range_results)
+        for signature_stats in signatures_stats:
+            previous_signature = previous_signatures.get(signature_stats.signature)
+            if previous_signature:
+                signature_stats.diff = previous_signature['percent'] - signature_stats.percent
+                signature_stats.rank_diff = previous_signature['rank'] - signature_stats.rank
+                signature_stats.previous_percent = previous_signature['percent']
+            else:
+                signature_stats.diff = 'new'
+                signature_stats.rank_diff = 0
+                signature_stats.previous_percent = 0
+
+    return signatures_stats
+
+
+class SignatureStats:
+    def __init__(self, signature, rank, num_signatures, platform_codes):
+        self.signature = signature['term']
+        self.rank = rank
+        self.percent = 100.0 * signature['count'] / num_signatures
+        self.count = signature['count']
+        self.platforms = get_num_crashes_per_platform(signature['facets']['platform'],
+                                                      platform_codes)
+        self.is_gc_count = get_num_crashes_in_garbage_collection(
+            signature['facets']['is_garbage_collecting'])
+        self.installs_count = (signature['facets']['cardinality_install_time']['value'])
+        self.startup_stats = SignatureStartupStats(signature)
+
+
+class SignatureStartupStats:
+    def __init__(self, signature):
+        self.count = signature['count']
+        self.plugin_count = get_num_plugin_crashes(signature['facets']['process_type'])
+        self.hang_count = get_num_hang_crashes(signature['facets']['hang_type'])
+        self.startup_count = get_num_startup_crashes(signature['facets']['startup_crash'])
+        self.startup_crash = get_is_startup_crash(signature['facets']['histogram_uptime'],
+                                                  signature['count'])
+
+
+def get_num_crashes_per_platform(platform_facet, platform_codes):
+    num_crashes_per_platform = {}
+    for platform in platform_codes:
+        num_crashes_per_platform[platform + '_count'] = 0
+    for platform in platform_facet:
+        code = platform['term'][:3].lower()
+        if code in platform_codes:
+            num_crashes_per_platform[code + '_count'] = platform['count']
+    return num_crashes_per_platform
+
+
+def get_num_crashes_in_garbage_collection(is_garbage_collecting_facet):
+    num_crashes_in_garbage_collection = 0
+    for row in is_garbage_collecting_facet:
+        if row['term'].lower() == 't':
+            num_crashes_in_garbage_collection = row['count']
+    return num_crashes_in_garbage_collection
+
+
+def get_num_plugin_crashes(process_type_facet):
+    num_plugin_crashes = 0
+    for row in process_type_facet:
+        if row['term'].lower() == 'plugin':
+            num_plugin_crashes = row['count']
+    return num_plugin_crashes
+
+
+def get_num_hang_crashes(hang_type_facet):
+    num_hang_crashes = 0
+    for row in hang_type_facet:
+        # Hangs have weird values in the database: a value of 1 or -1
+        # means it is a hang, a value of 0 or missing means it is not.
+        if row['term'] in (1, -1):
+            num_hang_crashes += row['count']
+    return num_hang_crashes
+
+
+def get_num_startup_crashes(startup_crash_facet):
+    return sum(
+        row['count'] for row in startup_crash_facet
+        if row['term'] in ('T', '1')
+    )
+
+
+def get_is_startup_crash(histogram_uptime_facet, crash_count):
+    is_startup_crash = False
+    for row in histogram_uptime_facet:
+        # Aggregation buckets use the lowest value of the bucket as
+        # term. So for everything between 0 and 60 excluded, the
+        # term will be `0`.
+        if row['term'] < 60:
+            ratio = 1.0 * row['count'] / crash_count
+            is_startup_crash = ratio > 0.5
+    return is_startup_crash
+
+
+def get_comparison_signatures(results):
+    signatures = results['facets']['signature']
+    num_signatures = results['total']
+    comparison_signatures = {}
+    for i, signature in enumerate(signatures):
+        comparison_signatures[signature['term']] = {
+            'count': signature['count'],
+            'rank': i + 1,
+            'percent': 100.0 * signature['count'] / num_signatures
+        }
+    return comparison_signatures

--- a/webapp-django/crashstats/base/utils.py
+++ b/webapp-django/crashstats/base/utils.py
@@ -5,6 +5,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 from django.template import engines
+from django.utils.functional import cached_property
 
 
 def render_exception(exception):
@@ -79,119 +80,136 @@ def requests_retry_session(
     return session
 
 
-def get_signatures_stats(results, previous_range_results, platforms):
-    signatures = results['facets']['signature']
-    num_signatures = results['total']
-    platform_codes = [x['code'] for x in platforms if x['code'] != 'unknown']
-
-    signatures_stats = []
-    for i, signature in enumerate(signatures):
-        signatures_stats.append(SignatureStats(signature, i, num_signatures, platform_codes))
-
-    if num_signatures > 0 and 'signature' in previous_range_results['facets']:
-        previous_signatures = get_comparison_signatures(previous_range_results)
-        for signature_stats in signatures_stats:
-            previous_signature = previous_signatures.get(signature_stats.signature)
-            if previous_signature:
-                signature_stats.diff = previous_signature['percent'] - signature_stats.percent
-                signature_stats.rank_diff = previous_signature['rank'] - signature_stats.rank
-                signature_stats.previous_percent = previous_signature['percent']
-            else:
-                signature_stats.diff = 'new'
-                signature_stats.rank_diff = 0
-                signature_stats.previous_percent = 0
-
-    return signatures_stats
-
-
-class SignatureStats:
-    def __init__(self, signature, rank, num_signatures, platform_codes):
-        self.signature = signature['term']
+class SignatureStats(object):
+    def __init__(
+        self,
+        signature,
+        num_total_crashes,
+        rank=0,
+        platforms=None,
+        previous_signature=None
+    ):
+        self.signature = signature
+        self.num_total_crashes = num_total_crashes
         self.rank = rank
-        self.percent = 100.0 * signature['count'] / num_signatures
-        self.count = signature['count']
-        self.platforms = get_num_crashes_per_platform(signature['facets']['platform'],
-                                                      platform_codes)
-        self.is_gc_count = get_num_crashes_in_garbage_collection(
-            signature['facets']['is_garbage_collecting'])
-        self.installs_count = (signature['facets']['cardinality_install_time']['value'])
-        self.startup_stats = SignatureStartupStats(signature)
+        self.platforms = platforms
+        self.previous_signature = previous_signature
 
+    @cached_property
+    def platform_codes(self):
+        return [x['code'] for x in self.platforms if x['code'] != 'unknown']
 
-class SignatureStartupStats:
-    def __init__(self, signature):
-        self.count = signature['count']
-        self.plugin_count = get_num_plugin_crashes(signature['facets']['process_type'])
-        self.hang_count = get_num_hang_crashes(signature['facets']['hang_type'])
-        self.startup_count = get_num_startup_crashes(signature['facets']['startup_crash'])
-        self.startup_crash = get_is_startup_crash(signature['facets']['histogram_uptime'],
-                                                  signature['count'])
+    @cached_property
+    def signature_term(self):
+        return self.signature['term']
 
+    @cached_property
+    def percent_of_total_crashes(self):
+        return 100.0 * self.signature['count'] / self.num_total_crashes
 
-def get_num_crashes_per_platform(platform_facet, platform_codes):
-    num_crashes_per_platform = {}
-    for platform in platform_codes:
-        num_crashes_per_platform[platform + '_count'] = 0
-    for platform in platform_facet:
-        code = platform['term'][:3].lower()
-        if code in platform_codes:
-            num_crashes_per_platform[code + '_count'] = platform['count']
-    return num_crashes_per_platform
+    @cached_property
+    def num_crashes(self):
+        return self.signature['count']
 
+    @cached_property
+    def num_crashes_per_platform(self):
+        num_crashes_per_platform = {platform + '_count': 0 for platform in self.platform_codes}
+        for platform in self.signature['facets']['platform']:
+            code = platform['term'][:3].lower()
+            if code in self.platform_codes:
+                num_crashes_per_platform[code + '_count'] = platform['count']
+        return num_crashes_per_platform
 
-def get_num_crashes_in_garbage_collection(is_garbage_collecting_facet):
-    num_crashes_in_garbage_collection = 0
-    for row in is_garbage_collecting_facet:
-        if row['term'].lower() == 't':
-            num_crashes_in_garbage_collection = row['count']
-    return num_crashes_in_garbage_collection
+    @cached_property
+    def num_crashes_in_garbage_collection(self):
+        num_crashes_in_garbage_collection = 0
+        for row in self.signature['facets']['is_garbage_collecting']:
+            if row['term'].lower() == 't':
+                num_crashes_in_garbage_collection = row['count']
+        return num_crashes_in_garbage_collection
 
+    @cached_property
+    def num_installs(self):
+        return self.signature['facets']['cardinality_install_time']['value']
 
-def get_num_plugin_crashes(process_type_facet):
-    num_plugin_crashes = 0
-    for row in process_type_facet:
-        if row['term'].lower() == 'plugin':
-            num_plugin_crashes = row['count']
-    return num_plugin_crashes
+    @cached_property
+    def percent_of_total_crashes_diff(self):
+        if self.previous_signature:
+            return self.previous_signature.percent_of_total_crashes - self.percent_of_total_crashes
+        return 'new'
 
+    @cached_property
+    def rank_diff(self):
+        if self.previous_signature:
+            return self.previous_signature.rank - self.rank
+        return 0
 
-def get_num_hang_crashes(hang_type_facet):
-    num_hang_crashes = 0
-    for row in hang_type_facet:
-        # Hangs have weird values in the database: a value of 1 or -1
-        # means it is a hang, a value of 0 or missing means it is not.
-        if row['term'] in (1, -1):
-            num_hang_crashes += row['count']
-    return num_hang_crashes
+    @cached_property
+    def previous_percent_of_total_crashes(self):
+        if self.previous_signature:
+            return self.previous_signature.percent_of_total_crashes
+        return 0
 
+    @cached_property
+    def num_startup_crashes(self):
+        return sum(
+            row['count'] for row in self.signature['facets']['startup_crash']
+            if row['term'] in ('T', '1')
+        )
 
-def get_num_startup_crashes(startup_crash_facet):
-    return sum(
-        row['count'] for row in startup_crash_facet
-        if row['term'] in ('T', '1')
-    )
+    @cached_property
+    def is_startup_crash(self):
+        return self.num_startup_crashes == self.num_crashes
 
+    @cached_property
+    def is_potential_startup_crash(self):
+        return self.num_startup_crashes > 0 and self.num_startup_crashes < self.num_crashes
 
-def get_is_startup_crash(histogram_uptime_facet, crash_count):
-    is_startup_crash = False
-    for row in histogram_uptime_facet:
-        # Aggregation buckets use the lowest value of the bucket as
-        # term. So for everything between 0 and 60 excluded, the
-        # term will be `0`.
-        if row['term'] < 60:
-            ratio = 1.0 * row['count'] / crash_count
-            is_startup_crash = ratio > 0.5
-    return is_startup_crash
+    @cached_property
+    def is_startup_window_crash(self):
+        is_startup_window_crash = False
+        for row in self.signature['facets']['histogram_uptime']:
+            # Aggregation buckets use the lowest value of the bucket as
+            # term. So for everything between 0 and 60 excluded, the
+            # term will be `0`.
+            if row['term'] < 60:
+                ratio = 1.0 * row['count'] / self.num_crashes
+                is_startup_window_crash = ratio > 0.5
+        return is_startup_window_crash
+
+    @cached_property
+    def is_hang_crash(self):
+        num_hang_crashes = 0
+        for row in self.signature['facets']['hang_type']:
+            # Hangs have weird values in the database: a value of 1 or -1
+            # means it is a hang, a value of 0 or missing means it is not.
+            if row['term'] in (1, -1):
+                num_hang_crashes += row['count']
+        return num_hang_crashes > 0
+
+    @cached_property
+    def is_plugin_crash(self):
+        for row in self.signature['facets']['process_type']:
+            if row['term'].lower() == 'plugin':
+                return row['count'] > 0
+        return False
+
+    @cached_property
+    def is_startup_related_crash(self):
+        return self.is_startup_crash \
+            or self.is_potential_startup_crash \
+            or self.is_startup_window_crash
 
 
 def get_comparison_signatures(results):
-    signatures = results['facets']['signature']
-    num_signatures = results['total']
     comparison_signatures = {}
-    for i, signature in enumerate(signatures):
-        comparison_signatures[signature['term']] = {
-            'count': signature['count'],
-            'rank': i + 1,
-            'percent': 100.0 * signature['count'] / num_signatures
-        }
+    for index, signature in enumerate(results['facets']['signature']):
+        signature_stats = SignatureStats(
+            signature=signature,
+            rank=index,
+            num_total_crashes=results['total'],
+            platforms=None,
+            previous_signature=None,
+        )
+        comparison_signatures[signature_stats.signature_term] = signature_stats
     return comparison_signatures

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -1,59 +1,55 @@
-{% if startup_stats %}
-<div class="panel tab-inner-panel">
-    <div class="status-message severity-warning">
-        {% if startup_stats.startup_count > 0 %}
-        {% if startup_stats.startup_count == startup_stats.count %}
-        <div>
-            <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
-                alt="red flag"
-                title="Startup Crash, all crashes happened during startup"
-                class="startup" height="16" width="16"
-            />
-            Startup Crash, all crashes happened during startup
-        </div>
-        {% else %}
-        <div>
-            <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
-                alt="yellow flag"
-                title="Potential Startup Crash, {{ startup_stats.startup_count }} out of {{ startup_stats.count }} crashes happened during startup"
-                class="startup" height="16" width="16"
-            />
-            Potential Startup Crash, {{ startup_stats.startup_count }} out of {{ startup_stats.count }} crashes happened during startup
-        </div>
-        {% endif %}
-        {% endif %}
+{% from "macros/signature_startup_icons.html" import startup_crash_icon,
+                                                     potential_startup_crash_icon,
+                                                     potential_startup_window_crash_icon,
+                                                     hang_crash_icon, plugin_crash_icon,
+                                                     browser_crash_icon %}
 
-        {% if startup_stats.startup_crash %}
-        <div>
-            <img
-            src="{{ static('img/icons/rocket_fly.png') }}"
-            alt="rocket"
-            title="Potential Startup Crash, more than half of the crashes happened during the first minute after launch"
-            class="startup" height="16" width="16"
-            />
-            Potential Startup Crash, more than half of the crashes happened during the first minute after launch
-        </div>
-        {% endif %}
-
-        {% if startup_stats.hang_count > 0 %}
-        <div>
-            <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}" alt="stop sign" title="Hanged Crash" class="hang" height="16" width="16">
-            Hanged Crash
-        </div>
-        {% endif %}
-
-        {% if startup_stats.plugin_count > 0 %}
-        <div>
-            <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}" alt="brick" title="Plugin Crash" class="plugin" height="16" width="16">
-            Plugin Crash
-        </div>
-        {% else %}
-        <div>
-            <img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}" width="16" height="16" alt="application" title="Browser Crash" class="browser" />
-            Browser Crash
-        </div>
-        {% endif %}
+{% if signature_stats %}
+<div class="panel tab-inner-panel crash-type-indicators-panel
+            {% if signature_stats.is_startup_related_crash %} startup-crash-warning {% endif %}">
+    {% if signature_stats.is_startup_crash %}
+    <div class="crash-type-indicator-container">
+        {{ startup_crash_icon() }}
+        Startup Crash, all crashes happened during startup
     </div>
+    {% endif %}
+
+    {% if signature_stats.is_potential_startup_crash %}
+    <div class="crash-type-indicator-container">
+        {{ potential_startup_crash_icon(
+            num_startup_crashes=signature_stats.num_startup_crashes,
+            num_crashes=signature_stats.num_crashes,
+        ) }}
+        Potential Startup Crash, {{ signature_stats.num_startup_crashes }}
+        out of {{ signature_stats.num_crashes }} crashes happened during startup
+    </div>
+    {% endif %}
+
+    {% if signature_stats.is_startup_window_crash %}
+    <div class="crash-type-indicator-container">
+        {{ potential_startup_window_crash_icon() }}
+        Potential Startup Crash, more than half of the crashes happened during the first minute after launch
+    </div>
+    {% endif %}
+
+    {% if signature_stats.is_hang_crash %}
+    <div class="crash-type-indicator-container">
+        {{ hang_crash_icon() }}
+        Hanged Crash
+    </div>
+    {% endif %}
+
+    {% if signature_stats.is_plugin_crash %}
+    <div class="crash-type-indicator-container">
+        {{ plugin_crash_icon() }}
+        Plugin Crash
+    </div>
+    {% else %}
+    <div class="crash-type-indicator-container">
+        {{ browser_crash_icon() }}
+        Browser Crash
+    </div>
+    {% endif %}
 </div>
 {% endif %}
 

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -1,3 +1,62 @@
+{% if startup_stats %}
+<div class="panel tab-inner-panel">
+    <div class="status-message severity-warning">
+        {% if startup_stats.startup_count > 0 %}
+        {% if startup_stats.startup_count == startup_stats.count %}
+        <div>
+            <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
+                alt="red flag"
+                title="Startup Crash, all crashes happened during startup"
+                class="startup" height="16" width="16"
+            />
+            Startup Crash, all crashes happened during startup
+        </div>
+        {% else %}
+        <div>
+            <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
+                alt="yellow flag"
+                title="Potential Startup Crash, {{ startup_stats.startup_count }} out of {{ startup_stats.count }} crashes happened during startup"
+                class="startup" height="16" width="16"
+            />
+            Potential Startup Crash, {{ startup_stats.startup_count }} out of {{ startup_stats.count }} crashes happened during startup
+        </div>
+        {% endif %}
+        {% endif %}
+
+        {% if startup_stats.startup_crash %}
+        <div>
+            <img
+            src="{{ static('img/icons/rocket_fly.png') }}"
+            alt="rocket"
+            title="Potential Startup Crash, more than half of the crashes happened during the first minute after launch"
+            class="startup" height="16" width="16"
+            />
+            Potential Startup Crash, more than half of the crashes happened during the first minute after launch
+        </div>
+        {% endif %}
+
+        {% if startup_stats.hang_count > 0 %}
+        <div>
+            <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}" alt="stop sign" title="Hanged Crash" class="hang" height="16" width="16">
+            Hanged Crash
+        </div>
+        {% endif %}
+
+        {% if startup_stats.plugin_count > 0 %}
+        <div>
+            <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}" alt="brick" title="Plugin Crash" class="plugin" height="16" width="16">
+            Plugin Crash
+        </div>
+        {% else %}
+        <div>
+            <img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}" width="16" height="16" alt="application" title="Browser Crash" class="browser" />
+            Browser Crash
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+
 <div class="panel tab-inner-panel" id="panel-platform">
     <header class="title" title="Toggle visibility">
         <h2>Operating System</h2>

--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -143,6 +143,24 @@ section.summary-panel {
             width: 30%;
         }
     }
+
+    .crash-type-indicators-panel {
+        background-color: @grey-90-a10;
+        padding: 15px;
+
+        &.startup-crash-warning {
+            background-color: @yellow-50;
+        }
+
+        .crash-type-indicator-container {
+            align-items: center;
+            display: flex;
+
+            img {
+                margin-right: 5px;
+            }
+        }
+    }
 }
 section.summary-panel .panel {
     header {

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import render
 from csp.decorators import csp_update
 from socorro.lib import BadArgumentError
 
-from crashstats.base.utils import SignatureStartupStats, render_exception, urlencode_obj
+from crashstats.base.utils import SignatureStats, render_exception, urlencode_obj
 from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.decorators import pass_default_context
@@ -452,7 +452,8 @@ def signature_summary(request, params):
     context['query'] = search_results
     context['product_version_total'] = search_results['total']
     if 'signature' in facets and len(facets['signature']) > 0:
-        context['startup_stats'] = SignatureStartupStats(search_results['facets']['signature'][0])
+        context['signature_stats'] = SignatureStats(search_results['facets']['signature'][0],
+                                                    search_results['total'])
 
     return render(request, 'signature/signature_summary.html', context)
 

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import render
 from csp.decorators import csp_update
 from socorro.lib import BadArgumentError
 
-from crashstats.base.utils import render_exception, urlencode_obj
+from crashstats.base.utils import SignatureStartupStats, render_exception, urlencode_obj
 from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.decorators import pass_default_context
@@ -404,6 +404,12 @@ def signature_summary(request, params):
     context = {}
 
     params['signature'] = '=' + params['signature'][0]
+    params['_aggs.signature'] = [
+        'hang_type',
+        'process_type',
+        'startup_crash',
+        '_histogram.uptime',
+    ]
     params['_results_number'] = 0
     params['_facets'] = [
         'platform_pretty_version',
@@ -445,6 +451,8 @@ def signature_summary(request, params):
 
     context['query'] = search_results
     context['product_version_total'] = search_results['total']
+    if 'signature' in facets and len(facets['signature']) > 0:
+        context['startup_stats'] = SignatureStartupStats(search_results['facets']['signature'][0])
 
     return render(request, 'signature/signature_summary.html', context)
 

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -1,3 +1,9 @@
+{% from "macros/signature_startup_icons.html" import startup_crash_icon,
+                                                     potential_startup_crash_icon,
+                                                     potential_startup_window_crash_icon,
+                                                     hang_crash_icon, plugin_crash_icon,
+                                                     browser_crash_icon %}
+
 {% extends "crashstats_base.html" %}
 {% block site_css %}
     {{ super() }}
@@ -128,104 +134,96 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                     </tr>
                 </thead>
                 <tbody>
-                {% for crash in tcbs %}
+                {% for topcrasher_stats in topcrashers_stats %}
                     <tr>
                         <td class="rank">
-                            {{ crash.rank }}
-                            {% if crash.rank_diff != 'new'
-                               and crash.rank_diff >= 5
-                               or crash.rank_diff <= -5 %}
-                            <span {% if crash.rank_diff > 1 %} class="moving-up" {% elif crash.rank_diff < -1 %} class="moving-down" {% endif %} title="Movement in rank since the {{ query.start_date }} report">{{ crash.rank_diff }}</span>
+                            {{ topcrasher_stats.rank }}
+                            {% if topcrasher_stats.rank_diff != 'new'
+                               and topcrasher_stats.rank_diff >= 5
+                               or topcrasher_stats.rank_diff <= -5 %}
+                            <span {% if topcrasher_stats.rank_diff > 1 %} class="moving-up" {% elif topcrasher_stats.rank_diff < -1 %} class="moving-down" {% endif %} title="Movement in rank since the {{ query.start_date }} report">{{ topcrasher_stats.rank_diff }}</span>
                             {% endif %}
                         </td>
-                        <td>{{ crash.percent | round(2) }}%</td>
-                        {% if crash.diff == 'new' %}
+                        <td>{{ topcrasher_stats.percent_of_total_crashes | round(2) }}%</td>
+                        {% if topcrasher_stats.percent_of_total_crashes_diff == 'new' %}
                         <td title="This is a new signature">new</td>
                         {% else %}
-                        <td title="A change of {{ crash.diff | round(2) }}% from {{ crash.previous_percent | round(2) }}%">{{ crash.diff | round(2) }}%</td>
+                        <td title="A change of {{ topcrasher_stats.percent_of_total_crashes_diff | round(2) }}% from {{ topcrasher_stats.previous_percent_of_total_crashes | round(2) }}%">
+                            {{ topcrasher_stats.percent_of_total_crashes_diff | round(2) }}%
+                        </td>
                         {% endif %}
                         <td class="signature-column">
                             <a class="signature"
                                 href="{{ url('signature:signature_report') }}?{{ make_query_string(
                                     product=product,
-                                    signature=crash.signature,
+                                    signature=topcrasher_stats.signature_term,
                                     version=version,
                                     date=['<' + query.end_date.isoformat(), '>=' + query.start_date.isoformat()],
-                                ) }}" title="{{ crash.signature }}"
+                                ) }}" title="{{ topcrasher_stats.signature_term }}"
                             >
-                                {{ crash.signature }}
+                                {{ topcrasher_stats.signature_term }}
                             </a>
                             <div class="sig-history-container hide">
-                                <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ crash.signature }}" />
+                                <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ topcrasher_stats.signature_term }}" />
                             </div>
                             <div class="signature-icons">
-                                {% if crash.startup_stats.startup_count > 0 %}
-                                {% if crash.startup_stats.startup_count == crash.count %}
-                                <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
-                                    alt="red flag"
-                                    title="Startup Crash, all crashes happened during startup"
-                                    class="startup" height="16" width="16"
-                                />
+                                {% if topcrasher_stats.is_startup_crash %}
+                                {{ startup_crash_icon() }}
+                                {% endif %}
+
+                                {% if topcrasher_stats.is_potential_startup_crash %}
+                                {{ potential_startup_crash_icon(
+                                    num_startup_crashes=topcrasher_stats.num_startup_crashes,
+                                    num_crashes=topcrasher_stats.num_crashes,
+                                ) }}
+                                {% endif %}
+
+                                {% if topcrasher_stats.is_startup_window_crash %}
+                                {{ potential_startup_window_crash_icon() }}
+                                {% endif %}
+
+                                {% if topcrasher_stats.is_hang_crash %}
+                                {{ hang_crash_icon() }}
+                                {% endif %}
+
+                                {% if topcrasher_stats.is_plugin_crash %}
+                                {{ plugin_crash_icon() }}
                                 {% else %}
-                                <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
-                                    alt="yellow flag"
-                                    title="Potential Startup Crash, {{ crash.startup_stats.startup_count }} out of {{ crash.count }} crashes happened during startup"
-                                    class="startup" height="16" width="16"
-                                />
-                                {% endif %}
-                                {% endif %}
-
-                                {% if crash.startup_stats.startup_crash %}
-                                <img
-                                    src="{{ static('img/icons/rocket_fly.png') }}"
-                                    alt="rocket"
-                                    title="Potential Startup Crash, more than half of the crashes happened during the first minute after launch"
-                                    class="startup" height="16" width="16"
-                                />
-                                {% endif %}
-
-                                {% if crash.startup_stats.hang_count > 0 %}
-                                <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}" alt="stop sign" title="Hanged Crash" class="hang" height="16" width="16">
-                                {% endif %}
-
-                                {% if crash.startup_stats.plugin_count > 0 %}
-                                <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}" alt="brick" title="Plugin Crash" class="plugin" height="16" width="16">
-                                {% else %}
-                                <img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}" width="16" height="16" alt="application" title="Browser Crash" class="browser" />
+                                {{ browser_crash_icon() }}
                                 {% endif %}
                             </div>
                         </td>
                         {% if not os_name %}
-                        <td>{{ crash.count }}</td>
-                        <td>{{ crash.platforms.win_count }}</td>
-                        <td>{{ crash.platforms.mac_count }}</td>
-                        <td>{{ crash.platforms.lin_count }}</td>
+                        <td>{{ topcrasher_stats.num_crashes }}</td>
+                        <td>{{ topcrasher_stats.num_crashes_per_platform.win_count }}</td>
+                        <td>{{ topcrasher_stats.num_crashes_per_platform.mac_count }}</td>
+                        <td>{{ topcrasher_stats.num_crashes_per_platform.lin_count }}</td>
                         {% elif os_name == 'Windows' %}
-                        <td>{{ crash.win_count }}</td>
+                        <td>{{ topcrasher_stats.win_count }}</td>
                         {% elif os_name == 'Linux' %}
-                        <td>{{ crash.lin_count }}</td>
+                        <td>{{ topcrasher_stats.lin_count }}</td>
                         {% elif os_name == 'Mac OS X' %}
-                        <td>{{ crash.mac_count }}</td>
+                        <td>{{ topcrasher_stats.mac_count }}</td>
                         {% endif %}
-                        <td>{{ crash.installs_count }}</td>
-                        <td>{{ crash.is_gc_count }}</td>
-                        {% if crash.first_report %}
-                        <td title="This crash signature first appeared at {{ crash.first_report }}" >
-                            <time datetime="{{ crash.first_report }}">
-                                {{ crash.first_report.date() }}
+                        <td>{{ topcrasher_stats.num_installs }}</td>
+                        <td>{{ topcrasher_stats.num_crashes_in_garbage_collection }}</td>
+                        {% if topcrasher_stats.first_report %}
+                        <td title="This crash signature first appeared at {{ topcrasher_stats.first_report }}" >
+                            <time datetime="{{ topcrasher_stats.first_report }}">
+                                {{ topcrasher_stats.first_report.date() }}
                             </time>
                         </td>
                         {% else %}
                         <td title="No known first appearance date">-</td>
                         {% endif %}
                         <td class="bug_ids_more">
-                            {% for bug in crash.bugs %}
+                            {% for bug in topcrasher_stats.bugs %}
                             {{ show_bug_link(bug) }}
                             {% endfor %}
                                 <div class="bug_ids_expanded_list">
-                                <h3>Bugs for <code>{{ crash.signature }}</code></h3>
+                                <h3>Bugs for <code>{{ topcrasher_stats.signature_term }}</code></h3>
                                 <ul class="bug_ids_expanded full_bug_ids popup">
-                                    {% for bug in crash.bugs %}
+                                    {% for bug in topcrasher_stats.bugs %}
                                     <li>{{ show_bug_link(bug) }}</li>
                                     {% endfor %}
                                 </ul>

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -159,8 +159,8 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                                 <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ crash.signature }}" />
                             </div>
                             <div class="signature-icons">
-                                {% if crash.startup_count > 0 %}
-                                {% if crash.startup_count == crash.count %}
+                                {% if crash.startup_stats.startup_count > 0 %}
+                                {% if crash.startup_stats.startup_count == crash.count %}
                                 <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
                                     alt="red flag"
                                     title="Startup Crash, all crashes happened during startup"
@@ -169,13 +169,13 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                                 {% else %}
                                 <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
                                     alt="yellow flag"
-                                    title="Potential Startup Crash, {{ crash.startup_count }} out of {{ crash.count }} crashes happened during startup"
+                                    title="Potential Startup Crash, {{ crash.startup_stats.startup_count }} out of {{ crash.count }} crashes happened during startup"
                                     class="startup" height="16" width="16"
                                 />
                                 {% endif %}
                                 {% endif %}
 
-                                {% if crash.startup_crash %}
+                                {% if crash.startup_stats.startup_crash %}
                                 <img
                                     src="{{ static('img/icons/rocket_fly.png') }}"
                                     alt="rocket"
@@ -184,11 +184,11 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                                 />
                                 {% endif %}
 
-                                {% if crash.hang_count > 0 %}
+                                {% if crash.startup_stats.hang_count > 0 %}
                                 <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}" alt="stop sign" title="Hanged Crash" class="hang" height="16" width="16">
                                 {% endif %}
 
-                                {% if crash.plugin_count > 0 %}
+                                {% if crash.startup_stats.plugin_count > 0 %}
                                 <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}" alt="brick" title="Plugin Crash" class="plugin" height="16" width="16">
                                 {% else %}
                                 <img src="{{ static('img/3rdparty/fatcow/application16x16.png') }}" width="16" height="16" alt="application" title="Browser Crash" class="browser" />
@@ -197,9 +197,9 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                         </td>
                         {% if not os_name %}
                         <td>{{ crash.count }}</td>
-                        <td>{{ crash.win_count }}</td>
-                        <td>{{ crash.mac_count }}</td>
-                        <td>{{ crash.lin_count }}</td>
+                        <td>{{ crash.platforms.win_count }}</td>
+                        <td>{{ crash.platforms.mac_count }}</td>
+                        <td>{{ crash.platforms.lin_count }}</td>
                         {% elif os_name == 'Windows' %}
                         <td>{{ crash.win_count }}</td>
                         {% elif os_name == 'Linux' %}

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -134,59 +134,59 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                     </tr>
                 </thead>
                 <tbody>
-                {% for topcrasher_stats in topcrashers_stats %}
+                {% for topcrashers_stats_item in topcrashers_stats %}
                     <tr>
                         <td class="rank">
-                            {{ topcrasher_stats.rank }}
-                            {% if topcrasher_stats.rank_diff != 'new'
-                               and topcrasher_stats.rank_diff >= 5
-                               or topcrasher_stats.rank_diff <= -5 %}
-                            <span {% if topcrasher_stats.rank_diff > 1 %} class="moving-up" {% elif topcrasher_stats.rank_diff < -1 %} class="moving-down" {% endif %} title="Movement in rank since the {{ query.start_date }} report">{{ topcrasher_stats.rank_diff }}</span>
+                            {{ topcrashers_stats_item.rank }}
+                            {% if topcrashers_stats_item.rank_diff != 'new'
+                               and topcrashers_stats_item.rank_diff >= 5
+                               or topcrashers_stats_item.rank_diff <= -5 %}
+                            <span {% if topcrashers_stats_item.rank_diff > 1 %} class="moving-up" {% elif topcrashers_stats_item.rank_diff < -1 %} class="moving-down" {% endif %} title="Movement in rank since the {{ query.start_date }} report">{{ topcrashers_stats_item.rank_diff }}</span>
                             {% endif %}
                         </td>
-                        <td>{{ topcrasher_stats.percent_of_total_crashes | round(2) }}%</td>
-                        {% if topcrasher_stats.percent_of_total_crashes_diff == 'new' %}
+                        <td>{{ topcrashers_stats_item.percent_of_total_crashes | round(2) }}%</td>
+                        {% if topcrashers_stats_item.percent_of_total_crashes_diff == 'new' %}
                         <td title="This is a new signature">new</td>
                         {% else %}
-                        <td title="A change of {{ topcrasher_stats.percent_of_total_crashes_diff | round(2) }}% from {{ topcrasher_stats.previous_percent_of_total_crashes | round(2) }}%">
-                            {{ topcrasher_stats.percent_of_total_crashes_diff | round(2) }}%
+                        <td title="A change of {{ topcrashers_stats_item.percent_of_total_crashes_diff | round(2) }}% from {{ topcrashers_stats_item.previous_percent_of_total_crashes | round(2) }}%">
+                            {{ topcrashers_stats_item.percent_of_total_crashes_diff | round(2) }}%
                         </td>
                         {% endif %}
                         <td class="signature-column">
                             <a class="signature"
                                 href="{{ url('signature:signature_report') }}?{{ make_query_string(
                                     product=product,
-                                    signature=topcrasher_stats.signature_term,
+                                    signature=topcrashers_stats_item.signature_term,
                                     version=version,
                                     date=['<' + query.end_date.isoformat(), '>=' + query.start_date.isoformat()],
-                                ) }}" title="{{ topcrasher_stats.signature_term }}"
+                                ) }}" title="{{ topcrashers_stats_item.signature_term }}"
                             >
-                                {{ topcrasher_stats.signature_term }}
+                                {{ topcrashers_stats_item.signature_term }}
                             </a>
                             <div class="sig-history-container hide">
-                                <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ topcrasher_stats.signature_term }}" />
+                                <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ topcrashers_stats_item.signature_term }}" />
                             </div>
                             <div class="signature-icons">
-                                {% if topcrasher_stats.is_startup_crash %}
+                                {% if topcrashers_stats_item.is_startup_crash %}
                                 {{ startup_crash_icon() }}
                                 {% endif %}
 
-                                {% if topcrasher_stats.is_potential_startup_crash %}
+                                {% if topcrashers_stats_item.is_potential_startup_crash %}
                                 {{ potential_startup_crash_icon(
-                                    num_startup_crashes=topcrasher_stats.num_startup_crashes,
-                                    num_crashes=topcrasher_stats.num_crashes,
+                                    num_startup_crashes=topcrashers_stats_item.num_startup_crashes,
+                                    num_crashes=topcrashers_stats_item.num_crashes,
                                 ) }}
                                 {% endif %}
 
-                                {% if topcrasher_stats.is_startup_window_crash %}
+                                {% if topcrashers_stats_item.is_startup_window_crash %}
                                 {{ potential_startup_window_crash_icon() }}
                                 {% endif %}
 
-                                {% if topcrasher_stats.is_hang_crash %}
+                                {% if topcrashers_stats_item.is_hang_crash %}
                                 {{ hang_crash_icon() }}
                                 {% endif %}
 
-                                {% if topcrasher_stats.is_plugin_crash %}
+                                {% if topcrashers_stats_item.is_plugin_crash %}
                                 {{ plugin_crash_icon() }}
                                 {% else %}
                                 {{ browser_crash_icon() }}
@@ -194,36 +194,36 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                             </div>
                         </td>
                         {% if not os_name %}
-                        <td>{{ topcrasher_stats.num_crashes }}</td>
-                        <td>{{ topcrasher_stats.num_crashes_per_platform.win_count }}</td>
-                        <td>{{ topcrasher_stats.num_crashes_per_platform.mac_count }}</td>
-                        <td>{{ topcrasher_stats.num_crashes_per_platform.lin_count }}</td>
+                        <td>{{ topcrashers_stats_item.num_crashes }}</td>
+                        <td>{{ topcrashers_stats_item.num_crashes_per_platform.win_count }}</td>
+                        <td>{{ topcrashers_stats_item.num_crashes_per_platform.mac_count }}</td>
+                        <td>{{ topcrashers_stats_item.num_crashes_per_platform.lin_count }}</td>
                         {% elif os_name == 'Windows' %}
-                        <td>{{ topcrasher_stats.win_count }}</td>
+                        <td>{{ topcrashers_stats_item.win_count }}</td>
                         {% elif os_name == 'Linux' %}
-                        <td>{{ topcrasher_stats.lin_count }}</td>
+                        <td>{{ topcrashers_stats_item.lin_count }}</td>
                         {% elif os_name == 'Mac OS X' %}
-                        <td>{{ topcrasher_stats.mac_count }}</td>
+                        <td>{{ topcrashers_stats_item.mac_count }}</td>
                         {% endif %}
-                        <td>{{ topcrasher_stats.num_installs }}</td>
-                        <td>{{ topcrasher_stats.num_crashes_in_garbage_collection }}</td>
-                        {% if topcrasher_stats.first_report %}
-                        <td title="This crash signature first appeared at {{ topcrasher_stats.first_report }}" >
-                            <time datetime="{{ topcrasher_stats.first_report }}">
-                                {{ topcrasher_stats.first_report.date() }}
+                        <td>{{ topcrashers_stats_item.num_installs }}</td>
+                        <td>{{ topcrashers_stats_item.num_crashes_in_garbage_collection }}</td>
+                        {% if topcrashers_stats_item.first_report %}
+                        <td title="This crash signature first appeared at {{ topcrashers_stats_item.first_report }}" >
+                            <time datetime="{{ topcrashers_stats_item.first_report }}">
+                                {{ topcrashers_stats_item.first_report.date() }}
                             </time>
                         </td>
                         {% else %}
                         <td title="No known first appearance date">-</td>
                         {% endif %}
                         <td class="bug_ids_more">
-                            {% for bug in topcrasher_stats.bugs %}
+                            {% for bug in topcrashers_stats_item.bugs %}
                             {{ show_bug_link(bug) }}
                             {% endfor %}
                                 <div class="bug_ids_expanded_list">
-                                <h3>Bugs for <code>{{ topcrasher_stats.signature_term }}</code></h3>
+                                <h3>Bugs for <code>{{ topcrashers_stats_item.signature_term }}</code></h3>
                                 <ul class="bug_ids_expanded full_bug_ids popup">
-                                    {% for bug in topcrasher_stats.bugs %}
+                                    {% for bug in topcrashers_stats_item.bugs %}
                                     <li>{{ show_bug_link(bug) }}</li>
                                     {% endfor %}
                                 </ul>

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -82,7 +82,6 @@ def get_topcrashers_stats(**kwargs):
         previous_range_results = api.get(**params)
         previous_signatures = get_comparison_signatures(previous_range_results)
 
-        signatures_stats = []
         for index, signature in enumerate(search_results['facets']['signature']):
             previous_signature = previous_signatures.get(signature['term'])
             signatures_stats.append(SignatureStats(
@@ -220,9 +219,9 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     count_of_included_crashes = 0
     signatures = []
 
-    for topcrasher_stats in topcrashers_stats[:int(result_count)]:
-        signatures.append(topcrasher_stats.signature_term)
-        count_of_included_crashes += topcrasher_stats.num_crashes
+    for topcrashers_stats_item in topcrashers_stats[:int(result_count)]:
+        signatures.append(topcrashers_stats_item.signature_term)
+        count_of_included_crashes += topcrashers_stats_item.num_crashes
 
     context['number_of_crashes'] = count_of_included_crashes
     context['total_percentage'] = len(topcrashers_stats) and (
@@ -247,7 +246,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         for signature_term, dates in first_dates.items():
             sig_date_data[signature_term] = dates['first_date']
 
-    for topcrasher_stats in topcrashers_stats:
+    for topcrashers_stats_item in topcrashers_stats:
         crash_counts = []
         # Due to the inconsistencies of OS usage and naming of
         # codes and props for operating systems the hacky bit below
@@ -259,23 +258,23 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
                 continue
             os_code = operating_system['code'][0:3].lower()
             key = '%s_count' % os_code
-            crash_counts.append([topcrasher_stats.num_crashes_per_platform[key],
+            crash_counts.append([topcrashers_stats_item.num_crashes_per_platform[key],
                                 operating_system['name']])
 
-        signature_term = topcrasher_stats.signature_term
+        signature_term = topcrashers_stats_item.signature_term
         # Augment with bugs.
         if signature_term in bugs:
-            if hasattr(topcrasher_stats, 'bugs'):
-                topcrasher_stats.bugs.extend(bugs[signature_term])
+            if hasattr(topcrashers_stats_item, 'bugs'):
+                topcrashers_stats_item.bugs.extend(bugs[signature_term])
             else:
-                topcrasher_stats.bugs = bugs[signature_term]
+                topcrashers_stats_item.bugs = bugs[signature_term]
 
         # Augment with first appearance dates.
         if signature_term in sig_date_data:
-            topcrasher_stats.first_report = sig_date_data[signature_term]
+            topcrashers_stats_item.first_report = sig_date_data[signature_term]
 
-        if hasattr(topcrasher_stats, 'bugs'):
-            topcrasher_stats.bugs.sort(reverse=True)
+        if hasattr(topcrashers_stats_item, 'bugs'):
+            topcrashers_stats_item.bugs.sort(reverse=True)
 
     context['topcrashers_stats'] = topcrashers_stats
     context['days'] = days


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1344864

## why:
- being able to distinguish startup crashes from non-startup crashes is useful

## what:
- added icons and text to the signature summary tab that indicate startup crash statistics
  - these are the same icons as those found on the topcrashers page

## notes
I split the changes into three commits:
- first commit does the refactoring of topcrashers
  - needed to extract some of the functionality used to generate topcrashers data because part of it will be used to generate signature summary data
  - started generating data through classes instead of a dictionary
  - extracted computations into methods
  - this extraction should also be useful for https://bugzilla.mozilla.org/show_bug.cgi?id=1472335
- second commit adds the startup stats to the signature summary
- third commit adds review updated:
  - converted topcrashers signature icons into macros
    - started using these macros in the topcrashers page
    - started using these macros in signature summary
  - updated SignatureStats class
    - merged SignatureStartupStats into SignatureStats
    - started doing the previous results checks through properties instead of after the fact
    - made all properties be cached_property's
    - changed properties for startup, hang, and plugin stats to be booleans instead of numbers
    - added unit test
  - updated signature summary
    - added custom LESS classes to change color and layout
  - updated topcrashers
    - removed `get_signatures_stats` util method and started doing the work in views.py instead
    - change variable naming to be simpler and more informative

## visuals (updated)
startup crash signature
![screen shot 2018-07-05 at 12 41 56 pm](https://user-images.githubusercontent.com/12681350/42344327-dc07a034-8050-11e8-9e9a-915a224e22bb.png)

non-startup crash signature
![screen shot 2018-07-05 at 12 42 01 pm](https://user-images.githubusercontent.com/12681350/42344338-e4d3ea10-8050-11e8-8acb-8cb81ffd7d2a.png)


