### PR TITLE
fix bug 1477726: add std::alloc::rust_oom to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -213,6 +213,7 @@ SocketWrite
 SocketWritev
 ssl_
 SSL_
+std::alloc::rust_oom
 std::_Allocate
 std::_Hash<T>::
 std::list<.*>::


### PR DESCRIPTION
Signature generation output:

```
app@processor:/app$ socorro-cmd signature 84b9b036-f933-4df2-b8cc-9b4170180703 5e440243-dd5c-4987-97df-1a6340180723
Crash id: 84b9b036-f933-4df2-b8cc-9b4170180703
Original: static void std::alloc::rust_oom
New:      static void std::alloc::rust_oom | static struct style::media_queries::media_list::MediaList style::media_queries::media_list::MediaList::parse
Same?:    False

Crash id: 5e440243-dd5c-4987-97df-1a6340180723
Original: static void std::alloc::rust_oom
New:      static void std::alloc::rust_oom | static void rayon::iter::plumbing::bridge_producer_consumer::helper<T>
Same?:    False
```