### PR TITLE
fix bug 1483318: don't show inactive products

### DIFF
--- a/alembic/versions/9f7bb4445d7a_bug_1483318_inactive_products.py
+++ b/alembic/versions/9f7bb4445d7a_bug_1483318_inactive_products.py
@@ -1,0 +1,54 @@
+"""bug 1483318 inactive products
+
+Fix sort for all products so that inactive products have a sort of -1 and
+active products have an appropriate sort number that gives us room to add new
+products without having to futz with sort numbers.
+
+Revision ID: 9f7bb4445d7a
+Revises: eb8269f6bb85
+Create Date: 2018-08-15 13:46:36.219981
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '9f7bb4445d7a'
+down_revision = 'eb8269f6bb85'
+
+
+def upgrade():
+    # First set everything to -1 making it all inactive.
+    op.execute("""
+        UPDATE products
+        SET sort = -1
+    """)
+
+    # Then set active products to appropriate sort numbers.
+    to_set = [
+        # These are key products
+        ('Firefox', 1),
+        ('FennecAndroid', 2),
+
+        # These are products that are in the system, but unsupported; we
+        # leave some room so we can add products between
+        ('Thunderbird', 80),
+        ('SeaMonkey', 90),
+
+        # This is an anomly that probably shouldn't show up and we need to
+        # figure out how to fix it
+        ('Fennec', 100),
+    ]
+    for product_name, sort_number in to_set:
+        op.execute("""
+            UPDATE products
+            SET sort = %s
+            WHERE product_name = '%s'
+        """ % (sort_number, product_name)
+        )
+
+
+def downgrade():
+    # There is no going back--only forward
+    pass

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -267,8 +267,10 @@ class Product(DeclarativeBase):
     rapid_beta_version = Column(u'rapid_beta_version', MAJOR_VERSION())
     rapid_release_version = Column(u'rapid_release_version', MAJOR_VERSION())
     release_name = Column(u'release_name', CITEXT(), nullable=False)
-    sort = Column(u'sort', SMALLINT(), nullable=False,
-                  server_default=text('0'))
+
+    # This is the sort order for products in product listings. A -1 here means
+    # the product is inactive and should not show up in listings.
+    sort = Column(u'sort', SMALLINT(), nullable=False, server_default=text('0'))
 
     # relationship definitions
     release_channels = relationship(

--- a/socorro/external/postgresql/staticdata.py
+++ b/socorro/external/postgresql/staticdata.py
@@ -84,11 +84,12 @@ class Products(BaseTable):
         'product_name', 'sort', 'rapid_release_version', 'release_name', 'rapid_beta_version'
     ]
     rows = [
-        ['Fennec', '3', '5.0', 'mobile', '999.0'],
-        ['Thunderbird', '2', '6.0', 'thunderbird', '999.0'],
         ['Firefox', '1', '5.0', 'firefox', '23.0'],
-        ['SeaMonkey', '6', '2.3', 'seamonkey', '999.0'],
-        ['FennecAndroid', '4', '5.0', '**SPECIAL**', '999.0'],
+        ['FennecAndroid', '2', '5.0', '**SPECIAL**', '999.0'],
+        ['Thunderbird', '80', '6.0', 'thunderbird', '999.0'],
+        ['SeaMonkey', '90', '2.3', 'seamonkey', '999.0'],
+        ['Fennec', '100', '5.0', 'mobile', '999.0'],
+        ['InactiveProduct', '-1', '5.0', 'inactive', '999.0'],
     ]
 
 

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -286,13 +286,16 @@ def build_default_context(product=None, versions=None):
 
     # Build product information
     api = models.Products()
-    context['products'] = {
-        hit['product_name']: hit for hit in api.get()['hits']
-    }
+    # NOTE(willkg): using an OrderedDict here since Products returns products
+    # sorted by sort order and we don't want to lose that ordering
+    all_products = OrderedDict()
+    for item in api.get()['hits']:
+        all_products[item['product_name']] = item
+    context['products'] = all_products
 
     # Build product version information
     api = models.ProductVersions()
-    active_versions = OrderedDict()  # so that products are in order
+    active_versions = OrderedDict()
 
     # Turn the list of all product versions into a dict, one per product.
     for pv in api.get(active=True)['hits']:

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -290,6 +290,10 @@ def build_default_context(product=None, versions=None):
     # sorted by sort order and we don't want to lose that ordering
     all_products = OrderedDict()
     for item in api.get()['hits']:
+        if item['sort'] == -1:
+            # A sort of -1 means this item is inactive and we shouldn't show it
+            # in product lists
+            continue
         all_products[item['product_name']] = item
     context['products'] = all_products
 


### PR DESCRIPTION
This fixes the code so that it doesn't show inactive products in the listing. It also goes through and updates the "sort" column of the "products" table so that all products except specified ones are now inactive.