### PR TITLE
fix bug 1491778: remove \r and \n from telemetry json blob

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -2,7 +2,7 @@
 
 $(document).ready(function() {
   /* Idempotent function to display the TelemetryEnvironment with
-     * jQuery JSONView */
+   * jQuery JSONView */
   var displayTelemetryEnvironment = (function() {
     var once = false;
     return function inner() {
@@ -14,11 +14,18 @@ $(document).ready(function() {
       var container = $('#telemetryenvironment-json');
       if (container.length) {
         var jsonData = container.data('telemetryenvironment');
-        try {
-          $('#telemetryenvironment-json').JSONView(jsonData);
-        } catch (ex) {
-          console.warn('The data in the #telemetryenvironment-json dataset is not valid JSON');
-          container.append($('<p>Invalid JSON in TelemetryEnvironment</p>'));
+        if (jsonData.length) {
+          // Nix \r and \n which shouldn't be in the JSON string and prevent
+          // it from being parsed. bug #1491778
+          jsonData = jsonData.replace(/\r/g, '').replace(/\n/g, '');
+          try {
+            $('#telemetryenvironment-json').JSONView(jsonData);
+          } catch (ex) {
+            console.warn('The data in the #telemetryenvironment-json dataset is not valid JSON');
+            container.append($('<p>Invalid JSON in TelemetryEnvironment</p>'));
+          }
+        } else {
+          container.append($('<p>No TelemetryEnvironment value</p>'));
         }
       }
     };


### PR DESCRIPTION
The telemetry environment data comes in as a json blob. If the json blob
is malformed, then it won't display in the Telemetry Environment tab. One
way it appears to be malformed is that it has `\r` and `\n` characters in
it--the actual characters and not the escape sequences.

This removes them if they exist before trying to parse it as JSON.