### PR TITLE
bug 1511032: move bug link over

### DIFF
--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -149,12 +149,12 @@
         <div class="nav-links">
             <a href="{{ url('documentation:home') }}">Documentation</a>
             |
-            <a href="{{ url('supersearch:search') }}?product={{ product }}{% if version and version != 'ALL' %}&amp;version={{ version }}{% endif %}&amp;_dont_run=1">
-                Super Search
-            </a>
-            |
             <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro">
                 File a bug
+            </a>
+            |
+            <a href="{{ url('supersearch:search') }}?product={{ product }}{% if version and version != 'ALL' %}&amp;version={{ version }}{% endif %}&amp;_dont_run=1">
+                Super Search
             </a>
         </div>
     </div>


### PR DESCRIPTION
This swaps the "file a bug" link with "super search" because the latter
is heavily used and it's better to put it on the right-most side for
easier mousing.