### PR TITLE
Add table of contents to API documentation

### DIFF
--- a/webapp-django/crashstats/api/jinja2/api/documentation.html
+++ b/webapp-django/crashstats/api/jinja2/api/documentation.html
@@ -28,6 +28,17 @@
     </div>
 </div>
 
+<div class="panel">
+    <div class="title"><h2>Contents</h2></div>
+    <div class="body">
+        <ul>
+            {% for endpoint in endpoints %}
+            <li><a href="#{{ endpoint.name }}">{{ endpoint.name }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
 {% for endpoint in endpoints %}
 <div class="panel" id="{{ endpoint.name }}">
     <div class="title">


### PR DESCRIPTION
SuperSearch is super super super long. Having a table of contents at the
top of the page makes it much easier to see which APIs are available
and also get to that part of the page quickly without excessive scrolling.