### PR TITLE
fix bug 1488774: fix another cause of & signatures

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -159,8 +159,11 @@ class CSignatureTool(SignatureTool):
             if function.endswith(ref):
                 function = function[:-len(ref)].strip()
 
-        # Drop the prefix and return type if there is any
-        function = drop_prefix_and_return_type(function)
+        # Drop the prefix and return type if there is any if it's not operator
+        # overloading--operator overloading syntax doesn't have the things
+        # we're dropping here and can look curious, so don't try
+        if '::operator' not in function:
+            function = drop_prefix_and_return_type(function)
 
         # Collapse types
         function = collapse(

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -182,6 +182,12 @@ class TestCSignatureTool:
             'class JSObject* DoCallback<JSObject*>(class JS::CallbackTracer*, class JSObject**, const char*)', '23',  # noqa
             'DoCallback<T>'
         ),
+        # But don't run drop_prefix_and_return_types for operator overloading
+        # functions
+        (
+            'JS::Heap<JSObject*>::operator JSObject* const &()', '23',
+            'JS::Heap<T>::operator JSObject* const&'
+        ),
 
         # Drop cv/ref qualifiers at end
         (


### PR DESCRIPTION
For this one kind of operator overloading, it ends up with this signature
that breaks the expectations for the `drop_prefix_and_return_type` code.
So instead of running that, we skip it. That prevents it from turning
into `"&"`.