### PR TITLE
fix bug 1520570: switch to multi-stage docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 .git
+build/
+breakpad/
+breakpad.tar.gz
+depot_tools/
 **/*.swp
 **/*.pyc
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ export
 SOCORRO_UID ?= 10001
 SOCORRO_GID ?= 10001
 
+# Set this in the environment to force --no-cache docker builds.
+DOCKER_BUILD_OPTS :=
+ifeq (1, ${NOCACHE})
+DOCKER_BUILD_OPTS := --no-cache
+endif
+
 DC := $(shell which docker-compose)
 
 
@@ -69,7 +75,7 @@ my.env:
 
 .PHONY: build
 build: my.env
-	${DC} build --build-arg userid=${SOCORRO_UID} --build-arg groupid=${SOCORRO_GID} app
+	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${SOCORRO_UID} --build-arg groupid=${SOCORRO_GID} app
 	${DC} build oidcprovider
 	touch .docker-build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.7-slim-jessie
+FROM python:3.6.7-slim-jessie as socorro_image_base
 
 # Set up user and group
 ARG groupid=10001
@@ -12,11 +12,22 @@ RUN groupadd --gid $groupid app && \
 COPY ./docker/set_up_ubuntu.sh /tmp/
 RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
 
-# Install breakpad and stackwalk bits
-COPY ./scripts/build-breakpad.sh /tmp/scripts/
-COPY ./scripts/build-stackwalker.sh /tmp/scripts/
-COPY ./minidump-stackwalk/ /tmp/minidump-stackwalk/
-RUN STACKWALKDIR=/stackwalk SRCDIR=/tmp /tmp/scripts/build-stackwalker.sh
+
+FROM socorro_image_base as socorro_breakpad
+WORKDIR /mdsw/
+
+# Build breakpad client and stackwalker binaries
+COPY ./scripts/build-breakpad.sh /mdsw/scripts/
+COPY ./scripts/build-stackwalker.sh /mdsw/scripts/
+COPY ./minidump-stackwalk/ /mdsw/minidump-stackwalk/
+RUN STACKWALKDIR=/stackwalk SRCDIR=/mdsw /mdsw/scripts/build-stackwalker.sh
+
+
+FROM socorro_image_base
+WORKDIR /app/
+
+# Copy stackwalk bits
+COPY --from=socorro_breakpad /stackwalk/* /stackwalk/
 
 # Install frontend JS deps
 COPY ./webapp-django/package.json /webapp-frontend-deps/package.json


### PR DESCRIPTION
This moves building breakpad client into a separate docker image build stage.
That way all its intermediary build tools and files don't swamp the final
`socorro_app` image and make it super huge.

This also adds support for `NOCACHE=1 make build` which will build the
docker image with `--no-cache` flag. I do that so often that it seemed
prudent to codify it in the `Makefile` and save myself some time.

This also tweaks the `.dockerignore` file to ignore breakpad client
build bits during the `COPY` which might show up in a local dev environment
when working on updating the breakpad client.