### PR TITLE
Adjust editorconfig with indent sizes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,17 @@ insert_final_newline = true
 [Makefile]
 indent_style = tab
 
+[*.html]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
 [*.yml]
 indent_size = 2
 
 [*.py]
 max_line_length = 100
+
+[*.js]
+indent_size = 2


### PR DESCRIPTION
This fixes `.editorconfig` for js, html, and json files. Anyone who uses
it won't have to fiddle with their editors.