### PR TITLE
fix bug 1503439 - stop using StopIteration

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -15,9 +15,8 @@ WORKING_TESTS=(
     socorro/unittest/external/boto/test_*.py
     socorro/unittest/external/es/test_*.py
     socorro/unittest/external/postgresql/test_*.py
+    socorro/unittest/external/rabbitmq/test_*.py
     socorro/unittest/lib/test_*.py
-
-    # socorro/unittest/external/rabbitmq/test_*.py
 )
 
 # This is the list of known working tests by directory/filename for the webapp.

--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -171,8 +171,7 @@ class FetchTransformSaveApp(App):
     def _all_iterator(self):
         """this is the iterator for the case when "number_of_submissions" is
         set to "all".  It goes through the innermost iterator exactly once
-        and raises the StopIteration exception when that innermost iterator is
-        exhausted"""
+        """
         for crash_id in self._basic_iterator():
             if crash_id is None:
                 break

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -151,7 +151,7 @@ class TaskManager(RequiredConfig):
         called at least once after the end of the task loop."""
         self.logger.debug('threadless start')
         try:
-            # May never raise StopIteration
+            # May never exhaust
             for job_params in self._get_iterator():
                 self.config.logger.debug('received %r', job_params)
                 self.quit_check()

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -216,7 +216,7 @@ class ThreadedTaskManager(TaskManager):
         quit itself."""
         self.logger.debug('_queuing_thread_func start')
         try:
-            # May never raise StopIteration
+            # May never exhaust
             for job_params in self._get_iterator():
                 self.config.logger.debug('received %r', job_params)
                 if job_params is None:

--- a/socorro/lib/transaction.py
+++ b/socorro/lib/transaction.py
@@ -84,8 +84,8 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
     def backoff_generator(self):
         """Generate a series of integers used for the length of the sleep
         between retries.  It produces after exhausting the list, it repeats
-        the last value from the list forever.  This generator will never raise
-        the StopIteration exception."""
+        the last value from the list forever.  This generator will never
+        exhaust"""
         for x in self.config.backoff_delays:
             yield x
         while True:


### PR DESCRIPTION
per PEP 479, this removes explicit calls and attempts to detect StopIteration that trigger warnings in 3.6+, which was breaking tests. I used `future.generator_stop` to force these into errors, but there's no backport to 2.x of that so I ended up removing before commit.

I don't like how many tests I removed here. I'm not convinced they had much value, and I left a multi-queue test that covers most of what they were already covering.