### PR TITLE
Add rust_begin_unwind to the irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -76,6 +76,7 @@ org\.mozilla\.f.*-\d\.apk@0x
 panic_abort::
 PR_WaitCondVar
 RaiseException
+rust_begin_unwind
 rtc::FatalMessage
 RtlpAdjustHeapLookasideDepth
 RtlSleepConditionVariableCS


### PR DESCRIPTION
This should give us useful signature on crashes like: https://crash-stats.mozilla.com/report/index/f6ee9128-a2a5-4e5d-a634-5e61c0181108 and will should fix https://bugzilla.mozilla.org/show_bug.cgi?id=1505954