### PR TITLE
bug 1457747: fix KeyError issue in report_index view

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -260,13 +260,21 @@
                             <tr title="{{ fields_desc['raw_crash.AdapterVendorID'] }}">
                                 <th scope="row">Adapter Vendor ID</th>
                                 <td>
-                                    <pre>{{ raw.AdapterVendorID }}{% if raw.AdapterVendorName %} ({{ raw.AdapterVendorName }}){% endif %}</pre>
+                                    {% if raw.AdapterVendorName %}
+                                        <pre>{{ raw.AdapterVendorName }} ({{ raw.AdapterVendorID }})</pre>
+                                    {% else %}
+                                        <pre>{{ raw.AdapterVendorID }}</pre>
+                                    {% endif %}
                                 </td>
                             </tr>
                             <tr title="{{ fields_desc['raw_crash.AdapterDeviceID'] }}">
                                 <th scope="row">Adapter Device ID</th>
                                 <td>
-                                    <pre>{{ raw.AdapterDeviceID }}{% if raw.AdapterDeviceName %} ({{ raw.AdapterDeviceName }}){% endif %}</pre>
+                                    {% if raw.AdapterDeviceName %}
+                                        <pre>{{ raw.AdapterDeviceName }} ({{ raw.AdapterDeviceID }})</pre>
+                                    {% else %}
+                                        <pre>{{ raw.AdapterDeviceID }}</pre>
+                                    {% endif %}
                                 </td>
                             </tr>
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -47,8 +47,8 @@ class GraphicsDeviceManager(models.Manager):
     def get_pair(self, vendor_hex, adapter_hex):
         """Returns (vendor_name, adapter_name) or None"""
         try:
-            obj = self.get(vendor_hex=vendor_hex, adapter_hex=adapter_hex).values()
-            return (obj['vendor_name'], obj['adapter_name'])
+            obj = self.get(vendor_hex=vendor_hex, adapter_hex=adapter_hex)
+            return (obj.vendor_name, obj.adapter_name)
         except self.model.DoesNotExist:
             return None
 

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -170,7 +170,7 @@ def enhance_raw(raw_crash):
     """Enhances raw crash with additional data"""
     if raw_crash.get('AdapterVendorID') and raw_crash.get('AdapterDeviceID'):
         # Look up the two and get friendly names and then add them
-        result = models.GraphicsDevice.objects.get_pairs(
+        result = models.GraphicsDevice.objects.get_pair(
             raw_crash['AdapterVendorID'],
             raw_crash['AdapterDeviceID']
         )


### PR DESCRIPTION
This fixes a `KeyError` from the last PR. Further, I adjusted the output of the hex vs. name in the report view to match what we do in the signature report.