### PR TITLE
fix bug 1346891: rewrite BetaVersionRule to use webapp API

### DIFF
--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -25,18 +25,18 @@ To change the database config, use --help to see what the parameters are called.
 
 import datetime
 
-import requests
 from dateutil import tz
 from configman import Namespace
 from crontabber.base import BaseCronApp
 from crontabber.mixins import with_postgres_transactions
 
-from socorro.lib.datetimeutil import utc_now
 from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,
     execute_no_results,
     SQLDidNotReturnSingleRow
 )
+from socorro.lib.datetimeutil import utc_now
+from socorro.lib.requestslib import session_with_retries
 
 
 # Query all bugs that changed since a given date, and that either were created
@@ -183,7 +183,8 @@ class BugzillaCronApp(BaseCronApp):
     def _iterator(self, from_date):
         payload = BUGZILLA_PARAMS.copy()
         payload['chfieldfrom'] = from_date
-        r = requests.get(BUGZILLA_BASE_URL, params=payload)
+        session = session_with_retries(BUGZILLA_BASE_URL)
+        r = session.get(BUGZILLA_BASE_URL, params=payload)
         if r.status_code < 200 or r.status_code >= 300:
             r.raise_for_status()
         results = r.json()

--- a/socorro/external/postgresql/version_string.py
+++ b/socorro/external/postgresql/version_string.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+from socorro.lib import MissingArgumentError, external_common
+from socorro.external.postgresql.base import PostgreSQLBase
+
+
+logger = logging.getLogger("webapi")
+
+
+class VersionString(PostgreSQLBase):
+    def get(self, **kwargs):
+        filters = [
+            ('product', None, 'str'),
+            ('version', None, 'str'),
+            ('build_id', None, 'int'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        required = ('product', 'build_id', 'version')
+        for key in required:
+            if not params.get(key):
+                raise MissingArgumentError(key)
+
+        sql = """
+            SELECT
+                pv.version_string
+            FROM product_versions pv
+                LEFT JOIN product_version_builds pvb ON
+                    (pv.product_version_id = pvb.product_version_id)
+            WHERE pv.product_name = %(product)s
+            AND pv.release_version = %(version)s
+            AND pvb.build_id = %(build_id)s
+        """
+        results = self.query(sql, params)
+
+        # The query can return multiple results, but they're the same value. So
+        # we just return the first one.
+        version_string = [
+            row['version_string'] for row in results.zipped()
+        ]
+        if version_string:
+            version_string = [version_string[0]]
+
+        return {
+            'hits': version_string
+        }

--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+In-memory caching utilities.
+"""
+
+from collections import MutableMapping, OrderedDict
+import datetime
+import threading
+
+import isodate
+
+
+UTC = isodate.UTC
+
+
+#: Default time-to-live for keys in seconds
+DEFAULT_TTL = 600
+
+
+def _utc_now():
+    return datetime.datetime.now(UTC)
+
+
+class ExpiringCache(MutableMapping):
+    """In-memory cache that drops data older than a specified ttl
+
+    This will do bookkeeping periodically when setting values. If you
+    want to explicitly remove all expired data, call ``.flush()``.
+
+    Example of usage:
+
+    >>> cache = ExpiringCache(max_size=1000, ttl=5 * 60)
+    >>> cache['key1'] = 'something'
+    >>> cache['key1']
+    'something'
+    >>> # wait 5 minutes
+    >>> cache['key1']
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    KeyError: 'key1'
+
+    """
+    def __init__(self, max_size=128, ttl=600):
+        if max_size <= 0:
+            raise ValueError('max_size must be greater than 0')
+        if ttl <= 0:
+            raise ValueError('ttl must be greater than 0')
+        self._max_size = max_size
+        self._ttl = datetime.timedelta(seconds=ttl)
+        # Map of key -> (expire time, value)
+        self._data = OrderedDict()
+        self._lock = threading.RLock()
+
+    def flush(self):
+        """Removes all expired keys"""
+        with self._lock:
+            NOW = _utc_now()
+
+            for key, value_record in self._data.items():
+                if value_record[0] < NOW:
+                    del self._data[key]
+
+    def __getitem__(self, key):
+        with self._lock:
+            value_record = self._data[key]
+
+            if value_record[0] < _utc_now():
+                del self._data[key]
+                raise KeyError()
+
+            return value_record[1]
+
+    def __setitem__(self, key, value):
+        self._data[key] = [_utc_now() + self._ttl, value]
+
+        # If we've exceeded the max size, remove the oldest one
+        if len(self._data) > self._max_size:
+            del self._data[self._data.keys()[0]]
+
+    def __delitem__(self, key):
+        del self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        raise len(self._data)

--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -36,7 +36,7 @@ class ExpiringCache(MutableMapping):
     KeyError: 'key1'
 
     """
-    def __init__(self, max_size=128, ttl=600):
+    def __init__(self, max_size=128, ttl=DEFAULT_TTL):
         """
         :arg max_size: maximum number of items in the cache
         :arg ttl: ttl for items in the cache in seconds

--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -10,18 +10,11 @@ from collections import MutableMapping, OrderedDict
 import datetime
 import threading
 
-import isodate
-
-
-UTC = isodate.UTC
+from socorro.lib.datetimeutil import utc_now
 
 
 #: Default time-to-live for keys in seconds
 DEFAULT_TTL = 600
-
-
-def _utc_now():
-    return datetime.datetime.now(UTC)
 
 
 class ExpiringCache(MutableMapping):
@@ -62,7 +55,7 @@ class ExpiringCache(MutableMapping):
     def flush(self):
         """Removes all expired keys"""
         with self._lock:
-            NOW = _utc_now()
+            NOW = utc_now()
 
             for key, value_record in self._data.items():
                 if value_record[0] < NOW:
@@ -72,14 +65,14 @@ class ExpiringCache(MutableMapping):
         with self._lock:
             value_record = self._data[key]
 
-            if value_record[0] < _utc_now():
+            if value_record[0] < utc_now():
                 del self._data[key]
                 raise KeyError()
 
             return value_record[1]
 
     def __setitem__(self, key, value):
-        self._data[key] = [_utc_now() + self._ttl, value]
+        self._data[key] = [utc_now() + self._ttl, value]
 
         # If we've exceeded the max size, remove the oldest one
         if len(self._data) > self._max_size:

--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -44,6 +44,11 @@ class ExpiringCache(MutableMapping):
 
     """
     def __init__(self, max_size=128, ttl=600):
+        """
+        :arg max_size: maximum number of items in the cache
+        :arg ttl: ttl for items in the cache in seconds
+
+        """
         if max_size <= 0:
             raise ValueError('max_size must be greater than 0')
         if ttl <= 0:

--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
 import datetime
-import isodate  # 3rd party
 import json
 from past.builtins import basestring
+import re
+
+import isodate
+
 
 UTC = isodate.UTC
 

--- a/socorro/lib/requestslib.py
+++ b/socorro/lib/requestslib.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+
+def session_with_retries(url):
+    """Generates a requests session that supports retries on HTTP 429
+
+    :arg url: url to use for requests
+
+    :returns: a requests Session instance
+
+    """
+    base_url = urlparse.urlparse(url).netloc
+    scheme = urlparse.urlparse(url).scheme
+
+    retries = Retry(total=32, backoff_factor=1, status_forcelist=[429])
+
+    s = requests.Session()
+
+    # Set the User-Agent header so we can distinguish our stuff from other stuff
+    s.headers.update({
+        'User-Agent': 'socorro-requests/1.0'
+    })
+    s.mount(scheme + '://' + base_url, HTTPAdapter(max_retries=retries))
+
+    return s

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -623,15 +623,23 @@ class BetaVersionRule(Rule):
     def version(self):
         return '1.0'
 
-    # FIXME(willkg): add ttl cache here
     def _get_version_data(self, product, version, build_id):
-        """Return the real version number of a specific product, version and
-        build.
+        """Return the real version number of a specific product, version and build
 
-        For example, beta builds of Firefox declare their version
-        number as the major version (i.e. version 54.0b3 would say its version
-        is 54.0). This database call returns the actual version number of said
-        build (i.e. 54.0b3 for the previous example).
+        For example, beta builds of Firefox declare their version number as the
+        major version (i.e. version 54.0b3 would say its version is 54.0). This
+        database call returns the actual version number of said build (i.e.
+        54.0b3 for the previous example).
+
+        :arg product: the product
+        :arg version: the version as a string. e.g. "56.0"
+        :arg build_id: the build_id as a string.
+
+        :returns: ``None`` or the version string that should be used
+
+        :raises requests.RequestException: raised if it has connection issues with
+            the host specified in ``version_string_api``
+
         """
         if not (product and version and build_id):
             return None

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -699,12 +699,12 @@ class BetaVersionRule(Rule):
                 )
         except KeyError:
             return False
-        except RequestException:
+        except RequestException as exc:
             processed_crash['version'] += 'b0'
             processor_meta.processor_notes.append(
-                'could not connect to VersionString API '
-                '- added "b0" suffix to version number'
+                'could not connect to VersionString API - added "b0" suffix to version number'
             )
+            self.config.logger.exception('%s when connecting to %s', exc, self.version_string_api)
         return True
 
 

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -659,22 +659,18 @@ class BetaVersionRule(Rule):
         return self._versions_data_cache.get(key)
 
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        try:
-            # We apply this Rule only if the release channel is beta, because
-            # beta versions are the only ones sending an "incorrect" version
-            # number in their data.
-            # 2017-06-14: Ohai! This is not true anymore! With the removal of
-            # the aurora channel, there is now a new type of build called
-            # "DevEdition", that is released on the aurora channel, but has
-            # the same version naming logic as builds on the beta channel.
-            # We thus want to apply the same logic to aurora builds
-            # as well now. Note that older crash reports won't be affected,
-            # because they have a "correct" version number, usually containing
-            # the letter 'a' (like '50.0a2').
-            return processed_crash['release_channel'].lower() in ('beta', 'aurora')
-        except KeyError:
-            # No release_channel.
-            return False
+        # We apply this Rule only if the release channel is beta, because
+        # beta versions are the only ones sending an "incorrect" version
+        # number in their data.
+        # 2017-06-14: Ohai! This is not true anymore! With the removal of
+        # the aurora channel, there is now a new type of build called
+        # "DevEdition", that is released on the aurora channel, but has
+        # the same version naming logic as builds on the beta channel.
+        # We thus want to apply the same logic to aurora builds
+        # as well now. Note that older crash reports won't be affected,
+        # because they have a "correct" version number, usually containing
+        # the letter 'a' (like '50.0a2').
+        return processed_crash.get('release_channel', '').lower() in ('beta', 'aurora')
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         try:

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -618,7 +618,7 @@ class BetaVersionRule(Rule):
         super(BetaVersionRule, self).__init__(config)
         # NOTE(willkg): These config values come from Processor2015 instance.
         self.version_string_api = config.version_string_api
-        self.cache = ExpiringCache(max_size=self.CACHE_MAX_SIZE, ttl=self.CACHE_TTL)
+        self.cache = ExpiringCache(max_size=self.CACHE_MAX_SIZE, default_ttl=self.CACHE_TTL)
 
     def version(self):
         return '1.0'
@@ -648,8 +648,6 @@ class BetaVersionRule(Rule):
         if key in self.cache:
             return self.cache[key]
 
-        # FIXME(willkg): take the request/retry code in socorro/scripts/ and
-        # put that in lib. Then reuse it here.
         session = session_with_retries(self.version_string_api)
 
         resp = session.get(self.version_string_api, params={

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -124,6 +124,11 @@ class Processor2015(RequiredConfig):
         reference_value_from='resource.postgresql',
     )
     required_config.add_option(
+        'version_string_api',
+        doc='url for the version string api endpoint',
+        default='https://crash-stats.mozilla.com/api/VersionString'
+    )
+    required_config.add_option(
         'dump_field',
         doc='the default name of a dump',
         default='upload_file_minidump',

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -10,9 +10,8 @@ import os
 import os.path
 import sys
 
-import requests
-
 from socorro.lib.datetimeutil import JsonDTEncoder
+from socorro.lib.requestslib import session_with_retries
 from socorro.scripts import FlagAction, WrappedTextHelpFormatter
 
 
@@ -65,7 +64,8 @@ def fetch_crash(fetchdumps, outputdir, api_token, crash_id):
         headers = {}
 
     # Fetch raw crash metadata
-    resp = requests.get(
+    session = session_with_retries(HOST)
+    resp = session.get(
         HOST + '/api/RawCrash/',
         params={
             'crash_id': crash_id,
@@ -103,7 +103,7 @@ def fetch_crash(fetchdumps, outputdir, api_token, crash_id):
             if file_name == 'upload_file_minidump':
                 file_name = 'dump'
 
-            resp = requests.get(
+            resp = session.get(
                 HOST + '/api/RawCrash/',
                 params={
                     'crash_id': crash_id,

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -12,11 +12,8 @@ from functools import total_ordering
 import sys
 from urlparse import urlparse, parse_qs
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
 from socorro.lib.datetimeutil import utc_now
+from socorro.lib.requestslib import session_with_retries
 from socorro.scripts import WrappedTextHelpFormatter
 
 
@@ -78,11 +75,7 @@ def fetch_crashids(params, num_results):
     """
     url = HOST + '/api/SuperSearch/'
 
-    # Set up retrying on 429s
-    retries = Retry(total=32, backoff_factor=1, status_forcelist=[429])
-    session = requests.Session()
-    session.mount('http://', HTTPAdapter(max_retries=retries))
-    session.mount('https://', HTTPAdapter(max_retries=retries))
+    session = session_with_retries(url)
 
     # Set up first page
     params['_results_offset'] = 0

--- a/socorro/scripts/reprocess.py
+++ b/socorro/scripts/reprocess.py
@@ -8,12 +8,8 @@ import argparse
 import os
 import sys
 import time
-import urlparse
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
+from socorro.lib.requestslib import session_with_retries
 from socorro.lib.util import chunkify
 from socorro.scripts import WrappedTextHelpFormatter
 
@@ -37,18 +33,6 @@ they should increase the number of processor nodes.
 DEFAULT_HOST = 'https://crash-stats.mozilla.com'
 CHUNK_SIZE = 50
 SLEEP_DEFAULT = 1
-
-
-def session_with_retries(url):
-    base_url = urlparse.urlparse(url).netloc
-    scheme = urlparse.urlparse(url).scheme
-
-    retries = Retry(total=32, backoff_factor=1, status_forcelist=[429])
-
-    s = requests.Session()
-    s.mount(scheme + '://' + base_url, HTTPAdapter(max_retries=retries))
-
-    return s
 
 
 def main(argv=None):

--- a/socorro/unittest/lib/test_cache.py
+++ b/socorro/unittest/lib/test_cache.py
@@ -1,0 +1,96 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+import mock
+import pytest
+
+from socorro.lib.cache import ExpiringCache, UTC
+
+
+class TestExpiringCache:
+    def test_get_set(self):
+        cache = ExpiringCache(ttl=600)
+        with pytest.raises(KeyError):
+            cache['foo']
+
+        cache['foo'] = 'bar'
+        assert cache['foo'] == 'bar'
+
+    @mock.patch('socorro.lib.cache._utc_now')
+    def test_expiration(self, mock_utc_now):
+        NOW = datetime.datetime.now(UTC)
+        # Mock _utc_now to return the current time so we can set the expiry for
+        # the key
+        mock_utc_now.return_value = NOW
+        cache = ExpiringCache(ttl=100)
+        cache['foo'] = 'bar'
+        assert len(cache._data) == 1
+
+        # ttl is 100, so 99 seconds into the future, we should get back the
+        # cached value
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=99)
+        assert cache['foo'] == 'bar'
+        assert len(cache._data) == 1
+
+        # ttl is 100, so 101 seconds into the future, we should get a KeyError
+        # and the key should be removed from the dict
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=101)
+        with pytest.raises(KeyError):
+            cache['foo']
+        assert len(cache._data) == 0
+
+    def test_max_size(self):
+        cache = ExpiringCache(max_size=5)
+        cache['foo1'] = 1
+        cache['foo2'] = 1
+        cache['foo3'] = 1
+        cache['foo4'] = 1
+        cache['foo5'] = 1
+
+        assert cache.keys() == ['foo1', 'foo2', 'foo3', 'foo4', 'foo5']
+
+        cache['foo6'] = 1
+
+        assert cache.keys() == ['foo2', 'foo3', 'foo4', 'foo5', 'foo6']
+
+    @mock.patch('socorro.lib.cache._utc_now')
+    def test_flush(self, mock_utc_now):
+        NOW = datetime.datetime.now(UTC)
+        NOW_PLUS_10 = NOW + datetime.timedelta(seconds=10)
+        NOW_PLUS_20 = NOW + datetime.timedelta(seconds=20)
+
+        mock_utc_now.return_value = NOW
+        cache = ExpiringCache(ttl=100)
+
+        # At time NOW
+        cache['foo'] = 'bar'
+
+        # At time NOW + 10
+        mock_utc_now.return_value = NOW_PLUS_10
+        cache['foo10'] = 'bar'
+
+        # At time NOW + 20
+        mock_utc_now.return_value = NOW_PLUS_20
+        cache['foo20'] = 'bar'
+
+        assert (
+            cache._data == {
+                'foo': [NOW + cache._ttl, 'bar'],
+                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
+                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+            }
+        )
+
+        # Set to NOW + 105 which expires the first, but not the other two
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=105)
+        cache.flush()
+
+        assert (
+            cache._data == {
+                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
+                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+            }
+        )

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1305,8 +1305,6 @@ class TestBetaVersionRule:
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        rule = BetaVersionRule(config)
-
         # A release crash, version won't get changed.
         with requests_mock.Mocker() as req_mock:
             processed_crash.version = '2.0'
@@ -1314,6 +1312,7 @@ class TestBetaVersionRule:
             processed_crash.build = '20000801101010'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '2.0'
             assert len(processor_meta.processor_notes) == 0
@@ -1332,6 +1331,7 @@ class TestBetaVersionRule:
             processed_crash.build = '20001001101010'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '3.0b1'
             assert processor_meta.processor_notes == []
@@ -1343,6 +1343,7 @@ class TestBetaVersionRule:
             processed_crash.build = '20000105101010'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '5.0a1'
             assert processor_meta.processor_notes == []
@@ -1354,6 +1355,7 @@ class TestBetaVersionRule:
             processed_crash.build = '",381,,"'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '5.0b0'
             assert processor_meta.processor_notes == [
@@ -1375,6 +1377,7 @@ class TestBetaVersionRule:
             processed_crash.build = '20000101101011'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '3.0b0'
             assert processor_meta.processor_notes == [
@@ -1395,8 +1398,6 @@ class TestBetaVersionRule:
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        rule = BetaVersionRule(config)
-
         # A normal aurora crash, with a known version.
         with requests_mock.Mocker() as req_mock:
             req_mock.get(
@@ -1411,6 +1412,7 @@ class TestBetaVersionRule:
             processed_crash.build = '20001001101010'
             processor_meta = get_basic_processor_meta()
 
+            rule = BetaVersionRule(config)
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '3.0b1'
             assert processor_meta.processor_notes == []

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1314,7 +1314,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = (('3.0b1',),)
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'beta'
-        processed_crash.build = 20001001101010
+        processed_crash.build = '20001001101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b1'
@@ -1324,7 +1324,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '2.0'
         processed_crash.release_channel = 'release'
-        processed_crash.build = 20000801101010
+        processed_crash.build = '20000801101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '2.0'
@@ -1334,7 +1334,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '5.0a1'
         processed_crash.release_channel = 'nightly'
-        processed_crash.build = 20000105101010
+        processed_crash.build = '20000105101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '5.0a1'
@@ -1354,7 +1354,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'beta'
-        processed_crash.build = 20000101101011
+        processed_crash.build = '20000101101011'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b0'
@@ -1385,7 +1385,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = (('3.0b1',),)
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'aurora'
-        processed_crash.build = 20001001101010
+        processed_crash.build = '20001001101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b1'

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -25,6 +25,7 @@ import socorro.external.postgresql.products
 import socorro.external.postgresql.graphics_devices
 import socorro.external.postgresql.crontabber_state
 import socorro.external.postgresql.signature_first_date
+import socorro.external.postgresql.version_string
 import socorro.external.boto.crash_data
 
 from socorro.app import socorro_app
@@ -498,6 +499,20 @@ class Products(SocorroMiddleware):
     API_WHITELIST = (
         'hits',
         'total',
+    )
+
+
+class VersionString(SocorroMiddleware):
+    implementation = socorro.external.postgresql.version_string.VersionString
+
+    required_params = (
+        'product',
+        'version',
+        ('build_id', int)
+    )
+
+    API_WHITELIST = (
+        'hits',
     )
 
 


### PR DESCRIPTION
This:

1. creates a webapp API called VersionString that returns ... well, ... version strings
2. creates a new `ExpiringCache` that has a ttl in addition to max size because we didn't have one and I wasn't enamored with the ones I saw (though `cachetools` might be a good choice)
3. rewrites the `BetaVersionRule` to use the new cache and new VersionString API
4. implements a `session_with_retries` and rewrites everything to use that rather than using requests directly

So... there's a lot of different things in this PR all lumped together, but it's all sort of related.

To test:

1. go to `http://localhost:8000/api/` and test the VersionString API using product/version/builds
2. set `processor.version_string_api` to `http://localhost:8000/api/VersionString` in your `my.env` file, then process a crash from the beta channel with a build that's in your db and make sure it gets the right version