### PR TITLE
fix bug 1478383: drop prefix and return type in function signatures

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -279,16 +279,12 @@ class CSignatureTool(SignatureTool):
         if sentinel_locations:
             source_list = source_list[min(sentinel_locations):]
 
-        # Get all the relevant frame signatures.
+        # Get all the relevant frame signatures. Note that these function signatures
+        # have already been normalized at this point.
         new_signature_list = []
         for a_signature in source_list:
-            # We want to match against the function signature or any of the parts of the
-            # signature in the case where there are specifiers and return types.
-            a_signature_parts = a_signature.split() + [a_signature]
-
-            # If one of the parts of the function signature matches the
-            # irrelevant signatures regex, skip to the next frame.
-            if any(self.irrelevant_signature_re.match(part) for part in a_signature_parts):
+            # If the signature matches the irrelevant signatures regex, skip to the next frame.
+            if self.irrelevant_signature_re.match(a_signature):
                 continue
 
             # If the signature matches the trim dll signatures regex, rewrite it to remove all but
@@ -303,10 +299,9 @@ class CSignatureTool(SignatureTool):
 
             new_signature_list.append(a_signature)
 
-            # If none of the parts of the function signature signature matches
-            # the prefix signatures regex, then it is the last one we add to
-            # the list.
-            if not any(self.prefix_signature_re.match(part) for part in a_signature_parts):
+            # If the signature does not match the prefix signatures regex, then it is the last
+            # one we add to the list.
+            if not self.prefix_signature_re.match(a_signature):
                 break
 
         # Add a special marker for hang crash reports.

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -153,6 +153,10 @@ class CSignatureTool(SignatureTool):
 
     def normalize_cpp_function(self, function, line):
         """Normalizes a single cpp frame with a function"""
+        # If the function ends in "const", drop that
+        if function.endswith(' const'):
+            function = function[:-6]
+
         # Drop the prefix and return type if there is any
         function = drop_prefix_and_return_type(function)
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -154,15 +154,13 @@ class TestCSignatureTool:
             'mozilla::layers::BasicImageLayer::Paint(mozilla::gfx::DrawTarget*, mozilla::gfx::PointTyped<mozilla::gfx::UnknownUnits, float> const&, mozilla::layers::Layer*)', '23',  # noqa
             'mozilla::layers::BasicImageLayer::Paint'
         ),
-        # FIXME(willkg): the specifiers and return types should get removed.
-        # That's covered in bug #1478383.
         (
             'void nsDocumentViewer::DestroyPresShell()', '23',
-            'void nsDocumentViewer::DestroyPresShell'
+            'nsDocumentViewer::DestroyPresShell'
         ),
         (
             'bool CCGraphBuilder::BuildGraph(class js::SliceBudget& const)', '23',
-            'bool CCGraphBuilder::BuildGraph'
+            'CCGraphBuilder::BuildGraph'
         ),
 
         # Handle converting types to generic
@@ -178,11 +176,10 @@ class TestCSignatureTool:
             'thread_start<unsigned int (__cdecl*)(void* __ptr64)>', '23',
             'thread_start<T>'
         ),
-        # FIXME(willkg): the specifiers and return types should get removed.
-        # That's covered in bug #1478383.
+        # Handle prefixes and return types
         (
             'class JSObject* DoCallback<JSObject*>(class JS::CallbackTracer*, class JSObject**, const char*)', '23',  # noqa
-            'class JSObject* DoCallback<T>'
+            'DoCallback<T>'
         ),
 
         # FIXME(willkg): increase tests here
@@ -202,16 +199,14 @@ class TestCSignatureTool:
             'expect_failed::h7f6350::blah', '23',
             'expect_failed::h7f6350::blah'
         ),
-        # Handle types and traits
-        # FIXME(willkg): the specifiers and return types should get removed.
-        # That's covered in bug #1478383.
+        # Handle prefixes, return types, types, and traits
         (
             'static void servo_arc::Arc<style::gecko_properties::ComputedValues>::drop_slow<style::gecko_properties::ComputedValues>()', '23',  # noqa
-            'static void servo_arc::Arc<T>::drop_slow<T>'
+            'servo_arc::Arc<T>::drop_slow<T>'
         ),
         (
             'static void core::ptr::drop_in_place<style::stylist::CascadeData>(struct style::stylist::CascadeData*)', '23',  # noqa
-            'static void core::ptr::drop_in_place<T>'
+            'core::ptr::drop_in_place<T>'
         ),
         # Handle trait methods by not collapsing them
         (

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -176,13 +176,18 @@ class TestCSignatureTool:
             'thread_start<unsigned int (__cdecl*)(void* __ptr64)>', '23',
             'thread_start<T>'
         ),
+
         # Handle prefixes and return types
         (
             'class JSObject* DoCallback<JSObject*>(class JS::CallbackTracer*, class JSObject**, const char*)', '23',  # noqa
             'DoCallback<T>'
         ),
 
-        # FIXME(willkg): increase tests here
+        # Drop "const" at end
+        (
+            'JSObject::allocKindForTenure const', '23',
+            'JSObject::allocKindForTenure'
+        )
     ])
     def test_normalize_cpp_function(self, function, line, expected):
         """Test normalization for cpp functions"""

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -321,23 +321,6 @@ class TestCSignatureTool:
         sig, notes = s.generate(a)
         assert sig == 'f | e | d | i'
 
-    def test_specifiers_and_return_types(self):
-        """prefix and irrelevant should match ignoring specifiers and return types"""
-        generator = self.setup_config_c_sig_tool(
-            # irrelevant
-            ig=['ignored'],
-            # prefix
-            pr=['pre1', 'pre2'],
-        )
-        source_list = (
-            'static void ignored',
-            'pre1',
-            'static bool pre2',
-            'foo'
-        )
-        sig, notes = generator.generate(source_list)
-        assert sig == 'pre1 | static bool pre2 | foo'
-
     def test_generate_with_merged_dll(self):
         generator = self.setup_config_c_sig_tool(
             ['a', 'b', 'c'],

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -4,7 +4,12 @@
 
 import pytest
 
-from ..utils import collapse, drop_bad_characters, parse_source_file
+from ..utils import (
+    collapse,
+    drop_bad_characters,
+    drop_prefix_and_return_type,
+    parse_source_file,
+)
 
 
 @pytest.mark.parametrize('text, expected', [
@@ -104,3 +109,140 @@ def test_collapse(function, expected):
         'exceptions': ['name omitted', 'IPC::ParamTraits', ' as ']
     }
     assert collapse(**params) == expected
+
+
+@pytest.mark.parametrize('function, expected', [
+    # C/C++
+    (
+        "`anonymous namespace'::xClose",
+        "`anonymous namespace'::xClose"
+    ),
+    (
+        'bool CCGraphBuilder::BuildGraph(class js::SliceBudget & const)',
+        'CCGraphBuilder::BuildGraph(class js::SliceBudget & const)'
+    ),
+    (
+        'int nsHtml5Tokenizer::stateLoop<nsHtml5SilentPolicy>(int, char16_t, int, char16_t*, bool, int, int)',  # noqa
+        'nsHtml5Tokenizer::stateLoop<nsHtml5SilentPolicy>(int, char16_t, int, char16_t*, bool, int, int)'  # noqa
+    ),
+    (
+        'js::ObjectGroup* DoCallback<js::ObjectGroup*>(JS::CallbackTracer*, js::ObjectGroup**, char const*)',  # noqa
+        'DoCallback<js::ObjectGroup*>(JS::CallbackTracer*, js::ObjectGroup**, char const*)'
+    ),
+    (
+        'js::Shape* js::Allocate<js::Shape, (js::AllowGC)1>(JSContext*)',
+        'js::Allocate<js::Shape, (js::AllowGC)1>(JSContext*)'
+    ),
+    (
+        'long sandbox::TargetNtCreateFile( *, void * *, unsigned long, struct _OBJECT_ATTRIBUTES *, struct _IO_STATUS_BLOCK *, union _LARGE_INTEGER *, unsigned long, unsigned long, unsigned long, unsigned long, void *, unsigned long)',  # noqa
+        'sandbox::TargetNtCreateFile( *, void * *, unsigned long, struct _OBJECT_ATTRIBUTES *, struct _IO_STATUS_BLOCK *, union _LARGE_INTEGER *, unsigned long, unsigned long, unsigned long, unsigned long, void *, unsigned long)'  # noqa
+    ),
+    (
+        "static `anonymous-namespace'::reflectStatus `anonymous namespace'::internal_ReflectHistogramAndSamples(struct JSContext *, class JS::Handle<JSObject *>, class base::Histogram *, const class base::Histogram::SampleSet & const)",  # noqa
+        "`anonymous namespace'::internal_ReflectHistogramAndSamples(struct JSContext *, class JS::Handle<JSObject *>, class base::Histogram *, const class base::Histogram::SampleSet & const)"  # noqa
+    ),
+    (
+        "static bool `anonymous namespace'::TypeAnalyzer::specializePhis()",
+        "`anonymous namespace'::TypeAnalyzer::specializePhis()"
+    ),
+    (
+        'static char * dtoa(struct DtoaState *, union U, int, int, int *, int *, char * *)',
+        'dtoa(struct DtoaState *, union U, int, int, int *, int *, char * *)'
+    ),
+    (
+        'static class js::HashSet<js::Shape *,js::ShapeHasher,js::SystemAllocPolicy> * HashChildren(class js::Shape *, class js::Shape *)',  # noqa
+        'HashChildren(class js::Shape *, class js::Shape *)'
+    ),
+    (
+        'static class mozilla::dom::Element * GetPropagatedScrollbarStylesForViewport(class nsPresContext *, struct mozilla::ScrollbarStyles *)',  # noqa
+        'GetPropagatedScrollbarStylesForViewport(class nsPresContext *, struct mozilla::ScrollbarStyles *)'  # noqa
+    ),
+    (
+        'static const class SkTMaskGamma<3,3,3> & const cached_mask_gamma(float, float, float)',
+        'cached_mask_gamma(float, float, float)'
+    ),
+    (
+        'static short ssl_Poll(struct PRFileDesc *, short, short *)',
+        'ssl_Poll(struct PRFileDesc *, short, short *)'
+    ),
+    (
+        "static struct already_AddRefed<nsIAsyncShutdownClient> `anonymous namespace'::GetShutdownPhase()",  # noqa
+        "`anonymous namespace'::GetShutdownPhase()"
+    ),
+    (
+        'static struct Index * sqlite3FindIndex(struct sqlite3 *, const char *, const char *)',
+        'sqlite3FindIndex(struct sqlite3 *, const char *, const char *)'
+    ),
+    (
+        'static unsigned int pr_root(void *)',
+        'pr_root(void *)'
+    ),
+    (
+        'static void * Allocator<MozJemallocBase>::malloc(unsigned __int64)',
+        'Allocator<MozJemallocBase>::malloc(unsigned __int64)'
+    ),
+    (
+        'static void * * NewUNumberFormat(struct JSContext *, class JS::Handle<js::NumberFormatObject *>)',  # noqa
+        'NewUNumberFormat(struct JSContext *, class JS::Handle<js::NumberFormatObject *>)'
+    ),
+    (
+        'void mozilla::layers::MLGDeviceD3D11::~MLGDeviceD3D11()',
+        'mozilla::layers::MLGDeviceD3D11::~MLGDeviceD3D11()'
+    ),
+    (
+        'void * arena_t::MallocSmall(unsigned int, bool)',
+        'arena_t::MallocSmall(unsigned int, bool)'
+    ),
+
+    # Rust
+    (
+        'bool prefs_parser::prefs_parser_parse(char *, prefs_parser::PrefValueKind, char *, unsigned __int64,  *,  *)',  # noqa
+        'prefs_parser::prefs_parser_parse(char *, prefs_parser::PrefValueKind, char *, unsigned __int64,  *,  *)'  # noqa
+    ),
+    (
+        'float geckoservo::glue::Servo_AnimationValue_GetOpacity(struct style::gecko_bindings::structs::root::RawServoAnimationValue *)',  # noqa
+        'geckoservo::glue::Servo_AnimationValue_GetOpacity(struct style::gecko_bindings::structs::root::RawServoAnimationValue *)'  # noqa
+    ),
+    (
+        'static <NoType> std::panicking::begin_panic<str*>(struct str*, struct (str*, u32, u32) *)',
+        'std::panicking::begin_panic<str*>(struct str*, struct (str*, u32, u32) *)'
+    ),
+    (
+        'static core::result::Result style::properties::PropertyDeclaration::to_css(struct nsstring::nsAString *)',  # noqa
+        'style::properties::PropertyDeclaration::to_css(struct nsstring::nsAString *)'
+    ),
+    (
+        'static struct atomic_refcell::AtomicRefMut<style::data::ElementData> style::gecko::wrapper::{{impl}}::ensure_data(struct style::gecko::wrapper::GeckoElement *)',  # noqa
+        'style::gecko::wrapper::{{impl}}::ensure_data(struct style::gecko::wrapper::GeckoElement *)'
+    ),
+    (
+        'static union core::option::Option<usize> encoding_rs::Encoder::max_buffer_length_from_utf16_without_replacement(unsigned __int64)',  # noqa
+        'encoding_rs::Encoder::max_buffer_length_from_utf16_without_replacement(unsigned __int64)'
+    ),
+    (
+        'static unsigned __int64 style::gecko::pseudo_element::PseudoElement::index()',
+        'style::gecko::pseudo_element::PseudoElement::index()'
+    ),
+    (
+        'static void alloc::boxed::{{impl}}::call_box<(),closure>(struct closure *, <NoType>)',
+        'alloc::boxed::{{impl}}::call_box<(),closure>(struct closure *, <NoType>)'
+    ),
+    (
+        'static void core::option::expect_failed()',
+        'core::option::expect_failed()'
+    ),
+    (
+        'struct style::gecko_bindings::sugar::ownership::Strong<style::gecko_bindings::structs::root::RawServoStyleSheetContents> geckoservo::glue::Servo_StyleSheet_Empty(style::gecko_bindings::structs::root::mozilla::css::SheetParsingMode)',  # noqa
+        'geckoservo::glue::Servo_StyleSheet_Empty(style::gecko_bindings::structs::root::mozilla::css::SheetParsingMode)'  # noqa
+    ),
+    (
+        'unsigned int encoding_glue::mozilla_encoding_encode_from_utf16(struct encoding_rs::Encoding * *, unsigned short *, unsigned int, struct nsstring::nsACString *)',  # noqa
+        'encoding_glue::mozilla_encoding_encode_from_utf16(struct encoding_rs::Encoding * *, unsigned short *, unsigned int, struct nsstring::nsACString *)'  # noqa
+    ),
+    (
+        'void geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)',  # noqa
+        'geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)'  # noqa
+    )
+])
+def test_drop_prefix_and_return_type(function, expected):
+    assert drop_prefix_and_return_type(function) == expected


### PR DESCRIPTION
Symbols for Linux and OSX don't have prefixes and return types, but symbols
for Windows do now (this wasn't the case until recently). That creates
a problem where signature's aren't matching between the platforms.

On Windows you might get this:

    void mozilla::layers::Grouper::ConstructGroupInsideInactive

On Linux and OSX you'd get this:

    mozilla::layers::Grouper::ConstructGroupInsideInactive

This fixes that by stripping prefixes (static, etc) and return types
(void, void *, etc) from function signatures during normalization.