### PR TITLE
fix bug 1519528: fix missing index

### DIFF
--- a/socorro/external/es/base.py
+++ b/socorro/external/es/base.py
@@ -7,6 +7,33 @@ import datetime
 from configman import Namespace, class_converter, RequiredConfig
 
 
+def generate_list_of_indexes(from_date, to_date, index_format):
+    """Return the list of indexes for crash reports processed between from_date and to_date
+
+    The naming pattern for indexes in elasticsearch is configurable, it is
+    possible to have an index per day, per week, per month...
+
+    :arg from_date: datetime object
+    :arg to_date: datetime object
+    :arg index_format: the format to use for the index name
+
+    :returns: list of strings
+
+    """
+    indexes = []
+    current_date = from_date
+    while current_date <= to_date:
+        index_name = current_date.strftime(index_format)
+
+        # Make sure no index is twice in the list
+        # (for weekly or monthly indexes for example)
+        if index_name not in indexes:
+            indexes.append(index_name)
+        current_date += datetime.timedelta(days=1)
+
+    return indexes
+
+
 class ElasticsearchConfig(RequiredConfig):
     required_config = Namespace()
     required_config.namespace('elasticsearch')
@@ -51,42 +78,3 @@ class ElasticsearchConfig(RequiredConfig):
         default=365,  # in days
         doc='the maximum date range for searches, in days'
     )
-
-
-class ElasticsearchBase(object):
-    def __init__(self, *args, **kwargs):
-        self.config = kwargs.get('config')
-        self.es_context = self.config.elasticsearch.elasticsearch_class(
-            self.config.elasticsearch
-        )
-
-    def get_connection(self):
-        with self.es_context() as conn:
-            return conn
-
-    def generate_list_of_indexes(self, from_date, to_date, es_index=None):
-        """Return the list of indexes to query to access all the crash reports
-        that were processed between from_date and to_date.
-
-        The naming pattern for indexes in elasticsearch is configurable, it is
-        possible to have an index per day, per week, per month...
-
-        Parameters:
-        * from_date datetime object
-        * to_date datetime object
-        """
-        if es_index is None:
-            es_index = self.config.elasticsearch.elasticsearch_index
-
-        indexes = []
-        current_date = from_date
-        while current_date <= to_date:
-            index = current_date.strftime(es_index)
-
-            # Make sure no index is twice in the list
-            # (for weekly or monthly indexes for example)
-            if index not in indexes:
-                indexes.append(index)
-            current_date += datetime.timedelta(days=1)
-
-        return indexes

--- a/socorro/external/es/index_creator.py
+++ b/socorro/external/es/index_creator.py
@@ -61,8 +61,7 @@ class IndexCreator(RequiredConfig):
         )
 
     def get_index_client(self):
-        """Maintained for interoperability purposes elsewhere in the codebase.
-        """
+        """Returns an Elasticsearch IndexClient"""
         return self.es_context.indices_client()
 
     def get_socorro_index_settings(self, mappings):
@@ -97,7 +96,7 @@ class IndexCreator(RequiredConfig):
         execution of this function, nothing will happen.
         """
         try:
-            client = self.es_context.indices_client()
+            client = self.get_index_client()
             client.create(
                 index=es_index,
                 body=es_settings,


### PR DESCRIPTION
This fixes `create_recent_indices` in the case where you run it at the
beginning of the year and it doesn't create the YYYY00 index.

In working on this, I cleaned up some related code and nixed
a base class that wasn't very helpful.