### PR TITLE
fix bug 1503034: change supersearch form to pull versions from supers…

### DIFF
--- a/webapp-django/crashstats/supersearch/forms.py
+++ b/webapp-django/crashstats/supersearch/forms.py
@@ -28,7 +28,7 @@ def make_restricted_choices(sequence, exclude=None):
 
 
 class SearchForm(forms.Form):
-    '''Handle the data populating the search form. '''
+    """Handle the data populating the search form"""
 
     def __init__(
         self,
@@ -45,17 +45,12 @@ class SearchForm(forms.Form):
         self.all_fields = all_fields.copy()
 
         # Default values loaded from a database.
-        product_names = list(set(
-            x['product_name'] for x in products
-        ))
+        product_names = list(set(x['product_name'] for x in products))
         if 'product' in self.all_fields:
             self.all_fields['product']['form_field_choices'] = product_names
 
         if 'version' in self.all_fields:
-            versions = uniqify_keep_order(
-                x['version'] for x in product_versions
-            )
-            self.all_fields['version']['form_field_choices'] = versions
+            self.all_fields['version']['form_field_choices'] = uniqify_keep_order(product_versions)
 
         if 'platform' in self.all_fields:
             self.all_fields['platform']['form_field_choices'] = [

--- a/webapp-django/crashstats/supersearch/tests/test_forms.py
+++ b/webapp-django/crashstats/supersearch/tests/test_forms.py
@@ -4,7 +4,6 @@ from socorro.external.es.super_search_fields import FIELDS
 
 
 class TestForms(TestCase):
-
     def setUp(self):
         self.products = [
             {
@@ -21,26 +20,10 @@ class TestForms(TestCase):
             }
         ]
         self.product_versions = [
-            {
-                'product': 'WaterWolf',
-                'version': '20.0',
-                'build_type': 'Beta',
-            },
-            {
-                'product': 'WaterWolf',
-                'version': '21.0a1',
-                'build_type': 'Nightly',
-            },
-            {
-                'product': 'NightTrain',
-                'version': '20.0',
-                'build_type': 'Beta',
-            },
-            {
-                'product': 'SeaMonkey',
-                'version': '9.5',
-                'build_type': 'Beta',
-            },
+            '20.0',
+            '21.0a1',
+            '20.0',
+            '9.5',
         ]
         self.current_platforms = [
             {
@@ -59,9 +42,7 @@ class TestForms(TestCase):
         self.all_fields = FIELDS
 
     def test_search_form(self):
-
         def get_new_form(data):
-
             class User(object):
                 def has_perm(self, permission):
                     return {
@@ -112,9 +93,7 @@ class TestForms(TestCase):
         assert 'exploitability' not in form.fields
 
     def test_search_form_with_admin_mode(self):
-
         def get_new_form(data):
-
             class User(object):
                 def has_perm(self, permission):
                     return {
@@ -164,9 +143,7 @@ class TestForms(TestCase):
         assert 'exploitability' in form.fields
 
     def test_get_fields_list(self):
-
         def get_new_form(data):
-
             class User(object):
                 def has_perm(self, permission):
                     return {

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -1,22 +1,32 @@
 import json
-import urllib
 import re
+import urllib
 
+import mock
 import pyquery
+from waffle.models import Switch
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
-from waffle.models import Switch
-
-from socorro.lib import BadArgumentError
-
 from crashstats.crashstats.models import BugAssociation
 from crashstats.crashstats.tests.test_views import BaseTestViews
 from crashstats.supersearch.models import Query, SuperSearchUnredacted
+from socorro.lib import BadArgumentError
 
 
 class TestViews(BaseTestViews):
+    def setUp(self):
+        super(TestViews, self).setUp()
+        # Mock get_versions_for_product() so it doesn't hit supersearch breaking the
+        # supersearch mocking
+        self.mock_gvfp = mock.patch('crashstats.crashstats.utils.get_versions_for_product')
+        self.mock_gvfp.return_value = ['20.0', '19.1', '19.0', '18.0']
+        self.mock_gvfp.start()
+
+    def tearDown(self):
+        self.mock_gvfp.stop()
+        super(TestViews, self).tearDown()
 
     def test_search_waffle_switch(self):
         url_custom = reverse('supersearch:search_custom')

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -66,7 +66,9 @@ def get_allowed_fields(user):
 def get_supersearch_form(request):
     platforms = models.Platform.objects.values()
     products = models.ProductsMiddleware().get()['hits']
-    product_versions = models.ProductVersionsMiddleware().get(active=True)['hits']
+    # FIXME(willkg): this hardcodes always getting Firefox versions which
+    # seems unhelpful
+    product_versions = utils.get_versions_for_product('Firefox')
 
     all_fields = SuperSearchFields().get()
 
@@ -276,7 +278,6 @@ def search_fields(request):
     '''Return the JSON document describing the fields used by the JavaScript
     dynamic_form library. '''
     form = get_supersearch_form(request)
-
     exclude = request.GET.getlist('exclude')
     return form.get_fields_list(exclude=exclude)
 


### PR DESCRIPTION
…earch

The supersearch form suggests and autocompletes versions in the version input
field. The list of versions used to come from the `ProductVersionMiddleware`
which pulled versions from the `product_versions` table for the Firefox product.

This reworks that to pull versions from a facet of crash reports for Firefox
over the last 3 months and no longer rely on the `product_versions` table.