### PR TITLE
fixi bug 1389197: fix os_name to be "Unknown" and not empty string

### DIFF
--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from glom import glom
+
 from socorro.lib.transform_rules import Rule
 
 
@@ -50,12 +52,10 @@ class OSInfoRule(Rule):
         return '1.0'
 
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.os_name = ''
-        processed_crash.os_version = ''
+        os_name = glom(processed_crash, 'json_dump.system_info.os', default='Unknown').strip()
+        processed_crash['os_name'] = os_name
 
-        system_info = processed_crash.get('json_dump', {}).get('system_info')
-        if system_info:
-            processed_crash.os_name = system_info.get('os', '').strip()
-            processed_crash.os_version = system_info.get('os_ver', '').strip()
+        os_ver = glom(processed_crash, 'json_dump.system_info.os_ver', default='').strip()
+        processed_crash['os_version'] = os_ver
 
         return True

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -213,42 +213,42 @@ class TestCPUInfoRule(TestCase):
 class TestOSInfoRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
-
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {}
-        processed_crash = copy.copy(canonical_processed_crash)
+        raw_crash = {}
+        processed_crash = DotDict({
+            'json_dump': {
+                'system_info': {
+                    'os': 'Windows NT',
+                    'os_ver': '6.1.7601 Service Pack 1'
+                }
+            }
+        })
         processor_meta = get_basic_processor_meta()
 
         rule = OSInfoRule(config)
 
         # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, {}, processed_crash, processor_meta)
 
-        assert processed_crash.os_name == "Windows NT"
-        assert processed_crash.os_version == "6.1.7601 Service Pack 1"
+        assert processed_crash['os_name'] == "Windows NT"
+        assert processed_crash['os_version'] == "6.1.7601 Service Pack 1"
 
         # raw crash should be unchanged
-        assert raw_crash == canonical_standard_raw_crash
+        assert raw_crash == {}
 
     def test_stuff_missing(self):
         config = get_basic_config()
-
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-
-        raw_dumps = {}
+        raw_crash = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
         rule = OSInfoRule(config)
 
         # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, {}, processed_crash, processor_meta)
 
         # processed crash should have empties
-        expected = DotDict()
-        expected.os_version = ''
-        expected.os_name = ''
-        assert processed_crash == expected
+        assert processed_crash['os_name'] == 'Unknown'
+        assert processed_crash['os_version'] == ''
 
         # raw crash should be unchanged
-        assert raw_crash == canonical_standard_raw_crash
+        assert raw_crash == {}


### PR DESCRIPTION
If an `os_name` can't be pulled from the minidump for whatever reason,
then set it to `"Unknown"` which works with the webapp interface better
rather than `""` which doesn't. This allows us to search for these
crashes and it makes it clearer that Socorro wasn't able to figure
out the `os_name` rather than who-knows-what-happened.

Also, this switches the `OSInfoRule` to use glom and getitem notation.