### PR TITLE
fix bug 1346883: remove postgres from processor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     depends_on:
       - statsd
       - localstack-s3
-      - postgresql
       - elasticsearch
       - rabbitmq
     volumes:

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -108,17 +108,8 @@ class Processor2015(RequiredConfig):
 
     required_config = Namespace('transform_rules')
     required_config.add_option(
-        'database_class',
-        doc="the class of the database",
-        default='socorro.external.postgresql.connection_context.'
-                'ConnectionContext',
-        from_string_converter=str_to_python_object,
-        reference_value_from='resource.postgresql',
-    )
-    required_config.add_option(
         'transaction_executor_class',
-        default="socorro.database.transaction_executor."
-                "TransactionExecutorWithInfiniteBackoff",
+        default='socorro.database.transaction_executor.TransactionExecutorWithInfiniteBackoff',
         doc='a class that will manage transactions',
         from_string_converter=str_to_python_object,
         reference_value_from='resource.postgresql',


### PR DESCRIPTION
The processor no longer needs postgres to function. This removes the
configuration from the app and the service from the docker-compose file
(which only affects the local development environment).

There are also a couple of cosmetic tweaks to code because I just
couldn't help myself.