### PR TITLE
fix bug 1515805: update breakpad client to 1459e5df

### DIFF
--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -15,7 +15,7 @@ set -v -e -x
 
 # Build the revision used in the snapshot unless otherwise specified.
 # Update this if you update the snapshot!
-: BREAKPAD_REV         "${BREAKPAD_REV:=a61afe7a3e865f1da7ff7185184fe23977c2adca}"
+: BREAKPAD_REV         "${BREAKPAD_REV:=1459e5df74dd03b7d3d473e6d271413d7aa98a88}"
 
 export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Once this lands, we can run the taskcluster task that uses this script to update the client binary. Once the binary is built, we'll need to trigger another stage deploy so that stage mdsw picks it up..