### PR TITLE
fix bug 1478741: add ftpscraper wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 clean:
 	-rm .docker-build
 	-rm -rf build breakpad stackwalk google-breakpad breakpad.tar.gz
+	-rm -rf .cache
 	cd minidump-stackwalk && make clean
 
 docs: my.env

--- a/docker/run_ftpscraper_wrapper.sh
+++ b/docker/run_ftpscraper_wrapper.sh
@@ -9,18 +9,19 @@
 
 set -eo pipefail
 
-# Fetch and update release information for these products (comma-delimited)
+# Fetch and update release information for these products (comma-delimited).
 PRODUCTS="firefox,mobile"
 CRONTABBERCMD="./socorro-cmd crontabber"
 CACHEDIR="./.cache"
 CACHEFILE="${CACHEDIR}/ftpscraper.log"
 
+# If the cache file exists...
 if [[ -e "${CACHEFILE}" ]]; then
-    # FIXME(willkg): check to see if it's older than a week.
-    FILEMODDATE=$(stat -c %Y ${CACHEFILE})
+    FILEMODDATE=$(date -r ${CACHEFILE} '+%s')
     NOW=$(date +%s)
     FILEAGE=$(((NOW - FILEMODDATE) / 60 / 60 / 24))
 
+    # And it's less than a week old... replay.
     if [[ ${FILEAGE} -lt 7 ]]; then
         echo "Found recent (${FILEAGE}d) ftpscraper log--replaying...."
         docker-compose run crontabber ./socorro-cmd replay_ftpscraper "${CACHEFILE}"

--- a/docker/run_ftpscraper_wrapper.sh
+++ b/docker/run_ftpscraper_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Checks the cached ftpscraper log and if it's less than 7 days old, replays it
+# which is super duper fast.
+
+set -eo pipefail
+
+# Fetch and update release information for these products (comma-delimited)
+PRODUCTS="firefox,mobile"
+CRONTABBERCMD="./socorro-cmd crontabber"
+CACHEDIR="./.cache"
+CACHEFILE="${CACHEDIR}/ftpscraper.log"
+
+if [[ -e "${CACHEFILE}" ]]; then
+    # FIXME(willkg): check to see if it's older than a week.
+    FILEMODDATE=$(stat -c %Y ${CACHEFILE})
+    NOW=$(date +%s)
+    FILEAGE=$(((NOW - FILEMODDATE) / 60 / 60 / 24))
+
+    if [[ ${FILEAGE} -lt 7 ]]; then
+        echo "Found recent (${FILEAGE}d) ftpscraper log--replaying...."
+        docker-compose run crontabber ./socorro-cmd replay_ftpscraper "${CACHEFILE}"
+        exit
+    fi
+fi
+
+# Create the cachedir if it doesn't exist.
+if [[ ! -e "${CACHEDIR}" ]]; then
+    mkdir "${CACHEDIR}"
+fi
+
+docker-compose run crontabber ${CRONTABBERCMD} --reset-job=ftpscraper
+docker-compose run crontabber bash -c "${CRONTABBERCMD} --job=ftpscraper --crontabber.class-FTPScraperCronApp.products=${PRODUCTS} |& tee ${CACHEFILE}"

--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Updates product release and other data in the docker environment.
 #
 # Usage: docker/run_update_data.sh
@@ -7,9 +11,6 @@
 set -eo pipefail
 
 HOSTUSER=$(id -u):$(id -g)
-
-# The assumption is that you're running this from /app inside the container
-CACHEDIR=/app/.cache/ftpscraper
 
 # Fetch and update release information for these products (comma-delimited)
 PRODUCTS="firefox,mobile"
@@ -21,7 +22,6 @@ CRONTABBERCMD="./socorro/cron/crontabber_app.py"
 docker-compose run crontabber ${CRONTABBERCMD} --reset-job=ftpscraper
 docker-compose run -u "${HOSTUSER}" crontabber ${CRONTABBERCMD} \
                --job=ftpscraper \
-               --crontabber.class-FTPScraperCronApp.cachedir=${CACHEDIR} \
                --crontabber.class-FTPScraperCronApp.products=${PRODUCTS}
 
 # Update featured versions data based on release data

--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -17,12 +17,9 @@ PRODUCTS="firefox,mobile"
 CRONTABBERCMD="./socorro/cron/crontabber_app.py"
 
 
-# Fetch release data -- do it as the user so it can cache things, but reset
-# the ftpscraper job first
-docker-compose run crontabber ${CRONTABBERCMD} --reset-job=ftpscraper
-docker-compose run -u "${HOSTUSER}" crontabber ${CRONTABBERCMD} \
-               --job=ftpscraper \
-               --crontabber.class-FTPScraperCronApp.products=${PRODUCTS}
+# Fetch release data -- use the ftpscraper wrapper which will use cached
+# data if it's available and run ftpscraper as a 20-minute last resort
+./docker/run_ftpscraper_wrapper.sh
 
 # Update featured versions data based on release data
 docker-compose run crontabber ${CRONTABBERCMD} --reset-job=featured-versions-automatic

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -107,6 +107,13 @@ Quickstart
    Depending on what you're working on, you might want to run this weekly or
    maybe even daily.
 
+   .. Note::
+
+      This runs ftpscraper which takes 10 minutes to run. To save your time
+      and ours, the script will replay the last run for 7 days. That takes
+      10 seconds. If you need fresh data, run ``make clean`` which will
+      wipe out the logs.
+
 
 At this point, you should have a basic functional Socorro development
 environment that has no crash data in it.
@@ -201,6 +208,12 @@ Run::
 
    If you don't have anything in the database that you need, then it might be
    better to wipe the database and start over.
+
+
+.. Note::
+
+   This will replay the most recent run. If you need fresh data, delete the
+   ``.cache/`` directory before running ``make updatedata``.
 
 
 .. _gettingstarted-chapter-configuration:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ max-line-length = 100
 # --tb=native  - print native traceback
 # -p no:django - disable the pytest-django plugin for Socorro tests
 addopts = -rsxX --tb=native -p no:django
-norecursedirs = .git docs scripts config docker __pycache__
+norecursedirs = .git docs config docker __pycache__
 testpaths = socorro/unittest/
 # Transform all warnings into errors
 filterwarnings = error

--- a/socorro-cmd
+++ b/socorro-cmd
@@ -81,6 +81,7 @@ COMMANDS = [
                 'socorro.external.boto.upload_telemetry_schema.UploadTelemetrySchema'
             ),
             'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
+            'replay_ftpscraper': 'socorro.scripts.replay_ftpscraper.main',
         }
     ),
     Group(

--- a/socorro/scripts/__init__.py
+++ b/socorro/scripts/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 
 class WrappedTextHelpFormatter(argparse.HelpFormatter):
@@ -70,3 +71,9 @@ class FlagAction(argparse.Action):
         else:
             value = True
         setattr(namespace, self.dest, value)
+
+
+def get_envvar(key, default=None):
+    if default is None:
+        return os.environ[key]
+    return os.environ.get(key, default)

--- a/socorro/scripts/add_crashid_to_queue.py
+++ b/socorro/scripts/add_crashid_to_queue.py
@@ -5,7 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
-import os
 import sys
 
 import pika

--- a/socorro/scripts/add_crashid_to_queue.py
+++ b/socorro/scripts/add_crashid_to_queue.py
@@ -12,7 +12,7 @@ import sys
 import pika
 
 from socorro.lib.ooid import is_crash_id_valid
-from socorro.scripts import WrappedTextHelpFormatter
+from socorro.scripts import get_envvar, WrappedTextHelpFormatter
 
 
 EPILOG = """
@@ -26,12 +26,6 @@ Queues:
 * socorro.priority - priority processing
 
 """
-
-
-def get_envvar(key, default=None):
-    if default is None:
-        return os.environ[key]
-    return os.environ.get(key, default)
 
 
 def build_pika_connection(host, port, virtual_host, user, password):

--- a/socorro/scripts/add_crashid_to_queue.py
+++ b/socorro/scripts/add_crashid_to_queue.py
@@ -6,7 +6,6 @@
 
 import argparse
 import os
-import os.path
 import sys
 
 import pika

--- a/socorro/scripts/replay_ftpscraper.py
+++ b/socorro/scripts/replay_ftpscraper.py
@@ -53,5 +53,5 @@ def main(argv=None):
             params = line[line.find('('):line.find(')') + 1]
             params = eval(params)
 
-            print('adding %s' % (params,))
+            print('(replay) adding %s' % (params,))
             insert_build(cursor, *params, ignore_duplicates=True)

--- a/socorro/scripts/replay_ftpscraper.py
+++ b/socorro/scripts/replay_ftpscraper.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import os
+import os.path
+
+import psycopg2
+
+from socorro.cron.buildutil import insert_build
+from socorro.scripts import get_envvar, WrappedTextHelpFormatter
+
+
+EPILOG = """
+This replays an ftpscraper log which will insert product_versions data without
+having to run ftpscraper.
+"""
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        formatter_class=WrappedTextHelpFormatter,
+        description='Replay an ftpscraper log',
+        epilog=EPILOG.strip(),
+    )
+    parser.add_argument('ftpscraperlog', help='the ftpscraper log to replay')
+
+    if argv is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(argv)
+
+    ftpscraperlog = args.ftpscraperlog
+
+    if not os.path.exists(ftpscraperlog):
+        print('ftpscraper log "%s" does not exist. Exiting.' % ftpscraperlog)
+        return 1
+
+    database_url = get_envvar('DATABASE_URL')
+    connection = psycopg2.connect(database_url)
+
+    cursor = connection.cursor()
+
+    with open(ftpscraperlog, 'r') as fp:
+        for line in fp:
+            if ' adding (' not in line or ')' not in line:
+                continue
+
+            line = line.strip()
+            params = line[line.find('('):line.find(')') + 1]
+            params = eval(params)
+
+            print('adding %s' % (params,))
+            insert_build(cursor, *params, ignore_duplicates=True)

--- a/socorro/unittest/scripts/__init__.py
+++ b/socorro/unittest/scripts/__init__.py
@@ -1,0 +1,13 @@
+import contextlib
+import sys
+
+
+@contextlib.contextmanager
+def with_scriptname(scriptname):
+    """Overrides the sys.argv[0] with specified scriptname"""
+    old_scriptname = sys.argv[0]
+    sys.argv[0] = scriptname
+    try:
+        yield
+    finally:
+        sys.argv[0] = old_scriptname

--- a/socorro/unittest/scripts/test_add_crashid_to_queue.py
+++ b/socorro/unittest/scripts/test_add_crashid_to_queue.py
@@ -8,24 +8,24 @@ from mock import MagicMock, patch
 import pytest
 
 from socorro.lib.ooid import create_new_ooid
-from socorro.scripts.add_crashid_to_queue import (
-    main,
-)
+from socorro.scripts.add_crashid_to_queue import main
+from socorro.unittest.scripts import with_scriptname
 
 
 def test_missing_args(capsys):
-    # Make sure that running main with no args causes the script to exit with exit_code 2
-    with pytest.raises(SystemExit) as exc_info:
-        main([])
-    assert exc_info.exconly() == 'SystemExit: 2'
+    with with_scriptname('add_crashid_to_queue'):
+        # Make sure that running main with no args causes the script to exit with exit_code 2
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.exconly() == 'SystemExit: 2'
 
-    # Make sure it prints some stuff to stdout
-    out, err = capsys.readouterr()
-    usage_text = (
-        'usage: add_crashid_to_queue.py [-h] queue crashid [crashid ...]\n'
-        'add_crashid_to_queue.py: error: too few arguments\n'
-    )
-    assert err == usage_text
+        # Make sure it prints some stuff to stdout
+        out, err = capsys.readouterr()
+        usage_text = (
+            'usage: add_crashid_to_queue [-h] queue [crashid [crashid ...]]\n'
+            'add_crashid_to_queue: error: too few arguments\n'
+        )
+        assert err == usage_text
 
 
 def test_bad_crashid(capsys):

--- a/socorro/unittest/scripts/test_replay_ftpscraper.py
+++ b/socorro/unittest/scripts/test_replay_ftpscraper.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from socorro.scripts.replay_ftpscraper import main
+from socorro.unittest.scripts import with_scriptname
+
+
+def test_missing_args(capsys):
+    with with_scriptname('replay_ftpscraper'):
+        # Make sure that running main with no args causes the script to exit with exit_code 2
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.exconly() == 'SystemExit: 2'
+
+        # Make sure it prints some stuff to stdout
+        out, err = capsys.readouterr()
+        usage_text = (
+            'usage: replay_ftpscraper [-h] ftpscraperlog\n'
+            'replay_ftpscraper: error: too few arguments\n'
+        )
+        assert err == usage_text
+
+
+def test_bad_file(capsys):
+    with with_scriptname('replay_ftpscraper'):
+        exit_code = main(['foo.txt'])
+        assert exit_code == 1
+
+        out, err = capsys.readouterr()
+        usage_text = 'ftpscraper log "foo.txt" does not exist. Exiting.\n'
+        assert out == usage_text


### PR DESCRIPTION
This adds a ftpscraper wrapper script to be used in local development environment which keeps a log of ftpscraper and if the log is less than 7 days old, it'll just replay the log on the next run.

For me, it takes 10 minutes to run ftpscraper. On the second run, replaying the log takes about 10 seconds. This radically reduces the amount of time it takes to slick and rebuild my local development environment which I do a lot.

To test:

1. run `make setup` which slicks the db and everything
2. run `make updatedata` which runs ftpscraper and will create an ftpscraper log in `./.cache/ftpscraper.log`
3. run `make setup` which slicks the db again
4. run `make updatedata` which will replay the ftpscraper log