### PR TITLE
fix bug 1493200: fix the double-clone vexing variation

### DIFF
--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -243,15 +243,18 @@ def test_collapse(function, expected):
         'void geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)',  # noqa
         'geckoservo::glue::Servo_MaybeGCRuleTree(struct style::gecko_bindings::bindings::RawServoStyleSet *)'  # noqa
     ),
-    # Handle whitespace between function and parenthesized arguments correctly
+    # Handle whitespace between function and parenthesized arguments and [clone .cold.xxx] correctly
     (
         '[thunk]:CShellItem::QueryInterface`adjustor{12}\' (_GUID const&, void**)',
         '[thunk]:CShellItem::QueryInterface`adjustor{12}\' (_GUID const&, void**)'
     ),
-    # Handle whitespace between function and [clone .cold.xxx] correctly
     (
         'nsXPConnect::InitStatics() [clone .cold.638]',
         'nsXPConnect::InitStatics() [clone .cold.638]'
+    ),
+    (
+        'js::AssertObjectIsSavedFrameOrWrapper(JSContext*, JS::Handle<JSObject*>) [clone .isra.234] [clone .cold.687]',  # noqa
+        'js::AssertObjectIsSavedFrameOrWrapper(JSContext*, JS::Handle<JSObject*>) [clone .isra.234] [clone .cold.687]'  # noqa
     )
 ])
 def test_drop_prefix_and_return_type(function, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -313,26 +313,20 @@ def drop_prefix_and_return_type(function):
     if current:
         tokens.append(''.join(current))
 
-    if tokens[-1][0] == '(':
+    while tokens and tokens[-1].startswith(('(', '[clone')):
         # It's possible for the function signature to have a space between
-        # the function name and the parenthesized arguments. If that's
-        # the case, we join the last two tokens and return that.
+        # the function name and the parenthesized arguments or [clone ...]
+        # thing. If that's the case, we join the last two tokens. We keep doing
+        # that until the last token is nice.
         #
         # Example:
         #
         #     somefunc (int arg1, int arg2)
         #             ^
-        return ' '.join(tokens[-2:])
-
-    if tokens[-1].startswith('[clone'):
-        # It's possible for the function signature to have a [clone .cold.xxx]
-        # at the end with a space between the args and that ... thing. If
-        # that's the case, we join the last two tokens and return that.
-        #
-        # Example:
-        #
         #     somefunc(int arg1, int arg2) [clone .cold.111]
         #                                 ^
-        return ' '.join(tokens[-2:])
+        #     somefunc(int arg1, int arg2) [clone .cold.111] [clone .cold.222]
+        #                                 ^                 ^
+        tokens = tokens[:-2] + [' '.join(tokens[-2:])]
 
     return tokens[-1]


### PR DESCRIPTION
It's possible for the function name to end with not one, but TWO
`[clone .cold.xxx]` things. This fixes the handling to cover that.