### PR TITLE
fix bug 1419899: implement __heartbeat__ and __lbheartbeat__

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1693,34 +1693,6 @@ class TestLogin(BaseTestViews):
         assert 'Insufficient Privileges' in smart_text(response.content)
 
 
-class TestDockerflow(object):
-    def test_version_no_file(self, client, settings, tmpdir):
-        """Test with no version.json file"""
-        # The tmpdir definitely doesn't have a version.json in it, so we use
-        # that
-        settings.SOCORRO_ROOT = str(tmpdir)
-
-        resp = client.get(reverse('crashstats:dockerflow_version'))
-        assert resp.status_code == 200
-        assert resp['Content-Type'] == 'application/json'
-        assert smart_text(resp.content) == '{}'
-
-    def test_version_with_file(self, client, settings, tmpdir):
-        """Test with a version.json file"""
-        text = '{"commit": "d6ac5a5d2acf99751b91b2a3ca651d99af6b9db3"}'
-
-        # Create the version.json file in the tmpdir
-        version_json = tmpdir.join('version.json')
-        version_json.write(text)
-
-        settings.SOCORRO_ROOT = str(tmpdir)
-
-        resp = client.get(reverse('crashstats:dockerflow_version'))
-        assert resp.status_code == 200
-        assert resp['Content-Type'] == 'application/json'
-        assert smart_text(resp.content) == text
-
-
 class TestProductHomeViews(BaseTestViews):
     def test_product_home(self):
         self.set_product_versions(['20.0', '19.1', '19.0', '18.0'])

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -22,12 +22,6 @@ urlpatterns = [
         views.robots_txt,
         name='robots_txt'),
 
-    # DEPRECATED(willkg): This endpoint should be deprecated in
-    # favor of the dockerflow /__version__ one
-    url(r'^status/json/$',
-        views.status_json,
-        name='status_json'),
-
     url(r'^report/index/(?P<crash_id>[\w-]+)$',
         views.report_index,
         name='report_index'),
@@ -57,12 +51,7 @@ urlpatterns = [
         views.home,
         name='home'),
 
-    # Dockerflow endpoints
-    url(r'__version__',
-        views.dockerflow_version,
-        name='dockerflow_version'),
-
-    # redirect deceased Advanced Search URL to Super Search
+    # Redirect deceased Advanced Search URL to Super Search
     url(r'^query/$',
         RedirectView.as_view(
             url='/search/',

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -4,7 +4,6 @@
 
 import datetime
 import json
-import os
 
 from django import http
 from django.conf import settings
@@ -240,28 +239,6 @@ def report_index(request, crash_id, default_context=None):
         ]
 
     return render(request, 'crashstats/report_index.html', context)
-
-
-def status_json(request):
-    """This is deprecated and should not be used.
-    Use the /api/Status/ endpoint instead.
-    """
-    if settings.DEBUG:
-        raise Exception(
-            'This view is deprecated and should not be accessed. '
-            'The only reason it\'s kept is for legacy reasons.'
-        )
-    return redirect(reverse('api:model_wrapper', args=('Status',)))
-
-
-def dockerflow_version(requst):
-    path = os.path.join(settings.SOCORRO_ROOT, 'version.json')
-    if os.path.exists(path):
-        with open(path, 'r') as fp:
-            data = fp.read()
-    else:
-        data = '{}'
-    return http.HttpResponse(data, content_type='application/json')
 
 
 @pass_default_context

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -9,13 +9,14 @@ from crashstats.monitoring import views
 
 app_name = 'monitoring'
 urlpatterns = [
-    url(r'^$',
-        views.index,
-        name='index'),
-    url(r'^crontabber/$',
-        views.crontabber_status,
-        name='crontabber_status'),
-    url(r'^healthcheck/$',
-        views.healthcheck,
-        name='healthcheck'),
+    url(r'^monitoring/$', views.index, name='index'),
+    url(r'^monitoring/crontabber/$', views.crontabber_status, name='crontabber_status'),
+
+    # Dockerflow endpoints
+    url(r'^__heartbeat__$', views.dockerflow_heartbeat, name='dockerflow_heartbeat'),
+    url(r'^__lbheartbeat__$', views.dockerflow_lbheartbeat, name='dockerflow_lbheartbeat'),
+    url(r'^__version__$', views.dockerflow_version, name='dockerflow_version'),
+
+    # FIXME(willkg): DEPRECATED
+    url(r'^monitoring/healthcheck/$', views.healthcheck, name='healthcheck'),
 ]

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -30,10 +30,10 @@ urlpatterns = [
     url(r'', include('crashstats.crashstats.urls', namespace='crashstats')),
     url(r'', include('crashstats.supersearch.urls', namespace='supersearch')),
     url(r'', include('crashstats.exploitability.urls', namespace='exploitability')),
+    url(r'', include('crashstats.monitoring.urls', namespace='monitoring')),
     url(r'^signature/', include('crashstats.signature.urls', namespace='signature')),
     url(r'^topcrashers/', include('crashstats.topcrashers.urls', namespace='topcrashers')),
     url(r'^sources/', include('crashstats.sources.urls', namespace='sources')),
-    url(r'^monitoring/', include('crashstats.monitoring.urls', namespace='monitoring')),
     url(r'^api/tokens/', include('crashstats.tokens.urls', namespace='tokens')),
     url(r'^api/', include('crashstats.api.urls', namespace='api')),
     # redirect all symbols/ requests to Tecken


### PR DESCRIPTION
This implements the `__heartbeat__` and `__lbheartbeat__` dockerflow endpoints
for the webapp. It reworks the existing `healthcheck` code and deprecates
the old version. We can remove that as soon as we update the infrastructure.

This also moves `__version__` from the crashstats app to the monitoring
app; seems to be a more appropriate place.