### PR TITLE
fix bug 1417612: use java_stack_trace if available

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
@@ -4,7 +4,11 @@ This bug was filed from the Socorro interface and is
 report bp-{{ uuid }}.
 =============================================================
 
-{% if crashing_thread_frames -%}
+{% if java_stack_trace -%}
+Java stack trace:
+
+{{ java_stack_trace }}
+{% elif crashing_thread_frames -%}
 Top {{ crashing_thread_frames|length }} frames of crashing thread:
 
 {% for frame in crashing_thread_frames -%}

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -206,6 +206,7 @@ def bugzilla_submit_url(report, parsed_dump, crashing_thread, bug_product):
 
     comment = render_to_string('crashstats/bugzilla_comment.txt', {
         'uuid': report['uuid'],
+        'java_stack_trace': report.get('java_stack_trace', None),
         'crashing_thread_frames': crashing_thread_frames,
     })
 

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -377,6 +377,25 @@ class TestBugzillaSubmitURL(TestCase):
         url = bugzilla_submit_url(report, parsed_dump, 0, 'Core')
         assert quote_plus('0 &test_module foo<char>::bar "foo".cpp:7') in url
 
+    def test_comment_java_stack_trace(self):
+        """If there's a java stack trace, use that instead"""
+        report = self._create_report()
+        report['java_stack_trace'] = 'java.lang.NullPointerException: list == null'
+        parsed_dump = self._create_dump(threads=[
+            self._create_thread(),  # Empty thread 0
+            self._create_thread(frames=[
+                self._create_frame(frame=0),
+                self._create_frame(frame=1),
+                self._create_frame(frame=2),
+            ]),
+        ])
+        url = bugzilla_submit_url(report, parsed_dump, 0, 'Core')
+        assert quote_plus('Java stack trace:') in url
+        assert quote_plus('java.lang.NullPointerException: list == null') in url
+
+        # Make sure it didn't also add the crashing frames
+        assert quote_plus('frames of crashing thread:') not in url
+
 
 class TestReplaceBugzillaLinks(TestCase):
     def test_simple(self):


### PR DESCRIPTION
When generating bugzilla submit urls, if the crash report has a
`java_stack_trace`, then that should be in the comment rather than
the crashing thread stack.