### PR TITLE
fix bug 1518576: fix bug description when filing bugs from crash reports

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
@@ -1,9 +1,8 @@
 {# This is a Jinja2 template for Bugzilla bugs filed from the Socorro interface.
    See crashstats.templatetags.jinja_helpers.bugzilla_submit_url. #}
-This bug was filed from the Socorro interface and is
-report bp-{{ uuid }}.
-=============================================================
+This bug is for crash report bp-{{ uuid }}.
 
+```
 {% if java_stack_trace -%}
 Java stack trace:
 
@@ -14,5 +13,5 @@ Top {{ crashing_thread_frames|length }} frames of crashing thread:
 {% for frame in crashing_thread_frames -%}
 {{ frame.frame|safe}} {{ frame.module|safe }} {{ frame.signature|safe }} {{ frame.source|safe }}
 {% endfor %}
-=============================================================
+```
 {% endif %}


### PR DESCRIPTION
Bugzilla switched to Markdown for formatting and the bugs that were created
from Bugzilla looked ter-rib-ble. This fixes that and reduces some of the
unnecessary boilerplate.