### PR TITLE
bug 1469718: all the changes for sub dir socorro.external.boto

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -21,6 +21,33 @@ WORKING_TESTS=(
     socorro/unittest/lib/test_transform_rules.py
     socorro/unittest/lib/test_util.py
     socorro/unittest/lib/test_vertools.py
+
+    socorro/unittest/external/boto/test_connection_context.py
+    socorro/unittest/external/boto/test_crash_data.py
+    socorro/unittest/external/boto/test_crashstorage.py
+    socorro/unittest/external/boto/test_upload_telemetry_schema.py
+
+    socorro/unittest/external/es/test_analyzers.py
+    socorro/unittest/external/es/test_connection_context.py
+    socorro/unittest/external/es/test_index_creator.py
+    socorro/unittest/external/es/test_new_crash_source.py
+    socorro/unittest/external/es/test_query.py
+
+    socorro/unittest/external/postgresql/test_adi.py
+    socorro/unittest/external/postgresql/test_base.py
+    socorro/unittest/external/postgresql/test_bugs.py
+    socorro/unittest/external/postgresql/test_connection_context.py
+    socorro/unittest/external/postgresql/test_crontabber_state.py
+    socorro/unittest/external/postgresql/test_dbapi2_util.py
+    socorro/unittest/external/postgresql/test_graphics_devices.py
+    socorro/unittest/external/postgresql/test_platforms.py
+    socorro/unittest/external/postgresql/test_product_build_types.py
+    socorro/unittest/external/postgresql/test_releases.py
+    socorro/unittest/external/postgresql/test_setupdb_app.py
+    socorro/unittest/external/postgresql/test_signature_first_date.py
+
+    socorro/unittest/external/rabbitmq/test_reprocessing.py
+    socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
 )
 
 pytest ${WORKING_TESTS[@]}

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -249,7 +249,7 @@ class ConnectionContextBase(RequiredConfig):
         return json.dumps(a_mapping, cls=JSONISOEncoder)
 
     def _convert_list_to_string(self, a_list):
-        return json.dumps(a_list)
+        return json.dumps(list(a_list))
 
     def _convert_string_to_list(self, a_string):
         return json.loads(a_string)

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -6,6 +6,7 @@ import json
 
 import json_schema_reducer
 from socorro.lib.converters import change_default
+from future.utils import iteritems
 
 from configman import Namespace
 from configman.converters import class_converter, py_obj_to_str
@@ -133,7 +134,7 @@ class BotoCrashStorage(CrashStorageBase):
         # however, that by calling the memory_dump_mapping method, we will
         # get a MemoryDumpMapping which is exactly what we need.
         dumps = dumps.as_memory_dumps_mapping()
-        for dump_name, dump in dumps.iteritems():
+        for dump_name, dump in iteritems(dumps):
             if dump_name in (None, '', 'upload_file_minidump'):
                 dump_name = 'dump'
             boto_connection.submit(crash_id, dump_name, dump)

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -14,6 +14,7 @@ import datetime
 from past.builtins import basestring
 
 from socorro.lib.util import DotDict as SocorroDotDict
+from future.utils import iteritems
 
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter, str_to_list
@@ -63,7 +64,7 @@ class MemoryDumpsMapping(dict):
         """convert this MemoryDumpMapping into a FileDumpsMappng by writing
         each of the dump to a filesystem."""
         name_to_pathname_mapping = FileDumpsMapping()
-        for a_dump_name, a_dump in self.iteritems():
+        for a_dump_name, a_dump in iteritems(self):
             if a_dump_name in (None, '', 'dump'):
                 a_dump_name = 'upload_file_minidump'
             dump_pathname = os.path.join(

--- a/socorro/unittest/external/boto/test_crash_data.py
+++ b/socorro/unittest/external/boto/test_crash_data.py
@@ -48,7 +48,7 @@ class TestSimplifiedCrashData:
         boto_helper.set_contents_from_string(
             bucket_name='crashstats',
             key='/v1/dump/0bba929f-8721-460c-dead-a43c20071027',
-            value='\xa0'
+            value=b'\xa0'
         )
 
         boto_s3_store = self.get_s3_store()
@@ -57,7 +57,7 @@ class TestSimplifiedCrashData:
             uuid='0bba929f-8721-460c-dead-a43c20071027',
             datatype='raw',
         )
-        assert result == '\xa0'
+        assert result == b'\xa0'
 
     @mock_s3_deprecated
     def test_get_raw_dump_not_found(self, boto_helper):

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -196,7 +196,7 @@ class TestBotoS3CrashStorage:
         boto_s3_store.save_raw_crash(
             {"submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"},
             MemoryDumpsMapping(
-                {'dump': 'fake dump', 'flash_dump': 'fake flash dump'}
+                {'dump': b'fake dump', 'flash_dump': b'fake flash dump'}
             ),
             "0bba929f-8721-460c-dead-a43c20071027"
         )
@@ -228,13 +228,13 @@ class TestBotoS3CrashStorage:
             bucket_name='crash_storage',
             key='dev/v1/dump/0bba929f-8721-460c-dead-a43c20071027'
         )
-        assert dump == 'fake dump'
+        assert dump == b'fake dump'
 
         flash_dump = boto_helper.get_contents_as_string(
             bucket_name='crash_storage',
             key='dev/v1/flash_dump/0bba929f-8721-460c-dead-a43c20071027'
         )
-        assert flash_dump == 'fake flash dump'
+        assert flash_dump == b'fake flash dump'
 
     @mock_s3_deprecated
     def test_save_processed(self, boto_helper):
@@ -326,13 +326,13 @@ class TestBotoS3CrashStorage:
         boto_helper.set_contents_from_string(
             bucket_name='crash_storage',
             key='dev/v1/dump/936ce666-ff3b-4c7a-9674-367fe2120408',
-            value='this is a raw dump'
+            value=b'this is a raw dump'
         )
 
         # the tested call
         boto_s3_store = setup_mocked_s3_storage()
         result = boto_s3_store.get_raw_dump('936ce666-ff3b-4c7a-9674-367fe2120408')
-        assert result == 'this is a raw dump'
+        assert result == b'this is a raw dump'
 
     @mock_s3_deprecated
     def test_get_raw_dump_not_found(self):
@@ -347,7 +347,7 @@ class TestBotoS3CrashStorage:
         boto_helper.set_contents_from_string(
             bucket_name='crash_storage',
             key='dev/v1/dump/936ce666-ff3b-4c7a-9674-367fe2120408',
-            value='this is a raw dump'
+            value=b'this is a raw dump'
         )
 
         # the tested call
@@ -357,7 +357,7 @@ class TestBotoS3CrashStorage:
             name='upload_file_minidump'
         )
 
-        assert result == 'this is a raw dump'
+        assert result == b'this is a raw dump'
 
     @mock_s3_deprecated
     def test_get_raw_dump_empty_string(self, boto_helper):
@@ -365,13 +365,13 @@ class TestBotoS3CrashStorage:
         boto_helper.set_contents_from_string(
             bucket_name='crash_storage',
             key='dev/v1/dump/936ce666-ff3b-4c7a-9674-367fe2120408',
-            value='this is a raw dump'
+            value=b'this is a raw dump'
         )
 
         # the tested call
         boto_s3_store = setup_mocked_s3_storage()
         result = boto_s3_store.get_raw_dump('936ce666-ff3b-4c7a-9674-367fe2120408', name='')
-        assert result == 'this is a raw dump'
+        assert result == b'this is a raw dump'
 
     @mock_s3_deprecated
     def test_get_raw_dumps(self, boto_helper):
@@ -393,7 +393,7 @@ class TestBotoS3CrashStorage:
         boto_helper.set_contents_from_string(
             bucket_name='crash_storage',
             key='dev/v1/city_dump/936ce666-ff3b-4c7a-9674-367fe2120408',
-            value='this is "city_dump", the last one'
+            value=b'this is "city_dump", the last one'
         )
 
         # the tested call
@@ -401,9 +401,9 @@ class TestBotoS3CrashStorage:
         result = boto_s3_store.get_raw_dumps('936ce666-ff3b-4c7a-9674-367fe2120408')
         assert (
             result == {
-                'dump': 'this is "dump", the first one',
-                'flash_dump': 'this is "flash_dump", the second one',
-                'city_dump': 'this is "city_dump", the last one',
+                'dump': b'this is "dump", the first one',
+                'flash_dump': b'this is "flash_dump", the second one',
+                'city_dump': b'this is "city_dump", the last one',
             }
         )
 


### PR DESCRIPTION
In testing the raw dump data there was an error in the test value
returning as a binary string. This value was failing in comparison to
the expected unicode value for python 3. Placing print statements in
class level functions didn’t tell us much.So we traced the function from
top to bottom and bottom to top. This pushed over the deep end as we
found ourselves in the boto service source code. We couldn’t find the
exact time this conversion of the test value occurred. To solve this
issue we made the assumption data being used in raw dump is binary. So
we change the test value to be a binary string and also changed the
expected comparison to be a binary string as well. The implementation of
the function iteritems() changed from python 2 to 3. Similar to the
range function the change in implementation went from generating a list
to using an iterator. Lastly objects of type ‘dict_values’ is not JSON
serializable. To solve this we wrap the call to values with a call to
list.