### PR TITLE
bug 1497957: upgrade to postgre 9.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
 
   # https://hub.docker.com/_/postgres/
   postgresql:
-    image: postgres:9.5
+    image: postgres:9.6
     ports:
       - "8574:5432"
     environment:


### PR DESCRIPTION
This upgrades the local development environment and the test environment to
PostgreSQL 9.6.

We're in the process of upgrading to 9.5 right now, so we'll want to wait until that's done before we land this.