### PR TITLE
bug 1491778: show raw value when TelemetryEnvironment doesn't parse

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
         } catch (ex) {
           console.warn('The data in the #telemetryenvironment-json dataset is not valid JSON');
           container.append($('<p>Error when parsing JSON. Showing raw value:</p>'));
-          container.append($(document.createTextNode(jsonData)));
+          container.append(document.createTextNode(jsonData));
         }
       }
     };

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -18,7 +18,8 @@ $(document).ready(function() {
           $('#telemetryenvironment-json').JSONView(jsonData);
         } catch (ex) {
           console.warn('The data in the #telemetryenvironment-json dataset is not valid JSON');
-          container.append($('<p>Invalid JSON in TelemetryEnvironment</p>'));
+          container.append($('<p>Error when parsing JSON. Showing raw value:</p>'));
+          container.append($(document.createTextNode(jsonData)));
         }
       }
     };


### PR DESCRIPTION
This changes the Telemetry Environment pane to show the raw value in the
case where the JSON doesn't parse.

This doesn't fix the original problem. I'm still fuzzy as to whether the data coming in is already broken or whether it breaks in the myriad of transformation, escaping, and unescaping passes it goes through. We can push figuring that off until later.