### PR TITLE
Re-add __future__ statement for siggen

### DIFF
--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# NOTE(willkg): Need to keep this until we drop Python 2.7 support in siggen
+from __future__ import print_function
+
 import argparse
 import csv
 import os


### PR DESCRIPTION
siggen still supports Python 2.7, so we need to re-add this `__future__`
line.