### PR TITLE
bug 1507916: improve difference logging

### DIFF
--- a/socorro/cron/jobs/archivescraper.py
+++ b/socorro/cron/jobs/archivescraper.py
@@ -108,7 +108,9 @@ class ArchiveScraperCronApp(BaseCronApp):
 
     def __init__(self, *args, **kwargs):
         super(ArchiveScraperCronApp, self).__init__(*args, **kwargs)
-        self.session = session_with_retries()
+        # NOTE(willkg): If archive.mozilla.org is timing out after 5 seconds,
+        # then it has issues and we should try again some other time
+        self.session = session_with_retries(default_timeout=5.0)
         self.successful_inserts = 0
 
     def _get_max_major_version(self, connection, product_name):

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -883,8 +883,11 @@ class BetaVersionRule(Rule):
                 maybe_version = self._get_real_version_db2(product, release_channel, build_id)
                 if real_version != maybe_version:
                     self.config.logger.info(
-                        'betaversionrule: got different versions: %r %r vs. %r',
+                        'betaversionrule: got different versions: %r %r %r %r %r vs. %r',
                         raw_crash.get('uuid', None),
+                        product,
+                        build_id,
+                        release_channel,
                         real_version,
                         maybe_version
                     )


### PR DESCRIPTION
This adjusts the logging line for when the new `BetaVersionRule` lookup differs
from the existing `BetaVersionRule`. We can use this data to generate new
entries in the `crashstats_productversion` table.