### PR TITLE
Add alloc::raw_vec::capacity_overflow to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -12,6 +12,7 @@ Abort
 .*alloc_impl
 alloc::oom::default_oom_handler
 alloc::oom::oom
+alloc::raw_vec::capacity_overflow
 _alloca_probe
 __android_log_assert
 arena_


### PR DESCRIPTION
This will help separate out https://bugzilla.mozilla.org/show_bug.cgi?id=1512440 into buckets that match the true cause.