### PR TITLE
fix bug 1497131: fix java stacktrace parsing for no message case

### DIFF
--- a/socorro/lib/javautil.py
+++ b/socorro/lib/javautil.py
@@ -71,12 +71,10 @@ def parse_java_stack_trace(text):
             continue
 
         if stage is CLASS_MESSAGE:
-            try:
+            if ':' in line:
                 cls, msg = line.split(':', 1)
-            except ValueError as ve:
-                # If there's no : in the line, then it raises a ValueError.
-                # That means this is malformed.
-                raise MalformedJavaStackTrace(repr(ve))
+            else:
+                cls, msg = line, ''
 
             # Append lines to the message until one of them starts with
             # a tab.

--- a/socorro/unittest/lib/test_javautil.py
+++ b/socorro/unittest/lib/test_javautil.py
@@ -26,6 +26,31 @@ def test_parse_basic():
     assert java_exc.additional == []
 
 
+EXC_NO_MESSAGE = """\
+Exception
+\tat org.File.function(File.java:100)
+\tat org.File.function2(File.java:200)
+"""
+
+
+def test_no_message():
+    """Parse a basic exception with a class, message, and some stack lines"""
+    java_exc = javautil.parse_java_stack_trace(EXC_NO_MESSAGE)
+    assert java_exc.exception_class == 'Exception'
+    assert java_exc.exception_message == ''
+    assert java_exc.stack == [
+        'at org.File.function(File.java:100)',
+        'at org.File.function2(File.java:200)'
+    ]
+    assert java_exc.additional == []
+
+    assert java_exc.to_public_string() == (
+        'Exception\n'
+        '\tat org.File.function(File.java:100)\n'
+        '\tat org.File.function2(File.java:200)'
+    )
+
+
 EXC_WITH_MULTILINE_MSG = """\
 android.database.sqlite.SQLiteDatabaseLockedException: database is locked (code 5)
 #################################################################
@@ -104,9 +129,6 @@ def test_parse_caused_by():
     # No text blob
     None,
     '',
-
-    # No msg
-    'Exception',
 
     # Line without a tab in STACK stage
     (

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -697,7 +697,7 @@ class TestJavaProcessRule(TestCase):
         config = get_basic_config()
 
         raw_crash = {
-            'JavaStackTrace': 'junk'
+            'JavaStackTrace': 'junk\n\tat org.File.function\njunk'
         }
 
         raw_dumps = {}


### PR DESCRIPTION
This fixes java stacktrace parsing to handle cases where there's an exception
class, but no message. Previously, this would raise a `MalformedJavaStackTrace`
exception. Now it should parse correctly.