### PR TITLE
fix bug 1496495: remove implementation cache in webapp

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -23,7 +23,6 @@ from crashstats.crashstats.models import (
     Reprocessing,
     RawCrash,
     SignaturesByBugs,
-    SocorroCommon,
     UnredactedCrash,
 )
 from crashstats.tokens.models import Token
@@ -1046,7 +1045,6 @@ class TestVersionString(object):
                 'hits': results
             }
             yield
-        SocorroCommon.clear_implementations_cache()
         cache.clear()
 
     def test_version_string_no_args(self, client):

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -45,13 +45,6 @@ class TestModels(DjangoTestCase):
     def tearDown(self):
         super(TestModels, self).tearDown()
 
-        # We use a memoization technique on the SocorroCommon so that we
-        # can get the same implementation class instance repeatedly under
-        # the same request. This is great for low-level performance but
-        # it makes it impossible to test classes that are imported only
-        # once like they are in unit test running.
-        models.SocorroCommon.clear_implementations_cache()
-
     @mock.patch('requests.Session')
     def test_bugzilla_api(self, rsession):
         model = models.BugzillaBugInfo

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -428,14 +428,6 @@ class BaseTestViews(DjangoTestCase):
         super(BaseTestViews, self).tearDown()
         cache.clear()
 
-        from crashstats.crashstats.models import SocorroCommon
-        # We use a memoization technique on the SocorroCommon so that we
-        # can get the same implementation class instance repeatedly under
-        # the same request. This is great for low-level performance but
-        # it makes it impossible to test classes that are imported only
-        # once like they are in unit test running.
-        SocorroCommon.clear_implementations_cache()
-
     def _add_permission(self, user, codename, group_name='Hackers'):
         group = self._create_group_with_permission(codename)
         user.groups.add(group)


### PR DESCRIPTION
The implementation cache was helpful once, but I don't think it's helpful
anymore. It does cache mocks and other things, so it seems more trouble
than it's worth, so I'm removing it for now.