### PR TITLE
bug 1503591: tweak create_recent_indices to have a dry run mode

### DIFF
--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -24,9 +24,9 @@ CRONTABBERCMD="./socorro/cron/crontabber_app.py"
 ./docker/run_ftpscraper_wrapper.sh
 
 # Update featured versions data based on release data
-${DC} run app shell bash -c ${CRONTABBERCMD} --reset-job=featured-versions-automatic
-${DC} run app shell bash -c ${CRONTABBERCMD} --job=featured-versions-automatic \
+${DC} run app shell ${CRONTABBERCMD} --reset-job=featured-versions-automatic
+${DC} run app shell ${CRONTABBERCMD} --job=featured-versions-automatic \
     --crontabber.class-FeaturedVersionsAutomaticCronApp.products=${PRODUCTS}
 
 # Create ES indexes for the next few weeks
-${DC} run app shell bash -c socorro/external/es/create_recent_indices_app.py
+${DC} run app shell ./socorro-cmd create_recent_indices

--- a/socorro/external/es/create_recent_indices_app.py
+++ b/socorro/external/es/create_recent_indices_app.py
@@ -29,7 +29,13 @@ class CreateRecentESIndicesApp(App):
         from_string_converter=class_converter
     )
     required_config.add_option(
-        'elasticsearch_weeks_to_create',
+        'weeks_to_create_future',
+        default=2,
+        reference_value_from='resource.elasticsearch',
+    )
+
+    required_config.add_option(
+        'weeks_to_create_past',
         default=2,
         reference_value_from='resource.elasticsearch',
     )
@@ -41,7 +47,10 @@ class CreateRecentESIndicesApp(App):
         today = date.today()
         current_monday = today - timedelta(days=today.weekday())
 
-        for week_diff in range(-2, self.config.elasticsearch_weeks_to_create):
+        past = self.config.weeks_to_create_past * -1
+        future = self.config.weeks_to_create_future
+
+        for week_diff in range(past, future):
             week_monday = current_monday + timedelta(weeks=week_diff)
             index = week_monday.strftime(index_name_template)
             index_creator.create_socorro_index(index)


### PR DESCRIPTION
This also fixes `clear_recent_indices_app` to be a little less clunky in what
it's doing in regards to the args passed in. And it fixes `run_update_data.sh`
which was running crontabber and apps wrong.