### PR TITLE
Fix signature generation with python 3

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -11,6 +11,8 @@
 # This is the list of known working tests by directory/filename. When you
 # have tests in a directory/file working, add it to this list as a new line.
 WORKING_TESTS=(
+    socorro/signature/tests/test_*.py
+
     socorro/unittest/lib/test_converters.py
     socorro/unittest/lib/test_datetimeutil.py
     socorro/unittest/lib/test_external_common.py
@@ -20,7 +22,6 @@ WORKING_TESTS=(
     socorro/unittest/lib/test_threaded_task_manager.py
     socorro/unittest/lib/test_transform_rules.py
     socorro/unittest/lib/test_util.py
-    socorro/unittest/lib/test_vertools.py
 
     socorro/unittest/external/boto/test_connection_context.py
     socorro/unittest/external/boto/test_crash_data.py
@@ -30,7 +31,6 @@ WORKING_TESTS=(
     socorro/unittest/external/es/test_analyzers.py
     socorro/unittest/external/es/test_connection_context.py
     socorro/unittest/external/es/test_index_creator.py
-    socorro/unittest/external/es/test_new_crash_source.py
     socorro/unittest/external/es/test_query.py
 
     socorro/unittest/external/postgresql/test_base.py
@@ -40,8 +40,6 @@ WORKING_TESTS=(
     socorro/unittest/external/postgresql/test_dbapi2_util.py
     socorro/unittest/external/postgresql/test_graphics_devices.py
     socorro/unittest/external/postgresql/test_platforms.py
-    socorro/unittest/external/postgresql/test_product_build_types.py
-    socorro/unittest/external/postgresql/test_releases.py
     socorro/unittest/external/postgresql/test_setupdb_app.py
     socorro/unittest/external/postgresql/test_signature_first_date.py
 

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -6,6 +6,7 @@ from itertools import islice
 import re
 
 from glom import glom
+import six
 import ujson
 
 from . import siglists_utils
@@ -624,7 +625,7 @@ class SigFixWhitespace(Rule):
     CONSECUTIVE_WHITESPACE_RE = re.compile('\s\s+')
 
     def predicate(self, crash_data, result):
-        return isinstance(result.get('signature'), basestring)
+        return isinstance(result.get('signature'), six.string_types)
 
     def action(self, crash_data, result):
         sig = result['signature']

--- a/socorro/signature/tests/test_siglists.py
+++ b/socorro/signature/tests/test_siglists.py
@@ -7,6 +7,7 @@ import importlib
 import mock
 from pkg_resources import resource_stream
 import pytest
+import six
 
 # NOTE(willkg): We do this so that we can extract signature generation into its
 # own namespace as an external library. This allows the tests to run if it's in
@@ -34,7 +35,7 @@ class TestSigLists:
 
             for line in content:
                 assert line
-                if isinstance(line, basestring):
+                if isinstance(line, six.string_types):
                     assert not line.startswith('#')
 
     @mock.patch(base_module + '.siglists_utils.resource_stream')
@@ -57,6 +58,6 @@ class TestSigLists:
             siglists_utils._get_file_content('test-invalid-sig-list')
 
         msg = exc_info.exconly()
-        assert msg.startswith('BadRegularExpressionLineError: Regex error: ')
+        assert 'BadRegularExpressionLineError: Regex error: ' in msg
         assert msg.endswith('at line 3')
         assert 'test-invalid-sig-list.txt' in msg

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -45,12 +45,12 @@ def test_drop_bad_characters(text, expected):
         'src/libcore/cmp.rs'
     ),
     (
-        'f:\dd\vctools\crt\crtw32\mbstring\mbsnbico.c',
-        '\dd\vctools\crt\crtw32\mbstring\mbsnbico.c'
+        'f:\\dd\\vctools\\crt\\crtw32\\mbstring\\mbsnbico.c',
+        '\\dd\\vctools\\crt\\crtw32\\mbstring\\mbsnbico.c'
     ),
     (
-        'd:\w7rtm\com\rpc\ndrole\udt.cxx',
-        '\w7rtm\com\rpc\ndrole\udt.cxx'
+        'd:\\w7rtm\\com\\rpc\\ndrole\\udt.cxx',
+        '\\w7rtm\\com\\rpc\\ndrole\\udt.cxx'
     ),
     (
         '/build/firefox-Kq_6Wg/firefox-54.0+build3/memory/mozjemalloc/jemalloc.c',


### PR DESCRIPTION
* remove a couple of files from the list of files to test in python 3
  that don't exist anymore
* fix issues with signature generation code and tests that caused
  them to fail in python 3