### PR TITLE
fix bug 1479097: sentry cleanup in processor

### DIFF
--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from pkg_resources import resource_string
+import sys
 
+from pkg_resources import resource_string
 import raven
 
 # When socorro is installed (python setup.py install), it will create
@@ -20,3 +21,43 @@ def get_client(dsn, **kwargs):
     if not kwargs.get('release') and SOCORRO_REVISION:
         kwargs['release'] = SOCORRO_REVISION
     return raven.Client(**kwargs)
+
+
+def capture_error(sentry_dsn, logger, exc_info=None, extra=None):
+    """Capture an error in sentry if able
+
+    :arg sentry_dsn: the sentry dsn (or None)
+    :arg logger: the logger to use
+    :arg exc_info: the exception information as a tuple like from `sys.exc_info`
+    :arg extra: any extra information to send along as a dict
+
+    """
+    exc_info = exc_info or sys.exc_info()
+
+    if sentry_dsn:
+        extra = extra or {}
+
+        try:
+            # Set up the Sentry client.
+            client = get_client(sentry_dsn)
+            client.context.activate()
+            client.context.merge({'extra': extra})
+
+            # Try to send the exception.
+            try:
+                identifier = client.captureException(exc_info)
+                logger.info('Error captured in Sentry! Reference: {}'.format(identifier))
+
+                # At this point, if everything is good, the exceptions were
+                # successfully sent to sentry and we can return.
+                return
+            finally:
+                client.context.clear()
+        except Exception:
+            # Log the exception from trying to send the error to Sentry.
+            logger.error('Unable to report error with Raven', exc_info=True)
+
+    # Sentry isn't configured or it's busted, so log the error we got that we
+    # wanted to capture.
+    logger.warning('Sentry DSN is not configured and an exception happened')
+    logger.error('Exception occurred', exc_info=exc_info)

--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -46,7 +46,7 @@ def capture_error(sentry_dsn, logger, exc_info=None, extra=None):
             # Try to send the exception.
             try:
                 identifier = client.captureException(exc_info)
-                logger.info('Error captured in Sentry! Reference: {}'.format(identifier))
+                logger.info('Error captured in Sentry! Reference: %s' % identifier)
 
                 # At this point, if everything is good, the exceptions were
                 # successfully sent to sentry and we can return.

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -863,10 +863,12 @@ class SignatureGeneratorRule(Rule):
         self.sentry_dsn = sentry_dsn
         self.generator = SignatureGenerator(error_handler=self._error_handler)
 
-    def _error_handler(self, raw_crash, processed_crash, extra):
+    def _error_handler(self, raw_crash, processed_crash, exc_info, extra):
         """Captures errors from signature generation"""
         extra['uuid'] = raw_crash.get('uuid', None)
-        raven_client.capture_error(self.sentry_dsn, self.config.logger, extra=extra)
+        raven_client.capture_error(
+            self.sentry_dsn, self.config.logger, exc_info=exc_info, extra=extra
+        )
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         # Generate a crash signature and capture the signature and notes

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -19,6 +19,7 @@ from socorro.lib.datetimeutil import (
     datetime_from_isodate_string,
 )
 from socorro.lib.ooid import dateFromOoid
+from socorro.lib import raven_client
 from socorro.lib.transform_rules import Rule
 from socorro.signature.generator import SignatureGenerator
 
@@ -857,10 +858,14 @@ class SignatureGeneratorRule(Rule):
         try:
             sentry_dsn = self.config.sentry.dsn
         except KeyError:
-            # DotDict raises a KeyError when things are missing
+            # NOTE(willkg): DotDict raises a KeyError when things are missing
             sentry_dsn = None
+        self.sentry_dsn = sentry_dsn
+        self.generator = SignatureGenerator(error_handler=self._error_handler)
 
-        self.generator = SignatureGenerator(sentry_dsn=sentry_dsn)
+    def _error_handler(self, extra):
+        """Captures errors from signature generation"""
+        raven_client.capture_error(self.sentry_dsn, self.config.logger, extra=extra)
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         # Generate a crash signature and capture the signature and notes

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -863,8 +863,9 @@ class SignatureGeneratorRule(Rule):
         self.sentry_dsn = sentry_dsn
         self.generator = SignatureGenerator(error_handler=self._error_handler)
 
-    def _error_handler(self, extra):
+    def _error_handler(self, raw_crash, processed_crash, extra):
         """Captures errors from signature generation"""
+        extra['uuid'] = raw_crash.get('uuid', None)
         raven_client.capture_error(self.sentry_dsn, self.config.logger, extra=extra)
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):

--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+import sys
 
 from socorro.signature.rules import (
     SignatureGenerationRule,
@@ -75,6 +76,7 @@ class SignatureGenerator:
                     self.error_handler(
                         raw_crash,
                         processed_crash,
+                        exc_info=sys.exc_info(),
                         extra={'rule': rule.__class__.__name__}
                     )
                 notes.append('Rule %s failed: %s' % (rule.__class__.__name__, exc))

--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -72,10 +72,11 @@ class SignatureGenerator:
 
             except Exception as exc:
                 if self.error_handler:
-                    self.error_handler({
-                        'rule': rule.__class__.__name__,
-                        'uuid': raw_crash.get('uuid', None),
-                    })
+                    self.error_handler(
+                        raw_crash,
+                        processed_crash,
+                        extra={'rule': rule.__class__.__name__}
+                    )
                 notes.append('Rule %s failed: %s' % (rule.__class__.__name__, exc))
 
             if notes:

--- a/socorro/unittest/__init__.py
+++ b/socorro/unittest/__init__.py
@@ -1,0 +1,15 @@
+from functools import total_ordering
+
+
+@total_ordering
+class EqualAnything(object):
+    def __eq__(self, other):
+        return True
+
+    def __lt__(self, other):
+        return True
+
+
+#: Sentinel that is equal to anything; simplifies assertions in cases where
+#: part of the value changes from test to test
+WHATEVER = EqualAnything()

--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -1,5 +1,8 @@
 import logging
 
+from configman.dotdict import DotDict as CDotDict
+from mock import Mock
+
 from socorro.lib.util import DotDict
 from socorro.signature.rules import CSignatureTool
 
@@ -21,3 +24,16 @@ def create_basic_fake_processor():
     fake_processor.config.logger = logging.getLogger(__name__)
     fake_processor.processor_notes = []
     return fake_processor
+
+
+def get_basic_config():
+    config = CDotDict()
+    config.logger = Mock()
+    return config
+
+
+def get_basic_processor_meta():
+    processor_meta = DotDict()
+    processor_meta.processor_notes = []
+    processor_meta.quit_check = lambda: False
+    return processor_meta

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -17,6 +17,7 @@ from socorro.processor.breakpad_transform_rules import (
     JitCrashCategorizeRule,
     MinidumpSha256Rule,
 )
+from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
 from socorro.unittest.testbase import TestCase
 
 
@@ -198,27 +199,14 @@ class MyBreakpadStackwalkerRule2015(BreakpadStackwalkerRule2015):
 
 
 class TestCrashingThreadRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processed_crash.json_dump = copy.copy(cannonical_stackwalker_output)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadRule(config)
 
@@ -228,13 +216,13 @@ class TestCrashingThreadRule(TestCase):
         assert processed_crash.crashedThread == 0
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processed_crash.json_dump = {}
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadRule(config)
 
@@ -246,39 +234,27 @@ class TestCrashingThreadRule(TestCase):
 
 
 class TestMinidumpSha256HashRule(object):
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
-
     def test_hash_not_in_raw_crash(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = DotDict()
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = MinidumpSha256Rule(config)
 
         assert rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta) is False
 
     def test_hash_in_raw_crash(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = DotDict({
             'MinidumpSha256Hash': 'hash'
         })
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = MinidumpSha256Rule(config)
 
@@ -297,8 +273,7 @@ cannonical_external_output_str = ujson.dumps(cannonical_external_output)
 class TestExternalProcessRule(TestCase):
 
     def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
+        config = get_basic_config()
         config.dump_field = 'upload_file_minidump'
         config.command_line = (
             'timeout -s KILL 30 {command_pathname} '
@@ -317,13 +292,6 @@ class TestExternalProcessRule(TestCase):
         config.result_key = 'bogus_command_result'
         config.return_code_key = 'bogus_command_return_code'
         return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
 
     def test_dot_save(self):
         d = {}
@@ -349,7 +317,7 @@ class TestExternalProcessRule(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -384,7 +352,7 @@ class TestExternalProcessRule(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = \
             mocked_subprocess_module.Popen.return_value
@@ -407,7 +375,7 @@ class TestExternalProcessRule(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -432,8 +400,7 @@ class TestExternalProcessRule(TestCase):
 class TestBreakpadTransformRule2015(TestCase):
 
     def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
+        config = get_basic_config()
         config.dump_field = 'upload_file_minidump'
         config.command_line = (
             BreakpadStackwalkerRule2015.required_config .command_line.default
@@ -446,13 +413,6 @@ class TestBreakpadTransformRule2015(TestCase):
         config.temporary_file_system_storage_path = '/tmp'
         return config
 
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
-
     @patch('socorro.processor.breakpad_transform_rules.subprocess')
     def test_everything_we_hoped_for(self, mocked_subprocess_module):
         config = self.get_basic_config()
@@ -460,7 +420,7 @@ class TestBreakpadTransformRule2015(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -487,7 +447,7 @@ class TestBreakpadTransformRule2015(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = \
             mocked_subprocess_module.Popen.return_value
@@ -512,7 +472,7 @@ class TestBreakpadTransformRule2015(TestCase):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -576,13 +536,6 @@ class TestJitCrashCategorizeRule(TestCase):
         config.temporary_file_system_storage_path = '/tmp'
         return config
 
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-        processor_meta.quit_check = lambda: False
-
-        return processor_meta
-
     @patch('socorro.processor.breakpad_transform_rules.subprocess')
     def test_everything_we_hoped_for(self, mocked_subprocess_module):
         config = self.get_basic_config()
@@ -597,7 +550,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -629,7 +582,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -674,7 +627,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -707,7 +660,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -739,7 +692,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -771,7 +724,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -803,7 +756,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'not_module': 'not-a-module'}),
             DotDict({'module': 'a-module'})
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value
@@ -835,7 +788,7 @@ class TestJitCrashCategorizeRule(TestCase):
             DotDict({'module': 'a-module'}),
             DotDict({'not_module': 'not-a-module'}),
         ]
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = (
             mocked_subprocess_module.Popen.return_value

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -4,9 +4,6 @@
 
 import copy
 
-from configman.dotdict import DotDict as CDotDict
-from mock import Mock
-
 from socorro.lib.util import DotDict
 from socorro.processor.general_transform_rules import (
     IdentifierRule,

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -13,6 +13,7 @@ from socorro.processor.general_transform_rules import (
     CPUInfoRule,
     OSInfoRule,
 )
+from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
 from socorro.unittest.testbase import TestCase
 
 
@@ -102,26 +103,13 @@ canonical_processed_crash = DotDict({
 
 
 class TestIdentifierRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = IdentifierRule(config)
 
@@ -135,7 +123,7 @@ class TestIdentifierRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.uuid
@@ -143,7 +131,7 @@ class TestIdentifierRule(TestCase):
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = IdentifierRule(config)
 
@@ -162,26 +150,13 @@ class TestIdentifierRule(TestCase):
 
 
 class TestCPUInfoRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(canonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = CPUInfoRule(config)
 
@@ -195,7 +170,7 @@ class TestCPUInfoRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_cpu_count(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -205,7 +180,7 @@ class TestCPUInfoRule(TestCase):
         processed_crash.json_dump = {
             'system_info': system_info
         }
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = CPUInfoRule(config)
 
@@ -219,12 +194,12 @@ class TestCPUInfoRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_json_dump(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {}
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = CPUInfoRule(config)
 
@@ -239,26 +214,13 @@ class TestCPUInfoRule(TestCase):
 
 
 class TestOSInfoRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(canonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = OSInfoRule(config)
 
@@ -272,13 +234,13 @@ class TestOSInfoRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = OSInfoRule(config)
 

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -12,28 +12,29 @@ from mock import Mock, patch
 from socorro.lib.datetimeutil import datetime_from_isodate_string
 from socorro.lib.util import DotDict
 from socorro.processor.mozilla_transform_rules import (
-    ProductRule,
-    UserDataRule,
-    EnvironmentRule,
-    PluginRule,
     AddonsRule,
+    AuroraVersionFixitRule,
+    BetaVersionRule,
     DatesAndTimesRule,
-    JavaProcessRule,
-    OutOfMemoryBinaryRule,
-    ProductRewrite,
     ESRVersionRewrite,
-    PluginContentURL,
-    PluginUserComment,
+    EnvironmentRule,
     ExploitablityRule,
     FlashVersionRule,
-    Winsock_LSPRule,
-    TopMostFilesRule,
-    BetaVersionRule,
-    AuroraVersionFixitRule,
+    JavaProcessRule,
     OSPrettyVersionRule,
+    OutOfMemoryBinaryRule,
+    PluginContentURL,
+    PluginRule,
+    PluginUserComment,
+    ProductRewrite,
+    ProductRule,
     ThemePrettyNameRule,
+    TopMostFilesRule,
+    UserDataRule,
+    Winsock_LSPRule,
 )
 from socorro.unittest.testbase import TestCase
+from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
 
 
 canonical_standard_raw_crash = DotDict({
@@ -151,27 +152,14 @@ cannonical_processed_crash = DotDict({
 
 
 class TestProductRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
         # does it even instantiate?
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ProductRule(config)
 
@@ -188,7 +176,7 @@ class TestProductRule(TestCase):
 
     def test_stuff_missing(self):
         # does it even instantiate?
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.Version
@@ -198,7 +186,7 @@ class TestProductRule(TestCase):
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ProductRule(config)
 
@@ -215,25 +203,13 @@ class TestProductRule(TestCase):
 
 
 class TestUserDataRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = UserDataRule(config)
 
@@ -246,7 +222,7 @@ class TestUserDataRule(TestCase):
         assert processed_crash.user_id == ""
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.URL
@@ -255,7 +231,7 @@ class TestUserDataRule(TestCase):
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = UserDataRule(config)
 
@@ -268,26 +244,13 @@ class TestUserDataRule(TestCase):
 
 
 class TestEnvironmentRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = EnvironmentRule(config)
 
@@ -297,14 +260,14 @@ class TestEnvironmentRule(TestCase):
         assert processed_crash.app_notes == raw_crash.Notes
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.Notes
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = EnvironmentRule(config)
 
@@ -315,21 +278,8 @@ class TestEnvironmentRule(TestCase):
 
 
 class TestPluginRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_plugin_hang(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.PluginHang = 1
@@ -340,7 +290,7 @@ class TestPluginRule(TestCase):
         raw_crash.PluginVersion = '0.0'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginRule(config)
 
@@ -355,14 +305,14 @@ class TestPluginRule(TestCase):
         assert processed_crash.PluginVersion == '0.0'
 
     def test_browser_hang(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.Hang = 1
         raw_crash.ProcessType = 'browser'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginRule(config)
 
@@ -378,26 +328,13 @@ class TestPluginRule(TestCase):
 
 
 class TestAddonsRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_action_nothing_unexpected(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule(config)
 
@@ -425,14 +362,14 @@ class TestAddonsRule(TestCase):
         assert processed_crash.addons_checked
 
     def test_action_colon_in_addon_version(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'adblockpopups@jessehakanen.net:0:3:1'
         raw_crash['EMCheckCompatibility'] = 'Nope'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule(config)
 
@@ -445,13 +382,13 @@ class TestAddonsRule(TestCase):
         assert not processed_crash.addons_checked
 
     def test_action_addon_is_nonsense(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'naoenut813teq;mz;<[`19ntaotannn8999anxse `'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule(config)
 
@@ -465,19 +402,6 @@ class TestAddonsRule(TestCase):
 
 
 class TestDatesAndTimesRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_get_truncate_or_warn(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         processor_notes = []
@@ -526,12 +450,12 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_notes == expected
 
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -549,13 +473,13 @@ class TestDatesAndTimesRule(TestCase):
         assert processed_crash.last_crash == 86985
 
     def test_bad_timestamp(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -574,14 +498,14 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == ['non-integer value of "timestamp"']
 
     def test_bad_timestamp_and_no_crash_time(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.CrashTime
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -605,14 +529,14 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == expected
 
     def test_no_startup_time_bad_timestamp(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.StartupTime
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -635,13 +559,13 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == expected
 
     def test_no_startup_time(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.StartupTime
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -660,13 +584,13 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == []
 
     def test_bad_startup_time(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.StartupTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -685,13 +609,13 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == ['non-integer value of "StartupTime"']
 
     def test_bad_install_time(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.InstallTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -710,13 +634,13 @@ class TestDatesAndTimesRule(TestCase):
         assert processor_meta.processor_notes == ['non-integer value of "InstallTime"']
 
     def test_bad_seconds_since_last_crash(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.SecondsSinceLastCrash = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule(config)
 
@@ -736,27 +660,14 @@ class TestDatesAndTimesRule(TestCase):
 
 
 class TestJavaProcessRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule(config)
 
@@ -766,14 +677,14 @@ class TestJavaProcessRule(TestCase):
         assert processed_crash.java_stack_trace == raw_crash.JavaStackTrace
 
     def test_stuff_missing(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.Notes
 
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule(config)
 
@@ -784,24 +695,11 @@ class TestJavaProcessRule(TestCase):
 
 
 class TestOutOfMemoryBinaryRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_extract_memory_info(self):
         config = CDotDict()
         config.logger = Mock()
 
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         with patch(
             'socorro.processor.mozilla_transform_rules.gzip.open'
@@ -827,7 +725,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         with patch(
             'socorro.processor.mozilla_transform_rules.gzip.open'
@@ -875,7 +773,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         with patch(
             'socorro.processor.mozilla_transform_rules.gzip.open'
@@ -903,7 +801,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         with patch(
             'socorro.processor.mozilla_transform_rules.gzip.open'
@@ -930,13 +828,13 @@ class TestOutOfMemoryBinaryRule(TestCase):
                 assert processed_crash.memory_report_error == expected
 
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         class MyOutOfMemoryBinaryRule(OutOfMemoryBinaryRule):
 
@@ -954,13 +852,13 @@ class TestOutOfMemoryBinaryRule(TestCase):
             assert processed_crash.memory_report == 'mysterious-awesome-memory'
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = OutOfMemoryBinaryRule(config)
 
@@ -971,27 +869,14 @@ class TestOutOfMemoryBinaryRule(TestCase):
 
 
 class TestProductRewrite(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ProductRewrite(config)
 
@@ -1004,12 +889,12 @@ class TestProductRewrite(TestCase):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ProductRewrite(config)
 
@@ -1023,27 +908,14 @@ class TestProductRewrite(TestCase):
 
 
 class TestESRVersionRewrite(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite(config)
 
@@ -1056,13 +928,13 @@ class TestESRVersionRewrite(TestCase):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'not_esr'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite(config)
 
@@ -1075,14 +947,14 @@ class TestESRVersionRewrite(TestCase):
         assert processed_crash == DotDict()
 
     def test_this_is_really_broken(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         del raw_crash.Version
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite(config)
 
@@ -1097,28 +969,15 @@ class TestESRVersionRewrite(TestCase):
 
 
 class TestPluginContentURL(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.PluginContentURL = 'http://mozilla.com'
         raw_crash.URL = 'http://google.com'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginContentURL(config)
 
@@ -1131,13 +990,13 @@ class TestPluginContentURL(TestCase):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.URL = 'http://google.com'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginContentURL(config)
 
@@ -1151,28 +1010,15 @@ class TestPluginContentURL(TestCase):
 
 
 class TestPluginUserComment(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.PluginUserComment = 'I hate it when this happens'
         raw_crash.Comments = 'I wrote something here, too'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginUserComment(config)
 
@@ -1185,13 +1031,13 @@ class TestPluginUserComment(TestCase):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.Comments = 'I wrote something here'
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = PluginUserComment(config)
 
@@ -1205,26 +1051,13 @@ class TestPluginUserComment(TestCase):
 
 
 class TestExploitablityRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(cannonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ExploitablityRule(config)
 
@@ -1237,12 +1070,12 @@ class TestExploitablityRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ExploitablityRule(config)
 
@@ -1256,21 +1089,8 @@ class TestExploitablityRule(TestCase):
 
 
 class TestFlashVersionRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_get_flash_version(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         rule = FlashVersionRule(config)
 
@@ -1306,12 +1126,12 @@ class TestFlashVersionRule(TestCase):
         assert ret == '9.0.16.0'
 
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(cannonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = FlashVersionRule(config)
 
@@ -1325,28 +1145,15 @@ class TestFlashVersionRule(TestCase):
 
 
 class TestWinsock_LSPRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_crash.Winsock_LSP = 'really long string'
         expected_raw_crash = copy.copy(raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(cannonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = Winsock_LSPRule(config)
 
@@ -1359,14 +1166,14 @@ class TestWinsock_LSPRule(TestCase):
         assert raw_crash == expected_raw_crash
 
     def test_missing_key(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         del raw_crash.Winsock_LSP
         expected_raw_crash = copy.copy(raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(cannonical_processed_crash)
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = Winsock_LSPRule(config)
 
@@ -1380,21 +1187,8 @@ class TestWinsock_LSPRule(TestCase):
 
 
 class TestTopMostFilesRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -1427,7 +1221,7 @@ class TestTopMostFilesRule(TestCase):
             ]
         }
 
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule(config)
 
@@ -1440,13 +1234,13 @@ class TestTopMostFilesRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_key(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         expected_raw_crash = copy.copy(raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule(config)
 
@@ -1459,7 +1253,7 @@ class TestTopMostFilesRule(TestCase):
         assert raw_crash == expected_raw_crash
 
     def test_missing_key_2(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -1477,7 +1271,7 @@ class TestTopMostFilesRule(TestCase):
             }
         }
 
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule(config)
 
@@ -1491,21 +1285,8 @@ class TestTopMostFilesRule(TestCase):
 
 
 class TestBetaVersion(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
         config.database_class = Mock()
         config.transaction_executor_class = Mock()
 
@@ -1515,7 +1296,7 @@ class TestBetaVersion(TestCase):
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         transaction = Mock()
         config.transaction_executor_class.return_value = transaction
@@ -1576,7 +1357,7 @@ class TestBetaVersion(TestCase):
         """Verify the version change is applied to crash reports with a
         release channel of "aurora".
         """
-        config = self.get_basic_config()
+        config = get_basic_config()
         config.database_class = Mock()
         config.transaction_executor_class = Mock()
 
@@ -1586,7 +1367,7 @@ class TestBetaVersion(TestCase):
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         transaction = Mock()
         config.transaction_executor_class.return_value = transaction
@@ -1605,14 +1386,8 @@ class TestBetaVersion(TestCase):
 
 
 class TestAuroraVersionFixitRule:
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
     def test_predicate(self):
-        rule = AuroraVersionFixitRule(self.get_basic_config())
+        rule = AuroraVersionFixitRule(get_basic_config())
 
         # No BuildID and wrong BuildID lead to False
         assert rule._predicate({}, {}, {}, {}) is False
@@ -1622,7 +1397,7 @@ class TestAuroraVersionFixitRule:
         assert rule._predicate({'BuildID': '20170612224034'}, {}, {}, {}) is True
 
     def test_action(self):
-        rule = AuroraVersionFixitRule(self.get_basic_config())
+        rule = AuroraVersionFixitRule(get_basic_config())
 
         raw_crash = {
             # This is the build id for Firefox aurora 55.0b1
@@ -1637,16 +1412,13 @@ class TestAuroraVersionFixitRule:
 
 
 class TestOsPrettyName(TestCase):
-
     def test_everything_we_hoped_for(self):
-        config = CDotDict()
-        config.logger = Mock()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
 
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
+        processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule(config)
 
@@ -1728,26 +1500,13 @@ class TestOsPrettyName(TestCase):
 
 
 class TestThemePrettyNameRule(TestCase):
-
-    def get_basic_config(self):
-        config = CDotDict()
-        config.logger = Mock()
-
-        return config
-
-    def get_basic_processor_meta(self):
-        processor_meta = DotDict()
-        processor_meta.processor_notes = []
-
-        return processor_meta
-
     def test_everything_we_hoped_for(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ThemePrettyNameRule(config)
 
@@ -1788,10 +1547,10 @@ class TestThemePrettyNameRule(TestCase):
         assert processed_crash.addons == expected_addon_list
 
     def test_missing_key(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
 
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         rule = ThemePrettyNameRule(config)
 
@@ -1813,11 +1572,11 @@ class TestThemePrettyNameRule(TestCase):
         assert not res
 
     def test_with_malformed_addons_field(self):
-        config = self.get_basic_config()
+        config = get_basic_config()
         rule = ThemePrettyNameRule(config)
 
         processed_crash = DotDict()
-        processor_meta = self.get_basic_processor_meta()
+        processor_meta = get_basic_processor_meta()
 
         processed_crash.addons = [
             'addon_with_no_version',

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -36,8 +36,8 @@ from socorro.processor.mozilla_transform_rules import (
 )
 from socorro.signature.generator import SignatureGenerator
 from socorro.unittest import WHATEVER
-from socorro.unittest.testbase import TestCase
 from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
+from socorro.unittest.testbase import TestCase
 
 
 canonical_standard_raw_crash = DotDict({

--- a/socorro/unittest/signature/test_signature_generator.py
+++ b/socorro/unittest/signature/test_signature_generator.py
@@ -5,7 +5,6 @@
 import mock
 
 from socorro.signature.generator import SignatureGenerator
-from socorro.unittest import WHATEVER
 
 
 class TestSignatureGenerator:
@@ -42,24 +41,24 @@ class TestSignatureGenerator:
 
         assert ret == expected
 
-    @mock.patch('socorro.lib.raven_client.raven')
-    def test_sentry_dsn(self, mock_raven):
+    def test_error_handler(self):
         exc_value = Exception('Cough')
 
         class BadRule(object):
             def predicate(self, raw_crash, processed_crash):
                 raise exc_value
 
-        sentry_dsn = 'https://blahblah:blahblah@sentry.example.com/'
-        generator = SignatureGenerator(pipeline=[BadRule()], sentry_dsn=sentry_dsn)
-        generator.generate({}, {})
+        error_handler = mock.MagicMock()
 
-        # Make sure the client was instantiated with the sentry_dsn
-        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn)
+        generator = SignatureGenerator(pipeline=[BadRule()], error_handler=error_handler)
+        generator.generate({'uuid': 'ou812'}, {})
 
-        # Make sure captureExeption was called with the right args.
+        # Make sure error_handler was called with right extra
         assert (
-            mock_raven.Client().captureException.call_args_list == [
-                mock.call((Exception, exc_value, WHATEVER))
+            error_handler.call_args_list == [
+                mock.call(({
+                    'rule': 'BadRule',
+                    'uuid': 'ou812'
+                }))
             ]
         )

--- a/socorro/unittest/signature/test_signature_generator.py
+++ b/socorro/unittest/signature/test_signature_generator.py
@@ -56,9 +56,10 @@ class TestSignatureGenerator:
         # Make sure error_handler was called with right extra
         assert (
             error_handler.call_args_list == [
-                mock.call(({
-                    'rule': 'BadRule',
-                    'uuid': 'ou812'
-                }))
+                mock.call(
+                    {'uuid': 'ou812'},
+                    {},
+                    extra={'rule': 'BadRule'}
+                )
             ]
         )

--- a/socorro/unittest/signature/test_signature_generator.py
+++ b/socorro/unittest/signature/test_signature_generator.py
@@ -5,6 +5,7 @@
 import mock
 
 from socorro.signature.generator import SignatureGenerator
+from socorro.unittest import WHATEVER
 
 
 class TestSignatureGenerator:
@@ -59,6 +60,7 @@ class TestSignatureGenerator:
                 mock.call(
                     {'uuid': 'ou812'},
                     {},
+                    exc_info=(Exception, exc_value, WHATEVER),
                     extra={'rule': 'BadRule'}
                 )
             ]


### PR DESCRIPTION
This does two big things:

1. clean up a bunch of processor code in regards to redundant setup
2. unify the two "let's capture something and send it to sentry" mechanisms we had and also fix them to use `exc_info` rather than exception values

This gives us two nice things:

1. the signature generation code no longer has anything about sentry in it--that's helpful for merging the two forks of signature generation
2. we can reuse send-this-to-sentry in other parts of the processor which was previous hard-ish