### PR TITLE
fix bug 1505030: switch BetaVersionRule to use Buildhub ES API

### DIFF
--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -123,8 +123,8 @@ class Processor2015(RequiredConfig):
     )
     required_config.add_option(
         'buildhub_api',
-        doc='url for the Buildhub API to query records',
-        default='https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/records'
+        doc='url for the Buildhub Elasticsearch API to query records',
+        default='https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/search'
     )
     required_config.add_option(
         'dump_field',


### PR DESCRIPTION
Buildhub has a Kinto API and an Elasticsearch API. This switches the
BetaVersionRule to use the Elasticsearch API which is MUCH faster
and will work with Buildhub2.