### PR TITLE
fix bug 1474037: add rewrite rule for FirefoxReality

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -382,6 +382,10 @@ class ProductRewrite(Rule):
         if product_name == 'FennecAndroid' and raw_crash.get('ProcessType', '') == 'content':
             product_name = 'Focus'
 
+        # Rewrite FirefoxReality crashes (bug #1474037).
+        if product_name == 'FennecAndroid' and raw_crash.get('Android_Manufacturer', '') == 'Oculus':
+            product_name = 'FirefoxReality'
+
         # If we made any product name changes, persist them and keep the
         # original one so we can look at things later
         if product_name != original_product_name:

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -383,7 +383,8 @@ class ProductRewrite(Rule):
             product_name = 'Focus'
 
         # Rewrite FirefoxReality crashes (bug #1474037).
-        if product_name == 'FennecAndroid' and raw_crash.get('Android_Manufacturer', '') == 'Oculus':
+        if ((product_name == 'FennecAndroid' and
+             raw_crash.get('Android_Manufacturer', '') == 'Oculus')):
             product_name = 'FirefoxReality'
 
         # If we made any product name changes, persist them and keep the


### PR DESCRIPTION
Incoming FirefoxReality crash reports have the wrong ProductName, so they're
getting put in the FennecAndroid bin. This rewrites the ProductName for crash
reports that have `Android_Manufacturer=Oculus` to FirefoxReality.