### PR TITLE
fix bug 1484755: remove Focus rewrite rule

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -388,10 +388,6 @@ class ProductRewrite(Rule):
         if raw_crash.get('ProductID', '') in self.PRODUCT_MAP:
             product_name = self.PRODUCT_MAP[raw_crash['ProductID']]
 
-        # Rewrite Focus crashes (bug #1481696).
-        if product_name == 'FennecAndroid' and raw_crash.get('ProcessType', '') == 'content':
-            product_name = 'Focus'
-
         # If we made any product name changes, persist them and keep the
         # original one so we can look at things later
         if product_name != original_product_name:

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -914,27 +914,6 @@ class TestProductRewriteRule(TestCase):
             "Rewriting ProductName from 'Fennec' to 'FennecAndroid'"
         ]
 
-    def test_focus_rewrite(self):
-        config = get_basic_config()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_crash['ProductName'] = 'Fennec'
-        raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
-        raw_crash['ProcessType'] = 'content'
-        processed_crash = DotDict()
-        processor_meta = get_basic_processor_meta()
-
-        rule = ProductRewrite(config)
-        rule.act(raw_crash, {}, processed_crash, processor_meta)
-
-        assert raw_crash.ProductName == 'Focus'
-        assert raw_crash.OriginalProductName == 'Fennec'
-
-        # processed_crash should be unchanged
-        assert processed_crash == DotDict()
-        assert processor_meta.processor_notes == [
-            "Rewriting ProductName from 'Fennec' to 'Focus'"
-        ]
-
 
 class TestESRVersionRewrite(TestCase):
     def test_everything_we_hoped_for(self):


### PR DESCRIPTION
We no longer need to rewrite incoming Focus crashes, so we can remove
this rule now.