### PR TITLE
fix bug 1454482: fixed crash index metrics

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -88,7 +88,7 @@ class BotoCrashStorage(CrashStorageBase):
             quit_check_callback=quit_check_callback
         )
 
-        self.connection_source = config.resource_class(config, namespace=namespace)
+        self.connection_source = config.resource_class(config, namespace='processor.s3')
         self.transaction = config.transaction_executor_class(
             config,
             self.connection_source,


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1454482

## why
`BotoS3CrashStorage` and `TelemetryBotoS3CrashStorage` currently give
their own namespace to their `ConnectionContextBase`'s `connection_context`.
`ConnectionContextBase` uses the passed namespace for its metrics.
This results in different metrics prefixes for submisisons to S3.

## what
This PR changes that by setting the desired namespace name for
`connection_context`.

## examples
before
```
processor_1      | 2018-07-06 17:03:05,864 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|histogram|processor.s3.submit|67.2330856323|#kind:processed_crash,outcome:successful
processor_1      | 2018-07-06 17:03:05,865 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|timing|processor.s3.BotoS3CrashStorage.save_raw_and_processed|72.3359584808|
processor_1      | 2018-07-06 17:03:05,937 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|histogram|processor.elasticsearch.raw_crash_size|10462|
processor_1      | 2018-07-06 17:03:05,939 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|histogram|processor.elasticsearch.processed_crash_size|5962|
processor_1      | 2018-07-06 17:03:05,977 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|histogram|processor.elasticsearch.index|7.75504112244|#outcome:successful
processor_1      | 2018-07-06 17:03:05,978 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|timing|processor.es.ESCrashStorageRedactedJsonDump.save_raw_and_processed|41.5148735046|
processor_1      | 2018-07-06 17:03:05,978 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:05|incr|processor.save_raw_and_processed|1|
processor_1      | 2018-07-06 17:03:06,049 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:06|histogram|processor.telemetry.submit|67.5790309906|#kind:crash_report,outcome:successful
processor_1      | 2018-07-06 17:03:06,050 INFO - markus - Thread-3 - METRICS|2018-07-06 17:03:06|timing|processor.telemetry.TelemetryBotoS3CrashStorage.save_raw_and_processed|70.8200931549|
```

after
```
processor_1      | 2018-07-06 17:14:12,858 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:12|histogram|processor.s3.submit|45.7589626312|#kind:processed_crash,outcome:successful
processor_1      | 2018-07-06 17:14:12,859 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:12|timing|processor.s3.BotoS3CrashStorage.save_raw_and_processed|48.0759143829|
processor_1      | 2018-07-06 17:14:12,869 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:12|histogram|processor.elasticsearch.raw_crash_size|3286|
processor_1      | 2018-07-06 17:14:12,870 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:12|histogram|processor.elasticsearch.processed_crash_size|4129|
processor_1      | 2018-07-06 17:14:13,103 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:13|histogram|processor.elasticsearch.index|180.83691597|#outcome:successful
processor_1      | 2018-07-06 17:14:13,104 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:13|timing|processor.es.ESCrashStorageRedactedJsonDump.save_raw_and_processed|235.795021057|
processor_1      | 2018-07-06 17:14:13,105 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:13|incr|processor.save_raw_and_processed|1|
processor_1      | 2018-07-06 17:14:13,119 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:13|histogram|processor.s3.submit|12.2790336609|#kind:crash_report,outcome:successful
processor_1      | 2018-07-06 17:14:13,121 INFO - markus - Thread-3 - METRICS|2018-07-06 17:14:13|timing|processor.telemetry.TelemetryBotoS3CrashStorage.save_raw_and_processed|15.2730941772|
```