### PR TITLE
fix bug 1501346: fix api use of classnames

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -19,7 +19,7 @@ from crashstats.crashstats.models import (
     BugAssociation,
     CrontabberState,
     ProcessedCrash,
-    ProductVersions,
+    ProductVersionsMiddleware,
     Reprocessing,
     RawCrash,
     UnredactedCrash,
@@ -145,17 +145,17 @@ class TestViews(BaseTestViews):
                 ]
             }
 
-        ProductVersions.implementation().get.side_effect = mocked_get
+        ProductVersionsMiddleware.implementation().get.side_effect = mocked_get
 
         url = reverse('api:model_wrapper', args=('ProductVersions',))
         response = self.client.get(url, {'product': settings.DEFAULT_PRODUCT})
         assert response.status_code == 200
         assert response['Cache-Control']
         assert 'private' in response['Cache-Control']
-        cache_seconds = ProductVersions.cache_seconds
+        cache_seconds = ProductVersionsMiddleware.cache_seconds
         assert 'max-age={}'.format(cache_seconds) in response['Cache-Control']
 
-    def test_ProductVersions(self):
+    def test_ProductVersionsMiddleware(self):
 
         def mocked_get(*args, **k):
             return {
@@ -169,7 +169,7 @@ class TestViews(BaseTestViews):
             }
             raise NotImplementedError
 
-        ProductVersions.implementation().get.side_effect = mocked_get
+        ProductVersionsMiddleware.implementation().get.side_effect = mocked_get
 
         url = reverse('api:model_wrapper', args=('ProductVersions',))
         response = self.client.get(url)

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -560,7 +560,7 @@ class SocorroMiddleware(SocorroCommon):
                 }
 
 
-class Products(SocorroMiddleware):
+class ProductsMiddleware(SocorroMiddleware):
     implementation = socorro.external.postgresql.products.Products
 
     possible_params = ()
@@ -586,7 +586,7 @@ class VersionString(SocorroMiddleware):
     )
 
 
-class ProductVersions(SocorroMiddleware):
+class ProductVersionsMiddleware(SocorroMiddleware):
 
     implementation = socorro.external.postgresql.products.ProductVersions
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -210,7 +210,7 @@ class BaseTestViews(DjangoTestCase):
 
         def mocked_products(**params):
             hits = [
-                # These have versions in the mocked ProductVersions
+                # These have versions in the mocked ProductVersionsMiddleware
                 {
                     'product_name': 'WaterWolf',
                     'release_name': 'waterwolf',
@@ -239,7 +239,7 @@ class BaseTestViews(DjangoTestCase):
                     'rapid_beta_version': '1.0',
                     'rapid_release_version': '999.0',
                 },
-                # This does not have versions in the mocked ProductVersions
+                # This does not have versions in the mocked ProductVersionsMiddleware
                 {
                     'product_name': 'Tinkerbell',
                     'release_name': 'tinkerbell',
@@ -253,7 +253,7 @@ class BaseTestViews(DjangoTestCase):
                 'total': len(hits),
             }
 
-        models.Products.implementation().get.side_effect = (
+        models.ProductsMiddleware.implementation().get.side_effect = (
             mocked_products
         )
 
@@ -365,7 +365,7 @@ class BaseTestViews(DjangoTestCase):
                 'total': len(hits),
             }
 
-        models.ProductVersions.implementation().get.side_effect = (
+        models.ProductVersionsMiddleware.implementation().get.side_effect = (
             mocked_product_versions
         )
 
@@ -387,7 +387,7 @@ class BaseTestViews(DjangoTestCase):
         # call these here so it gets patched for each test because
         # it gets used so often
 
-        models.ProductVersions().get(active=True)
+        models.ProductVersionsMiddleware().get(active=True)
 
     def tearDown(self):
         super(BaseTestViews, self).tearDown()

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -361,7 +361,7 @@ def build_default_context(product=None, versions=None):
     context = {}
 
     # Build product information
-    api = models.Products()
+    api = models.ProductsMiddleware()
     # NOTE(willkg): using an OrderedDict here since Products returns products
     # sorted by sort order and we don't want to lose that ordering
     all_products = OrderedDict()
@@ -374,7 +374,7 @@ def build_default_context(product=None, versions=None):
     context['products'] = all_products
 
     # Build product version information
-    api = models.ProductVersions()
+    api = models.ProductVersionsMiddleware()
     active_versions = OrderedDict()
 
     # Turn the list of all product versions into a dict, one per product.

--- a/webapp-django/crashstats/manage/admin.py
+++ b/webapp-django/crashstats/manage/admin.py
@@ -14,7 +14,7 @@ from crashstats.manage.decorators import superuser_required
 from crashstats.manage import forms
 from crashstats.manage import utils
 from crashstats.supersearch.models import SuperSearchMissingFields
-from crashstats.crashstats.models import GraphicsDevice, Products
+from crashstats.crashstats.models import GraphicsDevice, ProductsMiddleware
 
 
 @superuser_required
@@ -219,7 +219,7 @@ def debug_view(request):
 @superuser_required
 def products(request):
     context = {}
-    api = Products()
+    api = ProductsMiddleware()
     context['products'] = api.get()['hits']
     context['title'] = 'Products'
 

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -65,8 +65,8 @@ def get_allowed_fields(user):
 
 def get_supersearch_form(request):
     platforms = models.Platform.objects.values()
-    products = models.Products().get()['hits']
-    product_versions = models.ProductVersions().get(active=True)['hits']
+    products = models.ProductsMiddleware().get()['hits']
+    product_versions = models.ProductVersionsMiddleware().get(active=True)['hits']
 
     all_fields = SuperSearchFields().get()
 


### PR DESCRIPTION
This fixes the API code so that it can use model_name and model_name +
"Middleware" when looking up models for handling. This allows us
more leeway when naming middleware api classes.