### PR TITLE
fix bug 1483564: comment out Python 3 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,10 @@ jobs:
           working_directory: /socorro
           command: make test
 
-      - run:
-          name: Run tests in Python 3
-          working_directory: /socorro
-          command: make dockertest3
+#      - run:
+#          name: Run tests in Python 3
+#          working_directory: /socorro
+#          command: make dockertest3
 
       - run:
           name: Push to Dockerhub


### PR DESCRIPTION
The Python 3 tests step takes 4 minutes to run out of 18 minutes for an
entire CI pass. That's signficant.

We're putting Python 3 work on the back burner for now becuase we've got
other things to work on. It'll save us a lot of time to stop running
the Python 3 tests in CI for now. We'll re-enable them when Python 3
work is on the front burner again.