### PR TITLE
fix bug 1481282: correctly normalize frames based on source file

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -9,7 +9,7 @@ from glom import glom
 import ujson
 
 from . import siglists_utils
-from .utils import drop_bad_characters
+from .utils import drop_bad_characters, parse_source_file
 
 
 SIGNATURE_MAX_LENGTH = 255
@@ -271,19 +271,21 @@ class CSignatureTool(SignatureTool):
             return normalized
 
         if function:
-            # If there's a filename and it ends in .rs, then normalize using Rust
-            # rules
-            if file and file.endswith('.rs'):
-                return self.normalize_rust_function(
-                    function=function,
-                    line=line
-                )
-            else:
-                # Otherwise normalize it with C/C++ rules
-                return self.normalize_cpp_function(
-                    function=function,
-                    line=line
-                )
+            # If there's a filename and it ends in .rs, then normalize using
+            # Rust rules
+            if file:
+                source_file = parse_source_file(file)
+                if source_file and source_file.endswith('.rs'):
+                    return self.normalize_rust_function(
+                        function=function,
+                        line=line
+                    )
+
+            # Otherwise normalize it with C/C++ rules
+            return self.normalize_cpp_function(
+                function=function,
+                line=line
+            )
 
         # If there's a file and line number, use that
         if file and line:

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -93,6 +93,19 @@ class TestCSignatureTool:
                 (None, '', '', '', '0xFFF'),
                 '@0xFFF'
             ),
+
+            # Make sure frame normalization uses the right function: normalize
+            # Rust frame (has a Rust fingerprint)
+            (
+                (
+                    'module',
+                    'expect_failed::h7f635057bfba806a',
+                    'hg:hg.mozilla.org/a/b:servio/wrapper.rs:44444444444',
+                    '23',
+                    '0xFFF'
+                ),
+                'expect_failed'
+            ),
         ]
         for args, e in a:
             r = s.normalize_frame(*args)

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -108,3 +108,39 @@ def drop_bad_characters(text):
     # Strip all non-ascii and non-printable characters
     text = ''.join([c for c in text if c in ALLOWED_CHARS])
     return text
+
+
+def parse_source_file(source_file):
+    """Parses a source file thing and returns the file name
+
+    Example:
+
+    >>> parse_file('hg:hg.mozilla.org/releases/mozilla-esr52:js/src/jit/MIR.h:755067c14b06')
+    'js/src/jit/MIR.h'
+
+    :arg str source_file: the source file ("file") from a stack frame
+
+    :returns: the filename or ``None`` if it couldn't determine one
+
+    """
+    if not source_file:
+        return None
+
+    vcsinfo = source_file.split(':')
+    if len(vcsinfo) == 4:
+        # These are repositories or cloud file systems (e.g. hg, git, s3)
+        vcstype, root, vcs_source_file, revision = vcsinfo
+        return vcs_source_file
+
+    if len(vcsinfo) == 2:
+        # These are directories on someone's Windows computer and vcstype is a
+        # file system (e.g. "c:", "d:", "f:")
+        vcstype, vcs_source_file = vcsinfo
+        return vcs_source_file
+
+    if source_file.startswith('/'):
+        # These are directories on OSX or Linux
+        return source_file
+
+    # We have no idea what this is, so return None
+    return None


### PR DESCRIPTION
Previously, the code assumed the source file was something like `"foo.rs"`.
That was horrifically wrong. This fixes that.