### PR TITLE
fix bug 1485411: fix revision in sentry in stage

### DIFF
--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -9,10 +9,8 @@ import raven
 from socorro.lib.revision_data import get_version
 
 
-def get_client(dsn, **kwargs):
-    kwargs['dsn'] = dsn
-    kwargs['release'] = kwargs.get('release') or get_version()
-    return raven.Client(**kwargs)
+def get_client(dsn):
+    return raven.Client(dsn=dsn, release=get_version())
 
 
 def capture_error(sentry_dsn, logger, exc_info=None, extra=None):

--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -6,17 +6,12 @@ import sys
 
 import raven
 
-from socorro.lib.revision_data import get_revision_data
-
-
-# Get version data or "unknown"
-_revision_data = get_revision_data()
-SOCORRO_REVISION = _revision_data.get('version') or _revision_data.get('commit') or 'unknown'
+from socorro.lib.revision_data import get_version
 
 
 def get_client(dsn, **kwargs):
     kwargs['dsn'] = dsn
-    kwargs['release'] = kwargs.get('release') or SOCORRO_REVISION
+    kwargs['release'] = kwargs.get('release') or get_version()
     return raven.Client(**kwargs)
 
 

--- a/socorro/lib/raven_client.py
+++ b/socorro/lib/raven_client.py
@@ -10,7 +10,8 @@ from socorro.lib.revision_data import get_revision_data
 
 
 # Get version data or "unknown"
-SOCORRO_REVISION = get_revision_data().get('version', 'unknown')
+_revision_data = get_revision_data()
+SOCORRO_REVISION = _revision_data.get('version') or _revision_data.get('commit') or 'unknown'
 
 
 def get_client(dsn, **kwargs):

--- a/socorro/lib/revision_data.py
+++ b/socorro/lib/revision_data.py
@@ -44,3 +44,17 @@ def get_revision_data():
         with open(REVISION_DATA_PATH, 'r') as fp:
             return json.load(fp)
     return {}
+
+
+def get_version():
+    """Returns the Socorro version
+
+    This pulls revision data and then returns the best version-y thing
+    available: the tag, the commit, or "unknown" if there's no revision
+    data.
+
+    :returns: string
+
+    """
+    revision_data = get_revision_data()
+    return revision_data.get('version') or revision_data.get('commit') or 'unknown'

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -10,7 +10,7 @@ from configman.dotdict import DotDict as CDotDict
 from mock import call, Mock, patch
 
 from socorro.lib.datetimeutil import datetime_from_isodate_string
-from socorro.lib.revision_data import get_revision_data
+from socorro.lib.revision_data import get_version
 from socorro.lib.util import DotDict
 from socorro.processor.mozilla_transform_rules import (
     AddonsRule,
@@ -1665,12 +1665,7 @@ class TestSignatureGeneratorRule:
             def predicate(self, raw_crash, processed_crash):
                 raise exc_value
 
-        # NOTE(willkg): In a local development environment, there's no
-        # version.json file, so this ends up as "unknown". But in CI,
-        # there is a version.json file and the version is "". We need to
-        # account for the variation in the two test contexts.
-        release = get_revision_data().get('version', 'unknown')
-
+        version = get_version()
         sentry_dsn = 'https://username:password@sentry.example.com/'
 
         config = get_basic_config()
@@ -1701,7 +1696,7 @@ class TestSignatureGeneratorRule:
         ]
 
         # Make sure the client was instantiated with the sentry_dsn
-        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn, release=release)
+        mock_raven.Client.assert_called_once_with(dsn=sentry_dsn, release=version)
 
         # Make sure captureExeption was called with the right args.
         assert (

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -511,7 +511,8 @@ X_FRAME_OPTIONS = config('X_FRAME_OPTIONS', 'DENY')
 
 # When Socorro is deployed, it generates a version.json file which has
 # a version number in it. Get that if available.
-SOCORRO_REVISION = get_revision_data().get('version', 'unknown')
+_revision_data = get_revision_data()
+SOCORRO_REVISION = _revision_data.get('version') or _revision_data.get('commit') or 'unknown'
 
 # Comma-separated list of urls that serve version information in JSON format
 OVERVIEW_VERSION_URLS = config('OVERVIEW_VERSION_URLS', '')

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -8,7 +8,7 @@ import dj_database_url
 from decouple import config, Csv
 
 from .bundles import NPM_FILE_PATTERNS, PIPELINE_CSS, PIPELINE_JS  # noqa
-from socorro.lib.revision_data import get_revision_data
+from socorro.lib.revision_data import get_version
 
 
 ROOT = os.path.abspath(
@@ -509,10 +509,7 @@ SESSION_COOKIE_HTTPONLY = config('SESSION_COOKIE_HTTPONLY', True, cast=bool)
 # decorator on specific views that can be in a frame.
 X_FRAME_OPTIONS = config('X_FRAME_OPTIONS', 'DENY')
 
-# When Socorro is deployed, it generates a version.json file which has
-# a version number in it. Get that if available.
-_revision_data = get_revision_data()
-SOCORRO_REVISION = _revision_data.get('version') or _revision_data.get('commit') or 'unknown'
+SOCORRO_REVISION = get_version()
 
 # Comma-separated list of urls that serve version information in JSON format
 OVERVIEW_VERSION_URLS = config('OVERVIEW_VERSION_URLS', '')


### PR DESCRIPTION
When Socorro deploys to stage, there's no git tag, so the version is "".
Since that's a value in the dict, it never gets set to "unknown" so
then it doesn't get sent to sentry. It'd be better if we sent the
commit sha in this case.