### PR TITLE
Refactor transaction executor to catch and parse exceptions

### DIFF
--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -83,7 +83,7 @@ class ConnectionContextBase(RequiredConfig):
     )
 
     conditional_exceptions = (
-        boto.exception.StorageResponseError
+        boto.exception.StorageResponseError,
     )
 
     def is_operational_exception(self, x):


### PR DESCRIPTION
Fixes 1503434 by refactoring the transaction executor's error handling to catch all exceptions and then compare the exception type against known cases that can be handled.

This is an expedient solution to keep progressing on py2 -> py3. A few other things I noticed but decided were out of scope: the TransactionExecutor is not really leveraged by its descendant classes here, and when the postgres crash storage is removed it can probably go away entirely. Connection contexts lack a common base class. Comments on the RMQ class attributes and variable names clearly differ from the implementations of other classes. It's unclear if `is_operational_error()` should be the whole source of truth about a retry should occur, of if the transaction executor should really own all the different cases and outcomes for different exceptions. At a future date it would be good to simplify all this with https://github.com/jd/tenacity or even rethink how robust we want this to be in light of our architecture. Process supervisors, monitoring, and queue properties may reduce or eliminate the need to be clever with error and connection handling here. 