### PR TITLE
fix bug 1508215: make graphics adapter/device keywords

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -858,6 +858,7 @@ FIELDS = {
         'permissions_needed': [],
         'query_type': 'enum',
         'storage_mapping': {
+            'analyzer': 'keyword',
             'type': 'string'
         }
     },
@@ -912,6 +913,7 @@ FIELDS = {
         'permissions_needed': [],
         'query_type': 'enum',
         'storage_mapping': {
+            'analyzer': 'keyword',
             'type': 'string'
         }
     },


### PR DESCRIPTION
This fixes the analysis for graphics adapter id and graphics device id
so the values are not tokenized into smaller parts. Firefox sends
values like 0x8000 which tokenizes into a single token. Fennec, however,
sends values like "Imagination Technologies" which gets broken into two
tokens and then we end up with two facets which messes up the Graphics
Adapter section in the signature summary report.

This fixes that.