### PR TITLE
bug 1481696: add focus

### DIFF
--- a/alembic/versions/b8da3a85f665_bug_1481696_focus.py
+++ b/alembic/versions/b8da3a85f665_bug_1481696_focus.py
@@ -1,0 +1,28 @@
+"""bug 1481696 focus
+
+Revision ID: b8da3a85f665
+Revises: 9f7bb4445d7a
+Create Date: 2018-08-15 17:30:38.808486
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'b8da3a85f665'
+down_revision = '9f7bb4445d7a'
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO products
+        (product_name, sort, release_name, rapid_beta_version, rapid_release_version)
+        VALUES
+        ('Focus', 3, 'focus', 1.0, 1.0)
+    """)
+
+
+def downgrade():
+    # There is no downgrade
+    pass

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -245,7 +245,7 @@ def get_recent_versions_for_product(product):
     }
 
     ret = api.get(**params)
-    if 'facets' not in ret:
+    if 'facets' not in ret or 'version' not in ret['facets']:
         return []
 
     versions = [


### PR DESCRIPTION
This adds Focus as a supported product.

This also fixes a problem in local development environments where if you
haven't set up ES, it causes the product home page to throw HTTP 500s.