### PR TITLE
bug 1504067: first pass at removing unittest things

### DIFF
--- a/webapp-django/crashstats/api/tests/test_cleaner.py
+++ b/webapp-django/crashstats/api/tests/test_cleaner.py
@@ -1,11 +1,9 @@
 import mock
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.api.cleaner import Cleaner, SmartWhitelistMatcher
 
 
-class TestCleaner(TestCase):
-
+class TestCleaner(object):
     def test_simplest_case(self):
         whitelist = {'hits': ('foo', 'bar')}
         data = {
@@ -207,8 +205,7 @@ class TestCleaner(TestCase):
         assert data == expect
 
 
-class TestSmartWhitelistMatcher(TestCase):
-
+class TestSmartWhitelistMatcher(object):
     def test_basic_in(self):
         whitelist = ['some', 'thing*']
         matcher = SmartWhitelistMatcher(whitelist)

--- a/webapp-django/crashstats/api/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/api/tests/test_jinja_helpers.py
@@ -1,9 +1,7 @@
-from crashstats.base.tests.testbase import TestCase
 from crashstats.api.templatetags.jinja_helpers import pluralize
 
 
-class TestPluralize(TestCase):
-
+class TestPluralize(object):
     def test_basics(self):
         assert pluralize(0) == 's'
         assert pluralize(1) == ''

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -11,7 +11,6 @@ import mock
 from moto import mock_s3_deprecated
 import pyquery
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats.models import (
     BugAssociation,
     ProcessedCrash,
@@ -29,7 +28,7 @@ from socorro.lib.ooid import create_new_ooid
 from socorro.unittest.external.boto.conftest import BotoHelper
 
 
-class TestDedentLeft(TestCase):
+class TestDedentLeft(object):
     def test_dedent_left(self):
         from crashstats.api.views import dedent_left
         assert dedent_left('Hello', 2) == 'Hello'
@@ -45,9 +44,7 @@ class TestDedentLeft(TestCase):
 
 
 class TestDocumentationViews(BaseTestViews):
-
     def test_documentation_home_page(self):
-
         url = reverse('api:documentation')
         response = self.client.get(url)
         assert response.status_code == 200
@@ -60,7 +57,6 @@ class TestDocumentationViews(BaseTestViews):
 
 
 class TestViews(BaseTestViews):
-
     def setUp(self):
         super(TestViews, self).setUp()
         self._middleware_classes = settings.MIDDLEWARE_CLASSES
@@ -148,7 +144,6 @@ class TestViews(BaseTestViews):
         assert 'max-age={}'.format(cache_seconds) in response['Cache-Control']
 
     def test_ProductVersionsMiddleware(self):
-
         def mocked_get(*args, **k):
             return {
                 'hits': [
@@ -320,7 +315,6 @@ class TestViews(BaseTestViews):
         assert 'exploitability' in dump
 
     def test_RawCrash(self):
-
         def mocked_get(**params):
             if 'uuid' in params and params['uuid'] == 'abc123':
                 return {
@@ -384,7 +378,6 @@ class TestViews(BaseTestViews):
         assert 'upload_file_minidump_plugin' in dump
 
     def test_RawCrash_binary_blob(self):
-
         def mocked_get(**params):
             if 'uuid' in params and params['uuid'] == 'abc':
                 return '\xe0'
@@ -483,7 +476,6 @@ class TestViews(BaseTestViews):
         }
 
     def test_NewSignatures(self):
-
         def mocked_supersearch_get(**params):
             assert params['product'] == [settings.DEFAULT_PRODUCT]
 
@@ -646,7 +638,6 @@ class TestViews(BaseTestViews):
             assert response.status_code == 429
 
     def test_SuperSearch(self):
-
         def mocked_supersearch_get(**params):
             assert 'exploitability' not in params
 
@@ -717,7 +708,6 @@ class TestViews(BaseTestViews):
         assert response.status_code == 200
 
     def test_SuperSearchUnredacted(self):
-
         def mocked_supersearch_get(**params):
             assert 'exploitability' in params
             if 'product' in params:
@@ -740,9 +730,7 @@ class TestViews(BaseTestViews):
                 'total': 0
             }
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('api:model_wrapper', args=('SuperSearchUnredacted',))
         response = self.client.get(url, {'exploitability': 'high'})
@@ -780,7 +768,6 @@ class TestViews(BaseTestViews):
         assert response.status_code == 200
 
     def test_change_certain_exceptions_to_bad_request(self):
-
         # It actually doesn't matter so much which service we use
         # because we're heavily mocking it.
         # Here we use the SuperSearch model.
@@ -802,7 +789,6 @@ class TestViews(BaseTestViews):
         assert 'foobaz' in response.content
 
     def test_Reprocessing(self):
-
         def mocked_reprocess(crash_ids):
             assert crash_ids == ['xxxx']
             return True

--- a/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
+++ b/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
@@ -7,12 +7,11 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from crashstats.base.tests.testbase import DjangoTestCase
 from crashstats.authentication.management.commands import makesuperuser
 
 
-class TestMakeSuperuserCommand(DjangoTestCase):
-    def test_make_existing_user(self):
+class TestMakeSuperuserCommand(object):
+    def test_make_existing_user(self, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
         buffer = StringIO()
         call_command('makesuperuser', 'BOB@mozilla.com', stdout=buffer)
@@ -24,7 +23,7 @@ class TestMakeSuperuserCommand(DjangoTestCase):
         assert user.is_staff
         assert [g.name for g in user.groups.all()] == ['Hackers']
 
-    def test_make_already_user(self):
+    def test_make_already_user(self, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
         bob.is_superuser = True
         bob.is_staff = True
@@ -41,7 +40,7 @@ class TestMakeSuperuserCommand(DjangoTestCase):
         assert user.is_staff
         assert [g.name for g in user.groups.all()] == ['Hackers']
 
-    def test_make_two_user_superuser(self):
+    def test_make_two_user_superuser(self, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
         bob.is_superuser = True  # already
         bob.save()
@@ -63,7 +62,7 @@ class TestMakeSuperuserCommand(DjangoTestCase):
         assert otto.is_staff
         assert [g.name for g in otto.groups.all()] == ['Hackers']
 
-    def test_nonexisting_user(self):
+    def test_nonexisting_user(self, db):
         buffer = StringIO()
         email = 'neverheardof@mozilla.com'
         call_command('makesuperuser', email, stdout=buffer)
@@ -79,7 +78,7 @@ class TestMakeSuperuserCommand(DjangoTestCase):
         'get_input',
         return_value='BOB@mozilla.com '
     )
-    def test_with_raw_input(self, mocked_raw_input):
+    def test_with_raw_input(self, mocked_raw_input, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
         buffer = StringIO()
         cmd = makesuperuser.Command()
@@ -97,7 +96,7 @@ class TestMakeSuperuserCommand(DjangoTestCase):
         'get_input',
         return_value='\n'
     )
-    def test_with_raw_input_but_empty(self, mocked_raw_input):
+    def test_with_raw_input_but_empty(self, mocked_raw_input, db):
         with pytest.raises(CommandError):
             buffer = StringIO()
             cmd = makesuperuser.Command()

--- a/webapp-django/crashstats/base/tests/test_finders.py
+++ b/webapp-django/crashstats/base/tests/test_finders.py
@@ -2,27 +2,25 @@ import copy
 
 import pytest
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 
-from crashstats.base.tests.testbase import DjangoTestCase
 
-
-class LeftoverPipelineFinder(DjangoTestCase):
+class TestLeftoverPipelineFinder(object):
     """Test our custom staticfiles finder class."""
 
-    def test_missing_css_source_file(self):
+    def test_missing_css_source_file(self, settings):
         busted_pipeline = copy.deepcopy(settings.PIPELINE)
         # Doesn't matter which key we chose to bust, so let's just
         # pick the first one.
         key = busted_pipeline['STYLESHEETS'].keys()[0]
         filenames = busted_pipeline['STYLESHEETS'][key]['source_filenames']
+
         # add a junk one
         filenames += ('neverheardof.css',)
-        busted_pipeline['STYLESHEETS'][key]['source_filenames'] = (
-            filenames
-        )
-        with self.settings(PIPELINE=busted_pipeline):
-            with pytest.raises(ImproperlyConfigured):
-                call_command('collectstatic', '--noinput', interactive=False)
+        busted_pipeline['STYLESHEETS'][key]['source_filenames'] = filenames
+
+        settings.PIPELINE = busted_pipeline
+
+        with pytest.raises(ImproperlyConfigured):
+            call_command('collectstatic', '--noinput', interactive=False)

--- a/webapp-django/crashstats/base/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/base/tests/test_jinja_helpers.py
@@ -1,7 +1,6 @@
 from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.base.templatetags.jinja_helpers import (
     change_query_string,
     is_dangerous_cpu,
@@ -9,8 +8,7 @@ from crashstats.base.templatetags.jinja_helpers import (
 )
 
 
-class TestChangeURL(TestCase):
-
+class TestChangeURL(object):
     def test_root_url_no_query_string(self):
         context = {}
         context['request'] = RequestFactory().get('/')
@@ -60,8 +58,7 @@ class TestChangeURL(TestCase):
         assert result == '?foo=else'
 
 
-class TestURL(TestCase):
-
+class TestURL(object):
     def test_basic(self):
         output = url('crashstats:login')
         assert output == reverse('crashstats:login')
@@ -90,8 +87,7 @@ class TestURL(TestCase):
         assert output == reverse('crashstats:product_home', args=('Winterfoxnn',))
 
 
-class TestIsDangerousCPU:
-
+class TestIsDangerousCPU(object):
     def test_false(self):
         assert is_dangerous_cpu(None, None) is False
         assert is_dangerous_cpu(None, 'family 20 model 1') is False

--- a/webapp-django/crashstats/base/tests/test_utils.py
+++ b/webapp-django/crashstats/base/tests/test_utils.py
@@ -1,9 +1,7 @@
-from crashstats.base.tests.testbase import TestCase
 from crashstats.base.utils import render_exception, SignatureStats
 
 
-class TestRenderException(TestCase):
-
+class TestRenderException(object):
     def test_basic(self):
         html = render_exception('hi!')
         assert html == '<ul><li>hi!</li></ul>'
@@ -20,7 +18,7 @@ class TestRenderException(TestCase):
         assert html == '<ul><li>&lt;hack&gt;</li></ul>'
 
 
-class TestUtils(TestCase):
+class TestUtils(object):
     def test_SignatureStats(self):
         signature = {
             'count': 2,

--- a/webapp-django/crashstats/base/tests/testbase.py
+++ b/webapp-django/crashstats/base/tests/testbase.py
@@ -1,10 +1,9 @@
 import inspect
-import unittest
 
 import mock
 
-import django.test
 from django.contrib.auth.models import User
+import django.test
 
 import crashstats.crashstats.models
 import crashstats.supersearch.models
@@ -21,14 +20,7 @@ for module in (crashstats.crashstats.models, crashstats.supersearch.models):
                 classes_with_implementation.append(klass)
 
 
-class TestCase(unittest.TestCase):
-
-    def shortDescription(self):
-        return None
-
-
 class DjangoTestCase(django.test.TestCase):
-
     def setUp(self):
         super(DjangoTestCase, self).setUp()
 

--- a/webapp-django/crashstats/crashstats/tests/test_decorators.py
+++ b/webapp-django/crashstats/crashstats/tests/test_decorators.py
@@ -1,69 +1,61 @@
 from django import http
+
 from crashstats.crashstats import decorators
-from unittest import TestCase
-from django.test.client import RequestFactory
 
 
-class TestCheckDays(TestCase):
-
-    def setUp(self):
-        self.factory = RequestFactory()
-
-    def test_basics(self):
-
+class TestCheckDays(object):
+    def test_basics(self, rf):
         @decorators.check_days_parameter([1, 2], 2)
         def view(request, days=None, **kwargs):
             return http.HttpResponse(str(10000 + days))
 
-        request = self.factory.get('/')
+        request = rf.get('/')
         response = view(request)
-        self.assertEqual(response.content, '10002')  # default
+        assert response.content == '10002'  # default
 
-        request = self.factory.get('/', {'days': '1'})
+        request = rf.get('/', {'days': '1'})
         response = view(request)
-        self.assertEqual(response.content, '10001')
+        assert response.content == '10001'
 
         # not a number
-        request = self.factory.get('/', {'days': 'xxx'})
+        request = rf.get('/', {'days': 'xxx'})
         response = view(request)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
         # out of range
-        request = self.factory.get('/', {'days': 3})
+        request = rf.get('/', {'days': 3})
         response = view(request)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
-    def test_no_default(self):
+    def test_no_default(self, rf):
         # if no default is passed, it has to be one of list of days
 
         @decorators.check_days_parameter([1, 2])
         def view(request, days=None, **kwargs):
             return http.HttpResponse(str(10000 + days))
 
-        request = self.factory.get('/', {'days': 1})
+        request = rf.get('/', {'days': 1})
         response = view(request)
-        self.assertEqual(response.content, '10001')
+        assert response.content == '10001'
 
-        request = self.factory.get('/')
+        request = rf.get('/')
         response = view(request)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
-    def test_none_default(self):
-
+    def test_none_default(self, rf):
         @decorators.check_days_parameter([1, 2], default=None)
         def view(request, days=None, **kwargs):
             return http.HttpResponse(str(days))
 
-        request = self.factory.get('/')
+        request = rf.get('/')
         response = view(request)
-        self.assertEqual(response.content, 'None')
+        assert response.content == 'None'
 
-    def test_using_possible_days(self):
-
+    def test_using_possible_days(self, rf):
         @decorators.check_days_parameter([1, 2], 2)
         def view(request, days=None, possible_days=None):
             return http.HttpResponse(str(possible_days))
 
-        request = self.factory.get('/')
+        request = rf.get('/')
         response = view(request)
-        self.assertEqual(response.content, str([1, 2]))
+        assert response.content == str([1, 2])

--- a/webapp-django/crashstats/crashstats/tests/test_form_fields.py
+++ b/webapp-django/crashstats/crashstats/tests/test_form_fields.py
@@ -2,12 +2,10 @@ import pytest
 
 from django.forms import ValidationError
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats import form_fields
 
 
-class TestFormFields(TestCase):
-
+class TestFormFields(object):
     def test_build_ids_field(self):
         field = form_fields.BuildIdsField(required=False)
         res = field.clean('12')

--- a/webapp-django/crashstats/crashstats/tests/test_forms.py
+++ b/webapp-django/crashstats/crashstats/tests/test_forms.py
@@ -1,11 +1,8 @@
-from crashstats.base.tests.testbase import DjangoTestCase
 from crashstats.crashstats import forms
 
 
-class TestForms(DjangoTestCase):
-
-    def setUp(self):
-        super(TestForms, self).setUp()
+class TestForms(object):
+    def setup_method(self):
         self.active_versions = {
             'WaterWolf': [
                 {'version': '20.0', 'build_type': 'Beta'},
@@ -28,7 +25,6 @@ class TestForms(DjangoTestCase):
         )
 
     def test_buginfoform(self):
-
         def get_new_form(data):
             return forms.BugInfoForm(data)
 

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -6,7 +6,6 @@ from urllib import quote_plus
 from django.core.cache import cache
 from django.utils.safestring import SafeText
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats.templatetags.jinja_helpers import (
     bugzilla_submit_url,
     digitgroupseparator,
@@ -19,8 +18,7 @@ from crashstats.crashstats.templatetags.jinja_helpers import (
 )
 
 
-class TestTimestampToDate(TestCase):
-
+class TestTimestampToDate(object):
     def test_timestamp_to_date(self):
         timestamp = time.time()
         date = datetime.datetime.fromtimestamp(timestamp)
@@ -36,8 +34,7 @@ class TestTimestampToDate(TestCase):
         assert output == ''
 
 
-class TestTimeTag(TestCase):
-
+class TestTimeTag(object):
     def test_time_tag_with_datetime(self):
         date = datetime.datetime(2000, 1, 2, 3, 4, 5)
         output = time_tag(date)
@@ -84,8 +81,7 @@ class TestTimeTag(TestCase):
         assert output == expected
 
 
-class TestBugzillaLink(TestCase):
-
+class TestBugzillaLink(object):
     def test_show_bug_link_no_cache(self):
         output = show_bug_link(123)
         assert 'data-id="123"' in output
@@ -109,8 +105,7 @@ class TestBugzillaLink(TestCase):
         assert 'data-summary="&lt;script&gt;xss()&lt;/script&gt;"' in output
 
 
-class TestBugzillaSubmitURL(TestCase):
-
+class TestBugzillaSubmitURL(object):
     EMPTY_PARSED_DUMP = {}
     CRASHING_THREAD = 0
 
@@ -397,7 +392,7 @@ class TestBugzillaSubmitURL(TestCase):
         assert quote_plus('frames of crashing thread:') not in url
 
 
-class TestReplaceBugzillaLinks(TestCase):
+class TestReplaceBugzillaLinks(object):
     def test_simple(self):
         text = 'foo https://bugzilla.mozilla.org/show_bug.cgi?id=1129515 bar'
         res = replace_bugzilla_links(text)
@@ -446,8 +441,7 @@ class TestReplaceBugzillaLinks(TestCase):
         assert '</a>' in res
 
 
-class TesDigitGroupSeparator(TestCase):
-
+class TesDigitGroupSeparator(object):
     def test_basics(self):
         assert digitgroupseparator(None) is None
         assert digitgroupseparator(1000) == '1,000'
@@ -455,8 +449,7 @@ class TesDigitGroupSeparator(TestCase):
         assert digitgroupseparator(1000000) == '1,000,000'
 
 
-class TestHumanizers(TestCase):
-
+class TestHumanizers(object):
     def test_show_duration(self):
         html = show_duration(59)
         assert isinstance(html, SafeText)

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -1,28 +1,18 @@
-from django.test.client import RequestFactory
-
-from crashstats.base.tests.testbase import DjangoTestCase
 from crashstats.crashstats.middleware import SetRemoteAddrFromRealIP
 
 
-class TestSetRemoteAddrFromRealIP(DjangoTestCase):
-
-    def test_no_headers(self):
+class TestSetRemoteAddrFromRealIP(object):
+    def test_no_headers(self, rf):
         """Should not break if there is no HTTP_X_REAL_IP"""
         middleware = SetRemoteAddrFromRealIP()
-        request = RequestFactory().get('/')
+        request = rf.get('/')
         response = middleware.process_request(request)
         assert response is None
 
-    def test_real_ip(self):
-        """Ihe IP in HTTP_X_REAL_IP should update
-        request.META['REMOTE_ADDR'].
-
-        """
+    def test_real_ip(self, rf):
+        """Ihe IP in HTTP_X_REAL_IP should update request.META['REMOTE_ADDR']"""
         middleware = SetRemoteAddrFromRealIP()
-        request = RequestFactory(**{
-            'HTTP_X_REAL_IP': '100.100.100.100',
-            'REMOTE_ADDR': '123.123.123.123',
-        }).get('/')
+        request = rf.get('/', HTTP_X_REAL_IP='100.100.100.100', REMOTE_ADDR='123.123.123.123')
         response = middleware.process_request(request)
         assert response is None
         assert request.META['REMOTE_ADDR'] == '100.100.100.100'

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -6,7 +6,6 @@ import json
 from six import text_type, binary_type
 
 from django.http import HttpResponse
-from django.test.client import RequestFactory
 
 from crashstats.crashstats import utils
 
@@ -337,8 +336,8 @@ def test_unicode_writer():
     assert '1.23' in u_result
 
 
-def test_json_view_basic():
-    request = RequestFactory().get('/')
+def test_json_view_basic(rf):
+    request = rf.get('/')
 
     def func(request):
         return {'one': 'One'}
@@ -350,8 +349,8 @@ def test_json_view_basic():
     assert response.status_code == 200
 
 
-def test_json_view_indented():
-    request = RequestFactory().get('/?pretty=print')
+def test_json_view_indented(rf):
+    request = rf.get('/?pretty=print')
 
     def func(request):
         return {'one': 'One'}
@@ -363,8 +362,8 @@ def test_json_view_indented():
     assert response.status_code == 200
 
 
-def test_json_view_already_httpresponse():
-    request = RequestFactory().get('/')
+def test_json_view_already_httpresponse(rf):
+    request = rf.get('/')
 
     def func(request):
         return HttpResponse('something')
@@ -376,8 +375,8 @@ def test_json_view_already_httpresponse():
     assert response.status_code == 200
 
 
-def test_json_view_custom_status():
-    request = RequestFactory().get('/')
+def test_json_view_custom_status(rf):
+    request = rf.get('/')
 
     def func(request):
         return {'one': 'One'}, 403

--- a/webapp-django/crashstats/documentation/tests/test_views.py
+++ b/webapp-django/crashstats/documentation/tests/test_views.py
@@ -4,7 +4,6 @@ from crashstats.crashstats.tests.test_views import BaseTestViews
 
 
 class TestViews(BaseTestViews):
-
     def test_supersearch_home(self):
         url = reverse('documentation:supersearch_home')
         response = self.client.get(url)

--- a/webapp-django/crashstats/graphics/tests/test_views.py
+++ b/webapp-django/crashstats/graphics/tests/test_views.py
@@ -3,8 +3,8 @@ from cStringIO import StringIO
 import datetime
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.contrib.auth.models import Group
+from django.core.urlresolvers import reverse
 
 from crashstats.crashstats.tests.test_views import BaseTestViews
 from crashstats.graphics.views import GRAPHICS_REPORT_HEADER
@@ -41,9 +41,7 @@ class TestViews(BaseTestViews):
                 'total': 2
             }
 
-        SuperSearch.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('graphics:report')
 

--- a/webapp-django/crashstats/manage/tests/test_utils.py
+++ b/webapp-django/crashstats/manage/tests/test_utils.py
@@ -1,5 +1,4 @@
 import os
-from unittest import TestCase
 
 from crashstats.manage import utils
 
@@ -10,8 +9,7 @@ SAMPLE_CSV_FILE_PCI_IDS = os.path.join(
 )
 
 
-class TestUtils(TestCase):
-
+class TestUtils(object):
     def test_string_hex_to_hex_string(self):
         func = utils.string_hex_to_hex_string
         assert func('919A') == '0x919a'

--- a/webapp-django/crashstats/monitoring/tests/test_views.py
+++ b/webapp-django/crashstats/monitoring/tests/test_views.py
@@ -15,7 +15,6 @@ from crashstats.supersearch.models import SuperSearch
 
 
 class TestViews(BaseTestViews):
-
     def test_index(self):
         url = reverse('monitoring:index')
         response = self.client.get(url)
@@ -116,7 +115,7 @@ class TestHealthcheckViews(BaseTestViews):
         assert json.loads(response.content)['ok'] is True
 
         # This time, ignoring the results, make sure that running
-        # this does not cause an DB queries.
+        # this does not cause any DB queries.
         self.assertNumQueries(
             0,
             self.client.get,
@@ -143,9 +142,7 @@ class TestHealthcheckViews(BaseTestViews):
                 'errors': [],
             }
 
-        SuperSearch.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
 
         def mocked_requests_get(url, **params):
             return Response(True)
@@ -176,9 +173,7 @@ class TestHealthcheckViews(BaseTestViews):
                 'errors': ['bad'],
             }
 
-        SuperSearch.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
         with pytest.raises(AssertionError):
             assert_supersearch_no_errors()
 

--- a/webapp-django/crashstats/profile/tests/test_views.py
+++ b/webapp-django/crashstats/profile/tests/test_views.py
@@ -8,9 +8,7 @@ from crashstats.supersearch.models import SuperSearchUnredacted
 
 
 class TestViews(BaseTestViews):
-
     def test_profile(self):
-
         def mocked_supersearch_get(**params):
             assert '_columns' in params
             assert '_sort' in params
@@ -41,19 +39,14 @@ class TestViews(BaseTestViews):
                 'total': 0
             }
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('profile:profile')
 
         # Test that the user must be signed in.
-        response = self.client.get(url)
+        response = self.client.get(url, follow=False)
         assert response.status_code == 302
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
-        )
+        assert response.url == reverse('crashstats:login') + '?next=%s' % url
 
         # Now log in for the remaining tests.
         user = self._login()
@@ -65,9 +58,7 @@ class TestViews(BaseTestViews):
         assert '1234abcd-ef56-7890-ab12-abcdef130802' in response.content
         assert 'test@example.com' in response.content
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get_no_data
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get_no_data
 
         # Test with no results.
         response = self.client.get(url)
@@ -103,12 +94,9 @@ class TestViews(BaseTestViews):
         # If the user ceases to be active, this page should redirect instead
         user.is_active = False
         user.save()
-        response = self.client.get(url)
+        response = self.client.get(url, follow=False)
         assert response.status_code == 302
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
-        )
+        assert response.url == reverse('crashstats:login') + '?next=%s' % url
 
     def test_homepage_profile_footer(self):
         """This test isn't specifically for the profile page, because

--- a/webapp-django/crashstats/supersearch/tests/test_form_fields.py
+++ b/webapp-django/crashstats/supersearch/tests/test_form_fields.py
@@ -7,12 +7,10 @@ import pytest
 from django.utils.timezone import utc
 from django.forms import ValidationError
 
-from crashstats.base.tests.testbase import TestCase
 from crashstats.supersearch import form_fields
 
 
-class TestFormFields(TestCase):
-
+class TestFormFields(object):
     def test_integer_field(self):
         field = form_fields.IntegerField()
         cleaned_value = field.clean(['>13'])

--- a/webapp-django/crashstats/supersearch/tests/test_forms.py
+++ b/webapp-django/crashstats/supersearch/tests/test_forms.py
@@ -1,10 +1,9 @@
-from crashstats.base.tests.testbase import TestCase
 from crashstats.supersearch import forms
 from socorro.external.es.super_search_fields import FIELDS
 
 
-class TestForms(TestCase):
-    def setUp(self):
+class TestForms(object):
+    def setup_method(self):
         self.products = [
             {
                 'product_name': 'WaterWolf',

--- a/webapp-django/crashstats/supersearch/tests/test_utils.py
+++ b/webapp-django/crashstats/supersearch/tests/test_utils.py
@@ -2,11 +2,10 @@ import datetime
 
 from django.utils.timezone import utc
 
-from crashstats.crashstats.tests.test_views import BaseTestViews
 from crashstats.topcrashers.views import get_date_boundaries
 
 
-class TestDateBoundaries(BaseTestViews):
+class TestDateBoundaries(object):
     def test_get_date_boundaries(self):
         # Simple test.
         start, end = get_date_boundaries({

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -245,9 +245,7 @@ class TestViews(BaseTestViews):
             else:
                 return {"hits": [], "facets": [], "total": 0}
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
         response = self.client.get(
@@ -334,9 +332,7 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return {"hits": [], "facets": [], "total": 0}
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
         limit = int(re.findall('(\d+)', settings.RATELIMIT_SUPERSEARCH)[0])
@@ -358,9 +354,7 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             raise BadArgumentError('<script>xss')
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
         params = {'product': 'WaterWolf'}
@@ -454,9 +448,7 @@ class TestViews(BaseTestViews):
             )
             return results
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
 
@@ -543,9 +535,7 @@ class TestViews(BaseTestViews):
                 "total": 0
             }
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
 
@@ -587,9 +577,7 @@ class TestViews(BaseTestViews):
                 "total": len(hits)
             }
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_results')
 
@@ -632,9 +620,7 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return None
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_custom')
 
@@ -652,9 +638,7 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return None
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         self.create_custom_query_perm()
 
@@ -676,9 +660,7 @@ class TestViews(BaseTestViews):
                 "indices": ["socorro200000", "socorro200001"]
             }
 
-        SuperSearchUnredacted.implementation().get.side_effect = (
-            mocked_supersearch_get
-        )
+        SuperSearchUnredacted.implementation().get.side_effect = mocked_supersearch_get
 
         url = reverse('supersearch:search_custom')
         response = self.client.get(url, {'signature': 'nsA'})
@@ -696,9 +678,7 @@ class TestViews(BaseTestViews):
 
             return {"hits": []}
 
-        Query.implementation().get.side_effect = (
-            mocked_query_get
-        )
+        Query.implementation().get.side_effect = mocked_query_get
 
         url = reverse('supersearch:search_query')
         response = self.client.post(url, {'query': '{"query": {}}'})

--- a/webapp-django/crashstats/tokens/tests/test_views.py
+++ b/webapp-django/crashstats/tokens/tests/test_views.py
@@ -29,11 +29,8 @@ class TestViews(BaseTestViews):
 
     def test_home_page(self):
         url = reverse('tokens:home')
-        response = self.client.get(url)
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
-        )
+        response = self.client.get(url, follow=False)
+        assert response.url == reverse('crashstats:login') + '?next=%s' % url
 
         user = self._login()
         response = self.client.get(url)
@@ -41,11 +38,8 @@ class TestViews(BaseTestViews):
 
         user.is_active = False
         user.save()
-        response = self.client.get(url)
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
-        )
+        response = self.client.get(url, follow=False)
+        assert response.url == reverse('crashstats:login') + '?next=%s' % url
 
     def test_generate_new_token_form(self):
         url = reverse('tokens:home')
@@ -80,14 +74,12 @@ class TestViews(BaseTestViews):
         p2 = self._make_permission('Clean Things')
         p3 = self._make_permission('Play with sticks')
 
-        response = self.client.post(url, {
+        params = {
             'notes': ' Some notes ',
             'permissions': [p1.pk, p3.pk]
-        })
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
-        )
+        }
+        response = self.client.post(url, params, follow=False)
+        assert response.url == reverse('crashstats:login') + '?next=%s' % url
 
         # try again, but this time logged in
         user = self._login()


### PR DESCRIPTION
This converts some classes to subclass object rather than a TestCase thing.
For those tests, I switched to using fixtures where I could.

This removes all the `self.assert*` type calls except one that checks num
queries. There's a pytest-django fixture that does the same thing, but we'd
have to convert the class first. Tricky.

This removes all the `unittest.TestCase` subclassing. There are still a bunch
that subclass Django's TestCase. That'll require more work to remove since we
have a bunch of scaffolding that is intertwined with that.