### PR TITLE
bug 1357246: add de-nulling to processor

### DIFF
--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -7,6 +7,45 @@ from glom import glom
 from socorro.processor.rules.base import Rule
 
 
+class DeNullRule(Rule):
+    """Removes nulls from keys and values
+
+    Sometimes crash reports come in with junk data. This removes the egregious
+    junk that causes downstream processing and storage problems.
+
+    NOTE(willkg): While this changes the raw crash, that raw crash should never
+    get saved back to storage, so this doesn't overwrite the original material.
+
+    """
+    def de_null(self, s):
+        """Remove nulls from bytes and str values
+
+        :arg str/bytes value: The str or bytes to remove nulls from
+
+        :returns: str or bytes without nulls
+
+        """
+        if isinstance(s, bytes) and b'\0' in s:
+            return s.replace(b'\0', b'')
+
+        if isinstance(s, str) and '\0' in s:
+            return s.replace('\0', '')
+
+        # If it's not a bytes or a str, it's something else and we should
+        # return it as is
+        return s
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        # Go through the raw crash and de-null keys and values
+        for key, val in raw_crash.items():
+            new_key = self.de_null(key)
+            if key != new_key:
+                del raw_crash[key]
+
+            new_val = self.de_null(val)
+            raw_crash[new_key] = new_val
+
+
 class IdentifierRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         if 'uuid' in raw_crash:

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -30,6 +30,7 @@ from socorro.processor.breakpad_transform_rules import (
 
 from socorro.processor.general_transform_rules import (
     CPUInfoRule,
+    DeNullRule,
     IdentifierRule,
     OSInfoRule,
 )
@@ -63,6 +64,8 @@ from socorro.processor.mozilla_transform_rules import (
 )
 
 DEFAULT_RULES = [
+    # fix the raw crash removing null characters
+    DeNullRule,
     # rules to change the internals of the raw crash
     ProductRewrite,
     ESRVersionRewrite,


### PR DESCRIPTION
We want to move the de-nulling step from the collector to the processor. This
makes the raw crash data more authentic in regards to what we got from the
client. Further, it reduces the work that the collector needs to do.