### PR TITLE
bug 1510658: track cache misses for BetaVersionRule

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -604,6 +604,8 @@ class BetaVersionRule(Rule):
             self.metrics.incr('cache', tags=['result:hit'])
             return self.cache[key]
 
+        self.metrics.incr('cache', tags=['result:miss'])
+
         resp = self.session.get(self.version_string_api, params={
             'product': product,
             'channel': channel,


### PR DESCRIPTION
This fixes the code to also track cache misses for the BetaVersionRule.