### PR TITLE
fix bug 1473068: fix session refresh errors with xhr (buginfo)

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -664,6 +664,7 @@ OIDC_EXEMPT_URLS = [
     # Used by supersearch page as an XHR
     '/search/fields/',
     '/search/results/',
+    '/buginfo/',
 
     # Used by signature report as an XHR
     '/signature/summary/',


### PR DESCRIPTION
This adds another url used by the supersearch page to the exempt urls
list.