### PR TITLE
fix bug 1506781: fix silent ujson errors

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -93,8 +93,6 @@ requests==2.20.0 \
 statsd==3.3.0 \
     --hash=sha256:c610fb80347fca0ef62666d241bce64184bd7cc1efe582f9690e045c25535eaa \
     --hash=sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f
-ujson==1.35 \
-    --hash=sha256:f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86
 python-dateutil==2.7.5 \
     --hash=sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93 \
     --hash=sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -225,8 +225,7 @@ class ConnectionContextBase(RequiredConfig):
             )
 
     def fetch(self, id, name_of_thing):
-        """retrieve something from boto.
-        """
+        """retrieve something from boto"""
         conn = self._connect()
         bucket = self._get_bucket(conn, self.config.bucket_name)
 
@@ -234,6 +233,8 @@ class ConnectionContextBase(RequiredConfig):
         for key in all_keys:
             key_object = bucket.get_key(key)
             if key_object is not None:
+                # NOTE(willkg): this says "as string", but in Python 3 this
+                # will be bytes.
                 return key_object.get_contents_as_string()
 
         # None of the keys worked, so raise an error

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -100,13 +100,9 @@ class BotoCrashStorage(CrashStorageBase):
             dumps = MemoryDumpsMapping()
 
         raw_crash_as_string = boto_connection._convert_mapping_to_string(raw_crash)
-        boto_connection.submit(
-            crash_id,
-            "raw_crash",
-            raw_crash_as_string
-        )
+        boto_connection.submit(crash_id, 'raw_crash', raw_crash_as_string)
         dump_names_as_string = boto_connection._convert_list_to_string(dumps.keys())
-        boto_connection.submit(crash_id, "dump_names", dump_names_as_string)
+        boto_connection.submit(crash_id, 'dump_names', dump_names_as_string)
 
         # we don't know what type of dumps mapping we have.  We do know,
         # however, that by calling the memory_dump_mapping method, we will
@@ -124,11 +120,7 @@ class BotoCrashStorage(CrashStorageBase):
     def _do_save_processed(boto_connection, processed_crash):
         crash_id = processed_crash['uuid']
         processed_crash_as_string = boto_connection._convert_mapping_to_string(processed_crash)
-        boto_connection.submit(
-            crash_id,
-            "processed_crash",
-            processed_crash_as_string
-        )
+        boto_connection.submit(crash_id, "processed_crash", processed_crash_as_string)
 
     def save_processed(self, processed_crash):
         self.transaction(self._do_save_processed, processed_crash)
@@ -148,18 +140,10 @@ class BotoCrashStorage(CrashStorageBase):
     @staticmethod
     def do_get_raw_crash(boto_connection, crash_id, json_object_hook):
         try:
-            raw_crash_as_string = boto_connection.fetch(
-                crash_id,
-                "raw_crash"
-            )
-            return json.loads(
-                raw_crash_as_string,
-                object_hook=json_object_hook
-            )
+            raw_crash_as_string = boto_connection.fetch(crash_id, 'raw_crash')
+            return json.loads(raw_crash_as_string, object_hook=json_object_hook)
         except boto_connection.ResponseError as x:
-            raise CrashIDNotFound(
-                '%s not found: %s' % (crash_id, x)
-            )
+            raise CrashIDNotFound('%s not found: %s' % (crash_id, x))
 
     def get_raw_crash(self, crash_id):
         return self.transaction_for_get(
@@ -176,9 +160,7 @@ class BotoCrashStorage(CrashStorageBase):
             a_dump = boto_connection.fetch(crash_id, name)
             return a_dump
         except boto_connection.ResponseError as x:
-            raise CrashIDNotFound(
-                '%s not found: %s' % (crash_id, x)
-            )
+            raise CrashIDNotFound('%s not found: %s' % (crash_id, x))
 
     def get_raw_dump(self, crash_id, name=None):
         return self.transaction_for_get(self.do_get_raw_dump, crash_id, name)
@@ -186,28 +168,19 @@ class BotoCrashStorage(CrashStorageBase):
     @staticmethod
     def do_get_raw_dumps(boto_connection, crash_id):
         try:
-            dump_names_as_string = boto_connection.fetch(
-                crash_id,
-                "dump_names"
-            )
-            dump_names = boto_connection._convert_string_to_list(
-                dump_names_as_string
-            )
+            dump_names_as_string = boto_connection.fetch(crash_id, 'dump_names')
+            dump_names = boto_connection._convert_string_to_list(dump_names_as_string)
+
             # when we fetch the dumps, they are by default in memory, so we'll
             # put them into a MemoryDumpMapping.
             dumps = MemoryDumpsMapping()
             for dump_name in dump_names:
                 if dump_name in (None, '', 'upload_file_minidump'):
                     dump_name = 'dump'
-                dumps[dump_name] = boto_connection.fetch(
-                    crash_id,
-                    dump_name
-                )
+                dumps[dump_name] = boto_connection.fetch(crash_id, dump_name)
             return dumps
         except boto_connection.ResponseError as x:
-            raise CrashIDNotFound(
-                '%s not found: %s' % (crash_id, x)
-            )
+            raise CrashIDNotFound('%s not found: %s' % (crash_id, x))
 
     def get_raw_dumps(self, crash_id):
         """this returns a MemoryDumpsMapping"""
@@ -225,18 +198,10 @@ class BotoCrashStorage(CrashStorageBase):
     @staticmethod
     def _do_get_unredacted_processed(boto_connection, crash_id, json_object_hook):
         try:
-            processed_crash_as_string = boto_connection.fetch(
-                crash_id,
-                "processed_crash"
-            )
-            return json.loads(
-                processed_crash_as_string,
-                object_hook=json_object_hook,
-            )
+            processed_crash_as_string = boto_connection.fetch(crash_id, 'processed_crash')
+            return json.loads(processed_crash_as_string, object_hook=json_object_hook,)
         except boto_connection.ResponseError as x:
-            raise CrashIDNotFound(
-                '%s not found: %s' % (crash_id, x)
-            )
+            raise CrashIDNotFound('%s not found: %s' % (crash_id, x))
 
     def get_unredacted_processed(self, crash_id):
         return self.transaction_for_get(
@@ -312,34 +277,21 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
             crash_report[processed_fields_map.get(key, key)] = val
 
         # Validate crash_report.
-        crash_report = json_schema_reducer.make_reduced_dict(
-            CRASH_REPORT_JSON_SCHEMA, crash_report
-        )
+        crash_report = json_schema_reducer.make_reduced_dict(CRASH_REPORT_JSON_SCHEMA, crash_report)
         self.save_processed(crash_report)
 
     @staticmethod
     def _do_save_processed(boto_connection, processed_crash):
         """Overriding this to change "name of thing" to crash_report"""
         crash_id = processed_crash['uuid']
-        processed_crash_as_string = boto_connection._convert_mapping_to_string(
-            processed_crash
-        )
-        boto_connection.submit(
-            crash_id,
-            "crash_report",
-            processed_crash_as_string
-        )
+        processed_crash_as_string = boto_connection._convert_mapping_to_string(processed_crash)
+        boto_connection.submit(crash_id, "crash_report", processed_crash_as_string)
 
     @staticmethod
     def _do_get_unredacted_processed(boto_connection, crash_id, json_object_hook):
         """Overriding this to change "name of thing" to crash_report"""
         try:
             processed_crash_as_string = boto_connection.fetch(crash_id, 'crash_report')
-            return json.loads(
-                processed_crash_as_string,
-                object_hook=json_object_hook,
-            )
+            return json.loads(processed_crash_as_string, object_hook=json_object_hook)
         except boto_connection.ResponseError as x:
-            raise CrashIDNotFound(
-                '%s not found: %s' % (crash_id, x)
-            )
+            raise CrashIDNotFound('%s not found: %s' % (crash_id, x))

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -13,7 +13,6 @@ import time
 import markus
 from requests import RequestException
 from six.moves.urllib.parse import unquote_plus
-import ujson
 
 from socorro.external.postgresql.dbapi2_util import execute_query_fetchall
 from socorro.lib import javautil
@@ -327,7 +326,7 @@ class OutOfMemoryBinaryRule(Rule):
                 )
                 return error_out(error_message)
 
-            memory_info = ujson.loads(memory_info_as_string)
+            memory_info = json.loads(memory_info_as_string)
         except IOError as x:
             error_message = "error in gzip for %s: %r" % (dump_pathname, x)
             return error_out(error_message)

--- a/socorro/signature/README.rst
+++ b/socorro/signature/README.rst
@@ -58,7 +58,6 @@ This code can sort of be used as a library. It's been decoupled from many of
 Socorro's bits, but still has some requirements. Roughtly, it requires:
 
 * requests
-* ujson
 
 
 The main class is ``socorro.signature.SignatureGenerator``. It takes a pipeline

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -3,11 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from itertools import islice
+import json
 import re
 
 from glom import glom
 import six
-import ujson
 
 from . import siglists_utils
 from .utils import (
@@ -713,7 +713,7 @@ class SignatureShutdownTimeout(Rule):
     def action(self, crash_data, result):
         parts = ['AsyncShutdownTimeout']
         try:
-            shutdown_data = ujson.loads(crash_data['async_shutdown_timeout'])
+            shutdown_data = json.loads(crash_data['async_shutdown_timeout'])
             parts.append(shutdown_data['phase'])
             conditions = [
                 # NOTE(willkg): The AsyncShutdownTimeout notation condition can either be a string

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1679,6 +1679,7 @@ class TestSignatureShutdownTimeout:
         rule = rules.SignatureShutdownTimeout()
 
         crash_data = {
+            # This will cause json.load to raise an error
             'async_shutdown_timeout': '{{{{'
         }
         result = {
@@ -1691,7 +1692,7 @@ class TestSignatureShutdownTimeout:
         assert result['signature'] == 'AsyncShutdownTimeout | UNKNOWN'
 
         assert 'Error parsing AsyncShutdownTimeout:' in result['notes'][0]
-        assert 'Expected object or value' in result['notes'][0]
+        assert 'Expecting property name' in result['notes'][0]
         assert (
             'Signature replaced with a Shutdown Timeout signature, was: "foo"' in result['notes'][1]
         )

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -844,7 +844,7 @@ class TestOutOfMemoryBinaryRule(TestCase):
 
         with patch('socorro.processor.mozilla_transform_rules.gzip.open') as mocked_gzip_open:
             with patch(
-                'socorro.processor.mozilla_transform_rules.ujson.loads'
+                'socorro.processor.mozilla_transform_rules.json.loads'
             ) as mocked_json_loads:
                 mocked_json_loads.side_effect = ValueError
 

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -237,12 +237,7 @@ def model_wrapper(request, model_name):
         try:
             result = function(**form.cleaned_data)
         except ValueError as e:
-            if (
-                # built in json module ValueError
-                'No JSON object could be decoded' in e or
-                # ujson module ValueError
-                'Expected object or value' in e
-            ):
+            if 'No JSON object could be decoded' in e:
                 return http.HttpResponseBadRequest(
                     json.dumps({'error': 'Not a valid JSON response'}),
                     content_type='application/json; charset=UTF-8'

--- a/webapp-django/crashstats/supersearch/tests/common.py
+++ b/webapp-django/crashstats/supersearch/tests/common.py
@@ -1,4 +1,4 @@
-import ujson
+import json
 from past.builtins import basestring
 
 from crashstats.crashstats.tests.test_models import Response
@@ -7,7 +7,7 @@ from crashstats.crashstats.tests.test_models import Response
 class SuperSearchResponse(Response):
     def __init__(self, content=None, status_code=200, columns=None):
         if isinstance(content, basestring):
-            content = ujson.loads(content)
+            content = json.loads(content)
 
         if columns is None:
             columns = []


### PR DESCRIPTION
minidump-stackwalker was failing with exit code 134 because there was no
raw crash data to work on. There was no raw crash data to work on because
ujson and json handle parsing errors differently. Particularly, ujson
would shrug when trying to JSON serialize a configman DotDict. That's
really unhelpful.

This fixes the underlying issue (need to convert configman DotDict
to a dict before serializing to JSON), purges ujson from the codebase,
and fixes some tests that were testing what happens if the constants
of the universe were different which will never be the case.