### PR TITLE
fix bug 1505797: remove socorro's DotDict

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -463,11 +463,8 @@ class ESCrashStorageRedactedSave(ESCrashStorage):
         # This crash storage mutates the crash, so we mark it as such.
         return True
 
-    def save_raw_and_processed(self, raw_crash, dumps, processed_crash,
-                               crash_id):
-        """This is the only write mechanism that is actually employed in normal
-        usage.
-        """
+    def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
+        """This is the only write mechanism that is actually employed in normal usage"""
         self.redactor.redact(processed_crash)
         self.raw_crash_redactor.redact(raw_crash)
 
@@ -514,11 +511,8 @@ class ESCrashStorageRedactedJsonDump(ESCrashStorageRedactedSave):
         )
     )
 
-    def save_raw_and_processed(self, raw_crash, dumps, processed_crash,
-                               crash_id):
-        """This is the only write mechanism that is actually employed in normal
-        usage.
-        """
+    def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
+        """This is the only write mechanism that is actually employed in normal usage"""
         # Replace the `json_dump` with a subset.
         json_dump = processed_crash.get('json_dump', {})
         redacted_json_dump = {
@@ -570,7 +564,6 @@ class QueueContextSource(object):
 
 
 def _create_bulk_load_crashstore(base_class):
-
     class ESBulkClassTemplate(base_class):
         required_config = Namespace()
         required_config.add_option(
@@ -674,9 +667,7 @@ def _create_bulk_load_crashstore(base_class):
 ESBulkCrashStorage = _create_bulk_load_crashstore(ESCrashStorage)
 
 
-ESBulkCrashStorageRedactedSave = _create_bulk_load_crashstore(
-    ESCrashStorageRedactedSave
-)
+ESBulkCrashStorageRedactedSave = _create_bulk_load_crashstore(ESCrashStorageRedactedSave)
 
 
 ESCrashStorageNoStackwalkerOutput = ESCrashStorageRedactedSave

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -8,6 +8,7 @@ import json
 import os
 
 from configman import Namespace
+from configman.dotdict import DotDict
 from six import BytesIO
 
 from socorro.external.crashstorage_base import (
@@ -18,7 +19,6 @@ from socorro.external.crashstorage_base import (
 )
 from socorro.lib.datetimeutil import utc_now, JsonDTISOEncoder
 from socorro.lib.ooid import dateFromOoid, depthFromOoid
-from socorro.lib.util import DotDict
 
 
 @contextmanager

--- a/socorro/lib/external_common.py
+++ b/socorro/lib/external_common.py
@@ -10,8 +10,9 @@ import json
 import datetime
 from past.builtins import basestring
 
+from configman.dotdict import DotDict
+
 from socorro.lib import BadArgumentError
-from socorro.lib.util import DotDict
 import socorro.lib.datetimeutil as dtutil
 
 

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -9,10 +9,9 @@ from collections import Mapping
 
 from configman import Namespace
 from configman.converters import str_to_list
-from configman.dotdict import DotDict as ConfigmanDotDict
+from configman.dotdict import DotDict as DotDict
 
 from socorro.lib.converters import change_default
-from socorro.lib.util import DotDict
 from socorro.processor.rules.base import Rule
 
 
@@ -136,7 +135,7 @@ class ExternalProcessRule(Rule):
 
     @staticmethod
     def dot_save(a_mapping, key, value):
-        if '.' not in key or isinstance(a_mapping, ConfigmanDotDict):
+        if '.' not in key or isinstance(a_mapping, DotDict):
             a_mapping[key] = value
             return
         current_mapping = a_mapping

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -15,13 +15,11 @@ from configman import (
     RequiredConfig,
 )
 from configman.converters import str_to_list, str_to_python_object
+from configman.dotdict import DotDict
 
 from socorro.lib import raven_client
 from socorro.lib.converters import change_default
 from socorro.lib.datetimeutil import utc_now
-from socorro.lib.util import DotDict
-
-
 from socorro.processor.breakpad_transform_rules import (
     BreakpadStackwalkerRule2015,
     CrashingThreadRule,

--- a/socorro/unittest/app/test_generic_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_generic_fetch_transform_save_app.py
@@ -4,14 +4,13 @@
 
 import logging
 
+from configman.dotdict import DotDict
 from mock import Mock
-
 import pytest
 
 from socorro.app.fetch_transform_save_app import FetchTransformSaveApp
 from socorro.lib.threaded_task_manager import ThreadedTaskManager
 from socorro.lib.task_manager import TaskManager
-from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -6,6 +6,7 @@ import datetime
 from functools import wraps
 import unittest
 
+from configman.dotdict import DotDict
 import mock
 import requests
 import requests_mock
@@ -14,7 +15,6 @@ import pytest
 from socorro.cron.crontabber_app import CronTabberApp
 from socorro.cron.jobs import ftpscraper
 from socorro.lib.datetimeutil import utc_now
-from socorro.lib.util import DotDict
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.unittest.cron.setup_configman import get_config_manager_for_crontabber
 

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -5,6 +5,7 @@
 import json
 from os.path import join
 
+from configman.dotdict import DotDict
 from moto import mock_s3_deprecated
 import pytest
 
@@ -17,7 +18,7 @@ from socorro.external.crashstorage_base import (
     CrashIDNotFound,
     MemoryDumpsMapping,
 )
-from socorro.lib.util import DotDict
+from socorro.lib.util import dotdict_to_dict
 from socorro.unittest.external.boto import get_config
 
 
@@ -114,7 +115,7 @@ class TestBotoS3CrashStorage:
 
     def _fake_unredacted_processed_crash_as_string(self):
         d = self._fake_unredacted_processed_crash()
-        s = json.dumps(d)
+        s = json.dumps(dotdict_to_dict(d))
         return s
 
     @mock_s3_deprecated

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from configman.dotdict import DotDict
 import pytest
 
 from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.external.postgresql.connection_context import ConnectionContext
 from socorro.lib import DatabaseError
-from socorro.lib import util
 from socorro.unittest.testbase import TestCase
 from socorro.unittest.external.postgresql.unittestbase import PostgreSQLTestCase
 
@@ -17,7 +17,7 @@ class TestPostgreSQLBase(TestCase):
 
     def get_dummy_context(self):
         """Create a dummy config object to use when testing."""
-        context = util.DotDict({
+        context = DotDict({
             'database_class': ConnectionContext,
             'database_hostname': 'somewhere',
             'database_port': '8888',

--- a/socorro/unittest/external/rabbitmq/test_connection_context.py
+++ b/socorro/unittest/external/rabbitmq/test_connection_context.py
@@ -4,6 +4,7 @@
 
 from threading import currentThread
 
+from configman.dotdict import DotDict
 from mock import Mock, call, patch
 import pytest
 
@@ -12,7 +13,6 @@ from socorro.external.rabbitmq.connection_context import (
     ConnectionContext,
     ConnectionContextPooled
 )
-from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/external/rabbitmq/test_crashstorage.py
+++ b/socorro/unittest/external/rabbitmq/test_crashstorage.py
@@ -1,18 +1,13 @@
+from configman.dotdict import DotDict
 from mock import Mock, MagicMock, patch
 
-from socorro.external.rabbitmq.crashstorage import (
-    RabbitMQCrashStorage,
-)
-from socorro.lib.util import DotDict
-from socorro.lib.transaction import (
-    TransactionExecutor
-)
+from socorro.external.rabbitmq.crashstorage import RabbitMQCrashStorage
+from socorro.lib.transaction import TransactionExecutor
 from socorro.external.crashstorage_base import Redactor
 from socorro.unittest.testbase import TestCase
 
 
 class TestCrashStorage(TestCase):
-
     def _setup_config(self):
         config = DotDict()
         config.transaction_executor_class = Mock()

--- a/socorro/unittest/external/rabbitmq/test_reprocessing.py
+++ b/socorro/unittest/external/rabbitmq/test_reprocessing.py
@@ -5,18 +5,13 @@
 from configman.dotdict import DotDict
 from mock import Mock, MagicMock
 
-from socorro.external.crashstorage_base import (
-    Redactor,
-)
-from socorro.external.rabbitmq.crashstorage import (
-    ReprocessingOneRabbitMQCrashStore,
-)
+from socorro.external.crashstorage_base import Redactor
+from socorro.external.rabbitmq.crashstorage import ReprocessingOneRabbitMQCrashStore
 from socorro.external.rabbitmq.connection_context import ConnectionContext
 from socorro.unittest.testbase import TestCase
 
 
 class TestReprocessing(TestCase):
-
     def setUp(self):
         super(TestReprocessing, self).setUp()
 

--- a/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
+++ b/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from configman.dotdict import DotDict
+
 from socorro.external.rabbitmq.rmq_new_crash_source import (
     RMQNewCrashSource
 )
-from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 
 class FakeCrashStore(object):
-
     def __init__(self, config, quit_check):
         self.config = config
         self.quit_check = quit_check

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import copy
-
 from configman import Namespace, ConfigurationManager
 from configman.dotdict import DotDict
 import mock
@@ -17,11 +15,9 @@ from socorro.external.crashstorage_base import (
     BenchmarkingCrashStorage,
     MemoryDumpsMapping,
     FileDumpsMapping,
-    socorrodotdict_to_dict,
     MetricsCounter,
     MetricsBenchmarkingWrapper,
 )
-from socorro.lib.util import DotDict as SocorroDotDict
 from socorro.unittest.testbase import TestCase
 
 
@@ -65,76 +61,6 @@ class MutatingProcessedCrashCrashStorage(CrashStorageBase):
 
 def fake_quit_check():
     return False
-
-
-class Testsocorrodotdict_to_dict(TestCase):
-    def test_primitives(self):
-        # Test all the primitives
-        assert socorrodotdict_to_dict(None) is None
-        assert socorrodotdict_to_dict([]) == []
-        assert socorrodotdict_to_dict('') == ''
-        assert socorrodotdict_to_dict(1) == 1
-        assert socorrodotdict_to_dict({}) == {}
-
-    def test_complex(self):
-        def comp(data, expected):
-            # First socorrodotdict_to_dict the data and compare it.
-            new_dict = socorrodotdict_to_dict(data)
-            assert new_dict == expected
-
-            # Now deepcopy the new dict to make sure it's ok.
-            copy.deepcopy(new_dict)
-
-        # dict -> dict
-        comp({'a': 1}, {'a': 1})
-
-        # outer socorrodotdict -> dict
-        comp(SocorroDotDict({'a': 1}), {'a': 1})
-
-        # nested socorrodotdict -> dict
-        comp(
-            SocorroDotDict({
-                'a': 1,
-                'b': SocorroDotDict({
-                    'a': 2
-                })
-            }),
-            {'a': 1, 'b': {'a': 2}}
-        )
-        # inner socorrodotdict
-        comp(
-            {
-                'a': 1,
-                'b': SocorroDotDict({
-                    'a': 2
-                })
-            },
-            {'a': 1, 'b': {'a': 2}}
-        )
-        # in a list
-        comp(
-            {
-                'a': 1,
-                'b': [
-                    SocorroDotDict({
-                        'a': 2
-                    }),
-                    3,
-                    4
-                ]
-            },
-            {'a': 1, 'b': [{'a': 2}, 3, 4]}
-        )
-        # mixed dotdicts
-        comp(
-            DotDict({
-                'a': 1,
-                'b': SocorroDotDict({
-                    'a': 2
-                })
-            }),
-            {'a': 1, 'b': {'a': 2}}
-        )
 
 
 class TestBase(TestCase):
@@ -437,7 +363,7 @@ class TestBase(TestCase):
             dump = '12345'
             processed_crash = {
                 'foo': DotDict({'other': 'thing'}),
-                'bar': SocorroDotDict({'something': 'else'}),
+                'bar': DotDict({'something': 'else'}),
             }
 
             poly_store = config.storage(config)

--- a/socorro/unittest/lib/test_external_common.py
+++ b/socorro/unittest/lib/test_external_common.py
@@ -4,10 +4,11 @@
 
 import datetime
 
+from configman.dotdict import DotDict
 import isodate
 import pytest
 
-from socorro.lib import BadArgumentError, external_common, util
+from socorro.lib import BadArgumentError, external_common
 from socorro.unittest.testbase import TestCase
 
 
@@ -102,7 +103,7 @@ class TestExternalCommon(TestCase):
             "param1": "value1",
             "unknown": 12345
         }
-        params_exp = util.DotDict()
+        params_exp = DotDict()
         params_exp.param1 = ["value1"]
         params_exp.param2 = None
         params_exp.param3 = ["list", "of", "4", "values"]
@@ -136,7 +137,7 @@ class TestExternalCommon(TestCase):
             "param8": datetime.datetime(2016, 2, 9).isoformat(),
             # note the 'param9' is deliberately not specified.
         }
-        params_exp = util.DotDict()
+        params_exp = DotDict()
         params_exp.param1 = ["value1"]
         params_exp.param2 = None
         params_exp.param3 = ['some', 'default', 'list']
@@ -178,7 +179,7 @@ class TestExternalCommon(TestCase):
         arguments = {
             "param1": "one",
         }
-        params_exp = util.DotDict()
+        params_exp = DotDict()
         params_exp.param1 = 1
 
         params = external_common.parse_arguments(

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -4,10 +4,10 @@
 
 import logging
 
+from configman.dotdict import DotDict
 from mock import Mock
 
 from socorro.lib.task_manager import TaskManager, default_task_func
-from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -5,6 +5,7 @@
 import logging
 import time
 
+from configman.dotdict import DotDict
 from mock import Mock
 
 from socorro.lib.threaded_task_manager import (
@@ -12,7 +13,6 @@ from socorro.lib.threaded_task_manager import (
     ThreadedTaskManagerWithConfigSetup,
     default_task_func,
 )
-from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/lib/test_util.py
+++ b/socorro/unittest/lib/test_util.py
@@ -2,7 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorro.lib.util import chunkify
+import copy
+
+from configman.dotdict import DotDict
+
+from socorro.lib.util import chunkify, dotdict_to_dict
 
 
 def test_chunkify():
@@ -17,3 +21,53 @@ def test_chunkify():
 
     # chunking list where len(list) > n
     assert list(chunkify([1, 2, 3, 4, 5], 2)) == [(1, 2), (3, 4), (5,)]
+
+
+class Testdotdict_to_dict(object):
+    def test_primitives(self):
+        # Test all the primitives
+        assert dotdict_to_dict(None) is None
+        assert dotdict_to_dict([]) == []
+        assert dotdict_to_dict('') == ''
+        assert dotdict_to_dict(1) == 1
+        assert dotdict_to_dict({}) == {}
+
+    def test_complex(self):
+        def comp(data, expected):
+            # First dotdict_to_dict the data and compare it.
+            new_dict = dotdict_to_dict(data)
+            assert new_dict == expected
+
+            # Now deepcopy the new dict to make sure it's ok.
+            copy.deepcopy(new_dict)
+
+        # dict -> dict
+        comp({'a': 1}, {'a': 1})
+
+        # outer dotdict -> dict
+        comp(DotDict({'a': 1}), {'a': 1})
+
+        # in a list
+        comp(
+            {
+                'a': 1,
+                'b': [
+                    DotDict({
+                        'a': 2
+                    }),
+                    3,
+                    4
+                ]
+            },
+            {'a': 1, 'b': [{'a': 2}, 3, 4]}
+        )
+        # mixed dotdicts
+        comp(
+            DotDict({
+                'a': 1,
+                'b': DotDict({
+                    'a': 2
+                })
+            }),
+            {'a': 1, 'b': {'a': 2}}
+        )

--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -1,9 +1,8 @@
 import logging
 
-from configman.dotdict import DotDict as CDotDict
+from configman.dotdict import DotDict as DotDict
 from mock import Mock
 
-from socorro.lib.util import DotDict
 from socorro.signature.rules import CSignatureTool
 
 
@@ -27,7 +26,7 @@ def create_basic_fake_processor():
 
 
 def get_basic_config():
-    config = CDotDict()
+    config = DotDict()
     config.logger = Mock()
     return config
 

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -6,10 +6,9 @@ from contextlib import contextmanager
 import copy
 import ujson
 
-from configman.dotdict import DotDict as CDotDict
+from configman.dotdict import DotDict
 from mock import Mock, patch
 
-from socorro.lib.util import DotDict
 from socorro.processor.breakpad_transform_rules import (
     BreakpadStackwalkerRule2015,
     CrashingThreadRule,
@@ -299,7 +298,7 @@ class TestExternalProcessRule(TestCase):
         ExternalProcessRule.dot_save(d, 'a.b.c', 100)
         assert d['a']['b']['c'] == 100
 
-        dd = CDotDict()
+        dd = DotDict()
         ExternalProcessRule.dot_save(dd, 'a.b.c.d.e.f', 1000)
         assert dd.a.b.c.d.e.f == 1000
 
@@ -491,7 +490,7 @@ class TestBreakpadTransformRule2015(TestCase):
 class TestJitCrashCategorizeRule(TestCase):
 
     def get_basic_config(self):
-        config = CDotDict()
+        config = DotDict()
         config.logger = Mock()
         config.dump_field = 'upload_file_minidump'
         config.command_line = JitCrashCategorizeRule.required_config.command_line.default
@@ -506,7 +505,7 @@ class TestJitCrashCategorizeRule(TestCase):
         config = self.get_basic_config()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        processed_crash = CDotDict()
+        processed_crash = DotDict()
         processed_crash.product = 'Firefox'
         processed_crash.os_name = 'Windows 386'
         processed_crash.cpu_name = 'x86'
@@ -533,7 +532,7 @@ class TestJitCrashCategorizeRule(TestCase):
         config = self.get_basic_config()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        base_processed_crash = CDotDict()
+        base_processed_crash = DotDict()
         base_processed_crash.product = 'Firefox'
         base_processed_crash.os_name = 'Windows 386'
         base_processed_crash.cpu_name = 'x86'
@@ -558,7 +557,7 @@ class TestJitCrashCategorizeRule(TestCase):
             'Small | js::irregexp::ExecuteCode<T>',
         ]
         for signature in signatures:
-            processed_crash = CDotDict(base_processed_crash)
+            processed_crash = DotDict(base_processed_crash)
             processed_crash.signature = signature
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
@@ -571,7 +570,7 @@ class TestJitCrashCategorizeRule(TestCase):
         config = self.get_basic_config()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {config.dump_field: 'a_fake_dump.dump'}
-        processed_crash = CDotDict()
+        processed_crash = DotDict()
         processed_crash.product = 'Firefox'
         processed_crash.os_name = 'Windows 386'
         processed_crash.cpu_name = 'x86'

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -4,7 +4,8 @@
 
 import copy
 
-from socorro.lib.util import DotDict
+from configman.dotdict import DotDict
+
 from socorro.processor.general_transform_rules import (
     IdentifierRule,
     CPUInfoRule,

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -6,13 +6,13 @@ import copy
 import json
 from StringIO import StringIO
 
-from configman.dotdict import DotDict as CDotDict
+from configman.dotdict import DotDict
 from mock import call, Mock, patch
 import requests_mock
 
 from socorro.lib.datetimeutil import datetime_from_isodate_string
 from socorro.lib.revision_data import get_version
-from socorro.lib.util import DotDict
+from socorro.lib.util import dotdict_to_dict
 from socorro.processor.mozilla_transform_rules import (
     AddonsRule,
     BetaVersionRule,
@@ -160,7 +160,7 @@ class TestProductRule(TestCase):
         # does it even instantiate?
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -180,7 +180,7 @@ class TestProductRule(TestCase):
         # does it even instantiate?
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.Version
         del raw_crash.Distributor
         del raw_crash.Distributor_version
@@ -206,7 +206,7 @@ class TestUserDataRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -222,7 +222,7 @@ class TestUserDataRule(TestCase):
     def test_stuff_missing(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.URL
         del raw_crash.Comments
         del raw_crash.Email
@@ -243,7 +243,7 @@ class TestEnvironmentRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -256,7 +256,7 @@ class TestEnvironmentRule(TestCase):
     def test_stuff_missing(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.Notes
 
         raw_dumps = {}
@@ -273,7 +273,7 @@ class TestPluginRule(TestCase):
     def test_plugin_hang(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginHang = 1
         raw_crash.Hang = 0
         raw_crash.ProcessType = 'plugin'
@@ -297,7 +297,7 @@ class TestPluginRule(TestCase):
     def test_browser_hang(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.Hang = 1
         raw_crash.ProcessType = 'browser'
         raw_dumps = {}
@@ -319,7 +319,7 @@ class TestAddonsRule(TestCase):
     def test_action_nothing_unexpected(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -350,7 +350,7 @@ class TestAddonsRule(TestCase):
     def test_action_colon_in_addon_version(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'adblockpopups@jessehakanen.net:0:3:1'
         raw_crash['EMCheckCompatibility'] = 'Nope'
         raw_dumps = {}
@@ -369,7 +369,7 @@ class TestAddonsRule(TestCase):
     def test_action_addon_is_nonsense(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'naoenut813teq;mz;<[`19ntaotannn8999anxse `'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -387,7 +387,7 @@ class TestAddonsRule(TestCase):
 
 class TestDatesAndTimesRule(TestCase):
     def test_get_truncate_or_warn(self):
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         processor_notes = []
         ret = DatesAndTimesRule._get_truncate_or_warn(
             raw_crash,
@@ -436,7 +436,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -457,7 +457,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_bad_timestamp(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -480,7 +480,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_bad_timestamp_and_no_crash_time(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.CrashTime
         raw_dumps = {}
@@ -509,7 +509,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_no_startup_time_bad_timestamp(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.StartupTime
         raw_dumps = {}
@@ -537,7 +537,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_no_startup_time(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.StartupTime
         raw_dumps = {}
         processed_crash = DotDict()
@@ -560,7 +560,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_bad_startup_time(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.StartupTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -583,7 +583,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_bad_install_time(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.InstallTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -606,7 +606,7 @@ class TestDatesAndTimesRule(TestCase):
     def test_bad_seconds_since_last_crash(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.SecondsSinceLastCrash = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -735,7 +735,7 @@ class TestMozCrashReasonRule(TestCase):
 
 class TestOutOfMemoryBinaryRule(TestCase):
     def test_extract_memory_info(self):
-        config = CDotDict()
+        config = DotDict()
         config.logger = Mock()
 
         processor_meta = get_basic_processor_meta()
@@ -757,10 +757,10 @@ class TestOutOfMemoryBinaryRule(TestCase):
             assert memory == {'myserious': ['awesome', 'memory']}
 
     def test_extract_memory_info_too_big(self):
-        config = CDotDict()
+        config = DotDict()
         config.logger = Mock()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
@@ -804,11 +804,11 @@ class TestOutOfMemoryBinaryRule(TestCase):
             assert processed_crash.memory_report_error == expected_error_message
 
     def test_extract_memory_info_with_trouble(self):
-        config = CDotDict()
+        config = DotDict()
         config.max_size_uncompressed = 1024
         config.logger = Mock()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
@@ -832,11 +832,11 @@ class TestOutOfMemoryBinaryRule(TestCase):
             assert processed_crash.memory_report_error == 'error in gzip for a_pathname: IOError()'
 
     def test_extract_memory_info_with_json_trouble(self):
-        config = CDotDict()
+        config = DotDict()
         config.max_size_uncompressed = 1024
         config.logger = Mock()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
@@ -869,7 +869,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
         processed_crash = DotDict()
@@ -891,7 +891,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
     def test_this_is_not_the_crash_you_are_looking_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {}
         processed_crash = DotDict()
@@ -906,7 +906,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
 class TestProductRewriteRule(TestCase):
     def test_product_map_rewrite(self):
         config = get_basic_config()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['ProductName'] = 'Fennec'
         raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
         processed_crash = DotDict()
@@ -929,7 +929,7 @@ class TestESRVersionRewrite(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -946,7 +946,7 @@ class TestESRVersionRewrite(TestCase):
     def test_this_is_not_the_crash_you_are_looking_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'not_esr'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -963,7 +963,7 @@ class TestESRVersionRewrite(TestCase):
     def test_this_is_really_broken(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         del raw_crash.Version
         raw_dumps = {}
@@ -984,7 +984,7 @@ class TestPluginContentURL(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginContentURL = 'http://mozilla.com'
         raw_crash.URL = 'http://google.com'
         raw_dumps = {}
@@ -1002,7 +1002,7 @@ class TestPluginContentURL(TestCase):
     def test_this_is_not_the_crash_you_are_looking_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.URL = 'http://google.com'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -1021,7 +1021,7 @@ class TestPluginUserComment(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginUserComment = 'I hate it when this happens'
         raw_crash.Comments = 'I wrote something here, too'
         raw_dumps = {}
@@ -1039,7 +1039,7 @@ class TestPluginUserComment(TestCase):
     def test_this_is_not_the_crash_you_are_looking_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.Comments = 'I wrote something here'
         raw_dumps = {}
         processed_crash = DotDict()
@@ -1058,9 +1058,9 @@ class TestExploitablityRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
-        processed_crash = copy.copy(canonical_processed_crash)
+        processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = ExploitablityRule(config)
@@ -1074,7 +1074,7 @@ class TestExploitablityRule(TestCase):
     def test_this_is_not_the_crash_you_are_looking_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -1128,9 +1128,9 @@ class TestFlashVersionRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
-        processed_crash = copy.copy(canonical_processed_crash)
+        processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = FlashVersionRule(config)
@@ -1146,11 +1146,11 @@ class TestWinsock_LSPRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.Winsock_LSP = 'really long string'
-        expected_raw_crash = copy.copy(raw_crash)
+        expected_raw_crash = copy.deepcopy(raw_crash)
         raw_dumps = {}
-        processed_crash = copy.copy(canonical_processed_crash)
+        processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = Winsock_LSPRule(config)
@@ -1164,11 +1164,11 @@ class TestWinsock_LSPRule(TestCase):
     def test_missing_key(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.Winsock_LSP
-        expected_raw_crash = copy.copy(raw_crash)
+        expected_raw_crash = copy.deepcopy(raw_crash)
         raw_dumps = {}
-        processed_crash = copy.copy(canonical_processed_crash)
+        processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = Winsock_LSPRule(config)
@@ -1184,7 +1184,7 @@ class TestTopMostFilesRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processed_crash.json_dump = {
@@ -1228,8 +1228,8 @@ class TestTopMostFilesRule(TestCase):
     def test_missing_key(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
-        expected_raw_crash = copy.copy(raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
+        expected_raw_crash = copy.deepcopy(raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -1245,7 +1245,7 @@ class TestTopMostFilesRule(TestCase):
     def test_missing_key_2(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processed_crash.json_dump = {
@@ -1775,7 +1775,7 @@ class TestOsPrettyName(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
 
         processor_meta = get_basic_processor_meta()
@@ -1863,7 +1863,7 @@ class TestThemePrettyNameRule(TestCase):
     def test_everything_we_hoped_for(self):
         config = get_basic_config()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -1885,7 +1885,7 @@ class TestThemePrettyNameRule(TestCase):
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # the raw crash & raw_dumps should not have changed
-        assert raw_crash == canonical_standard_raw_crash
+        assert dotdict_to_dict(raw_crash) == dotdict_to_dict(canonical_standard_raw_crash)
         assert raw_dumps == {}
 
         expected_addon_list = [
@@ -1953,7 +1953,7 @@ class TestThemePrettyNameRule(TestCase):
 class TestSignatureGeneratorRule:
     def test_signature(self):
         rule = SignatureGeneratorRule(get_basic_config())
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         processed_crash = DotDict({
             'json_dump': {
                 'crash_info': {
@@ -2017,7 +2017,7 @@ class TestSignatureGeneratorRule:
         sentry_dsn = 'https://username:password@sentry.example.com/'
 
         config = get_basic_config()
-        config.sentry = CDotDict()
+        config.sentry = DotDict()
         config.sentry.dsn = sentry_dsn
         rule = SignatureGeneratorRule(config)
 


### PR DESCRIPTION
This removes one of the DotDicts from the codebase. Now there's only the
configman DotDict.

One architectural change this required was in crashstorage. Previously,
`save_raw_and_processed` would take DotDicts for the `raw_crash` and
`processed_crash`. Now the processor converts the two crash structures
into dicts before calling `save_raw_and_processed`.