### PR TITLE
fix bug 1504281, 1492213: BetaVersionRule should degrade gracefully; add metrics

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -700,7 +700,6 @@ class BetaVersionRule(Rule):
 
         :returns: ``None`` or the version string that should be used
 
-
         """
         if not (product and build_id and version):
             return None

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -108,6 +108,14 @@ class Processor2015(RequiredConfig):
 
     required_config = Namespace('transform_rules')
     required_config.add_option(
+        'database_class',
+        doc="the class of the database",
+        default='socorro.external.postgresql.connection_context.'
+                'ConnectionContext',
+        from_string_converter=str_to_python_object,
+        reference_value_from='resource.postgresql',
+    )
+    required_config.add_option(
         'transaction_executor_class',
         default='socorro.lib.transaction.TransactionExecutorWithInfiniteBackoff',
         doc='a class that will manage transactions',

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -110,8 +110,7 @@ class Processor2015(RequiredConfig):
     required_config.add_option(
         'database_class',
         doc="the class of the database",
-        default='socorro.external.postgresql.connection_context.'
-                'ConnectionContext',
+        default='socorro.external.postgresql.connection_context.ConnectionContext',
         from_string_converter=str_to_python_object,
         reference_value_from='resource.postgresql',
     )

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1469,7 +1469,6 @@ class TestBetaVersionRule:
     def test_beta_channel_unknown_version(self):
         """Beta crash that Buildhub doesn't know about gets b0"""
         config = self.get_config()
-
         raw_crash = {}
         raw_dumps = {}
 
@@ -1510,7 +1509,6 @@ class TestBetaVersionRule:
     def test_beta_channel_version_in_db(self):
         """Beta crash that Buildhub doesn't know, but db does gets db version"""
         config = self.get_config()
-
         raw_crash = {}
         raw_dumps = {}
 
@@ -1543,7 +1541,7 @@ class TestBetaVersionRule:
             # tuples
             rule.transaction = lambda *args, **kwargs: [('3.0.1b2',)]
 
-            rule._action(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '3.0.1b2'
 
     def test_beta_channel_non_buildhub_product(self):
@@ -1664,7 +1662,7 @@ class TestBetaVersionRule:
             processor_meta = get_basic_processor_meta()
 
             rule = BetaVersionRule(config)
-            rule._action(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '63.0rc2'
             assert processor_meta.processor_notes == []
 

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1349,11 +1349,16 @@ class TestTopMostFilesRule(TestCase):
 class TestBetaVersionRule:
     API_URL = 'http://buildhub.example.com/v1/buckets/build-hub/collections/releases/records'
 
-    def test_beta_channel_known_version(self):
-        # Beta channel with known version gets converted correctly
+    def get_config(self):
         config = get_basic_config()
         config.buildhub_api = self.API_URL
+        config.database_class = Mock()
+        config.transaction_executor_class = Mock()
+        return config
 
+    def test_beta_channel_known_version(self):
+        # Beta channel with known version gets converted correctly
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1397,9 +1402,7 @@ class TestBetaVersionRule:
 
     def test_release_channel(self):
         """Release channel doesn't trigger rule"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1420,9 +1423,7 @@ class TestBetaVersionRule:
 
     def test_nightly_channel(self):
         """Nightly channel doesn't trigger rule"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1443,9 +1444,7 @@ class TestBetaVersionRule:
 
     def test_bad_buildid(self):
         """Invalid buildids don't cause errors"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1469,13 +1468,13 @@ class TestBetaVersionRule:
 
     def test_beta_channel_unknown_version(self):
         """Beta crash that Buildhub doesn't know about gets b0"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
+        config = self.get_config()
 
         raw_crash = {}
         raw_dumps = {}
 
         with requests_mock.Mocker() as req_mock:
+            # Buildhub has no data for that (product, build_id, channel)
             req_mock.get(
                 self.API_URL + '?' + urlencode({
                     'source.product': 'firefox',
@@ -1497,18 +1496,59 @@ class TestBetaVersionRule:
             processor_meta = get_basic_processor_meta()
 
             rule = BetaVersionRule(config)
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+
+            # The db has no data for that (product, build_id, version)
+            rule.transaction = lambda *args, **kwargs: []
+
+            rule._action(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '3.0.1b0'
             assert processor_meta.processor_notes == [
                 'release channel is beta but no version data was found - '
                 'added "b0" suffix to version number'
             ]
 
+    def test_beta_channel_version_in_db(self):
+        """Beta crash that Buildhub doesn't know, but db does gets db version"""
+        config = self.get_config()
+
+        raw_crash = {}
+        raw_dumps = {}
+
+        with requests_mock.Mocker() as req_mock:
+            # Buildhub has no data for that (product, build_id, channel)
+            req_mock.get(
+                self.API_URL + '?' + urlencode({
+                    'source.product': 'firefox',
+                    'build.id': '"220000101101011"',
+                    'target.channel': 'beta',
+                }),
+                json={
+                    'data': []
+                }
+            )
+
+            processed_crash = {
+                'product': 'Firefox',
+                'version': '3.0.1',
+                'release_channel': 'beta',
+                'build': '220000101101011',
+            }
+
+            processor_meta = get_basic_processor_meta()
+
+            rule = BetaVersionRule(config)
+
+            # The db has one record for (product, build_id, version) which is
+            # returned by the execute_sql_fetchall transaction as a list of
+            # tuples
+            rule.transaction = lambda *args, **kwargs: [('3.0.1b2',)]
+
+            rule._action(raw_crash, raw_dumps, processed_crash, processor_meta)
+            assert processed_crash['version'] == '3.0.1b2'
+
     def test_beta_channel_non_buildhub_product(self):
         """Beta crash with a product not on Buildhub gets b0"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1532,9 +1572,7 @@ class TestBetaVersionRule:
 
     def test_aurora_channel(self):
         """Test aurora channel lookup"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1578,9 +1616,7 @@ class TestBetaVersionRule:
 
     def test_rc(self):
         """Test rc which are marked beta channel, but the data is in release channel"""
-        config = get_basic_config()
-        config.buildhub_api = self.API_URL
-
+        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
 
@@ -1628,7 +1664,7 @@ class TestBetaVersionRule:
             processor_meta = get_basic_processor_meta()
 
             rule = BetaVersionRule(config)
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule._action(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash['version'] == '63.0rc2'
             assert processor_meta.processor_notes == []
 

--- a/socorro/unittest/processor/test_processor_2015.py
+++ b/socorro/unittest/processor/test_processor_2015.py
@@ -13,25 +13,22 @@ from socorro.unittest.testbase import TestCase
 
 
 class TestProcessor2015(TestCase):
+    def get_config(self):
+        cm = ConfigurationManager(
+            definition_source=Processor2015.get_required_config(),
+            values_source_list=[],
+        )
+        config = cm.get_config()
+        config.logger = Mock()
+        config.database_class = Mock()
+        config.transaction_executor_class = Mock()
+        return config
 
     def test_Processor2015_init(self):
-        cm = ConfigurationManager(
-            definition_source=Processor2015.get_required_config(),
-            values_source_list=[],
-        )
-        config = cm.get_config()
-        config.logger = Mock()
-
-        Processor2015(config)
+        Processor2015(self.get_config())
 
     def test_process_crash_existing_processed_crash(self):
-        cm = ConfigurationManager(
-            definition_source=Processor2015.get_required_config(),
-            values_source_list=[],
-        )
-        config = cm.get_config()
-        config.logger = Mock()
-
+        config = self.get_config()
         config.processor_name = 'dwight'
 
         p = Processor2015(config, rules=[
@@ -114,14 +111,7 @@ class TestProcessor2015(TestCase):
             },
         })
 
-        cm = ConfigurationManager(
-            definition_source=(
-                Processor2015.get_required_config(),
-            ),
-            values_source_list=[]
-        )
-        config = cm.get_config()
-        config.logger = Mock()
+        config = self.get_config()
         config.processor_name = 'dwight'
 
         mocked_subprocess_handle = (


### PR DESCRIPTION
This re-adds the `product_versions` lookup code for the case where Buildhub
doesn't know anything about that `(product, build_id, channel)`. This
is a temporary fix to deal with latency in Buildhub knowing about new
builds.