### PR TITLE
fix bug 1493200: fix an infinite loop

### DIFF
--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -255,6 +255,11 @@ def test_collapse(function, expected):
     (
         'js::AssertObjectIsSavedFrameOrWrapper(JSContext*, JS::Handle<JSObject*>) [clone .isra.234] [clone .cold.687]',  # noqa
         'js::AssertObjectIsSavedFrameOrWrapper(JSContext*, JS::Handle<JSObject*>) [clone .isra.234] [clone .cold.687]'  # noqa
+    ),
+    # Handle an aberrant case
+    (
+        '(foo)',
+        '(foo)'
     )
 ])
 def test_drop_prefix_and_return_type(function, expected):

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -258,8 +258,8 @@ def test_collapse(function, expected):
     ),
     # Handle an aberrant case
     (
-        '(foo)',
-        '(foo)'
+        '(anonymous namespace)::EnqueueTask(already_AddRefed<nsIRunnable>, int)',
+        '(anonymous namespace)::EnqueueTask(already_AddRefed<nsIRunnable>, int)'
     )
 ])
 def test_drop_prefix_and_return_type(function, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -313,7 +313,7 @@ def drop_prefix_and_return_type(function):
     if current:
         tokens.append(''.join(current))
 
-    while tokens and tokens[-1].startswith(('(', '[clone')):
+    while len(tokens) > 1 and tokens[-1].startswith(('(', '[clone')):
         # It's possible for the function signature to have a space between
         # the function name and the parenthesized arguments or [clone ...]
         # thing. If that's the case, we join the last two tokens. We keep doing


### PR DESCRIPTION
The token merging should only happen if there are at least two tokens. This
fixes that.