### PR TITLE
bug 1457747: rewrite GraphicsDeviceManager.get_pairs()

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -46,8 +46,8 @@ class TestGraphicsDevices(DjangoTestCase):
     def test_get_pairs(self):
         """Test get_pairs() works correctly
 
-        The GraphicsDevice.get_pairs() lets you make a bunch of requests at
-        the same time. It's more performant since it caches results.
+        The GraphicsDevice.get_pairs() lets you expand a bunch of (vendor, adapter)
+        pairs at the same time. It's more performant since it does a single query.
 
         """
         models.GraphicsDevice.objects.create(
@@ -70,27 +70,25 @@ class TestGraphicsDevices(DjangoTestCase):
         )
 
         r = models.GraphicsDevice.objects.get_pairs(
-            ['ahex1', 'ahex2'],
             ['vhex1', 'vhex2'],
+            ['ahex1', 'ahex2'],
         )
         expected = {
-            ('ahex1', 'vhex1'): ('A 1', 'V 1'),
-            ('ahex2', 'vhex2'): ('A 2', 'V 2'),
+            ('vhex1', 'ahex1'): ('V 1', 'A 1'),
+            ('vhex2', 'ahex2'): ('V 2', 'A 2'),
         }
         assert r == expected
 
         r = models.GraphicsDevice.objects.get_pairs(
-            ['ahex2', 'ahex3'],
             ['vhex2', 'vhex3'],
+            ['ahex2', 'ahex3'],
         )
         assert len(r) == 2
         expected = {
-            ('ahex2', 'vhex2'): ('A 2', 'V 2'),
-            ('ahex3', 'vhex3'): ('A 3', 'V 3'),
+            ('vhex2', 'ahex2'): ('V 2', 'A 2'),
+            ('vhex3', 'ahex3'): ('V 3', 'A 3'),
         }
         assert r == expected
-
-        # FIXME(willkg): verify caching is working
 
 
 class TestSignatureFirstDate(DjangoTestCase):

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -168,15 +168,15 @@ def enhance_json_dump(dump, vcs_mappings):
 
 def enhance_raw(raw_crash):
     """Enhances raw crash with additional data"""
-    if raw_crash.get('AdapterDeviceID') and raw_crash.get('AdapterVendorID'):
+    if raw_crash.get('AdapterVendorID') and raw_crash.get('AdapterDeviceID'):
         # Look up the two and get friendly names and then add them
-        result = models.GraphicsDevice.objects.get_pair(
-            raw_crash['AdapterDeviceID'],
-            raw_crash['AdapterVendorID']
+        result = models.GraphicsDevice.objects.get_pairs(
+            raw_crash['AdapterVendorID'],
+            raw_crash['AdapterDeviceID']
         )
         if result is not None:
-            raw_crash['AdapterDeviceName'] = result[0]
-            raw_crash['AdapterVendorName'] = result[1]
+            raw_crash['AdapterVendorName'] = result[0]
+            raw_crash['AdapterDeviceName'] = result[1]
 
 
 def parse_version(version):

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -468,7 +468,7 @@ def _transform_graphics_summary(facets):
                 vendor_hexes.append(vendor['term'])
                 adapter_hexes.append(adapter['term'])
 
-        all_names = models.GraphicsDevice.objects.get_pairs(adapter_hexes, vendor_hexes)
+        all_names = models.GraphicsDevice.objects.get_pairs(vendor_hexes, adapter_hexes)
         graphics = []
         for vendor in facets['adapter_vendor_id']:
             for adapter in vendor['facets']['adapter_device_id']:
@@ -477,18 +477,12 @@ def _transform_graphics_summary(facets):
                     'adapter': adapter['term'],
                     'count': adapter['count'],
                 }
-                key = (adapter['term'], vendor['term'])
+                key = (vendor['term'], adapter['term'])
                 names = all_names.get(key)
                 if names and names[0]:
-                    entry['adapter'] = '{} ({})'.format(
-                        names[0],
-                        adapter['term'],
-                    )
+                    entry['vendor'] = '%s (%s)' % (names[0], vendor['term'])
                 if names and names[1]:
-                    entry['vendor'] = '{} ({})'.format(
-                        names[1],
-                        vendor['term'],
-                    )
+                    entry['adapter'] = '%s (%s)' % (names[1], adapter['term'])
 
                 graphics.append(entry)
 


### PR DESCRIPTION
This reworks `get_pairs` to do a single SQL query. It also ditches all the
caching work which I think is done at the wrong granularity.