### PR TITLE
fix bug 1475482 - Skip "__fixunsdfsi"

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -25,6 +25,7 @@ dalvik-mark-stack
 data@app@org\.mozilla\.f.*-\d\.apk@classes\.dex@0x
 .*FNODOBFM
 framework\.odex@0x
+__fixunsdfsi
 GetLCIDFromLangListNodeWithLICCheck
 gfxPlatform::GetPlatform
 google_breakpad::CrashGenerationClient::RequestDumpForException


### PR DESCRIPTION
"__fixunsdfsi" is a compiler intrinsic for floating point number conversions. There are many other floating point intrinsic functions, but for now we can just add this one. We're seeing crashes on Android ARM devices, like [Firefox bug 1475482](https://bugzilla.mozilla.org/show_bug.cgi?id=1475482).

https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html