### PR TITLE
bug 1463121: Add row counts for non-pg tables to debug view

### DIFF
--- a/webapp-django/crashstats/manage/admin.py
+++ b/webapp-django/crashstats/manage/admin.py
@@ -194,6 +194,22 @@ def debug_view(request):
     for meta_header in ['HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR', 'HTTP_X_REAL_IP']:
         debug_info['request.META["' + meta_header + '"]'] = request.META.get(meta_header, 'none')
 
+    # Add table counts for all non-pg tables
+    with connection.cursor() as cursor:
+        cursor.execute("""
+        SELECT c.relname
+        FROM pg_catalog.pg_class c
+        WHERE c.relkind = 'r'
+        """)
+        tables = cursor.fetchall()
+    for tablename in sorted(tables):
+        tablename = tablename[0]
+        if tablename.startswith(('pg_', 'sql_')):
+            continue
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT count(*) FROM %s' % tablename)
+            debug_info['%s count' % tablename] = cursor.fetchone()[0]
+
     context['debug_info'] = debug_info
     context['title'] = 'Debug information'
 


### PR DESCRIPTION
This will make it easier to verify that the `crashstats_signature` table
is growing at the same pace as the `signatures` table. Further, it shows
all the tables in the db so it'll surface other possible issues like whether
there are tables that shouldn't be there.