### PR TITLE
bug 1497956: upgrade postgres to 9.5 in local dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
 
   # https://hub.docker.com/_/postgres/
   postgresql:
-    image: postgres:9.4
+    image: postgres:9.5
     ports:
       - "8574:5432"
     environment:


### PR DESCRIPTION
This updates the local dev and test environments to use PostgreSQL 9.5.