### PR TITLE
fix bug 1505592: fix socorro/unittest/app tests in Python 3

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -12,7 +12,7 @@
 # have tests in a directory/file working, add it to this list as a new line.
 WORKING_TESTS=(
     socorro/signature/tests/test_*.py
-    # socorro/unittest/app/test_*.py
+    socorro/unittest/app/test_*.py
     # socorro/unittest/cron/test_*.py
     # socorro/unittest/cron/jobs/test_*.py
     socorro/unittest/external/test_*.py

--- a/socorro/unittest/app/test_generic_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_generic_fetch_transform_save_app.py
@@ -58,7 +58,7 @@ class TestFetchTransformSaveApp(TestCase):
         fts_app = TestFTSAppClass(config)
         fts_app.main()
         assert len(fts_app.the_list) == 5
-        assert sorted(fts_app.the_list) == range(5)
+        assert sorted(fts_app.the_list) == [0, 1, 2, 3, 4]
 
     def test_bogus_source_and_destination(self):
         class NonInfiniteFTSAppClass(FetchTransformSaveApp):

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -4,7 +4,6 @@
 
 import logging
 import time
-from past.builtins import xrange
 
 from mock import Mock
 
@@ -93,7 +92,7 @@ class TestThreadedTaskManager(TestCase):
         ttm = ThreadedTaskManager(config,
                                   task_func=insert_into_list,
                                   job_source_iterator=(((x,), {}) for x in
-                                                       xrange(10))
+                                                       range(10))
                                   )
         try:
             ttm.start()
@@ -108,7 +107,7 @@ class TestThreadedTaskManager(TestCase):
 
     def test_doing_work_with_two_workers_and_config_setup(self):
         def new_iter():
-            for x in xrange(5):
+            for x in range(5):
                 yield ((x,), {})
 
         my_list = []
@@ -143,7 +142,7 @@ class TestThreadedTaskManager(TestCase):
         count = 0
 
         def new_iter():
-            for x in xrange(10):
+            for x in range(10):
                 yield (x,)
 
         my_list = []


### PR DESCRIPTION
This gets the socorro/unittest/app/ tests passing. It also removes use of
xrange--we don't need that in these cases.