### PR TITLE
fix bug 1485411: fix revision information acquisition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,7 @@ setup(
             glob.glob('socorro/external/postgresql/raw_sql/views/*.sql')),
         ('socorro/external/postgresql/raw_sql/types',
             glob.glob('socorro/external/postgresql/raw_sql/types/*.sql')),
-        ('socorro', [
-            'socorro_revision.txt',
-            'breakpad_revision.txt',
-            'JENKINS_BUILD_NUMBER'
-        ]),
-        ('socorro/siglists', glob.glob('socorro/siglists/*.txt')),
+        ('socorro/siglists', glob.glob('socorro/signature/siglists/*.txt')),
         ('socorro/schemas', glob.glob('socorro/schemas/*.json')),
     ],
 )

--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -4,16 +4,13 @@
 
 import sys
 
-from pkg_resources import resource_string
 import raven
 
-# When socorro is installed (python setup.py install), it will create
-# a file in site-packages for socorro called "socorro/socorro_revision.txt".
-# If this socorro was installed like that, let's pick it up and use it.
-try:
-    SOCORRO_REVISION = resource_string('socorro', 'socorro_revision.txt').strip()
-except IOError:
-    SOCORRO_REVISION = None
+from socorro.lib.revision_data import get_revision_data
+
+
+# Get version data or "unknown"
+SOCORRO_REVISION = get_revision_data().get('version', 'unknown')
 
 
 def get_client(dsn, **kwargs):

--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -15,8 +15,7 @@ SOCORRO_REVISION = get_revision_data().get('version', 'unknown')
 
 def get_client(dsn, **kwargs):
     kwargs['dsn'] = dsn
-    if not kwargs.get('release') and SOCORRO_REVISION:
-        kwargs['release'] = SOCORRO_REVISION
+    kwargs['release'] = kwargs.get('release') or SOCORRO_REVISION
     return raven.Client(**kwargs)
 
 

--- a/socorro/lib/revision_data.py
+++ b/socorro/lib/revision_data.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Holds utility functions for interacting with Socorro revision data
+which is generated during deploys.
+"""
+
+import json
+import os
+
+
+# This path is hard-coded to the repository root in .circleci/config.yml. This
+# file is generated during deploys to server environments.
+REVISION_DATA_PATH = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+    'version.json'
+)
+
+
+def get_revision_data():
+    """Returns revision data
+
+    During deploys, the deploy scripts generate a ``version.json`` file
+    containing revision information. This information includes the following:
+
+    * commit
+    * version
+    * source
+    * build
+
+    If the file is there, this function will return a dict with that. If
+    not--as in the case of a local development environment--then this function
+    will return an empty dict.
+
+    :returns: dict of revision data or empty dict if there's no revision data
+        file
+
+    """
+    if os.path.exists(REVISION_DATA_PATH):
+        with open(REVISION_DATA_PATH, 'r') as fp:
+            return json.load(fp)
+    return {}

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -10,6 +10,7 @@ from configman.dotdict import DotDict as CDotDict
 from mock import call, Mock, patch
 
 from socorro.lib.datetimeutil import datetime_from_isodate_string
+from socorro.lib.revision_data import get_revision_data
 from socorro.lib.util import DotDict
 from socorro.processor.mozilla_transform_rules import (
     AddonsRule,
@@ -1664,6 +1665,12 @@ class TestSignatureGeneratorRule:
             def predicate(self, raw_crash, processed_crash):
                 raise exc_value
 
+        # NOTE(willkg): In a local development environment, there's no
+        # version.json file, so this ends up as "unknown". But in CI,
+        # there is a version.json file and the version is "". We need to
+        # account for the variation in the two test contexts.
+        release = get_revision_data().get('version', 'unknown')
+
         sentry_dsn = 'https://username:password@sentry.example.com/'
 
         config = get_basic_config()
@@ -1694,7 +1701,7 @@ class TestSignatureGeneratorRule:
         ]
 
         # Make sure the client was instantiated with the sentry_dsn
-        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn, release='unknown')
+        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn, release=release)
 
         # Make sure captureExeption was called with the right args.
         assert (

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1664,7 +1664,7 @@ class TestSignatureGeneratorRule:
             def predicate(self, raw_crash, processed_crash):
                 raise exc_value
 
-        sentry_dsn = 'https://blahblah:blahblah@sentry.example.com/'
+        sentry_dsn = 'https://username:password@sentry.example.com/'
 
         config = get_basic_config()
         config.sentry = CDotDict()

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1694,7 +1694,7 @@ class TestSignatureGeneratorRule:
         ]
 
         # Make sure the client was instantiated with the sentry_dsn
-        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn)
+        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn, release='unknown')
 
         # Make sure captureExeption was called with the right args.
         assert (

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -9,6 +9,7 @@ import dj_database_url
 from decouple import config, Csv
 
 from .bundles import NPM_FILE_PATTERNS, PIPELINE_CSS, PIPELINE_JS  # noqa
+from socorro.lib.revision_data import get_revision_data
 
 
 ROOT = os.path.abspath(
@@ -509,13 +510,9 @@ SESSION_COOKIE_HTTPONLY = config('SESSION_COOKIE_HTTPONLY', True, cast=bool)
 # decorator on specific views that can be in a frame.
 X_FRAME_OPTIONS = config('X_FRAME_OPTIONS', 'DENY')
 
-# When socorro is installed (python setup.py install), it will create
-# a file in site-packages for socorro called "socorro/socorro_revision.txt".
-# If this socorro was installed like that, let's pick it up and use it.
-try:
-    SOCORRO_REVISION = resource_string('socorro', 'socorro_revision.txt')
-except IOError:
-    SOCORRO_REVISION = None
+# When Socorro is deployed, it generates a version.json file which has
+# a version number in it. Get that if available.
+SOCORRO_REVISION = get_revision_data().get('version', 'unknown')
 
 # Comma-separated list of urls that serve version information in JSON format
 OVERVIEW_VERSION_URLS = config('OVERVIEW_VERSION_URLS', '')

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -3,7 +3,6 @@
 # variables.
 
 import os
-from pkg_resources import resource_string
 
 import dj_database_url
 from decouple import config, Csv


### PR DESCRIPTION
In the old infrastructure, we had a "socorro_revision.txt" file that
was generated when we built the socorro package. We don't do that anymore.
Now we generate a version.json file when socorro is deployed.

This updates the revision acquiring code to use the correct file.