### PR TITLE
fix bug 1476697: switch from X_FORWARDED_FOR to X_REAL_IP

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -68,7 +68,7 @@ class TestViews(BaseTestViews):
         super(TestViews, self).setUp()
         self._middleware_classes = settings.MIDDLEWARE_CLASSES
         settings.MIDDLEWARE_CLASSES += (
-            'crashstats.crashstats.middleware.SetRemoteAddrFromForwardedFor',
+            'crashstats.crashstats.middleware.SetRemoteAddrFromRealIP',
         )
 
     def tearDown(self):

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -652,12 +652,12 @@ class TestViews(BaseTestViews):
             # Double to avoid
             # https://bugzilla.mozilla.org/show_bug.cgi?id=1148470
             for __ in range(current_limit * 2):
-                response = self.client.get(url, HTTP_X_FORWARDED_FOR='12.12.12.12')
+                response = self.client.get(url, HTTP_X_REAL_IP='12.12.12.12')
             assert response.status_code == 429
 
-            # But it'll work if you use a different X-Forwarded-For IP
+            # But it'll work if you use a different X-Real-IP
             # because the rate limit is based on your IP address
-            response = self.client.get(url, HTTP_X_FORWARDED_FOR='11.11.11.11')
+            response = self.client.get(url, HTTP_X_REAL_IP='11.11.11.11')
             assert response.status_code == 200
 
             user = User.objects.create(username='test')

--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 
 
-class SetRemoteAddrFromForwardedFor(object):
+class SetRemoteAddrFromRealIP(object):
     """
     Middleware that sets REMOTE_ADDR based on HTTP_X_REAL_IP, if the
     latter is set. This is useful if you're sitting behind a reverse proxy that

--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -3,16 +3,17 @@ from django.shortcuts import render
 
 class SetRemoteAddrFromForwardedFor(object):
     """
-    Middleware that sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, if the
+    Middleware that sets REMOTE_ADDR based on HTTP_X_REAL_IP, if the
     latter is set. This is useful if you're sitting behind a reverse proxy that
     causes each request's REMOTE_ADDR to be set to 127.0.0.1.
 
-    Note that this does NOT validate HTTP_X_FORWARDED_FOR. If you're not behind
-    a reverse proxy that sets HTTP_X_FORWARDED_FOR automatically, do not use
-    this middleware. Anybody can spoof the value of HTTP_X_FORWARDED_FOR, and
-    because this sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, that means
+    Note that this does NOT validate HTTP_X_REAL_IP. If you're not behind
+    a reverse proxy that sets HTTP_X_REAL_IP automatically, do not use
+    this middleware. Anybody can spoof the value of HTTP_X_REAL_IP, and
+    because this sets REMOTE_ADDR based on HTTP_X_REAL_IP, that means
     anybody can "fake" their IP address. Only use this when you can absolutely
-    trust the value of HTTP_X_FORWARDED_FOR.
+    trust the value of HTTP_X_REAL_IP.
+
     """
     def __init__(self, get_response=None):
         self.get_response = get_response
@@ -22,16 +23,8 @@ class SetRemoteAddrFromForwardedFor(object):
         return self.get_response(request)
 
     def process_request(self, request):
-        try:
-            real_ip = request.META['HTTP_X_FORWARDED_FOR']
-        except KeyError:
-            pass
-        else:
-            # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
-            # Production Socorro runs behind an Amazon ELB, which puts
-            # the client IP at the end of the list instead of the
-            # beginning.
-            real_ip = real_ip.split(',')[-1].strip()
+        real_ip = request.META.get('HTTP_X_REAL_IP')
+        if real_ip:
             request.META['REMOTE_ADDR'] = real_ip
 
 

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -1,14 +1,14 @@
 from django.test.client import RequestFactory
 
 from crashstats.base.tests.testbase import DjangoTestCase
-from crashstats.crashstats.middleware import SetRemoteAddrFromForwardedFor
+from crashstats.crashstats.middleware import SetRemoteAddrFromRealIP
 
 
-class TestSetRemoteAddrFromForwardedFor(DjangoTestCase):
+class TestSetRemoteAddrFromRealIP(DjangoTestCase):
 
     def test_no_headers(self):
         """Should not break if there is no HTTP_X_REAL_IP"""
-        middleware = SetRemoteAddrFromForwardedFor()
+        middleware = SetRemoteAddrFromRealIP()
         request = RequestFactory().get('/')
         response = middleware.process_request(request)
         assert response is None
@@ -18,7 +18,7 @@ class TestSetRemoteAddrFromForwardedFor(DjangoTestCase):
         request.META['REMOTE_ADDR'].
 
         """
-        middleware = SetRemoteAddrFromForwardedFor()
+        middleware = SetRemoteAddrFromRealIP()
         request = RequestFactory(**{
             'HTTP_X_REAL_IP': '100.100.100.100',
             'REMOTE_ADDR': '123.123.123.123',

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -7,34 +7,20 @@ from crashstats.crashstats.middleware import SetRemoteAddrFromForwardedFor
 class TestSetRemoteAddrFromForwardedFor(DjangoTestCase):
 
     def test_no_headers(self):
-        """Should not break if there is no HTTP_X_FORWARDED_FOR"""
+        """Should not break if there is no HTTP_X_REAL_IP"""
         middleware = SetRemoteAddrFromForwardedFor()
         request = RequestFactory().get('/')
         response = middleware.process_request(request)
         assert response is None
 
-    def test_single_ip(self):
-        """Ihe IP in HTTP_X_FORWARDED_FOR should update
+    def test_real_ip(self):
+        """Ihe IP in HTTP_X_REAL_IP should update
         request.META['REMOTE_ADDR'].
 
         """
         middleware = SetRemoteAddrFromForwardedFor()
         request = RequestFactory(**{
-            'HTTP_X_FORWARDED_FOR': '100.100.100.100',
-            'REMOTE_ADDR': '123.123.123.123',
-        }).get('/')
-        response = middleware.process_request(request)
-        assert response is None
-        assert request.META['REMOTE_ADDR'] == '100.100.100.100'
-
-    def test_ip_list(self):
-        """The last (comma separated) IP in HTTP_X_FORWARDED_FOR should
-        update request.META['REMOTE_ADDR'].
-
-        """
-        middleware = SetRemoteAddrFromForwardedFor()
-        request = RequestFactory(**{
-            'HTTP_X_FORWARDED_FOR': '245.245.245.245 , 100.100.100.100',
+            'HTTP_X_REAL_IP': '100.100.100.100',
             'REMOTE_ADDR': '123.123.123.123',
         }).get('/')
         response = middleware.process_request(request)

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -117,11 +117,14 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     # If you run crashstats behind a load balancer, your `REMOTE_ADDR` header
-    # will be that of the load balancer instead of the actual user.
-    # The solution is to instead rely on the `X-Forwarded-For` header.
-    # You ONLY want this if you know you can trust `X-Forwarded-For`.
-    # Make sure this is *before* the `RatelimitMiddleware` middleware.
-    'crashstats.crashstats.middleware.SetRemoteAddrFromForwardedFor',
+    # will be that of the load balancer instead of the actual user. The
+    # solution is to instead rely on the `X-Real-IP' header set by nginx
+    # module or something else.
+    #
+    # You ONLY want this if you know you can trust `X-Real-IP`. Make sure this
+    # is *before* the `RatelimitMiddleware` middleware. Otherwise that
+    # middleware is operating on the wrong value.
+    'crashstats.crashstats.middleware.SetRemoteAddrFromRealIP',
 
     'csp.middleware.CSPMiddleware',
     'waffle.middleware.WaffleMiddleware',


### PR DESCRIPTION
This switches the middleware from looking at the `X_FORWARDED_FOR` header
and all its interetingness to looking at the `X_REAL_IP` header which
is set by nginx module we're using.