### PR TITLE
fix bug 1502038: rework version sorting

### DIFF
--- a/socorro/lib/versionutil.py
+++ b/socorro/lib/versionutil.py
@@ -1,0 +1,52 @@
+def generate_version_key(version):
+    """Serializes the version into a string that can sort with other versions
+
+    :arg str version: the version string; e.g. "62.0.3b15rc1"
+
+    :returns: a sortable version of the version string to be used as a key
+        for sorting
+
+    Example:
+
+    >>> generate_version_key('62.0.2b5rc1')
+    '062000002b005001'
+
+    """
+    if 'rc' in version:
+        version, rc = version.split('rc')
+    else:
+        # We use 999 so that the release always sorts after the release
+        # candidates
+        rc = 999
+
+    if 'pre' in version:
+        # Treat "pre" like we do rc, but call it 1 if there's no number
+        version, rc = version.split('pre')
+        if not rc:
+            rc = 1
+
+    ending = []
+    if 'a' in version:
+        version, num = version.split('a')
+        ending = ['a', 1, int(rc)]
+    elif 'b' in version:
+        version, num = version.split('b')
+        # Handle the 62.0b case which is a superset of betas
+        if not num:
+            num = 999
+        ending = ['b', int(num), int(rc)]
+    elif 'esr' in version:
+        version = version.replace('esr', '')
+        ending = ['x', 0, int(rc)]
+    else:
+        ending = ['r', 0, int(rc)]
+
+    version = [int(part) for part in version.split('.')]
+
+    while len(version) < 3:
+        version.append(0)
+
+    version.extend(ending)
+
+    # (x, y, z, channel, beta number, rc number)
+    return '%03d%03d%03d%s%03d%03d' % tuple(version)

--- a/socorro/unittest/lib/test_versionutil.py
+++ b/socorro/unittest/lib/test_versionutil.py
@@ -1,0 +1,50 @@
+import pytest
+
+from socorro.lib.versionutil import generate_version_key
+
+
+@pytest.mark.parametrize('version, expected', [
+    # Nightly variations
+    ('62.0a1', '062000000a001999'),
+
+    # Aurora versions
+    ('3.7a5pre', '003007000a001001'),
+
+    # Beta variations
+    ('63.0b9', '063000000b009999'),
+    ('63.0b9rc1', '063000000b009001'),
+    ('4.0b2pre', '004000000b002001'),
+
+    # Release variations
+    ('62.0', '062000000r000999'),
+    ('62.0.1', '062000001r000999'),
+    ('62.0.2', '062000002r000999'),
+    ('62.0.2rc1', '062000002r000001'),
+
+    # ESR
+    ('62.0.2esr', '062000002x000999'),
+    ('62.0.2esrrc1', '062000002x000001'),
+    ('62.0.2esrrc2', '062000002x000002'),
+])
+def test_generate_version_key(version, expected):
+    assert generate_version_key(version) == expected
+
+
+def test_generate_version_key_sorted():
+    """Test whether the result sorts correctly"""
+    versions = [
+        '62.0.2a1',
+        '62.0.2b1',
+        '62.0.2b5rc1',
+        '62.0.2b5',
+        '62.0.2rc1',
+        '62.0.2',
+        '62.0.2esrrc1',
+        '62.0.2esr',
+    ]
+
+    sorted_versions = sorted(
+        versions,
+        key=lambda v: generate_version_key(v)
+    )
+    assert sorted_versions == versions

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -388,36 +388,3 @@ def test_json_view_custom_status():
     assert isinstance(response, HttpResponse)
     assert json.loads(response.content) == {'one': 'One'}
     assert response.status_code == 403
-
-
-@pytest.mark.parametrize('version_string, expected', [
-    ('59.0', (59, 0, 0, 'zz')),
-    ('59.0.1', (59, 0, 1, 'zz')),
-
-    # alphas
-    ('59.0a1', (59, 0, 0, 'a1')),
-
-    # betas
-    ('59.0b1', (59, 0, 0, 'b1')),
-    ('59.0.1b1', (59, 0, 1, 'b1')),
-
-    # esr
-    ('59.0.1esr', (59, 0, 1, 'zz', 'esr')),
-
-    # junk data
-    ('49p', (-1)),
-])
-def test_parse_version(version_string, expected):
-    assert utils.parse_version(version_string) == expected
-
-
-def test_sorted_versions():
-    """Test that using parse_version produces version keys that sort correctly"""
-    versions = ['59.0', '59.0b2', '59.0.2', '59.0a1', '60p', '59.0.2esr']
-    assert utils.sorted_versions(versions) == [
-        '59.0.2esr',
-        '59.0.2',
-        '59.0',
-        '59.0b2',
-        '59.0a1',
-    ]

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -3,7 +3,6 @@ import datetime
 from cStringIO import StringIO
 import json
 
-import pytest
 from six import text_type, binary_type
 
 from django.http import HttpResponse


### PR DESCRIPTION
This handles the kinds of versions we have on Crash Stats including
"catch-all" versions like 62.0b which covers all the betas. Rewriting
it allows us to save it to the db as a string and also use it
elsewhere in the code.