### PR TITLE
bug 1525614: adjust server logging settings for webapp

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -221,7 +221,7 @@ LOGGING = {
             'formatter': 'socorroapp',
         },
         'mozlog': {
-            'level': 'DEBUG',
+            'level': LOGGING_LEVEL,
             'class': 'logging.StreamHandler',
             'formatter': 'mozlog',
             'filters': ['add_hostid']
@@ -247,15 +247,21 @@ if LOCAL_DEV_ENV:
             'handlers': ['console'],
             'level': LOGGING_LEVEL,
         },
+        'django.server': {
+            'handlers': ['console'],
+            'level': LOGGING_LEVEL,
+        },
         'django.request': {
             'handlers': ['console'],
+            'level': LOGGING_LEVEL,
         },
         'py.warnings': {
             'handlers': ['console'],
+            'level': LOGGING_LEVEL,
         },
         'markus': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': LOGGING_LEVEL,
         },
         'crashstats': {
             'handlers': ['console'],
@@ -269,8 +275,9 @@ else:
             'handlers': ['mozlog'],
             'level': LOGGING_LEVEL,
         },
-        'django.request': {
+        'django.server': {
             'handlers': ['mozlog'],
+            'level': LOGGING_LEVEL,
         },
         'crashstats': {
             'handlers': ['mozlog'],


### PR DESCRIPTION
This tweaks the server logging settings for the webapp. It removes
`django.request` and adds `django.server`. That'll show incoming HTTP requests.

This also fixes all the loggers to use the same `LOGGING_LEVEL`.