### PR TITLE
fix bug 1436063: set processor threads in my.env.dist

### DIFF
--- a/docker/config/my.env.dist
+++ b/docker/config/my.env.dist
@@ -12,6 +12,13 @@
 # SOCORRO_GID=
 
 # ---------------------------------------------
+# processor settings
+# ---------------------------------------------
+
+# Only use 2 threads for the processor
+producer_consumer.number_of_threads=2
+
+# ---------------------------------------------
 # crash-stats.mozilla.com settings
 # ---------------------------------------------
 


### PR DESCRIPTION
In a local development environment, you probably don't want 16
processor threads running. You're much more likely to want something
like 2.

This makes that change to my.env.dist. Developers can change the
number to meet their specific needs.