### PR TITLE
bug 1519475: switch worker in taskcluster task

### DIFF
--- a/minidump-stackwalk/README.rst
+++ b/minidump-stackwalk/README.rst
@@ -70,39 +70,12 @@ Building with Taskcluster
 The ``build-stackwalker.sh`` script will download a pre-built breakpad
 client binary if possible.
 
-To update this binary, copy the following task definition into the
-`TaskCluster task creation tool`_:
-
-.. code:: yaml
-
-   created: '2017-04-11T14:17:56.960Z'
-   deadline: '2017-04-11T15:17:56.960Z'
-   provisionerId: aws-provisioner-v1
-   workerType: gecko-misc
-   retries: 0
-   expires: '2020-01-01T00:00:00.000Z'
-   routes:
-     - index.project.socorro.breakpad.v1.builds.linux64.latest
-   scopes:
-     - 'queue:route:index.project.socorro.breakpad.v1.builds.linux64.latest'
-   payload:
-     image: 'mozilla/socorro_app:latest'
-     command:
-       - shell
-       - /app/scripts/build-breakpad.sh
-     artifacts:
-       public/breakpad.tar.gz:
-         type: file
-         path: /app/breakpad.tar.gz
-     maxRunTime: 7200
-   metadata:
-     name: Build Breakpad
-     description: Build Breakpad for Socorro consumption
-     owner: ted@mielczarek.org
-     source: 'http://tools.taskcluster.net/task-creator/'
+To update this binary, copy the task definition from ``taskcluster_script.txt``
+into the `TaskCluster task creation tool`_ and run it.
 
 This task will update a Taskcluster index if it succeeds, such that the
 most recent tarball can be fetched from:
+
 https://index.taskcluster.net/v1/task/project.socorro.breakpad.v1.builds.linux64.latest/artifacts/public/breakpad.tar.gz
 
 You must be a member of the ``socorro`` project in Taskcluster for this

--- a/minidump-stackwalk/taskcluster_script.txt
+++ b/minidump-stackwalk/taskcluster_script.txt
@@ -1,0 +1,25 @@
+created: '2017-04-11T14:17:56.960Z'
+deadline: '2017-04-11T15:17:56.960Z'
+provisionerId: aws-provisioner-v1
+workerType: github-worker
+retries: 0
+expires: '2020-01-01T00:00:00.000Z'
+routes:
+  - index.project.socorro.breakpad.v1.builds.linux64.latest
+scopes:
+  - 'queue:route:index.project.socorro.breakpad.v1.builds.linux64.latest'
+payload:
+  image: 'mozilla/socorro_app:latest'
+  command:
+    - shell
+    - /app/scripts/build-breakpad.sh
+  artifacts:
+    public/breakpad.tar.gz:
+      type: file
+      path: /app/breakpad.tar.gz
+  maxRunTime: 7200
+metadata:
+  name: Build Breakpad
+  description: Build Breakpad client for Socorro consumption
+  owner: willkg@mozilla.com
+  source: 'http://tools.taskcluster.net/task-creator/'


### PR DESCRIPTION
Bug 1519475 covers redoing how we build the breakpad client. This is
an interim fix to the task and how we document it so that I can run it.
This takes the urgency from figuring out a more permanent solution.

Also, in this change, I'm taking "ownership" and responsibility of the taskcluster task figuring then it's off of @luser's plate and he'll be happier for it. If that's not true, I'm happy to change it back.