### PR TITLE
fix bug 1459216: drop signature_products and signature_products_rollup

### DIFF
--- a/alembic/versions/84445597d92f_1459216_drop_signature_products.py
+++ b/alembic/versions/84445597d92f_1459216_drop_signature_products.py
@@ -1,0 +1,24 @@
+"""1459216 drop signature_products and signature_products_rollup tables
+
+Revision ID: 84445597d92f
+Revises: f355b5458f82
+Create Date: 2018-09-24 18:54:53.315200
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '84445597d92f'
+down_revision = 'f355b5458f82'
+
+
+def upgrade():
+    op.execute('DROP TABLE IF EXISTS signature_products')
+    op.execute('DROP TABLE IF EXISTS signature_products_rollup')
+
+
+def downgrade():
+    # No downgrade
+    pass

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -492,47 +492,6 @@ class Signature(DeclarativeBase):
     signature_id = Column(u'signature_id', INTEGER(),
                           primary_key=True, nullable=False)
 
-    # relationship definitions
-    products = relationship(
-        'Product',
-        primaryjoin='Signature.signature_id==SignatureProductsRollup.signature_id',
-        secondary='SignatureProductsRollup',
-        secondaryjoin='SignatureProductsRollup.product_name==Product.product_name')
-
-
-class SignatureProduct(DeclarativeBase):
-    __tablename__ = 'signature_products'
-
-    # column definitions
-    first_report = Column(u'first_report', TIMESTAMP(timezone=True))
-    product_version_id = Column(u'product_version_id', INTEGER(),
-                                primary_key=True, nullable=False, autoincrement=False, index=True)
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey(
-        'signatures.signature_id'), primary_key=True, nullable=False)
-
-    # relationship definitions
-    signatures = relationship(
-        'Signature', primaryjoin='SignatureProduct.signature_id==Signature.signature_id')
-
-
-class SignatureProductsRollup(DeclarativeBase):
-    __tablename__ = 'signature_products_rollup'
-
-    signature_id = Column(u'signature_id', INTEGER(), ForeignKey(
-        'signatures.signature_id'), primary_key=True, nullable=False)
-    product_name = Column(u'product_name', CITEXT(), ForeignKey(
-        'products.product_name'), primary_key=True, nullable=False)
-    ver_count = Column(u'ver_count', INTEGER(),
-                       nullable=False, server_default=text('0'))
-    version_list = Column(u'version_list', ARRAY(
-        TEXT()), nullable=False, server_default=text("'{}'::text[]"))
-
-    # relationship definitions
-    products = relationship(
-        'Product', primaryjoin='SignatureProductsRollup.product_name==Product.product_name')
-    signatures = relationship(
-        'Signature', primaryjoin='SignatureProductsRollup.signature_id==Signature.signature_id')
-
 
 class GraphicsDevice(DeclarativeBase):
     __tablename__ = 'graphics_device'


### PR DESCRIPTION
We don't use these tables anymore, so we should remove them.