### PR TITLE
bug 1475820: tweak rust panic symbols in siglists

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -72,6 +72,7 @@ NtWaitForAlertByThreadId
 nvmap@0x
 objc_begin_catch
 org\.mozilla\.f.*-\d\.apk@0x
+panic_abort::
 PR_WaitCondVar
 RaiseException
 rtc::FatalMessage

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -216,8 +216,6 @@ SSL_
 std::_Allocate
 std::_Hash<T>::
 std::list<.*>::
-std::panicking::begin_panic<.*>
-std::panicking::rust_panic_with_hook
 std::collections::hash::map::
 stdext::hash_map<T>::
 strcat

--- a/socorro/signature/siglists/signature_sentinels.txt
+++ b/socorro/signature/siglists/signature_sentinels.txt
@@ -9,3 +9,8 @@ _purecall
 _sigtramp
 Java_org_mozilla_gecko_GeckoAppShell_reportJavaCrash
 google_breakpad::ExceptionHandler::HandleInvalidParameter
+
+# These mark the top-most interesting frame in a Rust panic. Anything before
+# these is a lot of, "yes, I'm panicking!"
+std::panicking::begin_panic
+std::panicking::begin_panic_fmt


### PR DESCRIPTION
* removes `std::panicking::*` from the prefix list because that's covered
  in the irrelevant list, so it doesn't have any effect
* add `panic_abort::` to the irrelevant list so it gets skipped over