### PR TITLE
fix bug 1315109: don't show correlations tab if not supported

### DIFF
--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -29,6 +29,7 @@
     data-fields="{{ fields | to_json }}"
     data-columns="{{ columns | to_json }}"
     data-sort="{{ sort | join(',') }}"
+    data-correlations-products="{{ correlations_products | to_json }}"
 >
     <div class="page-heading">
         <h2>Signature report for <em>{{ signature }}</em></h2>
@@ -70,13 +71,15 @@
             <li><a href="#graphs" class="graphs" data-tab-name="graphs">Graphs</a></li>
             <li><a href="#bugzilla" class="bugzilla" data-tab-name="bugzilla">Bugzilla</a></li>
             <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
-            <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
+            {% if product in correlations_products %}
+                <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
+            {% endif %}
         </ul>
     </nav>
 
     <!-- Loading panel.
-        Shows a loading bar, is displayed by default when the page is
-        loading initial data.
+         Shows a loading bar, is displayed by default when the page is
+         loading initial data.
     -->
     <section class="panel tab-panel" id="loading-panel">
         <header class="title">

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_correlations.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_correlations.js
@@ -23,22 +23,18 @@ SignatureReport.CorrelationsTab.prototype = SignatureReport.inherit(SignatureRep
 SignatureReport.CorrelationsTab.prototype.loadControls = function() {
   var self = this;
 
-  var channels = $('#mainbody').data('channels');
-
   // Create a select box for the product.
+  var correlationsProducts = $('#mainbody').data('correlations-products');
   this.productSelect = $('<select>', { class: 'products-list', id: 'correlations-products-list' });
-  this.productSelect.append($('<option>', { value: 'Firefox', text: 'Firefox' }));
-  this.productSelect.append($('<option>', { value: 'FennecAndroid', text: 'FennecAndroid' }));
+  correlationsProducts.forEach(function(product) {
+    self.productSelect.append($('<option>', { value: product, text: product }));
+  });
 
   // Create a select box for the channel.
+  var channels = $('#mainbody').data('channels');
   this.channelSelect = $('<select>', { class: 'channels-list', id: 'correlations-channels-list' });
   channels.forEach(function(channel) {
-    self.channelSelect.append(
-      $('<option>', {
-        value: channel,
-        text: channel,
-      })
-    );
+    self.channelSelect.append($('<option>', { value: channel, text: channel }));
   });
 
   // Append the controls.

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -42,6 +42,16 @@ DEFAULT_SORT = (
     '-date',
 )
 
+# These products are supported by correlations. Looking at the signature report
+# and filtering on other products will not show the correlations tab.
+#
+# NOTE(willkg): To add support for another product, you have to add a url
+# to crashstats/static/crashstats/js/socorro/correlations.js getDataURL.
+CORRELATIONS_PRODUCTS = [
+    'Firefox',
+    'FennecAndroid'
+]
+
 
 def pass_validated_params(view):
     @functools.wraps(view)
@@ -98,6 +108,8 @@ def signature_report(request, params, default_context=None):
 
     context['channels'] = ','.join(settings.CHANNELS).split(',')
     context['channel'] = settings.CHANNEL
+
+    context['correlations_products'] = CORRELATIONS_PRODUCTS
 
     # Compute dates to show them to the user.
     start_date, end_date = get_date_boundaries(params)


### PR DESCRIPTION
This moves the list of supported products for correlations to the view
code and fixes the JS to build the options based on that. The correlations.js
code still has its own list of supported products, but we can fix that
another day.

This also adjusts the jinja template such that if the specified product
isn't supported by correlations, it won't show the correlations tab at
all.