### PR TITLE
fix bug 606630: show friendly build date

### DIFF
--- a/webapp-django/crashstats/crashstats/context_processors.py
+++ b/webapp-django/crashstats/crashstats/context_processors.py
@@ -3,7 +3,5 @@ from django.conf import settings as django_settings
 
 def settings(request):
     return {
-        'SETTINGS': django_settings,
-        'DEBUG': django_settings.DEBUG,
-        'GOOGLE_ANALYTICS_ID': django_settings.GOOGLE_ANALYTICS_ID,
+        'settings': django_settings,
     }

--- a/webapp-django/crashstats/crashstats/context_processors.py
+++ b/webapp-django/crashstats/crashstats/context_processors.py
@@ -3,6 +3,7 @@ from django.conf import settings as django_settings
 
 def settings(request):
     return {
+        'SETTINGS': django_settings,
         'DEBUG': django_settings.DEBUG,
         'GOOGLE_ANALYTICS_ID': django_settings.GOOGLE_ANALYTICS_ID,
     }

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -185,7 +185,7 @@
                                 <td>
                                     {{ report.build }}
                                     <span class="humanized">({{ report.build | buildid_to_date }})</span>
-                                    <a href="{{ SETTINGS.BUILDHUB_BASE_URL }}?{{ make_query_string(**{'q': report.build, 'channel[0]': report.release_channel}) }}" class="sig-overview" title="Buildhub data">Buildhub data</a>
+                                    <a href="{{ settings.BUILDHUB_BASE_URL }}?{{ make_query_string(**{'q': report.build, 'channel[0]': report.release_channel}) }}" class="sig-overview" title="Buildhub data">Buildhub data</a>
                                 </td>
                             </tr>
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -183,9 +183,9 @@
                             <tr title="{{ fields_desc['processed_crash.build'] }}">
                                 <th scope="row">Build ID</th>
                                 <td>
-                                    <a href="https://mozilla-services.github.io/buildhub/?{{ make_query_string(q=report.build) }}">
-                                        {{ report.build }}
-                                    </a>
+                                    {{ report.build }}
+                                    <span class="humanized">({{ report.build | buildid_to_date }})</span>
+                                    <a href="{{ SETTINGS.BUILDHUB_BASE_URL }}?{{ make_query_string(**{'q': report.build, 'channel[0]': report.release_channel}) }}" class="sig-overview" title="Buildhub data">Buildhub data</a>
                                 </td>
                             </tr>
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
@@ -1,6 +1,6 @@
 {% from "macros/pagination.html" import pagination %}
 <!DOCTYPE html>
-<html lang="en-US" class="production" data-google-analytics-id="{{ GOOGLE_ANALYTICS_ID }}">
+<html lang="en-US" class="production" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}">
     <head>
         <meta charset="UTF-8" />
         <title>{% block page_title %}Crash Data for {{ product }}{% endblock %}</title>
@@ -9,7 +9,7 @@
             {% stylesheet 'crashstats_base' %}
         {% endblock %}
 
-        {% if GOOGLE_ANALYTICS_ID %}
+        {% if settings.GOOGLE_ANALYTICS_ID %}
             {#
                 Use the preload technique which gives a performance boost for
                 modern browsers.

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -38,8 +38,26 @@ def digitgroupseparator(number):
 
 
 @library.filter
-def timestamp_to_date(timestamp, format='%Y-%m-%d %H:%M:%S'):
-    """ Python datetime to a time tag with JS Date.parse-parseable format. """
+def buildid_to_date(buildid, fmt='%Y-%m-%d'):
+    """Returns the date portion of the build id"""
+    try:
+        dt = datetime.datetime.strptime(buildid[0:8], '%Y%m%d')
+    except (TypeError, ValueError):
+        return ''
+
+    return jinja2.Markup(
+        '<time datetime="{}" class="jstime" data-format="{}">{}</time>'
+        .format(
+            dt.isoformat(),
+            fmt,
+            dt.strftime(fmt)
+        )
+    )
+
+
+@library.filter
+def timestamp_to_date(timestamp, fmt='%Y-%m-%d %H:%M:%S'):
+    """Python datetime to a time tag with JS Date.parse-parseable format"""
     try:
         timestamp = float(timestamp)
     except (TypeError, ValueError):
@@ -58,8 +76,8 @@ def timestamp_to_date(timestamp, format='%Y-%m-%d %H:%M:%S'):
         '<time datetime="{}" class="jstime" data-format="{}">{}</time>'
         .format(
             dt.isoformat(),
-            format,
-            dt.strftime(format)
+            fmt,
+            dt.strftime(fmt)
         )
     )
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -323,6 +323,9 @@ ENGAGE_ROBOTS = False
 # Base URL for when we use the Bugzilla API
 BZAPI_BASE_URL = 'https://bugzilla.mozilla.org/rest'
 
+# Base URL for Buildhub
+BUILDHUB_BASE_URL = 'https://mozilla-services.github.io/buildhub/'
+
 # The index schema used in our elasticsearch databases, used in the
 # Super Search Custom Query page.
 ELASTICSEARCH_INDEX_SCHEMA = 'socorro%Y%W'


### PR DESCRIPTION
This fixes the display of the build id in the report view so that it shows
the build id, a humanized version of the build id date, and then an explicit
link to the Buildhub data for that build.

This also adds the channel to the Buildhub link--that will focus the data
better. That'll help a little with bug #1056217.

This also moves the buildhub base url to settings--we shouldn't have had
it hardcoded in the template.