### PR TITLE
fix bug 1493200: fix empty string signature generation

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -303,8 +303,8 @@ class CSignatureTool(SignatureTool):
 
             new_signature_list.append(a_signature)
 
-            # If we have some signature already and the signature does not match the prefix
-            # signatures regex, then it is the last one we add to the list.
+            # If the signature does not match the prefix signatures regex, then it is the last
+            # one we add to the list.
             if not self.prefix_signature_re.match(a_signature):
                 break
 

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -180,6 +180,7 @@ class CSignatureTool(SignatureTool):
                 replacement='',
                 exceptions=('anonymous namespace', 'operator')
             )
+
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if 'clone .cold' in function:
             function = collapse(
@@ -188,6 +189,7 @@ class CSignatureTool(SignatureTool):
                 close_string=']',
                 replacement=''
             )
+
         if self.signatures_with_line_numbers_re.match(function):
             function = "%s:%s" % (function, line)
 
@@ -301,8 +303,8 @@ class CSignatureTool(SignatureTool):
 
             new_signature_list.append(a_signature)
 
-            # If the signature does not match the prefix signatures regex, then it is the last
-            # one we add to the list.
+            # If we have some signature already and the signature does not match the prefix
+            # signatures regex, then it is the last one we add to the list.
             if not self.prefix_signature_re.match(a_signature):
                 break
 
@@ -513,7 +515,8 @@ class SignatureGenerationRule(Rule):
 
         if signature_list:
             result['proto_signature'] = ' | '.join(signature_list)
-        result['signature'] = signature
+        if signature:
+            result['signature'] = signature
         result['notes'].extend(signature_notes)
 
         return True

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -242,6 +242,16 @@ def test_collapse(function, expected):
     (
         'void geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)',  # noqa
         'geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)'  # noqa
+    ),
+    # Handle whitespace between function and parenthesized arguments correctly
+    (
+        '[thunk]:CShellItem::QueryInterface`adjustor{12}\' (_GUID const&, void**)',
+        '[thunk]:CShellItem::QueryInterface`adjustor{12}\' (_GUID const&, void**)'
+    ),
+    # Handle whitespace between function and [clone .cold.xxx] correctly
+    (
+        'nsXPConnect::InitStatics() [clone .cold.638]',
+        'nsXPConnect::InitStatics() [clone .cold.638]'
     )
 ])
 def test_drop_prefix_and_return_type(function, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -302,16 +302,37 @@ def drop_prefix_and_return_type(function):
             else:
                 # This is an unmatched close.
                 current.append(char)
+        elif levels:
+            current.append(char)
         elif char == ' ':
-            if levels:
-                current.append(char)
-            else:
-                tokens.append(''.join(current))
-                current = []
+            tokens.append(''.join(current))
+            current = []
         else:
             current.append(char)
 
     if current:
         tokens.append(''.join(current))
+
+    if tokens[-1][0] == '(':
+        # It's possible for the function signature to have a space between
+        # the function name and the parenthesized arguments. If that's
+        # the case, we join the last two tokens and return that.
+        #
+        # Example:
+        #
+        #     somefunc (int arg1, int arg2)
+        #             ^
+        return ' '.join(tokens[-2:])
+
+    if tokens[-1].startswith('[clone'):
+        # It's possible for the function signature to have a [clone .cold.xxx]
+        # at the end with a space between the args and that ... thing. If
+        # that's the case, we join the last two tokens and return that.
+        #
+        # Example:
+        #
+        #     somefunc(int arg1, int arg2) [clone .cold.111]
+        #                                 ^
+        return ' '.join(tokens[-2:])
 
     return tokens[-1]


### PR DESCRIPTION
There were two situations and a bug that were causing signature
generation to generate signatures of an empty string.

The bug was stomping on the signature regardless of what `CSignatureTool`
figured out. We only want to stomp on the signature if we have a valid
signature. That's fixed in this commit.

The two situations that weren't handled correctly both involve a space
between the last token and the previous token where the two tokens
together are the function name, args, and some `[clone .cold.xyz]` suffix.
This fixes that by making sure we're not losing bits.