### PR TITLE
fix bug 1473068: fix session refresh errors with xhr

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -658,6 +658,16 @@ OIDC_RP_CLIENT_SECRET = config('OIDC_RP_CLIENT_SECRET', '')
 OIDC_OP_AUTHORIZATION_ENDPOINT = config('OIDC_OP_AUTHORIZATION_ENDPOINT', '')
 OIDC_OP_TOKEN_ENDPOINT = config('OIDC_OP_TOKEN_ENDPOINT', '')
 OIDC_OP_USER_ENDPOINT = config('OIDC_OP_USER_ENDPOINT', '')
+# List of urls that are exempt from session refresh because they're used in XHR
+# contexts and that doesn't handle redirecting.
+OIDC_EXEMPT_URLS = [
+    # Used by supersearch page as an XHR
+    '/search/fields/',
+    '/search/results/',
+
+    # Used by signature report as an XHR
+    '/signature/summary/',
+]
 LOGOUT_REDIRECT_URL = '/'
 
 # Max number of seconds you are allowed to be signed in with OAuth2.


### PR DESCRIPTION
The search page does XHR requests when switching between searches. Other
pages do similar things. When the SessionRefresh middleware handles those
requests, it can return a 403 or a redirect, but the js can't handle that.

This fixes the SessionRefresh middleware to ignore those urls and not
refresh the session on them.