### PR TITLE
fix bug 1481302: fix API test drive button

### DIFF
--- a/webapp-django/crashstats/api/jinja2/api/documentation.html
+++ b/webapp-django/crashstats/api/jinja2/api/documentation.html
@@ -5,6 +5,11 @@
 {% stylesheet 'api_documentation' %}
 {% endblock %}
 
+{% block site_js %}
+{{ super() }}
+{% javascript 'api_documentation' %}
+{% endblock %}
+
 {% block doc_title %}API Reference{% endblock %}
 
 {% block main_content %}


### PR DESCRIPTION
This adds the js that the page needs that got removed in the docs overhaul.