### PR TITLE
fix bug 1491431: get versions from bigger window

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -411,15 +411,13 @@ def test_parse_version(version_string, expected):
     assert utils.parse_version(version_string) == expected
 
 
-def test_parse_version_sorted():
+def test_sorted_versions():
     """Test that using parse_version produces version keys that sort correctly"""
     versions = ['59.0', '59.0b2', '59.0.2', '59.0a1', '60p', '59.0.2esr']
-    assert sorted(versions, key=utils.parse_version, reverse=1) == [
+    assert utils.sorted_versions(versions) == [
         '59.0.2esr',
         '59.0.2',
         '59.0',
         '59.0b2',
         '59.0a1',
-        # junk data, so it goes to the bottom of the pile
-        '60p',
     ]

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -4,6 +4,7 @@ import datetime
 import isodate
 import functools
 import json
+import random
 import re
 from past.builtins import basestring
 from collections import OrderedDict
@@ -229,7 +230,8 @@ def sorted_versions(list_of_versions):
     ['63.0.2', '63.0', '62.0esr', '62.0b1', '47.0'])
 
     """
-    # Build a list of (version, parsed) tuples
+    # Build a list of (parsed, version) tuples--parsed is first because that's
+    # what we want to sort on
     version_parsed = [(parse_version(version), version) for version in list_of_versions]
 
     # Remove bad versions which are denoted by the parsed version being (-1)
@@ -333,8 +335,8 @@ def get_versions_for_product(product):
         for version in versions
     ]
 
-    # Cache value for an hour
-    cache.set(key, ret, 60 * 60)
+    # Cache value for an hour plus a fudge factor in seconds
+    cache.set(key, ret, (60 * 60) + random.randint(60, 120))
     return ret
 
 


### PR DESCRIPTION
For products that don't have build information in `product_versions` table,
we pull versions for crash reports from Elasticsearch. This increases the
window we look at when doing that.