### PR TITLE
 fix bug 1474368: preserve URL params after login 

### DIFF
--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -169,7 +169,7 @@
                         <button class="sign-out-button" type="submit">Sign out</button>
                     </form>
                 {% else %}
-                    <a href="{{ url('oidc_authentication_init') }}?{{ make_query_string(next=request.path) }}">Sign in</a>
+                    <a href="{{ url('oidc_authentication_init') }}?{{ make_query_string(next=request.get_full_path()) }}">Sign in</a>
                 {% endif %}
                 </li>
             </ul>


### PR DESCRIPTION
fix bug https://bugzilla.mozilla.org/show_bug.cgi?id=1474368: preserve URL params after login

## why
- we want to preserve query parameters when going back to the original page after a login
- this problem was introduced in #4471 when switching from Google Sign-In to OpenID Connect

## what
- changed the login link to include the full path with query parameters instead of the just the path

## testing
1. be logged out
2. go to a signature page (/signature/?...)
3. click the `Login` button and complete the login
4. expect to back to the same signature page instead of being taken to a page that display indicating that a parameter is required