### PR TITLE
fix bug 1299460: improve crash not found page

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index_not_found.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index_not_found.html
@@ -3,11 +3,13 @@
 {% block content %}
 <div id="mainbody">
     <div class="page-heading">
-        <h2>Crash Not Found</h2>
+        <h2>Crash Report Not Found</h2>
     </div>
     <div class="panel">
         <div class="body">
-            <p>We couldn't find the Crash ID you're after. If you recently submitted this crash, it may still be in the queue.</p>
+            <p>We couldn't find the crash report for the Crash ID you requested.</p>
+            <p>If you recently submitted this crash report, it may still be in the queue to be processed. Wait a few minutes and try reloading this page.</p>
+            <p>If this crash report is more than 6 months old, the data may have been removed from our system. We only retain crash reports for 6 months.</p>
 
             <p>
                 If you believe this message is an error, please submit a
@@ -15,8 +17,7 @@
                     product='Socorro',
                     component='Webapp',
                     bug_file_loc=request.build_absolute_uri(),
-                ) }}">Bugzilla ticket</a> describing what happened,
-                and please include the URL for this page.
+                ) }}">Bugzilla ticket</a> describing what happened, and please include the URL for this page.
             </p>
         </div>
     </div>

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1353,7 +1353,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
 
         assert response.status_code == 404
-        assert 'Crash Not Found' in smart_text(response.content)
+        assert 'Crash Report Not Found' in smart_text(response.content)
 
     def test_report_index_processed_crash_not_found(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'


### PR DESCRIPTION
This improves the crash report not found page. It explains several reasons
why the crash report may not be available and what to do about it. This
includes the possibility that the crash report is no longer on our system.