### PR TITLE
fix bug 1482505: added React crash Details view 

### DIFF
--- a/webapp-django/staticfiles/index.js
+++ b/webapp-django/staticfiles/index.js
@@ -4,6 +4,10 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import ReportIndex from 'socorro/report-index';
 
-ReactDOM.render(<ReportIndex />, document.getElementById('crash-report-container'));
+const crashReportContainer = document.getElementById('crash-report-container');
+const crashId = crashReportContainer.dataset.crashId;
+
+ReactDOM.render(<ReportIndex crashId={crashId} />, crashReportContainer);

--- a/webapp-django/staticfiles/report-index/index.js
+++ b/webapp-django/staticfiles/report-index/index.js
@@ -2,11 +2,52 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+
 import PageHeading from 'socorro/report-index/page-heading';
+import Panel from 'socorro/report-index/panel';
+import Frames from 'socorro/report-index/panel/frames';
+import RecordsTable from 'socorro/report-index/panel/records-table';
+import ReportHeaderDetails from 'socorro/report-index/panel/report-header-details';
+import SumoLink from 'socorro/report-index/panel/sumo-link';
 
 export default class ReportIndex extends React.Component {
+  static propTypes = { crashId: PropTypes.string.isRequired };
+
+  componentDidMount() {
+    fetch(`/api/ReportDetails?crash_id=${this.props.crashId}`)
+      .then(response => response.json())
+      .then(details => this.setState({ details }));
+  }
+
   render() {
-    return <PageHeading product="product" version="version" signature="signature" />;
+    if (this.state === null) {
+      return <React.Fragment>Fetching data...</React.Fragment>;
+    }
+    const details = this.state.details;
+    if (details.error === 'Invalid crash ID') {
+      return <React.Fragment>Invalid crash ID.</React.Fragment>;
+    }
+    return (
+      <React.Fragment>
+        <PageHeading
+          product={details.report.product}
+          version={details.report.version}
+          signature={details.report.signature}
+        />
+        <Panel>
+          <SumoLink sumoLink={details.sumoLink} mdnLink={details.mdnLink} />
+          <ReportHeaderDetails uuid={details.report.uuid} signature={details.report.signature} />
+          <RecordsTable
+            report={details.report}
+            rawCrash={details.rawCrash}
+            descriptions={details.descriptions}
+            sensitive={details.sensitive}
+          />
+          <Frames crashingThread={details.crashingThread} threads={details.threads} />
+        </Panel>
+      </React.Fragment>
+    );
   }
 }

--- a/webapp-django/staticfiles/report-index/page-heading/page-heading.test.js
+++ b/webapp-django/staticfiles/report-index/page-heading/page-heading.test.js
@@ -2,15 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
+
 import PageHeading from 'socorro/report-index/page-heading';
 
 describe('<PageHeading />', () => {
   it('has the right content', () => {
     const container = shallow(<PageHeading product="product" version="version" signature="signature" />);
-    const title = container.find('h2');
     expect(container.prop('className')).toEqual('page-heading');
-    expect(title.text()).toEqual('product version Crash Report [@ signature ]');
+
+    const heading = container.find('h2');
+    expect(heading.text()).toEqual('product version Crash Report [@ signature ]');
   });
 });

--- a/webapp-django/staticfiles/report-index/panel/frames/frames.test.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/frames.test.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Frames from 'socorro/report-index/panel/frames';
+
+describe('<Frames />', () => {
+  it('has the right content if crashing thread is null', () => {
+    const container = shallow(<Frames threads={[]} crashingThread={null} />);
+    expect(container.type()).toEqual(null);
+  });
+
+  it('has the right content', () => {
+    const container = shallow(<Frames threads={[{ thread: 0 }, { thread: 1 }]} crashingThread={0} />);
+    const threads = container.find('Thread');
+    expect(threads.length).toEqual(2);
+
+    const crashingThread = threads.at(0);
+    expect(crashingThread.props()).toEqual({ thread: { thread: 0 }, isCrashingThread: true });
+
+    let nonThrashingThreadsContainer = container.find('#allthreads');
+    expect(nonThrashingThreadsContainer.hasClass('hidden')).toEqual(true);
+    container.find('button').simulate('click');
+    nonThrashingThreadsContainer = container.find('#allthreads');
+    expect(nonThrashingThreadsContainer.hasClass('hidden')).toEqual(false);
+
+    const nonCrashingThread = threads.at(1);
+    expect(nonCrashingThread.props()).toEqual({ thread: { thread: 1 }, isCrashingThread: false });
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/frames/index.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/index.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Thread from 'socorro/report-index/panel/frames/thread';
+
+export default class Frames extends React.Component {
+  static propTypes = {
+    threads: PropTypes.array.isRequired,
+    crashingThread: PropTypes.number,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { hideNonCrashingThreads: props.crashingThread !== null };
+  }
+
+  flipHideNonCrashingThreads = () => {
+    this.setState({ hideNonCrashingThreads: !this.state.hideNonCrashingThreads });
+  };
+
+  render() {
+    const { crashingThread, threads } = this.props;
+    if (crashingThread === null) {
+      return null;
+    }
+    return (
+      <div>
+        <Thread thread={threads[crashingThread]} isCrashingThread={true} />
+        <button className="text-button" onClick={this.flipHideNonCrashingThreads}>
+          {this.state.hideNonCrashingThreads ? 'Show other threads' : 'Hide other threads'}
+        </button>
+        <div id="allthreads" className={this.state.hideNonCrashingThreads ? 'hidden' : ''}>
+          {threads
+            .filter(thread => thread.thread != crashingThread)
+            .map(thread => <Thread key={thread.thread} thread={thread} isCrashingThread={false} />)}
+        </div>
+      </div>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/frame/frame.test.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/frame/frame.test.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Frame from 'socorro/report-index/panel/frames/thread/frame';
+
+describe('<Frame />', () => {
+  it('has the right content when isMissingSymbols is true', () => {
+    const container = shallow(
+      <Frame
+        frame={{
+          isMissingSymbols: true,
+          frame: 0,
+          module: 'moduleText',
+          signature: 'signatureText',
+          sourceLink: 'sourceLinkText',
+          file: 'fileText',
+          line: 'lineText',
+        }}
+      />
+    );
+    const row = container.find('tr');
+    expect(row.hasClass('missingsymbols')).toEqual(true);
+
+    const cells = row.find('td');
+    expect(cells.length).toEqual(4);
+
+    const frameCell = cells.at(0);
+    const missingSymbolsNotice = frameCell.find('span');
+    expect(missingSymbolsNotice.props()).toEqual({ children: 'Ø', className: 'row-notice', title: 'missing symbol' });
+    expect(missingSymbolsNotice.text()).toEqual('Ø');
+
+    expect(frameCell.text()).toEqual('Ø0');
+
+    expect(cells.at(1).text()).toEqual('moduleText');
+
+    const signatureCell = cells.at(2);
+    expect(signatureCell.props().title).toEqual('signatureText');
+    expect(signatureCell.text()).toEqual('signatureText');
+
+    const sourceCell = cells.at(3);
+    const sourceLink = sourceCell.find('a');
+    expect(sourceLink.props().href).toEqual('sourceLinkText');
+    expect(sourceLink.text()).toEqual('fileText:lineText');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/frame/index.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/frame/index.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Frame extends React.Component {
+  static propTypes = { frame: PropTypes.object.isRequired };
+
+  getMissingSymbolsIndicator(isMissingSymbols) {
+    if (isMissingSymbols) {
+      return (
+        <span className="row-notice" title="missing symbol">
+          &Oslash;
+        </span>
+      );
+    }
+    return null;
+  }
+
+  getSource(frame) {
+    if (frame.sourceLink) {
+      return (
+        <a href={frame.sourceLink}>
+          {frame.file}:{frame.line}
+        </a>
+      );
+    }
+    if (frame.line) {
+      return `${frame.file}:${frame.line}`;
+    }
+    return frame.file;
+  }
+
+  render() {
+    const frame = this.props.frame;
+    return (
+      <tr className={frame.isMissingSymbols ? 'missingsymbols' : ''}>
+        <td>
+          {this.getMissingSymbolsIndicator(frame.isMissingSymbols)}
+          {frame.frame}
+        </td>
+        <td>{frame.module}</td>
+        <td title={frame.signature}>{frame.signature}</td>
+        <td>{this.getSource(frame)}</td>
+      </tr>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/index.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/index.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Frame from 'socorro/report-index/panel/frames/thread/frame';
+import ThreadName from 'socorro/report-index/panel/frames/thread/thread-name';
+import ThreadTable from 'socorro/report-index/panel/frames/thread/thread-table';
+
+export default class Thread extends React.Component {
+  static propTypes = {
+    thread: PropTypes.object.isRequired,
+    isCrashingThread: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    const thread = this.props.thread;
+    return (
+      <React.Fragment>
+        <ThreadName number={thread.thread} name={thread.name} isCrashingThread={this.props.isCrashingThread} />
+        <ThreadTable>{thread.frames.map(frame => <Frame key={frame.frame} frame={frame} />)}</ThreadTable>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/thread-name/index.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/thread-name/index.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class ThreadName extends React.Component {
+  static propTypes = {
+    name: PropTypes.string,
+    number: PropTypes.number.isRequired,
+    isCrashingThread: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    const { name, number, isCrashingThread } = this.props;
+    return (
+      <h2>
+        {isCrashingThread ? `Crashing Thread (${number})` : `Thread ${number}`}
+        {name ? `, Name: ${name}` : ''}
+      </h2>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/thread-name/thread-name.test.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/thread-name/thread-name.test.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ThreadName from 'socorro/report-index/panel/frames/thread/thread-name';
+
+describe('<ThreadName />', () => {
+  it('has the right content', () => {
+    const container = shallow(<ThreadName name="nameText" number={0} isCrashingThread={true} />);
+    const header = container.find('h2');
+    expect(header.text()).toEqual('Crashing Thread (0), Name: nameText');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/thread-table/index.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/thread-table/index.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class ThreadTable extends React.Component {
+  static propTypes = { children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]) };
+
+  render() {
+    return (
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Frame</th>
+            <th scope="col">Module</th>
+            <th className="signature-column" scope="col">
+              Signature
+            </th>
+            <th scope="col">Source</th>
+          </tr>
+        </thead>
+        <tbody>{this.props.children}</tbody>
+      </table>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/thread-table/thread-table.test.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/thread-table/thread-table.test.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ThreadTable from 'socorro/report-index/panel/frames/thread/thread-table';
+
+describe('<ThreadTable />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <ThreadTable>
+        <tr>
+          <td>firstCellText</td>
+          <td>secondCellText</td>
+        </tr>
+      </ThreadTable>
+    );
+    const table = container.find('table');
+    expect(table.props().className).toEqual('data-table');
+
+    const tableHead = table.find('thead');
+    const tableHeadRow = tableHead.find('tr');
+    const headers = tableHeadRow.find('th');
+    expect(headers.length).toEqual(4);
+    headers.forEach(header => expect(header.props().scope).toEqual('col'));
+    expect(headers.at(0).text()).toEqual('Frame');
+    expect(headers.at(1).text()).toEqual('Module');
+    expect(headers.at(2).text()).toEqual('Signature');
+    expect(headers.at(3).text()).toEqual('Source');
+
+    const tableBody = table.find('tbody');
+    const tableBodyRow = tableBody.find('tr');
+    const cells = tableBodyRow.find('td');
+    expect(cells.at(0).text()).toEqual('firstCellText');
+    expect(cells.at(1).text()).toEqual('secondCellText');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/frames/thread/thread.test.js
+++ b/webapp-django/staticfiles/report-index/panel/frames/thread/thread.test.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Thread from 'socorro/report-index/panel/frames/thread';
+
+describe('<Thread />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <Thread
+        thread={{ thread: 0, name: 'threadName', frames: [{ frame: 0 }, { frame: 1 }] }}
+        isCrashingThread={true}
+      />
+    );
+    const threadName = container.find('ThreadName');
+    expect(threadName.props()).toEqual({ number: 0, name: 'threadName', isCrashingThread: true });
+
+    const threadTable = container.find('ThreadTable');
+    expect(threadTable.exists()).toEqual(true);
+
+    const frames = threadTable.find('Frame');
+    expect(frames.length).toEqual(2);
+
+    const firstFrame = frames.at(0);
+    expect(firstFrame.props()).toEqual({ frame: { frame: 0 } });
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/index.js
+++ b/webapp-django/staticfiles/report-index/panel/index.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Panel extends React.Component {
+  static propTypes = { children: PropTypes.object.isRequired };
+
+  render() {
+    return (
+      <div className="panel">
+        <div className="body">{this.props.children}</div>
+      </div>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/panel.test.js
+++ b/webapp-django/staticfiles/report-index/panel/panel.test.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Panel from 'socorro/report-index/panel';
+
+describe('<ReportIndex />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <Panel>
+        <h1>Hello</h1>
+      </Panel>
+    );
+    const panel = container.find('div .panel');
+    expect(panel.exists()).toEqual(true);
+
+    const body = container.find('div .body');
+    expect(body.exists()).toEqual(true);
+
+    const childHeader = container.find('h1');
+    expect(childHeader.text()).toEqual('Hello');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/crash-circumstance-records/crash-circumstance-records.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/crash-circumstance-records/crash-circumstance-records.test.js
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import CrashCircusmstanceRecords from 'socorro/report-index/panel/records-table/crash-circumstance-records';
+import Record from 'socorro/report-index/panel/records-table/record';
+
+describe('<CrashCircusmstanceRecords />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <CrashCircusmstanceRecords
+        report={{
+          crashReason: 'crashReasonText',
+          crashAddress: 'crashAddressText',
+        }}
+        rawCrash={{
+          isStartupCrash: true,
+          flashProcessDump: 'flashProcessDumpText',
+          mozCrashReason: 'mozCrashReasonText',
+          javaStackTrace: 'javaStackTraceText',
+        }}
+        descriptions={{
+          report: {
+            crashReason: 'crashReasonDescription',
+            crashAddress: 'crashAddressDescription',
+            exploitability: 'exploitabilityDescription',
+          },
+          rawCrash: {
+            isStartupCrash: 'isStartupCrashDescription',
+            flashProcessDump: 'flashProcessDumpDescription',
+            mozCrashReason: 'mozCrashReasonDescription',
+            javaStackTrace: 'javaStackTraceDescription',
+          },
+        }}
+        sensitive={{ exploitability: 'exploitabilityText' }}
+      />
+    );
+    const records = container.find(Record);
+    expect(records.length).toEqual(7);
+
+    const startupCrashRecord = records.at(0);
+    expect(startupCrashRecord.props()).toEqual({
+      children: true,
+      header: 'Startup Crash',
+      description: 'isStartupCrashDescription',
+      show: true,
+    });
+
+    const flashProcessDumpRecord = records.at(1);
+    expect(flashProcessDumpRecord.props()).toEqual({
+      children: 'flashProcessDumpText',
+      header: 'Flash Process Dump',
+      description: 'flashProcessDumpDescription',
+      show: true,
+    });
+
+    const mozCrashReasonRecord = records.at(2);
+    expect(mozCrashReasonRecord.props()).toEqual({
+      children: 'mozCrashReasonText',
+      header: 'MOZ_CRASH Reason',
+      description: 'mozCrashReasonDescription',
+      show: true,
+    });
+
+    const crashReasonRecord = records.at(3);
+    expect(crashReasonRecord.props()).toEqual({
+      children: 'crashReasonText',
+      header: 'Crash Reason',
+      description: 'crashReasonDescription',
+      show: true,
+    });
+
+    const crashAddressRecord = records.at(4);
+    expect(crashAddressRecord.props()).toEqual({
+      children: 'crashAddressText',
+      header: 'Crash Address',
+      description: 'crashAddressDescription',
+      show: true,
+    });
+
+    const javaStackTraceRecord = records.at(5);
+    expect(javaStackTraceRecord.props()).toEqual({
+      children: 'javaStackTraceText',
+      header: 'Java Stack Trace',
+      description: 'javaStackTraceDescription',
+      show: true,
+    });
+
+    const exploitabilityRecord = records.at(6);
+    expect(exploitabilityRecord.props()).toEqual({
+      children: 'exploitabilityText',
+      header: 'Exploitability',
+      description: 'exploitabilityDescription',
+      show: true,
+    });
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/crash-circumstance-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/crash-circumstance-records/index.js
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class CrashCircumstanceRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+    sensitive: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions, sensitive } = this.props;
+    return (
+      <React.Fragment>
+        <Record
+          header="Startup Crash"
+          description={descriptions.rawCrash.isStartupCrash}
+          show={rawCrash.isStartupCrash !== null}
+        >
+          {rawCrash.isStartupCrash}
+        </Record>
+        <Record
+          header="Flash Process Dump"
+          description={descriptions.rawCrash.flashProcessDump}
+          show={rawCrash.flashProcessDump !== null}
+        >
+          {rawCrash.flashProcessDump}
+        </Record>
+        <Record
+          header="MOZ_CRASH Reason"
+          description={descriptions.rawCrash.mozCrashReason}
+          show={rawCrash.mozCrashReason !== null}
+        >
+          {rawCrash.mozCrashReason}
+        </Record>
+        <Record header="Crash Reason" description={descriptions.report.crashReason} show={report.crashReason !== null}>
+          {report.crashReason}
+        </Record>
+        <Record
+          header="Crash Address"
+          description={descriptions.report.crashAddress}
+          show={report.crashAddress !== null}
+        >
+          {report.crashAddress}
+        </Record>
+        <Record
+          header="Java Stack Trace"
+          description={descriptions.rawCrash.javaStackTrace}
+          show={rawCrash.javaStackTrace !== null}
+        >
+          {rawCrash.javaStackTrace}
+        </Record>
+        <Record
+          header="Exploitability"
+          description={descriptions.report.exploitability}
+          show={sensitive.exploitability !== null}
+        >
+          {sensitive.exploitability}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/filesize/filesize.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/filesize/filesize.test.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Filesize from 'socorro/report-index/panel/records-table/filesize';
+
+describe('<Filesize />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <Filesize filesizeData={{ formatted: 'formattedText', bytes: 2000, humanfriendly: 'humanfriendlyText' }} />
+    );
+    expect(container.text()).toEqual('formattedText bytes (humanfriendlyText)');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/filesize/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/filesize/index.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Filesize extends React.Component {
+  static propTypes = { filesizeData: PropTypes.object.isRequired };
+
+  render() {
+    const filesizeData = this.props.filesizeData;
+    return (
+      <React.Fragment>
+        {filesizeData.formatted} bytes
+        {filesizeData.bytes > 1024 ? (
+          <span className="humanized" title={`${filesizeData.formatted} bytes`}>
+            {' '}
+            ({filesizeData.humanfriendly})
+          </span>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/hardware-records/hardware-records.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/hardware-records/hardware-records.test.js
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import HardwareRecords from 'socorro/report-index/panel/records-table/hardware-records';
+import Record from 'socorro/report-index/panel/records-table/record';
+
+describe('<HardwareRecords />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <HardwareRecords
+        report={{
+          cpuName: 'cpuNameText',
+          cpuInfo: 'cpuInfoText',
+        }}
+        rawCrash={{
+          androidManufacturer: 'androidManufacturerText',
+          androidModel: 'androidModelText',
+          androidCpuAbi: 'androidCpuAbiText',
+          adapterVendorId: 'adapterVendorIdText',
+          adapterDeviceId: 'adapterDeviceIdText',
+        }}
+        descriptions={{
+          report: {
+            cpuName: 'cpuNameDescription',
+            cpuInfo: 'cpuInfoDescription',
+          },
+          rawCrash: {
+            androidManufacturer: 'androidManufacturerDescription',
+            androidModel: 'androidModelDescription',
+            androidCpuAbi: 'androidCpuAbiDescription',
+            adapterVendorId: 'adapterVendorIdDescription',
+            adapterDeviceId: 'adapterDeviceIdDescription',
+          },
+        }}
+      />
+    );
+    const records = container.find(Record);
+    expect(records.length).toEqual(7);
+
+    const buildArchitectureRecord = records.at(0);
+    expect(buildArchitectureRecord.props()).toEqual({
+      children: 'cpuNameText',
+      header: 'Build Architecture',
+      description: 'cpuNameDescription',
+      show: true,
+    });
+
+    const buildArchitectureInfoRecord = records.at(1);
+    expect(buildArchitectureInfoRecord.props()).toEqual({
+      children: 'cpuInfoText',
+      header: 'Build Architecture Info',
+      description: 'cpuInfoDescription',
+      show: true,
+    });
+
+    const androidManufacturerRecord = records.at(2);
+    expect(androidManufacturerRecord.props()).toEqual({
+      children: 'androidManufacturerText',
+      header: 'Android Manufacturer',
+      description: 'androidManufacturerDescription',
+      show: true,
+    });
+
+    const androidModelRecord = records.at(3);
+    expect(androidModelRecord.props()).toEqual({
+      children: 'androidModelText',
+      header: 'Android Model',
+      description: 'androidModelDescription',
+      show: true,
+    });
+
+    const androidCpuAbiRecord = records.at(4);
+    expect(androidCpuAbiRecord.props()).toEqual({
+      children: 'androidCpuAbiText',
+      header: 'Android CPU ABI',
+      description: 'androidCpuAbiDescription',
+      show: true,
+    });
+
+    const adapterVendorIdRecord = records.at(5);
+    expect(adapterVendorIdRecord.props()).toEqual({
+      children: 'adapterVendorIdText',
+      header: 'Adapter Vendor ID',
+      description: 'adapterVendorIdDescription',
+      show: true,
+    });
+
+    const adapterDeviceIdRecord = records.at(6);
+    expect(adapterDeviceIdRecord.props()).toEqual({
+      children: 'adapterDeviceIdText',
+      header: 'Adapter Device ID',
+      description: 'adapterDeviceIdDescription',
+      show: true,
+    });
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/hardware-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/hardware-records/index.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class HardwareRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="Build Architecture" description={descriptions.report.cpuName}>
+          {report.cpuName}
+        </Record>
+        <Record header="Build Architecture Info" description={descriptions.report.cpuInfo}>
+          {report.cpuInfo}
+        </Record>
+        <Record
+          header="Android Manufacturer"
+          description={descriptions.rawCrash.androidManufacturer}
+          show={rawCrash.androidManufacturer !== null}
+        >
+          {rawCrash.androidManufacturer}
+        </Record>
+        <Record
+          header="Android Model"
+          description={descriptions.rawCrash.androidModel}
+          show={rawCrash.androidModel !== null}
+        >
+          {rawCrash.androidModel}
+        </Record>
+        <Record
+          header="Android CPU ABI"
+          description={descriptions.rawCrash.androidCpuAbi}
+          show={rawCrash.androidCpuAbi !== null}
+        >
+          {rawCrash.androidCpuAbi}
+        </Record>
+        <Record header="Adapter Vendor ID" description={descriptions.rawCrash.adapterVendorId}>
+          {rawCrash.adapterVendorId}
+        </Record>
+        <Record header="Adapter Device ID" description={descriptions.rawCrash.adapterDeviceId}>
+          {rawCrash.adapterDeviceId}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/index.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import MetadataRecords from 'socorro/report-index/panel/records-table/metadata-records';
+import TimeRecords from 'socorro/report-index/panel/records-table/time-records';
+import ProductRecords from 'socorro/report-index/panel/records-table/product-records';
+import OsRecords from 'socorro/report-index/panel/records-table/os-records';
+import HardwareRecords from 'socorro/report-index/panel/records-table/hardware-records';
+import CrashCircumstanceRecords from 'socorro/report-index/panel/records-table/crash-circumstance-records';
+import PersonalUserInfoRecords from 'socorro/report-index/panel/records-table/personal-user-info-records';
+import MemoryUsageRecords from 'socorro/report-index/panel/records-table/memory-usage-records';
+import MiscellaneousRecords from 'socorro/report-index/panel/records-table/miscellaneous-records';
+import NotesRecords from 'socorro/report-index/panel/records-table/notes-records';
+
+export default class RecordsTable extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+    sensitive: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions, sensitive } = this.props;
+    return (
+      <table className="record data-table vertical">
+        <tbody>
+          <MetadataRecords report={report} descriptions={descriptions} />
+          <TimeRecords report={report} rawCrash={rawCrash} descriptions={descriptions} />
+          <ProductRecords report={report} descriptions={descriptions} />
+          <OsRecords report={report} rawCrash={rawCrash} descriptions={descriptions} />
+          <HardwareRecords report={report} rawCrash={rawCrash} descriptions={descriptions} />
+          <CrashCircumstanceRecords
+            report={report}
+            rawCrash={rawCrash}
+            descriptions={descriptions}
+            sensitive={sensitive}
+          />
+          <PersonalUserInfoRecords sensitive={sensitive} descriptions={descriptions} />
+          <MemoryUsageRecords rawCrash={rawCrash} descriptions={descriptions} />
+          <MiscellaneousRecords report={report} rawCrash={rawCrash} descriptions={descriptions} />
+          <NotesRecords report={report} descriptions={descriptions} />
+        </tbody>
+      </table>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/memory-usage-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/memory-usage-records/index.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Filesize from 'socorro/report-index/panel/records-table/filesize';
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class MemoryUsageRecords extends React.Component {
+  static propTypes = {
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { rawCrash, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="Total Virtual Memory" description={descriptions.rawCrash.totalVirtualMemory}>
+          <Filesize filesizeData={rawCrash.totalVirtualMemory} />
+        </Record>
+        <Record header="Available Virtual Memory" description={descriptions.rawCrash.availableVirtualMemory}>
+          <Filesize filesizeData={rawCrash.availableVirtualMemory} />
+        </Record>
+        <Record header="Available Page File" description={descriptions.rawCrash.availablePageFile}>
+          <Filesize filesizeData={rawCrash.availablePageFile} />
+        </Record>
+        <Record header="Available Physical Memory" description={descriptions.rawCrash.availablePhysicalMemory}>
+          <Filesize filesizeData={rawCrash.availablePhysicalMemory} />
+        </Record>
+        <Record header="System Memory Use Percentage" description={descriptions.rawCrash.systemMemoryUsePercentage}>
+          {rawCrash.systemMemoryUsePercentage}
+        </Record>
+        <Record
+          header="OOM Allocation Size"
+          description={descriptions.rawCrash.oomAllocationSize}
+          show={rawCrash.oomAllocationSize.bytes !== undefined}
+        >
+          <Filesize filesizeData={rawCrash.oomAllocationSize} />
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/memory-usage-records/memory-usage-records.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/memory-usage-records/memory-usage-records.test.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Filesize from 'socorro/report-index/panel/records-table/filesize';
+import MemoryUsageRecords from 'socorro/report-index/panel/records-table/memory-usage-records';
+import Record from 'socorro/report-index/panel/records-table/record';
+
+describe('<MemoryUsageRecords />', () => {
+  it('has the right content', () => {
+    const container = shallow(
+      <MemoryUsageRecords
+        rawCrash={{
+          totalVirtualMemory: {},
+          availableVirtualMemory: {},
+          availablePageFile: {},
+          availablePhysicalMemory: {},
+          systemMemoryUsePercentage: 50,
+          oomAllocationSize: { bytes: 50 },
+        }}
+        descriptions={{
+          rawCrash: {
+            totalVirtualMemory: 'totalVirtualMemoryDescription',
+            availableVirtualMemory: 'availableVirtualMemoryDescription',
+            availablePageFile: 'availablePageFileDescription',
+            availablePhysicalMemory: 'availablePhysicalMemoryDescription',
+            systemMemoryUsePercentage: 'systemMemoryUsePercentageDescription',
+            oomAllocationSize: 'oomAllocationSizeDescription',
+          },
+        }}
+      />
+    );
+    const records = container.find(Record);
+    expect(records.length).toEqual(6);
+
+    const totalVirtualMemoryRecord = records.at(0);
+    expect(totalVirtualMemoryRecord.props()).toEqual({
+      children: <Filesize filesizeData={{}} />,
+      header: 'Total Virtual Memory',
+      description: 'totalVirtualMemoryDescription',
+      show: true,
+    });
+
+    const availableVirtualMemoryRecord = records.at(1);
+    expect(availableVirtualMemoryRecord.props()).toEqual({
+      children: <Filesize filesizeData={{}} />,
+      header: 'Available Virtual Memory',
+      description: 'availableVirtualMemoryDescription',
+      show: true,
+    });
+
+    const availablePageFileRecord = records.at(2);
+    expect(availablePageFileRecord.props()).toEqual({
+      children: <Filesize filesizeData={{}} />,
+      header: 'Available Page File',
+      description: 'availablePageFileDescription',
+      show: true,
+    });
+
+    const availablePhysicalMemoryRecord = records.at(3);
+    expect(availablePhysicalMemoryRecord.props()).toEqual({
+      children: <Filesize filesizeData={{}} />,
+      header: 'Available Physical Memory',
+      description: 'availablePhysicalMemoryDescription',
+      show: true,
+    });
+
+    const systemMemoryUsePercentageRecord = records.at(4);
+    expect(systemMemoryUsePercentageRecord.props()).toEqual({
+      children: 50,
+      header: 'System Memory Use Percentage',
+      description: 'systemMemoryUsePercentageDescription',
+      show: true,
+    });
+
+    const oomAllocationSizeRecord = records.at(5);
+    expect(oomAllocationSizeRecord.props()).toEqual({
+      children: <Filesize filesizeData={{ bytes: 50 }} />,
+      header: 'OOM Allocation Size',
+      description: 'oomAllocationSizeDescription',
+      show: true,
+    });
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/metadata-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/metadata-records/index.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class Metadata extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="Signature" description={descriptions.report.signature}>
+          {report.signature}
+          <a
+            className="sig-overview"
+            href={`/signature/?product=Firefox&signature=${report.signature}`}
+            title="View more reports of this type"
+          >
+            More Reports
+          </a>
+          <a
+            className="sig-search"
+            href={`/search/?product=Firefox&signature=${report.signature}`}
+            title="Search for more reports of this type"
+          >
+            Search
+          </a>
+        </Record>
+        <Record header="UUID" description={descriptions.report.uuid}>
+          {report.uuid}
+        </Record>
+        <Record header="Date Processed" description={descriptions.report.dateProcessed}>
+          {report.dateProcessed}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/miscellaneous-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/miscellaneous-records/index.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class MiscellaneousRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record
+          header="Accessibility"
+          description={descriptions.rawCrash.accessibility}
+          show={rawCrash.accessibility !== undefined}
+        >
+          {rawCrash.accessibility}
+        </Record>
+        <Record header="EMCheckCompatibility" description={descriptions.report.addonsChecked}>
+          <pre>{report.addonsChecked ? 'True' : 'False'}</pre>
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/notes-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/notes-records/index.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class NotesRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="App Notes" description={descriptions.report.appNotes}>
+          {report.appNotes}
+        </Record>
+        <Record header="Processor Notes" description={descriptions.report.processorNotes}>
+          {report.processorNotes}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/os-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/os-records/index.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class OsRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    rawCrash: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="OS" description={descriptions.report.os}>
+          {report.os}
+        </Record>
+        <Record header="OS Version" description={descriptions.report.osVersion}>
+          {report.osVersion}
+        </Record>
+        <Record
+          header="Android Version"
+          description={descriptions.rawCrash.androidVersion}
+          show={rawCrash.androidVersion}
+        >
+          {rawCrash.androidVersion}
+        </Record>
+        <Record header="B2G OS Version" description={descriptions.rawCrash.b2gOsVersion} show={rawCrash.b2gOsVersion}>
+          {rawCrash.b2gOsVersion}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/personal-user-info-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/personal-user-info-records/index.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+import SensitiveWarning from 'socorro/report-index/panel/records-table/sensitive-warning';
+
+export default class PersonalUserInfoRecords extends React.Component {
+  static propTypes = {
+    descriptions: PropTypes.object.isRequired,
+    sensitive: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { descriptions, sensitive } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="URL" description={descriptions.report.url} show={sensitive.url !== undefined}>
+          <a href={sensitive.url} title={sensitive.url}>
+            {sensitive.url}
+          </a>
+          - <SensitiveWarning isYourCrash={sensitive.isYourCrash} />
+        </Record>
+        <Record header="Email Address" description={descriptions.report.url} show={sensitive.email !== undefined}>
+          <a href={`mailto:${sensitive.email}`} title={sensitive.email}>
+            {sensitive.email}
+          </a>
+          - <SensitiveWarning isYourCrash={sensitive.isYourCrash} />
+        </Record>
+        <Record header="User Comments" description={descriptions.report.userComments}>
+          {sensitive.userComments}
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/product-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/product-records/index.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+
+export default class ProductRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object.isRequired,
+    descriptions: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { report, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="Product" description={descriptions.report.product}>
+          {report.product}
+        </Record>
+        <Record header="Release Channel" description={descriptions.report.releaseChannel}>
+          {report.releaseChannel}
+        </Record>
+        <Record header="Version" description={descriptions.report.version}>
+          {report.version}
+        </Record>
+        <Record header="Build ID" description={descriptions.report.build}>
+          <a href={`https://mozilla-services.github.io/buildhub/?q=${report.build}`}>{report.build}</a>
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/record/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/record/index.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Records extends React.Component {
+  static propTypes = {
+    header: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    show: PropTypes.bool,
+    children: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string, PropTypes.object]),
+  };
+  static defaultProps = { show: true };
+
+  render() {
+    if (!this.props.show) {
+      return null;
+    }
+    return (
+      <tr title={this.props.description}>
+        <th scope="row">{this.props.header}</th>
+        <td>{this.props.children} </td>
+      </tr>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/records-table.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/records-table.test.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import RecordsTable from 'socorro/report-index/panel/records-table';
+
+describe('<RecordsTable />', () => {
+  it('has the right content', () => {
+    const container = shallow(<RecordsTable report={{}} rawCrash={{}} descriptions={{}} sensitive={{}} />);
+    const table = container.find('table');
+    expect(table.props().className).toEqual('record data-table vertical');
+
+    const tableBody = table.find('tbody');
+    expect(tableBody.exists()).toEqual(true);
+
+    const records = tableBody.children();
+    expect(records.length).toEqual(10);
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/sensitive-warning/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/sensitive-warning/index.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class SensitiveWarning extends React.Component {
+  static propTypes = { isYourCrash: PropTypes.bool.isRequired };
+
+  render() {
+    if (this.props.isYourCrash) {
+      return <React.Fragment>You can only see this because it is your crash!</React.Fragment>;
+    }
+    return <React.Fragment>This is super sensitive data! Be careful how you use it!</React.Fragment>;
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/sensitive-warning/sensitive-warning.test.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/sensitive-warning/sensitive-warning.test.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import SensitiveWarning from 'socorro/report-index/panel/records-table/sensitive-warning';
+
+describe('<SensitiveWarning />', () => {
+  it('has the right content when isYourCrash is true', () => {
+    const container = shallow(<SensitiveWarning isYourCrash={true} />);
+    expect(container.text()).toEqual('You can only see this because it is your crash!');
+  });
+
+  it('has the right content when isYourCrash is false', () => {
+    const container = shallow(<SensitiveWarning isYourCrash={false} />);
+    expect(container.text()).toEqual('This is super sensitive data! Be careful how you use it!');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/records-table/time-records/duration/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/time-records/duration/index.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Duration extends React.Component {
+  static propTypes = {
+    durationData: PropTypes.object.isRequired,
+    text: PropTypes.string,
+  };
+
+  render() {
+    const { durationData, text } = this.props;
+    return (
+      <React.Fragment>
+        {durationData.formatted} seconds {text}
+        {durationData.seconds > 60 ? (
+          <span className="humanized" title={`${durationData.formatted} seconds`}>
+            {' '}
+            ({durationData.humanfriendly})
+          </span>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/time-records/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/time-records/index.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Record from 'socorro/report-index/panel/records-table/record';
+import Duration from 'socorro/report-index/panel/records-table/time-records/duration';
+import Time from 'socorro/report-index/panel/records-table/time-records/time';
+
+export default class TimeRecords extends React.Component {
+  static propTypes = {
+    report: PropTypes.object,
+    rawCrash: PropTypes.object,
+    descriptions: PropTypes.object,
+  };
+
+  render() {
+    const { report, rawCrash, descriptions } = this.props;
+    return (
+      <React.Fragment>
+        <Record header="Uptime" description={descriptions.report.uptime}>
+          <Duration durationData={report.uptime} />
+        </Record>
+        <Record
+          header="Last Crash"
+          description={descriptions.report.lastCrash}
+          show={report.lastCrash.seconds !== null}
+        >
+          <Duration durationData={report.lastCrash} />
+        </Record>
+        <Record header="Install Age" description={descriptions.report.installAge}>
+          <Duration durationData={report.installAge} text="since version was first installed" />
+        </Record>
+        <Record header="Install Time" description={descriptions.rawCrash.installTime}>
+          <Time time={rawCrash.installTime} />
+        </Record>
+      </React.Fragment>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/records-table/time-records/time/index.js
+++ b/webapp-django/staticfiles/report-index/panel/records-table/time-records/time/index.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Time extends React.Component {
+  static propTypes = {
+    time: PropTypes.string.isRequired,
+  };
+
+  render() {
+    return <time dateTime={this.props.time}>{this.props.time}</time>;
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/report-header-details/index.js
+++ b/webapp-django/staticfiles/report-index/panel/report-header-details/index.js
@@ -5,20 +5,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class PageHeading extends React.Component {
+export default class ReportHeaderDetails extends React.Component {
   static propTypes = {
-    product: PropTypes.string.isRequired,
-    version: PropTypes.string.isRequired,
+    uuid: PropTypes.string.isRequired,
     signature: PropTypes.string.isRequired,
   };
 
   render() {
-    const { product, version, signature } = this.props;
+    const { uuid, signature } = this.props;
     return (
-      <div className="page-heading">
-        <h2>
-          {product} {version} Crash Report [@ {signature} ]
-        </h2>
+      <div>
+        ID: <code>{uuid}</code>
+        <br />
+        Signature: <code>{signature}</code>
       </div>
     );
   }

--- a/webapp-django/staticfiles/report-index/panel/report-header-details/report-header-details.test.js
+++ b/webapp-django/staticfiles/report-index/panel/report-header-details/report-header-details.test.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ReportHeaderDetails from 'socorro/report-index/panel/report-header-details';
+
+describe('<ReportHeaderDetails />', () => {
+  it('has the right content', () => {
+    const container = shallow(<ReportHeaderDetails uuid={'reportId'} signature={'signatureName'} />);
+    const body = container.find('div');
+    expect(body.exists()).toEqual(true);
+
+    const codes = container.find('code');
+    expect(codes.at(0).text()).toEqual('reportId');
+    expect(codes.at(1).text()).toEqual('signatureName');
+  });
+});

--- a/webapp-django/staticfiles/report-index/panel/sumo-link/index.js
+++ b/webapp-django/staticfiles/report-index/panel/sumo-link/index.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class SumoLink extends React.Component {
+  static propTypes = {
+    sumoLink: PropTypes.string.isRequired,
+    mdnLink: PropTypes.string.isRequired,
+  };
+
+  render() {
+    const { sumoLink, mdnLink } = this.props;
+    return (
+      <div id="sumo-link">
+        <a href={sumoLink} title="Find more answers at support.mozilla.org!">
+          Search Mozilla Support for this signature
+        </a>
+        <a href={mdnLink} title="MDN documentation about crash reports">
+          How to read this crash report
+        </a>
+      </div>
+    );
+  }
+}

--- a/webapp-django/staticfiles/report-index/panel/sumo-link/sumo-link.test.js
+++ b/webapp-django/staticfiles/report-index/panel/sumo-link/sumo-link.test.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import SumoLink from 'socorro/report-index/panel/sumo-link';
+
+describe('<SumoLink />', () => {
+  it('has the right content', () => {
+    const container = shallow(<SumoLink sumoLink={'sumoLink'} mdnLink={'mdnLink'} />);
+    const links = container.find('a');
+    const sumoLink = links.at(0);
+    const mdnLink = links.at(1);
+    expect(sumoLink.prop('href')).toEqual('sumoLink');
+    expect(sumoLink.prop('title')).toEqual('Find more answers at support.mozilla.org!');
+    expect(sumoLink.text()).toEqual('Search Mozilla Support for this signature');
+    expect(mdnLink.prop('href')).toEqual('mdnLink');
+    expect(mdnLink.prop('title')).toEqual('MDN documentation about crash reports');
+    expect(mdnLink.text()).toEqual('How to read this crash report');
+  });
+});

--- a/webapp-django/staticfiles/report-index/report-index.test.js
+++ b/webapp-django/staticfiles/report-index/report-index.test.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ReportIndex from 'socorro/report-index';
+
+describe('<ReportIndex />', () => {
+  it('has the right content for no crashId', () => {
+    const container = shallow(<ReportIndex crashId={'crashId'} />);
+    expect(container.text()).toEqual('Fetching data...');
+  });
+
+  it('has the right content for no crashId', () => {
+    const container = shallow(<ReportIndex crashId={'crashId'} />);
+    expect(container.text()).toEqual('Fetching data...');
+  });
+});

--- a/webapp-django/staticfiles/setup-tests.js
+++ b/webapp-django/staticfiles/setup-tests.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import 'isomorphic-fetch';
 
 const Enzyme = require('enzyme');
 const EnzymeAdapter = require('enzyme-adapter-react-16');


### PR DESCRIPTION
fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1482505

## why
- we want to recreate the report index page in React with better testing

## what
- re-created the crash report Details tab using React
- added Enzyme unit tests for most of the new components

## image
![image](https://user-images.githubusercontent.com/12681350/43981105-621f52c8-9ca5-11e8-8c72-3868d0af60b7.png)
