### PR TITLE
fix bug 1377632: fix crash signature bug summary

### DIFF
--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -190,10 +190,12 @@ def show_bug_link(bug_id):
 @library.global_function
 def bugzilla_submit_url(report, parsed_dump, crashing_thread, bug_product):
     url = 'https://bugzilla.mozilla.org/enter_bug.cgi'
+
     # Some crashes has the `os_name` but it's null so we
     # fall back on an empty string on it instead. That way the various
     # `.startswith(...)` things we do don't raise an AttributeError.
     op_sys = report.get('os_pretty_version') or report['os_name'] or ''
+
     # At the time of writing, these pretty versions of the OS name
     # don't perfectly fit with the drop-down choices that Bugzilla
     # has in its OS drop-down. So we have to make some adjustments.
@@ -222,7 +224,7 @@ def bugzilla_submit_url(report, parsed_dump, crashing_thread, bug_product):
         # NOTE(willkg): cpu_name is deprecated; switch to just cpu_arch in July 2019
         'rep_platform': report.get('cpu_arch', report['cpu_name']),
         'cf_crash_signature': '[@ {}]'.format(smart_str(report['signature'])),
-        'short_desc': 'Crash in {}'.format(smart_str(report['signature'])),
+        'short_desc': 'Crash in [@ {}]'.format(smart_str(report['signature'])),
         'comment': comment,
     }
 

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -170,7 +170,7 @@ class TestBugzillaSubmitURL(object):
         assert qs['format'] == ['__default__']
         assert qs['product'] == ['Plugin']
         assert qs['rep_platform'] == ['x86']
-        assert qs['short_desc'] == ['Crash in $&#;deadbeef']
+        assert qs['short_desc'] == ['Crash in [@ $&#;deadbeef]']
         assert qs['keywords'] == ['crash']
         assert qs['op_sys'] == ['Windows']
         assert qs['bug_severity'] == ['critical']
@@ -254,7 +254,7 @@ class TestBugzillaSubmitURL(object):
         )
         url = bugzilla_submit_url(report, self.EMPTY_PARSED_DUMP, self.CRASHING_THREAD, 'Core')
         # Most important that it should work
-        assert 'Crash+in+YouTube%E2%84%A2+No+Buffer+%28Stop+Auto-playing' in url
+        assert 'Crash+in+%5B%40+YouTube%E2%84%A2+No+Buffer+%28Stop+Auto-playing%29%5D' in url
 
     def test_comment(self):
         report = self._create_report()


### PR DESCRIPTION
This changes the bug summary from:

```
Crash in OOM | Small
```

to something easier to parse:

```
Crash in [@ OOM | Small]
```

which matches how we do crash signatures elsewhere.