### PR TITLE
bug 1515805: fix breakpad client building in image; add scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ default:
 .PHONY: clean
 clean:
 	-rm .docker-build*
-	-rm -rf build breakpad stackwalk google-breakpad breakpad.tar.gz
+	-rm -rf build breakpad stackwalk google-breakpad breakpad.tar.gz depot_tools
 	-rm -rf .cache
 	cd minidump-stackwalk && make clean
 

--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -35,6 +35,15 @@ cd ..
 export PATH
 PATH=$(pwd)/depot_tools:$PATH
 
+# depot_tools only work in Python 2 and it uses "/usr/bin/env python", so
+# we take advantage of depot_tools being first in the PATH and create a
+# symlink to the happy Python if "python" is Python 3.
+PYV=$(python -c "import sys; print(sys.version_info[0]);")
+if [ "${PYV}" == "3" ]; then
+  echo "'/usr/bin/env python' is Python 3, so making symlink to python2"
+  ln -s /usr/bin/python2 $(pwd)/depot_tools/python
+fi
+
 # Checkout and build Breakpad
 echo "PREFIX: ${PREFIX:=$(pwd)/build/breakpad}"
 if [ ! -d "breakpad" ]; then

--- a/scripts/run_mdsw.sh
+++ b/scripts/run_mdsw.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This runs minidump-stackwalk just like it runs in the processor. This
+# will help debug minidump-stackwalk problems.
+#
+# Usage:
+#
+#    app@socorro:/app$ ./scripts/run_mdsw.sh [CRASHID]
+
+set -e
+
+# First convert configman environment vars which have bad identifiers to ones
+# that don't
+function getenv {
+    python -c "import os; print(os.environ['$1'])"
+}
+
+DATADIR=./crashdata_mdsw_tmp
+STACKWALKER="$(getenv 'processor.command_pathname')"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: run_mdsw.sh CRASHID"
+    exit 1
+fi
+
+mkdir "${DATADIR}" || echo "${DATADIR} already exists."
+
+# Pull down the data for the crash if we don't have it, yet
+if [ ! -f "${DATADIR}/v1/dump/$1" ]; then
+    echo "Fetching crash data..."
+    ./socorro-cmd fetch_crash_data "${DATADIR}" $1
+fi
+
+# Find the raw crash file
+RAWCRASHFILE=$(find ${DATADIR}/v2/raw_crash/ -name $1 -type f)
+
+timeout -s KILL 600 "${STACKWALKER}" \
+    --raw-json $RAWCRASHFILE \
+    --symbols-url "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1" \
+    --symbols-cache /tmp/symbols/cache \
+    --symbols-tmp /tmp/symbols/tmp \
+    ${DATADIR}/v1/dump/$1


### PR DESCRIPTION
Building the breakpad client requires using depot_tools which only work with
Python 2. This fixes the `build-breakpad.sh` script so it makes sure depot_tools
are using Python 2 in the Docker container.

This adds a `scripts/run_mdsw.sh` script which runs minidump-stackwalker just
like we do in the processor, but outside of the processor. This makes it
a lot easier to debug issues with minidump-stackwalker.