### PR TITLE
bug 1493768: fix ordering of /api/Bugs results

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -899,7 +899,7 @@ class Bugs(SocorroMiddleware):
             BugAssociation.objects
             .get_bugs_and_related_bugs(signatures=params['signatures'])
             .values('bug_id', 'signature')
-            .order_by('-bug_id', 'signature')
+            .order_by('bug_id', 'signature')
         )
 
         hits = [

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -129,12 +129,12 @@ class TestBugs(DjangoTestCase):
         assert resp == {
             'hits': [
                 {
-                    'id': 1000000,
-                    'signature': 'OOM | large'
-                },
-                {
                     'id': 999999,
                     'signature': 'OOM | small'
+                },
+                {
+                    'id': 1000000,
+                    'signature': 'OOM | large'
                 }
             ],
             'total': 2


### PR DESCRIPTION
This was the one minor difference between the rewrite I did which is on stage and the old code which is in prod.