### PR TITLE
fix bug 1505591: update socorro/unittest/processor tests in Python 3

### DIFF
--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -22,8 +22,8 @@ WORKING_TESTS=(
     socorro/unittest/external/postgresql/test_*.py
     socorro/unittest/external/rabbitmq/test_*.py
     socorro/unittest/lib/test_*.py
-    # socorro/unittest/processor/test_*.py
-    # socorro/unittest/processor/rules/test_*.py
+    socorro/unittest/processor/test_*.py
+    socorro/unittest/processor/rules/test_*.py
     # socorro/unittest/scripts/test_*.py
 )
 

--- a/docker/run_tests_python3.sh
+++ b/docker/run_tests_python3.sh
@@ -24,7 +24,7 @@ WORKING_TESTS=(
     socorro/unittest/lib/test_*.py
     socorro/unittest/processor/test_*.py
     socorro/unittest/processor/rules/test_*.py
-    # socorro/unittest/scripts/test_*.py
+    socorro/unittest/scripts/test_*.py
 )
 
 # This is the list of known working tests by directory/filename for the webapp.

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -329,7 +329,7 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
             raw_crash,
             raw_crash.uuid
         ) as raw_crash_pathname:
-            for dump_name in raw_dumps.iterkeys():
+            for dump_name in raw_dumps.keys():
 
                 if processor_meta.quit_check:
                     processor_meta.quit_check()

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -255,7 +255,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
             reraise(exc_type, exc_value, exc_tb)
         finally:
             # Clean up any dump files saved to the file system
-            for a_dump_pathname in dumps.itervalues():
+            for a_dump_pathname in dumps.values():
                 try:
                     if 'TEMPORARY' in a_dump_pathname:
                         os.unlink(a_dump_pathname)

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -10,7 +10,8 @@ import argparse
 import datetime
 from functools import total_ordering
 import sys
-from urlparse import urlparse, parse_qs
+
+from six.moves.urllib.parse import urlparse, parse_qs
 
 from socorro.lib.datetimeutil import utc_now
 from socorro.lib.requestslib import session_with_retries

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -23,16 +23,13 @@ def sequencer(*args):
 
 
 class TestProcessorApp(TestCase):
-
     def get_standard_config(self, sentry_dsn=None):
         config = DotDict()
 
         config.source = DotDict()
         mocked_source_crashstorage = mock.Mock()
         mocked_source_crashstorage.id = 'mocked_source_crashstorage'
-        config.source.crashstorage_class = mock.Mock(
-            return_value=mocked_source_crashstorage
-        )
+        config.source.crashstorage_class = mock.Mock(return_value=mocked_source_crashstorage)
 
         config.destination = DotDict()
         mocked_destination_crashstorage = mock.Mock()
@@ -44,15 +41,12 @@ class TestProcessorApp(TestCase):
         config.processor = DotDict()
         mocked_processor = mock.Mock()
         mocked_processor.id = 'mocked_processor'
-        config.processor.processor_class = mock.Mock(
-            return_value=mocked_processor
-        )
+        config.processor.processor_class = mock.Mock(return_value=mocked_processor)
 
         config.number_of_submissions = 'forever'
         config.new_crash_source = DotDict()
 
         class FakedNewCrashSource(object):
-
             def __init__(self, *args, **kwargs):
                 pass
 
@@ -68,9 +62,7 @@ class TestProcessorApp(TestCase):
 
         config.companion_process = DotDict()
         mocked_companion_process = mock.Mock()
-        config.companion_process.companion_class = mock.Mock(
-            return_value=mocked_companion_process
-        )
+        config.companion_process.companion_class = mock.Mock(return_value=mocked_companion_process)
 
         config.logger = mock.MagicMock()
 
@@ -84,10 +76,10 @@ class TestProcessorApp(TestCase):
         pa = ProcessorApp(config)
         pa._setup_source_and_destination()
         g = pa.source_iterator()
-        assert g.next() == ((1,), {})
-        assert g.next() == ((2,), {})
-        assert g.next() is None
-        assert g.next() == ((3,), {})
+        assert next(g) == ((1,), {})
+        assert next(g) == ((2,), {})
+        assert next(g) is None
+        assert next(g) == ((3,), {})
 
     def test_transform_success(self):
         config = self.get_standard_config()
@@ -103,9 +95,7 @@ class TestProcessorApp(TestCase):
         pa.source.get_raw_dumps_as_files = mocked_get_raw_dumps_as_files
 
         fake_processed_crash = DotDict()
-        mocked_get_unredacted_processed = mock.Mock(
-            return_value=fake_processed_crash
-        )
+        mocked_get_unredacted_processed = mock.Mock(return_value=fake_processed_crash)
         pa.source.get_unredacted_processed = mocked_get_unredacted_processed
 
         mocked_process_crash = mock.Mock(return_value=7)

--- a/socorro/unittest/scripts/test_add_crashid_to_queue.py
+++ b/socorro/unittest/scripts/test_add_crashid_to_queue.py
@@ -21,11 +21,15 @@ def test_missing_args(capsys):
 
         # Make sure it prints some stuff to stdout
         out, err = capsys.readouterr()
-        usage_text = (
+        python2_usage_text = (
             'usage: add_crashid_to_queue [-h] queue [crashid [crashid ...]]\n'
             'add_crashid_to_queue: error: too few arguments\n'
         )
-        assert err == usage_text
+        python3_usage_text = (
+            'usage: add_crashid_to_queue [-h] queue [crashid [crashid ...]]\n'
+            'add_crashid_to_queue: error: the following arguments are required: queue, crashid\n'
+        )
+        assert err in [python2_usage_text, python3_usage_text]
 
 
 def test_bad_crashid(capsys):

--- a/socorro/unittest/scripts/test_replay_ftpscraper.py
+++ b/socorro/unittest/scripts/test_replay_ftpscraper.py
@@ -17,11 +17,15 @@ def test_missing_args(capsys):
 
         # Make sure it prints some stuff to stdout
         out, err = capsys.readouterr()
-        usage_text = (
+        python2_usage_text = (
             'usage: replay_ftpscraper [-h] ftpscraperlog\n'
             'replay_ftpscraper: error: too few arguments\n'
         )
-        assert err == usage_text
+        python3_usage_text = (
+            'usage: replay_ftpscraper [-h] ftpscraperlog\n'
+            'replay_ftpscraper: error: the following arguments are required: ftpscraperlog\n'
+        )
+        assert err in [python2_usage_text, python3_usage_text]
 
 
 def test_bad_file(capsys):


### PR DESCRIPTION
This also updates `socorro/unittest/scripts/` because I didn't feel like writing up a bug for that--there isn't much there.