### PR TITLE
bug 1481696: add processor rule to fix Focus crashes

### DIFF
--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -870,43 +870,47 @@ class TestOutOfMemoryBinaryRule(TestCase):
         assert 'memory_report' not in processed_crash
 
 
-class TestProductRewrite(TestCase):
-    def test_everything_we_hoped_for(self):
+class TestProductRewriteRule(TestCase):
+    def test_product_map_rewrite(self):
         config = get_basic_config()
-
         raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash['ProductName'] = 'Fennec'
         raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
-        raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
         rule = ProductRewrite(config)
-
-        # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, {}, processed_crash, processor_meta)
 
         assert raw_crash.ProductName == 'FennecAndroid'
+        assert raw_crash.OriginalProductName == 'Fennec'
 
         # processed_crash should be unchanged
         assert processed_crash == DotDict()
+        assert processor_meta.processor_notes == [
+            "Rewriting ProductName from 'Fennec' to 'FennecAndroid'"
+        ]
 
-    def test_this_is_not_the_crash_you_are_looking_for(self):
+    def test_focus_rewrite(self):
         config = get_basic_config()
-
         raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        raw_crash['ProductName'] = 'Fennec'
+        raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
+        raw_crash['ProcessType'] = 'content'
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
         rule = ProductRewrite(config)
+        rule.act(raw_crash, {}, processed_crash, processor_meta)
 
-        # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert raw_crash.ProductName == 'Firefox'
+        assert raw_crash.ProductName == 'Focus'
+        assert raw_crash.OriginalProductName == 'Fennec'
 
         # processed_crash should be unchanged
         assert processed_crash == DotDict()
+        assert processor_meta.processor_notes == [
+            "Rewriting ProductName from 'Fennec' to 'Focus'"
+        ]
 
 
 class TestESRVersionRewrite(TestCase):


### PR DESCRIPTION
This reworks the ProductRewrite rule so it logs what it did in the crash
report better. It also adjusts the rule to act as a "this is where we're
going to do all the product rewriting" place.

This adds product rewriting logic for Focus GV. That's using GeckoView,
but incoming crash reports are using `ProductName=Fennec`. So the ProductRewrite
rule was convering those to FennecAndroid. This will then convert it to
Focus if the `ProcessType=content`.

We should remove this as soon as we can, but it'll fix an existing issue
we have right now.