### PR TITLE
fix bug 1146956: add UTC label to date processed field

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -114,7 +114,7 @@
                   <th scope="row">Date Processed</th>
                   <td>
                     {% if report.date_processed %}
-                      {{ report.date_processed | human_readable_iso_date }}
+                      {{ report.date_processed | human_readable_iso_date }} UTC
                     {% endif %}
                   </td>
                 </tr>


### PR DESCRIPTION
Since the date processed field comes from Socorro, we can guarantee that it
is in UTC. We can do the same for the submitted datetime stamp. We can't do
that for other datetime stamps because they come from the client and who
knows what state it's in.

This adds a UTC label to the "Date processed" field in the report view.