### PR TITLE
fix bug 1487381: fix topcrasher IndexError bug

### DIFF
--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -154,7 +154,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     context['versions_have_builds'] = versions_have_builds
 
     # Used to pick a version in the dropdown menu.
-    context['version'] = versions[0]
+    context['version'] = versions[0] if versions else ''
 
     if tcbs_mode == 'realtime':
         end_date = timezone.now().replace(microsecond=0)


### PR DESCRIPTION
If we add a new product, but it hasn't gotten any crash reports, then
there are no versions and topcrashers errors out.

The version it needs it solely to figure out which version to select
in the drop down menu. So we set it to "" if there are no versions.