### PR TITLE
bug 1323033: Apply doc_values=True to boolean fields

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -70,8 +70,8 @@ def is_doc_values_friendly(field_value):
     if not field_type:
         return False
 
-    # boolean, object, and multi_fields fields don't work with doc_values=True
-    if field_type in ('boolean', 'object', 'multi_field'):
+    # object, and multi_fields fields don't work with doc_values=True
+    if field_type in ('object', 'multi_field'):
         return False
 
     # analyzed string fields don't work with doc_values=True

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -279,8 +279,7 @@ def test_validate_super_search_fields(name, properties):
     # No type -> False
     ({}, False),
 
-    # Boolean or object -> False
-    ({'type': 'boolean'}, False),
+    # object -> False
     ({'type': 'object'}, False),
 
     # Analyzed string -> False


### PR DESCRIPTION
Elasticsearch 1.4 seems to drop `doc_values=True` for boolean fields as
observed by the mapping we use to create the index has these properties,
but the mapping we get when querying Elasticsearch afterwards doesn't.

The documentation suggests boolean values should work with `doc_values=True`.

Given that, we're going to re-add it since it doesn't seem to break
anything even if it has no effect.