### PR TITLE
fix bug 1481828: fix proto_signature in SignatureGeneratorRule

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -876,5 +876,7 @@ class SignatureGeneratorRule(Rule):
         crash_data = convert_to_crash_data(raw_crash, processed_crash)
         ret = self.generator.generate(crash_data)
         processed_crash['signature'] = ret['signature']
+        if 'proto_signature' in ret:
+            processed_crash['proto_signature'] = ret['proto_signature']
         processor_meta['processor_notes'].extend(ret['notes'])
         return True


### PR DESCRIPTION
I recently refactored signature generation using the code from the
socorro-siggen fork. One thing I missed was making sure `proto_signature`
made it into the processed crash.

This fixes that bug, adds a test to make sure everything that needs
to be in the processed crash makes it there, and fixes the spelling
of "canonical".