### PR TITLE
fix bug 1503383: fix crontabber

### DIFF
--- a/docker/run_crontabber.sh
+++ b/docker/run_crontabber.sh
@@ -13,7 +13,7 @@ while true
 do
     # FIXME(willkg): We don't want crontabber to exit weird and then have that
     # kill the container, but this is a lousy thing to do.
-    ${CMDPREFIX} ./socorro/cron/crontabber_app.py || true
+    ./socorro-cmd crontabber || true
     echo "Sleep 5 minutes..."
     sleep 300
 done


### PR DESCRIPTION
Crontabber isn't running because the "main()" bit was taken out of the
Python module. Need to run it via socorro-cmd now.