### PR TITLE
fix bug 1470704: fix rule metrics key

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -33,7 +33,7 @@ def kw_str_parse(a_string):
         return {}
 
 
-metrics = markus.get_metrics('rule')
+metrics = markus.get_metrics('processor.rule')
 
 
 class Rule(RequiredConfig):


### PR DESCRIPTION
Processor transform rules are part of the processor so the key should
start with "processor". This fixes that.