### PR TITLE
bug 1477782: change dryrun to persist

### DIFF
--- a/webapp-django/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp-django/crashstats/authentication/management/commands/auditgroups.py
@@ -26,11 +26,11 @@ class Command(BaseCommand):
         # FIXME(willkg): change this to default to False after we've tested
         # it.
         parser.add_argument(
-            '--dryrun', type=bool, default=True,
-            help='enables dry run which will not persist changes to db'
+            '--persist', action='store_true',
+            help='persists recommended changes to db'
         )
 
-    def audit_hackers_group(self, dryrun):
+    def audit_hackers_group(self, persist=False):
         # Figure out the cutoff date for inactivity
         cutoff = timezone.now() - datetime.timedelta(days=365)
 
@@ -70,12 +70,13 @@ class Command(BaseCommand):
         # Log or remove the users that have been marked
         for user, reason in users_to_remove:
             self.stdout.write('Removing: %s (%s)' % (user.email, reason))
-            if not dryrun:
+            if persist is True:
                 hackers_group.user_set.remove(user)
 
         self.stdout.write('Total removed: %s' % len(users_to_remove))
 
     def handle(self, **options):
-        dryrun = options['dryrun']
-
-        self.audit_hackers_group(dryrun)
+        persist = options['persist']
+        if not persist:
+            self.stdout.write('Dry run--this is what we think should happen.')
+        self.audit_hackers_group(persist)

--- a/webapp-django/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp-django/crashstats/authentication/tests/test_auditgroups.py
@@ -25,7 +25,7 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.save()
 
         buffer = StringIO()
-        call_command('auditgroups', dryrun=False, stdout=buffer)
+        call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@mozilla.com (!is_active)' in buffer.getvalue()
 
@@ -38,7 +38,7 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.save()
 
         buffer = StringIO()
-        call_command('auditgroups', dryrun=False, stdout=buffer)
+        call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@mozilla.com (inactive 366d, no tokens)' in buffer.getvalue()
 
@@ -51,7 +51,7 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.save()
 
         buffer = StringIO()
-        call_command('auditgroups', dryrun=False, stdout=buffer)
+        call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@example.com (invalid email domain)' in buffer.getvalue()
 
@@ -67,7 +67,7 @@ class TestAuditGroupsCommand(DjangoTestCase):
         token.save()
 
         buffer = StringIO()
-        call_command('auditgroups', dryrun=False, stdout=buffer)
+        call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert (
             'SKIP: bob@mozilla.com (inactive 366d, but has active tokens: 1)' in buffer.getvalue()
@@ -82,11 +82,11 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.save()
 
         buffer = StringIO()
-        call_command('auditgroups', dryrun=False, stdout=buffer)
+        call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert 'Removing:' not in buffer.getvalue()
 
-    def test_dryrun(self):
+    def test_persist_false(self):
         hackers_group = Group.objects.get(name='Hackers')
 
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
@@ -94,7 +94,11 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.groups.add(hackers_group)
         bob.save()
 
+        assert hackers_group.user_set.count() == 1
+
         buffer = StringIO()
-        call_command('auditgroups', dryrun=True, stdout=buffer)
+        call_command('auditgroups', persist=False, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert 'Removing: bob@mozilla.com (inactive 366d, no tokens)' in buffer.getvalue()
+
+        assert hackers_group.user_set.count() == 1

--- a/webapp-django/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp-django/crashstats/authentication/tests/test_auditgroups.py
@@ -24,10 +24,14 @@ class TestAuditGroupsCommand(DjangoTestCase):
         bob.groups.add(hackers_group)
         bob.save()
 
+        assert hackers_group.user_set.count() == 1
+
         buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@mozilla.com (!is_active)' in buffer.getvalue()
+
+        assert hackers_group.user_set.count() == 0
 
     def test_old_user_is_removed(self):
         hackers_group = Group.objects.get(name='Hackers')


### PR DESCRIPTION
This changes the dryrun argument for the auditgroups command to a "persist"
argument. It also fixes the argument value parsing which was busted before.