### PR TITLE
fix bug 1477013: fix signature generation for rust trait methods

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -9,7 +9,7 @@ from glom import glom
 import ujson
 
 from . import siglists_utils
-from .utils import drop_bad_characters, parse_source_file
+from .utils import collapse, drop_bad_characters, parse_source_file
 
 
 SIGNATURE_MAX_LENGTH = 255
@@ -109,89 +109,22 @@ class CSignatureTool(SignatureTool):
         self.fixup_comma = re.compile(r',(?! )')
         self.fixup_hash = re.compile(r'::h[0-9a-fA-F]+$')
 
-    @staticmethod
-    def _is_exception(exception_list, remaining_original_line, line_up_to_current_position):
-        for an_exception in exception_list:
-            if remaining_original_line.startswith(an_exception):
-                return True
-            if line_up_to_current_position.endswith(an_exception):
-                return True
-        return False
-
-    def _collapse(
-        self,
-        function_signature_str,
-        open_string,
-        replacement_open_string,
-        close_string,
-        replacement_close_string,
-        exception_substring_list=None,
-    ):
-        """Replaces bits between two (possibly nested) delimiters
-
-        this method takes a string representing a C/C++ function signature and
-        replaces anything between two possibly nested delimiters
-
-        :arg str function_signature_str: the original string
-        :arg str open_string: the open string. e.g. "<"
-        :arg str replacement_open_string: the string to replace the open string with
-        :arg str close_string: the close string. e.g. ">"
-        :arg str replacement_close_string: the string to replace the closestring with
-        :arg list exception_substring_list: list of exceptions that shouldn't collapse
-
-        """
-        target_counter = 0
-        collapsed_list = []
-        exception_mode = False
-        exception_substring_list = exception_substring_list or []
-
-        def append_if_not_in_collapse_mode(a_character):
-            if not target_counter:
-                collapsed_list.append(a_character)
-
-        for index, a_character in enumerate(function_signature_str):
-            if a_character == open_string:
-                if self._is_exception(
-                    exception_substring_list,
-                    function_signature_str[index + 1:],
-                    function_signature_str[:index]
-                ):
-                    exception_mode = True
-                    append_if_not_in_collapse_mode(a_character)
-                    continue
-                append_if_not_in_collapse_mode(replacement_open_string)
-                target_counter += 1
-            elif a_character == close_string:
-                if exception_mode:
-                    append_if_not_in_collapse_mode(a_character)
-                    exception_mode = False
-                else:
-                    target_counter -= 1
-                    append_if_not_in_collapse_mode(replacement_close_string)
-            else:
-                append_if_not_in_collapse_mode(a_character)
-
-        edited_function = ''.join(collapsed_list)
-        return edited_function
-
     def normalize_rust_function(self, function, line):
         """Normalizes a single rust frame with a function"""
-        function = self._collapse(
+        function = collapse(
             function,
             open_string='<',
-            replacement_open_string='<',
             close_string='>',
-            replacement_close_string='T>',
-            exception_substring_list=('name omitted', 'IPC::ParamTraits')
+            replacement='<T>',
+            exceptions=('name omitted', 'IPC::ParamTraits', ' as ')
         )
         if self.collapse_arguments:
-            function = self._collapse(
+            function = collapse(
                 function,
                 open_string='(',
-                replacement_open_string='',
                 close_string=')',
-                replacement_close_string='',
-                exception_substring_list=('anonymous namespace', 'operator')
+                replacement='',
+                exceptions=('anonymous namespace', 'operator')
             )
 
         if self.signatures_with_line_numbers_re.match(function):
@@ -209,31 +142,28 @@ class CSignatureTool(SignatureTool):
 
     def normalize_cpp_function(self, function, line):
         """Normalizes a single cpp frame with a function"""
-        function = self._collapse(
+        function = collapse(
             function,
             open_string='<',
-            replacement_open_string='<',
             close_string='>',
-            replacement_close_string='T>',
-            exception_substring_list=('name omitted', 'IPC::ParamTraits')
+            replacement='<T>',
+            exceptions=('name omitted', 'IPC::ParamTraits')
         )
         if self.collapse_arguments:
-            function = self._collapse(
+            function = collapse(
                 function,
                 open_string='(',
-                replacement_open_string='',
                 close_string=')',
-                replacement_close_string='',
-                exception_substring_list=('anonymous namespace', 'operator')
+                replacement='',
+                exceptions=('anonymous namespace', 'operator')
             )
         if 'clone .cold' in function:
             # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
-            function = self._collapse(
+            function = collapse(
                 function,
                 open_string='[',
-                replacement_open_string='',
                 close_string=']',
-                replacement_close_string=''
+                replacement=''
             )
         if self.signatures_with_line_numbers_re.match(function):
             function = "%s:%s" % (function, line)

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -116,15 +116,14 @@ class CSignatureTool(SignatureTool):
             open_string='<',
             close_string='>',
             replacement='<T>',
-            exceptions=('name omitted', 'IPC::ParamTraits', ' as ')
+            exceptions=(' as ',)
         )
         if self.collapse_arguments:
             function = collapse(
                 function,
                 open_string='(',
                 close_string=')',
-                replacement='',
-                exceptions=('anonymous namespace', 'operator')
+                replacement=''
             )
 
         if self.signatures_with_line_numbers_re.match(function):

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -202,8 +202,7 @@ class TestCSignatureTool:
             'expect_failed::h7f6350::blah', '23',
             'expect_failed::h7f6350::blah'
         ),
-        # FIXME(willkg): The type/trait handling here is wrong for Rust. That'll
-        # get fixed in bug #1477013
+        # Handle types and traits
         # FIXME(willkg): the specifiers and return types should get removed.
         # That's covered in bug #1478383.
         (
@@ -211,16 +210,13 @@ class TestCSignatureTool:
             'static void servo_arc::Arc<T>::drop_slow<T>'
         ),
         (
-            'static void core::ptr::drop_in_place<hashglobe::table::RawTable<style::gecko_string_cache::Atom, smallvec::SmallVec<[style::stylist::Rule; 1]>>>(struct hashglobe::table::RawTable<style::gecko_string_cache::Atom, smallvec::SmallVec<[style::stylist::Rule; 1]>>*)', '23',  # noqa
-            'static void core::ptr::drop_in_place<T>'
-        ),
-        (
             'static void core::ptr::drop_in_place<style::stylist::CascadeData>(struct style::stylist::CascadeData*)', '23',  # noqa
             'static void core::ptr::drop_in_place<T>'
         ),
+        # Handle trait methods by not collapsing them
         (
             '<rayon_core::job::HeapJob<BODY> as rayon_core::job::Job>::execute', '23',
-            '<T>::execute'
+            '<rayon_core::job::HeapJob<BODY> as rayon_core::job::Job>::execute'
         ),
     ])
     def test_normalize_rust_function(self, function, line, expected):

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from ..utils import drop_bad_characters
+from ..utils import drop_bad_characters, parse_source_file
 
 
 @pytest.mark.parametrize('text, expected', [
@@ -28,3 +28,33 @@ from ..utils import drop_bad_characters
 ])
 def test_drop_bad_characters(text, expected):
     assert drop_bad_characters(text) == expected
+
+
+@pytest.mark.parametrize('source_file, expected', [
+    (
+        'hg:hg.mozilla.org/releases/mozilla-release:js/src/vm/JSFunction.cpp:7d280b7e277b82ef282325fefb601c10698e075b',  # noqa
+        'js/src/vm/JSFunction.cpp'
+    ),
+    (
+        'git:github.com/rust-lang/rust:src/libcore/cmp.rs:4d90ac38c0b61bb69470b61ea2cccea0df48d9e5',  # noqa
+        'src/libcore/cmp.rs'
+    ),
+    (
+        'f:\dd\vctools\crt\crtw32\mbstring\mbsnbico.c',
+        '\dd\vctools\crt\crtw32\mbstring\mbsnbico.c'
+    ),
+    (
+        'd:\w7rtm\com\rpc\ndrole\udt.cxx',
+        '\w7rtm\com\rpc\ndrole\udt.cxx'
+    ),
+    (
+        '/build/firefox-Kq_6Wg/firefox-54.0+build3/memory/mozjemalloc/jemalloc.c',
+        '/build/firefox-Kq_6Wg/firefox-54.0+build3/memory/mozjemalloc/jemalloc.c'
+    ),
+    (
+        None,
+        None
+    ),
+])
+def test_parse_source_file(source_file, expected):
+    assert parse_source_file(source_file) == expected


### PR DESCRIPTION
This reimplements collapse, adds documentation, adds tests, and fixes the case where it shouldn't collapse a rust trait method.