### PR TITLE
fix bug 1346891: betaversionrule

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -91,7 +91,7 @@ destination.telemetry.bucket_name=telemetry_bucket
 # webapp
 # ------
 
-ALLOWED_HOSTS=localhost
+ALLOWED_HOSTS=localhost,webapp
 AWS_HOST=localstack-s3
 AWS_PORT=5000
 AWS_ACCESS_KEY=foo

--- a/socorro/external/postgresql/version_string.py
+++ b/socorro/external/postgresql/version_string.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+from socorro.lib import MissingArgumentError, external_common
+from socorro.external.postgresql.base import PostgreSQLBase
+
+
+logger = logging.getLogger("webapi")
+
+
+class VersionString(PostgreSQLBase):
+    def get(self, **kwargs):
+        filters = [
+            ('product', None, 'str'),
+            ('version', None, 'str'),
+            ('build_id', None, 'int'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        required = ('product', 'build_id', 'version')
+        for key in required:
+            if not params.get(key):
+                raise MissingArgumentError(key)
+
+        sql = """
+            SELECT
+                pv.version_string
+            FROM product_versions pv
+                LEFT JOIN product_version_builds pvb ON
+                    (pv.product_version_id = pvb.product_version_id)
+            WHERE pv.product_name = %(product)s
+            AND pv.release_version = %(version)s
+            AND pvb.build_id = %(build_id)s
+        """
+        results = self.query(sql, params)
+
+        # The query can return multiple results, but they're the same value. So
+        # we just return the first one.
+        version_string = [
+            row['version_string'] for row in results.zipped()
+        ]
+        if version_string:
+            version_string = [version_string[0]]
+
+        return {
+            'hits': version_string
+        }

--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+In-memory caching utilities.
+"""
+
+from collections import MutableMapping, OrderedDict
+import datetime
+import threading
+
+import isodate
+
+
+UTC = isodate.UTC
+
+
+#: Default time-to-live for keys in seconds
+DEFAULT_TTL = 600
+
+
+def _utc_now():
+    return datetime.datetime.now(UTC)
+
+
+class ExpiringCache(MutableMapping):
+    """In-memory cache that drops data older than a specified ttl
+
+    This will do bookkeeping periodically when setting values. If you
+    want to explicitly remove all expired data, call ``.flush()``.
+
+    Example of usage:
+
+    >>> cache = ExpiringCache(max_size=1000, ttl=5 * 60)
+    >>> cache['key1'] = 'something'
+    >>> cache['key1']
+    'something'
+    >>> # wait 5 minutes
+    >>> cache['key1']
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    KeyError: 'key1'
+
+    """
+    def __init__(self, max_size=128, ttl=600):
+        if max_size <= 0:
+            raise ValueError('max_size must be greater than 0')
+        if ttl <= 0:
+            raise ValueError('ttl must be greater than 0')
+        self._max_size = max_size
+        self._ttl = datetime.timedelta(seconds=ttl)
+        # Map of key -> (expire time, value)
+        self._data = OrderedDict()
+        self._lock = threading.RLock()
+
+    def flush(self):
+        """Removes all expired keys"""
+        with self._lock:
+            NOW = _utc_now()
+
+            for key, value_record in self._data.items():
+                if value_record[0] < NOW:
+                    del self._data[key]
+
+    def __getitem__(self, key):
+        with self._lock:
+            value_record = self._data[key]
+
+            if value_record[0] < _utc_now():
+                del self._data[key]
+                raise KeyError()
+
+            return value_record[1]
+
+    def __setitem__(self, key, value):
+        self._data[key] = [_utc_now() + self._ttl, value]
+
+        # If we've exceeded the max size, remove the oldest one
+        if len(self._data) > self._max_size:
+            del self._data[self._data.keys()[0]]
+
+    def __delitem__(self, key):
+        del self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        raise len(self._data)

--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
 import datetime
-import isodate  # 3rd party
 import json
 from past.builtins import basestring
+import re
+
+import isodate
+
 
 UTC = isodate.UTC
 

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -659,22 +659,18 @@ class BetaVersionRule(Rule):
         return self._versions_data_cache.get(key)
 
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        try:
-            # We apply this Rule only if the release channel is beta, because
-            # beta versions are the only ones sending an "incorrect" version
-            # number in their data.
-            # 2017-06-14: Ohai! This is not true anymore! With the removal of
-            # the aurora channel, there is now a new type of build called
-            # "DevEdition", that is released on the aurora channel, but has
-            # the same version naming logic as builds on the beta channel.
-            # We thus want to apply the same logic to aurora builds
-            # as well now. Note that older crash reports won't be affected,
-            # because they have a "correct" version number, usually containing
-            # the letter 'a' (like '50.0a2').
-            return processed_crash['release_channel'].lower() in ('beta', 'aurora')
-        except KeyError:
-            # No release_channel.
-            return False
+        # We apply this Rule only if the release channel is beta, because
+        # beta versions are the only ones sending an "incorrect" version
+        # number in their data.
+        # 2017-06-14: Ohai! This is not true anymore! With the removal of
+        # the aurora channel, there is now a new type of build called
+        # "DevEdition", that is released on the aurora channel, but has
+        # the same version naming logic as builds on the beta channel.
+        # We thus want to apply the same logic to aurora builds
+        # as well now. Note that older crash reports won't be affected,
+        # because they have a "correct" version number, usually containing
+        # the letter 'a' (like '50.0a2').
+        return processed_crash.get('release_channel', '').lower() in ('beta', 'aurora')
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         try:

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -124,6 +124,11 @@ class Processor2015(RequiredConfig):
         reference_value_from='resource.postgresql',
     )
     required_config.add_option(
+        'version_string_api',
+        doc='url for the version string api endpoint',
+        default='https://crash-stats.mozilla.com/api/VersionString'
+    )
+    required_config.add_option(
         'dump_field',
         doc='the default name of a dump',
         default='upload_file_minidump',

--- a/socorro/unittest/lib/test_cache.py
+++ b/socorro/unittest/lib/test_cache.py
@@ -7,40 +7,46 @@ import datetime
 import mock
 import pytest
 
-from socorro.lib.cache import ExpiringCache, UTC
+from socorro.lib.cache import ExpiringCache
+from socorro.lib.datetimeutil import utc_now
 
 
 class TestExpiringCache:
     def test_get_set(self):
-        cache = ExpiringCache(ttl=600)
+        cache = ExpiringCache(default_ttl=600)
         with pytest.raises(KeyError):
             cache['foo']
 
         cache['foo'] = 'bar'
         assert cache['foo'] == 'bar'
 
-    @mock.patch('socorro.lib.cache._utc_now')
+    @mock.patch('socorro.lib.cache.utc_now')
     def test_expiration(self, mock_utc_now):
-        NOW = datetime.datetime.now(UTC)
-        # Mock _utc_now to return the current time so we can set the expiry for
+        # Mock utc_now to return the current time so we can set the expiry for
         # the key
-        mock_utc_now.return_value = NOW
-        cache = ExpiringCache(ttl=100)
+        now = utc_now()
+        mock_utc_now.return_value = now
+
+        cache = ExpiringCache(default_ttl=100)
         cache['foo'] = 'bar'
         assert len(cache._data) == 1
+        cache.set('long_foo', value='bar2', ttl=1000)
+        assert len(cache._data) == 2
 
-        # ttl is 100, so 99 seconds into the future, we should get back the
-        # cached value
-        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=99)
+        # default ttl is 100, so 99 seconds into the future, we should get back
+        # both cached values
+        mock_utc_now.return_value = now + datetime.timedelta(seconds=99)
         assert cache['foo'] == 'bar'
-        assert len(cache._data) == 1
+        assert cache['long_foo'] == 'bar2'
+        assert len(cache._data) == 2
 
         # ttl is 100, so 101 seconds into the future, we should get a KeyError
-        # and the key should be removed from the dict
-        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=101)
+        # for one cached key and the other should be fine
+        mock_utc_now.return_value = now + datetime.timedelta(seconds=101)
         with pytest.raises(KeyError):
             cache['foo']
-        assert len(cache._data) == 0
+        assert cache['long_foo'] == 'bar2'
+        assert len(cache._data) == 1
 
     def test_max_size(self):
         cache = ExpiringCache(max_size=5)
@@ -56,41 +62,41 @@ class TestExpiringCache:
 
         assert cache.keys() == ['foo2', 'foo3', 'foo4', 'foo5', 'foo6']
 
-    @mock.patch('socorro.lib.cache._utc_now')
+    @mock.patch('socorro.lib.cache.utc_now')
     def test_flush(self, mock_utc_now):
-        NOW = datetime.datetime.now(UTC)
-        NOW_PLUS_10 = NOW + datetime.timedelta(seconds=10)
-        NOW_PLUS_20 = NOW + datetime.timedelta(seconds=20)
+        now = utc_now()
+        now_plus_10 = now + datetime.timedelta(seconds=10)
+        now_plus_20 = now + datetime.timedelta(seconds=20)
 
-        mock_utc_now.return_value = NOW
-        cache = ExpiringCache(ttl=100)
+        mock_utc_now.return_value = now
+        cache = ExpiringCache(default_ttl=100)
 
-        # At time NOW
+        # At time now
         cache['foo'] = 'bar'
 
-        # At time NOW + 10
-        mock_utc_now.return_value = NOW_PLUS_10
+        # At time now + 10
+        mock_utc_now.return_value = now_plus_10
         cache['foo10'] = 'bar'
 
-        # At time NOW + 20
-        mock_utc_now.return_value = NOW_PLUS_20
+        # At time now + 20
+        mock_utc_now.return_value = now_plus_20
         cache['foo20'] = 'bar'
 
         assert (
             cache._data == {
-                'foo': [NOW + cache._ttl, 'bar'],
-                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
-                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+                'foo': [now + cache._default_ttl, 'bar'],
+                'foo10': [now_plus_10 + cache._default_ttl, 'bar'],
+                'foo20': [now_plus_20 + cache._default_ttl, 'bar'],
             }
         )
 
-        # Set to NOW + 105 which expires the first, but not the other two
-        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=105)
+        # Set to now + 105 which expires the first, but not the other two
+        mock_utc_now.return_value = now + datetime.timedelta(seconds=105)
         cache.flush()
 
         assert (
             cache._data == {
-                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
-                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+                'foo10': [now_plus_10 + cache._default_ttl, 'bar'],
+                'foo20': [now_plus_20 + cache._default_ttl, 'bar'],
             }
         )

--- a/socorro/unittest/lib/test_cache.py
+++ b/socorro/unittest/lib/test_cache.py
@@ -1,0 +1,96 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+import mock
+import pytest
+
+from socorro.lib.cache import ExpiringCache, UTC
+
+
+class TestExpiringCache:
+    def test_get_set(self):
+        cache = ExpiringCache(ttl=600)
+        with pytest.raises(KeyError):
+            cache['foo']
+
+        cache['foo'] = 'bar'
+        assert cache['foo'] == 'bar'
+
+    @mock.patch('socorro.lib.cache._utc_now')
+    def test_expiration(self, mock_utc_now):
+        NOW = datetime.datetime.now(UTC)
+        # Mock _utc_now to return the current time so we can set the expiry for
+        # the key
+        mock_utc_now.return_value = NOW
+        cache = ExpiringCache(ttl=100)
+        cache['foo'] = 'bar'
+        assert len(cache._data) == 1
+
+        # ttl is 100, so 99 seconds into the future, we should get back the
+        # cached value
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=99)
+        assert cache['foo'] == 'bar'
+        assert len(cache._data) == 1
+
+        # ttl is 100, so 101 seconds into the future, we should get a KeyError
+        # and the key should be removed from the dict
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=101)
+        with pytest.raises(KeyError):
+            cache['foo']
+        assert len(cache._data) == 0
+
+    def test_max_size(self):
+        cache = ExpiringCache(max_size=5)
+        cache['foo1'] = 1
+        cache['foo2'] = 1
+        cache['foo3'] = 1
+        cache['foo4'] = 1
+        cache['foo5'] = 1
+
+        assert cache.keys() == ['foo1', 'foo2', 'foo3', 'foo4', 'foo5']
+
+        cache['foo6'] = 1
+
+        assert cache.keys() == ['foo2', 'foo3', 'foo4', 'foo5', 'foo6']
+
+    @mock.patch('socorro.lib.cache._utc_now')
+    def test_flush(self, mock_utc_now):
+        NOW = datetime.datetime.now(UTC)
+        NOW_PLUS_10 = NOW + datetime.timedelta(seconds=10)
+        NOW_PLUS_20 = NOW + datetime.timedelta(seconds=20)
+
+        mock_utc_now.return_value = NOW
+        cache = ExpiringCache(ttl=100)
+
+        # At time NOW
+        cache['foo'] = 'bar'
+
+        # At time NOW + 10
+        mock_utc_now.return_value = NOW_PLUS_10
+        cache['foo10'] = 'bar'
+
+        # At time NOW + 20
+        mock_utc_now.return_value = NOW_PLUS_20
+        cache['foo20'] = 'bar'
+
+        assert (
+            cache._data == {
+                'foo': [NOW + cache._ttl, 'bar'],
+                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
+                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+            }
+        )
+
+        # Set to NOW + 105 which expires the first, but not the other two
+        mock_utc_now.return_value = NOW + datetime.timedelta(seconds=105)
+        cache.flush()
+
+        assert (
+            cache._data == {
+                'foo10': [NOW_PLUS_10 + cache._ttl, 'bar'],
+                'foo20': [NOW_PLUS_20 + cache._ttl, 'bar'],
+            }
+        )

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -8,6 +8,7 @@ from StringIO import StringIO
 
 from configman.dotdict import DotDict as CDotDict
 from mock import call, Mock, patch
+import requests_mock
 
 from socorro.lib.datetimeutil import datetime_from_isodate_string
 from socorro.lib.revision_data import get_version
@@ -1291,11 +1292,12 @@ class TestTopMostFilesRule(TestCase):
         assert raw_crash == canonical_standard_raw_crash
 
 
-class TestBetaVersion(TestCase):
+class TestBetaVersionRule:
+    API_URL = 'https://example.com/api/VersionString'
+
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
-        config.database_class = Mock()
-        config.transaction_executor_class = Mock()
+        config.version_string_api = self.API_URL
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -1303,70 +1305,92 @@ class TestBetaVersion(TestCase):
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        processor_meta = get_basic_processor_meta()
-
-        transaction = Mock()
-        config.transaction_executor_class.return_value = transaction
-
-        rule = BetaVersionRule(config)
-
-        # A normal beta crash, with a know version.
-        transaction.return_value = (('3.0b1',),)
-        processed_crash.version = '3.0'
-        processed_crash.release_channel = 'beta'
-        processed_crash.build = '20001001101010'
-
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '3.0b1'
-        assert len(processor_meta.processor_notes) == 0
-
         # A release crash, version won't get changed.
-        transaction.return_value = tuple()
-        processed_crash.version = '2.0'
-        processed_crash.release_channel = 'release'
-        processed_crash.build = '20000801101010'
+        with requests_mock.Mocker() as req_mock:
+            processed_crash.version = '2.0'
+            processed_crash.release_channel = 'release'
+            processed_crash.build = '20000801101010'
+            processor_meta = get_basic_processor_meta()
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '2.0'
-        assert len(processor_meta.processor_notes) == 0
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '2.0'
+            assert len(processor_meta.processor_notes) == 0
 
-        # An unkwown version.
-        transaction.return_value = tuple()
-        processed_crash.version = '5.0a1'
-        processed_crash.release_channel = 'nightly'
-        processed_crash.build = '20000105101010'
+        # A normal beta crash, with a known version.
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                self.API_URL + '?product=WaterWolf&version=3.0&build_id=20001001101010',
+                json={
+                    'hits': ['3.0b1']
+                }
+            )
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '5.0a1'
-        assert len(processor_meta.processor_notes) == 0
+            processed_crash.version = '3.0'
+            processed_crash.release_channel = 'beta'
+            processed_crash.build = '20001001101010'
+            processor_meta = get_basic_processor_meta()
+
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '3.0b1'
+            assert processor_meta.processor_notes == []
+
+        # A nightly.
+        with requests_mock.Mocker() as req_mock:
+            processed_crash.version = '5.0a1'
+            processed_crash.release_channel = 'nightly'
+            processed_crash.build = '20000105101010'
+            processor_meta = get_basic_processor_meta()
+
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '5.0a1'
+            assert processor_meta.processor_notes == []
 
         # An incorrect build id.
-        transaction.return_value = tuple()
-        processed_crash.version = '5.0'
-        processed_crash.release_channel = 'beta'
-        processed_crash.build = '",381,,"'
+        with requests_mock.Mocker() as req_mock:
+            processed_crash.version = '5.0'
+            processed_crash.release_channel = 'beta'
+            processed_crash.build = '",381,,"'
+            processor_meta = get_basic_processor_meta()
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '5.0b0'
-        assert len(processor_meta.processor_notes) == 1
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '5.0b0'
+            assert processor_meta.processor_notes == [
+                'release channel is beta but no version data was found - '
+                'added "b0" suffix to version number'
+            ]
 
         # A beta crash with an unknown version, gets a special mark.
-        transaction.return_value = tuple()
-        processed_crash.version = '3.0'
-        processed_crash.release_channel = 'beta'
-        processed_crash.build = '20000101101011'
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                self.API_URL + '?product=WaterWolf&version=3.0&build_id=20000101101011',
+                json={
+                    'hits': []
+                }
+            )
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '3.0b0'
-        assert len(processor_meta.processor_notes) == 2
+            processed_crash.version = '3.0'
+            processed_crash.release_channel = 'beta'
+            processed_crash.build = '20000101101011'
+            processor_meta = get_basic_processor_meta()
+
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '3.0b0'
+            assert processor_meta.processor_notes == [
+                'release channel is beta but no version data was found - '
+                'added "b0" suffix to version number'
+            ]
 
     def test_with_aurora_channel(self):
         """Verify the version change is applied to crash reports with a
         release channel of "aurora".
         """
         config = get_basic_config()
-        config.database_class = Mock()
-        config.transaction_executor_class = Mock()
+        config.version_string_api = self.API_URL
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -1374,22 +1398,24 @@ class TestBetaVersion(TestCase):
         processed_crash.date_processed = '2014-12-31'
         processed_crash.product = 'WaterWolf'
 
-        processor_meta = get_basic_processor_meta()
+        # A normal aurora crash, with a known version.
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                self.API_URL + '?product=WaterWolf&version=3.0&build_id=20001001101010',
+                json={
+                    'hits': ['3.0b1']
+                }
+            )
 
-        transaction = Mock()
-        config.transaction_executor_class.return_value = transaction
+            processed_crash.version = '3.0'
+            processed_crash.release_channel = 'aurora'
+            processed_crash.build = '20001001101010'
+            processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
-
-        # A normal beta crash, with a known version.
-        transaction.return_value = (('3.0b1',),)
-        processed_crash.version = '3.0'
-        processed_crash.release_channel = 'aurora'
-        processed_crash.build = '20001001101010'
-
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-        assert processed_crash['version'] == '3.0b1'
-        assert len(processor_meta.processor_notes) == 0
+            rule = BetaVersionRule(config)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '3.0b1'
+            assert processor_meta.processor_notes == []
 
 
 class TestAuroraVersionFixitRule:

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1314,7 +1314,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = (('3.0b1',),)
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'beta'
-        processed_crash.build = 20001001101010
+        processed_crash.build = '20001001101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b1'
@@ -1324,7 +1324,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '2.0'
         processed_crash.release_channel = 'release'
-        processed_crash.build = 20000801101010
+        processed_crash.build = '20000801101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '2.0'
@@ -1334,7 +1334,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '5.0a1'
         processed_crash.release_channel = 'nightly'
-        processed_crash.build = 20000105101010
+        processed_crash.build = '20000105101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '5.0a1'
@@ -1354,7 +1354,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = tuple()
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'beta'
-        processed_crash.build = 20000101101011
+        processed_crash.build = '20000101101011'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b0'
@@ -1385,7 +1385,7 @@ class TestBetaVersion(TestCase):
         transaction.return_value = (('3.0b1',),)
         processed_crash.version = '3.0'
         processed_crash.release_channel = 'aurora'
-        processed_crash.build = 20001001101010
+        processed_crash.build = '20001001101010'
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash['version'] == '3.0b1'

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -25,6 +25,7 @@ import socorro.external.postgresql.products
 import socorro.external.postgresql.graphics_devices
 import socorro.external.postgresql.crontabber_state
 import socorro.external.postgresql.signature_first_date
+import socorro.external.postgresql.version_string
 import socorro.external.boto.crash_data
 
 from socorro.app import socorro_app
@@ -498,6 +499,20 @@ class Products(SocorroMiddleware):
     API_WHITELIST = (
         'hits',
         'total',
+    )
+
+
+class VersionString(SocorroMiddleware):
+    implementation = socorro.external.postgresql.version_string.VersionString
+
+    required_params = (
+        'product',
+        'version',
+        ('build_id', int)
+    )
+
+    API_WHITELIST = (
+        'hits',
     )
 
 


### PR DESCRIPTION
This:

1. creates a webapp API called `VersionString` that returns ... well, ... version strings
2. creates a new `ExpiringCache` that has a ttl in addition to max size because we didn't have one and I wasn't enamored with the ones I saw (though cachetools might be a good choice)
3. rewrites the `BetaVersionRule` to use the new cache and new `VersionString` API

To test:

1. go to `http://localhost:8000/api/` and test the `VersionString` API using product/version/builds
2. set `processor.version_string_api` to `http://webapp:8000/api/VersionString/` in your `my.env` file, then process a recent crash from the beta channel with a build that's in your db and make sure it gets the right version
