### PR TITLE
fix bug 1401274: nix the user-provided value

### DIFF
--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -211,9 +211,11 @@ class SearchBase(object):
                     except ValueError:
                         raise BadArgumentError(
                             param.name,
-                            msg='Bad value for parameter %s:'
-                            ' "%s" is not a valid %s' %
-                            (param.name, value, param.data_type)
+                            msg=(
+                                'Bad value for parameter %s: not a valid %s' % (
+                                    param.name, param.data_type
+                                )
+                            )
                         )
 
                     if param.name not in parameters:


### PR DESCRIPTION
This removes the user-provided value from the error message. It's a
possible security issue depending on what is done with the text. We
could escape it or change it, but I think that reduces its helpfulness
and it's better to just nix it.