### PR TITLE
fix bug 1474037: revert FirefoxReality processor rule change

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -383,8 +383,7 @@ class ProductRewrite(Rule):
             product_name = 'Focus'
 
         # Rewrite FirefoxReality crashes (bug #1474037).
-        if ((product_name == 'FennecAndroid' and
-             raw_crash.get('Android_Manufacturer', '') == 'Oculus')):
+        if product_name == 'FennecAndroid' and raw_crash.get('Android_Manufacturer', '') == 'Oculus':
             product_name = 'FirefoxReality'
 
         # If we made any product name changes, persist them and keep the

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -382,10 +382,6 @@ class ProductRewrite(Rule):
         if product_name == 'FennecAndroid' and raw_crash.get('ProcessType', '') == 'content':
             product_name = 'Focus'
 
-        # Rewrite FirefoxReality crashes (bug #1474037).
-        if product_name == 'FennecAndroid' and raw_crash.get('Android_Manufacturer', '') == 'Oculus':
-            product_name = 'FirefoxReality'
-
         # If we made any product name changes, persist them and keep the
         # original one so we can look at things later
         if product_name != original_product_name:


### PR DESCRIPTION
This removes the FirefoxReality processor ProductRewrite bit. It's not correct and we don't need it, so this nixes it.