### PR TITLE
Add missing versions to "make updatedata"

### DIFF
--- a/docker/run_update_data.sh
+++ b/docker/run_update_data.sh
@@ -19,5 +19,8 @@ ${DC} run app shell ./socorro-cmd crontabber --reset-job=archivescraper
 ${DC} run app shell ./socorro-cmd crontabber --job=archivescraper \
     --crontabber.class-ArchiveScraperCronApp.verbose
 
+# Insert data that's no longer on archive.mozilla.org
+${DC} run app shell python ./scripts/insert_missing_versions.py
+
 # Create ES indexes for the next few weeks
 ${DC} run app shell ./socorro-cmd create_recent_indices


### PR DESCRIPTION
This changes "make updatedata" to also run the insert_missing_versions.py
script after running the archivescraper crontabber job.