### PR TITLE
fix bug 1323033: add doc_values=True to ES mapping

### DIFF
--- a/socorro/external/es/index_creator.py
+++ b/socorro/external/es/index_creator.py
@@ -2,16 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 import elasticsearch
 
 from socorro.external.es.super_search_fields import SuperSearchFields
-
-
-DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 
 # Elasticsearch indices configuration.
@@ -45,8 +40,10 @@ class IndexCreator(RequiredConfig):
     required_config.elasticsearch.add_option(
         'shards_per_index',
         default=10,
-        doc='number of shards to set in newly created indices. Elasticsearch '
-            'default is 5.',
+        doc=(
+            'number of shards to set in newly created indices. Elasticsearch '
+            'default is 5.'
+        )
     )
 
     def __init__(self, config):
@@ -67,9 +64,7 @@ class IndexCreator(RequiredConfig):
         return {
             'settings': {
                 'index': {
-                    'number_of_shards': (
-                        self.config.elasticsearch.shards_per_index
-                    ),
+                    'number_of_shards': self.config.elasticsearch.shards_per_index,
                     'query': ES_QUERY_SETTINGS,
                     'analysis': ES_CUSTOM_ANALYZERS,
                 },
@@ -97,9 +92,7 @@ class IndexCreator(RequiredConfig):
                 index=es_index,
                 body=es_settings,
             )
-            self.config.logger.info(
-                'Created new elasticsearch index: %s', es_index
-            )
+            self.config.logger.info('Created new elasticsearch index: %s', es_index)
         except elasticsearch.exceptions.RequestError as e:
             # If this index already exists, swallow the error.
             # NOTE! This is NOT how the error looks like in ES 2.x

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -163,13 +163,19 @@ class IntegrationTestSuperSearchFields(ElasticsearchTestCase):
         assert 'fake_field' not in properties['raw_crash']['properties']
 
         # Those fields have a `storage_mapping`.
-        assert processed_crash['release_channel'] == {'analyzer': 'keyword', 'type': 'string'}
+        assert processed_crash['release_channel'] == {
+            'analyzer': 'keyword',
+            'type': 'string'
+        }
 
         # Test nested objects.
         assert 'json_dump' in processed_crash
         assert 'properties' in processed_crash['json_dump']
         assert 'write_combine_size' in processed_crash['json_dump']['properties']
-        assert processed_crash['json_dump']['properties']['write_combine_size'] == {'type': 'long'}
+        assert processed_crash['json_dump']['properties']['write_combine_size'] == {
+            'type': 'long',
+            'doc_values': True
+        }
 
         # Test overwriting a field.
         mapping = self.api.get_mapping(overwrite_mapping={


### PR DESCRIPTION
This adds `doc_values=True` to fields that are either not strings or explicitly
have `index=not_analyzed`. Per the ES docs, this will cause ES to store data
on disk for sorting and aggregations rather than in memory which should
reduce some of our memory problems when doing aggregations.