### PR TITLE
fix bug 1488774: remove cv/ref qualifiers in function names

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -154,9 +154,10 @@ class CSignatureTool(SignatureTool):
 
     def normalize_cpp_function(self, function, line):
         """Normalizes a single cpp frame with a function"""
-        # If the function ends in "const", drop that
-        if function.endswith(' const'):
-            function = function[:-6]
+        # Drop member function cv/ref qualifiers like const, const&, &, and &&
+        for ref in ('const', 'const&', '&&', '&'):
+            if function.endswith(ref):
+                function = function[:-len(ref)].strip()
 
         # Drop the prefix and return type if there is any
         function = drop_prefix_and_return_type(function)

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -183,11 +183,15 @@ class TestCSignatureTool:
             'DoCallback<T>'
         ),
 
-        # Drop "const" at end
+        # Drop cv/ref qualifiers at end
         (
             'JSObject::allocKindForTenure const', '23',
             'JSObject::allocKindForTenure'
-        )
+        ),
+        (
+            'mozilla::jni::GlobalRef<mozilla::jni::Object>::operator=(mozilla::jni::Ref<mozilla::jni::Object, _jobject*> const&)&', '23',  # noqa
+            'mozilla::jni::GlobalRef<T>::operator='
+        ),
     ])
     def test_normalize_cpp_function(self, function, line, expected):
         """Test normalization for cpp functions"""


### PR DESCRIPTION
This adjusts the code to remove `const` at the end of function names
to also remove ref qualifiers `const&`, `&`, and `&&`. That way they
don't interact poorly with the code that removes types and specifiers.