### PR TITLE
bug 1511163: increase BugzillaCronApp timeout

### DIFF
--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -166,7 +166,8 @@ class BugzillaCronApp(BaseCronApp):
         # field changed since from_date
         payload = BUGZILLA_PARAMS.copy()
         payload['chfieldfrom'] = from_date
-        session = session_with_retries()
+        # Use a 30-second timeout because Bugzilla is slow sometimes
+        session = session_with_retries(default_timeout=30.0)
         r = session.get(BUGZILLA_BASE_URL, params=payload)
         if r.status_code < 200 or r.status_code >= 300:
             r.raise_for_status()


### PR DESCRIPTION
Today, the BugzillaCronApp is timing out when reading from Bugzilla. This
increases the timeout to 30 seconds for that app because it seems it needs
more time to read.