### PR TITLE
fix bug 1389186: stop doing shell=True

### DIFF
--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -270,7 +270,7 @@ class TestExternalProcessRule(object):
         config.command_line = (
             'timeout -s KILL 30 {command_pathname} '
             '{dump_file_pathname} '
-            '{processor_symbols_pathname_list} 2>/dev/null'
+            '{processor_symbols_pathname_list}'
         )
         config.command_pathname = 'bogus_command'
         config.processor_symbols_pathname_list = (
@@ -320,12 +320,13 @@ class TestExternalProcessRule(object):
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         mocked_subprocess_module.Popen.assert_called_with(
-            'timeout -s KILL 30 bogus_command a_fake_dump.dump '
-            '/mnt/socorro/symbols/symbols_ffx,/mnt/socorro/symbols/'
-            'symbols_sea,/mnt/socorro/symbols/symbols_tbrd,/mnt/socorro/'
-            'symbols/symbols_sbrd,/mnt/socorro/symbols/symbols_os'
-            ' 2>/dev/null',
-            shell=True,
+            [
+                'timeout', '-s', 'KILL', '30',
+                'bogus_command',
+                'a_fake_dump.dump',
+                '/mnt/socorro/symbols/symbols_ffx,/mnt/socorro/symbols/symbols_sea,/mnt/socorro/symbols/symbols_tbrd,/mnt/socorro/symbols/symbols_sbrd,/mnt/socorro/symbols/symbols_os'  # noqa
+            ],
+            stderr=mocked_subprocess_module.DEVNULL,
             stdout=mocked_subprocess_module.PIPE
         )
 


### PR DESCRIPTION
When running minidump-stackwalker as an external process, it'd use `shell=True`
because the command line was complicated and involved redirection. Instead
of doing that, we can use `shlex.split` to split it into arguments and do
the redirection in the `subprocess.Popen` call. Then we're not using `shell=True`
which has security implications.