### PR TITLE
Exclude build/ from linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ exclude =
     stackwalk/,
     webapp-django/crashstats/*/migrations/*,
     webapp-django/node_modules/,
+    build/,
     depot_tools/,
     breakpad/
 max-line-length = 100


### PR DESCRIPTION
The `build/` directory holds breakpad-client-related build stuff that's
external to this project, but has a bunch of Python files that have
linting issues. This excludes them.