### PR TITLE
fix bug 1393416: stop copying Winsock_LSP to processed crash

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -513,11 +513,6 @@ class FlashVersionRule(Rule):
             processed_crash.flash_version = '[blank]'
 
 
-class Winsock_LSPRule(Rule):
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.Winsock_LSP = raw_crash.get('Winsock_LSP', None)
-
-
 class TopMostFilesRule(Rule):
     """Origninating from Bug 519703, the topmost_filenames was specified as
     singular, there would be only one.  The original programmer, in the

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -60,7 +60,6 @@ from socorro.processor.mozilla_transform_rules import (
     ThemePrettyNameRule,
     TopMostFilesRule,
     UserDataRule,
-    Winsock_LSPRule,
 )
 
 DEFAULT_RULES = [
@@ -84,7 +83,6 @@ DEFAULT_RULES = [
     OutOfMemoryBinaryRule,
     JavaProcessRule,
     MozCrashReasonRule,
-    Winsock_LSPRule,
     # post processing of the processed crash
     CrashingThreadRule,
     CPUInfoRule,

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -34,7 +34,6 @@ from socorro.processor.mozilla_transform_rules import (
     ThemePrettyNameRule,
     TopMostFilesRule,
     UserDataRule,
-    Winsock_LSPRule,
 )
 from socorro.signature.generator import SignatureGenerator
 from socorro.unittest import WHATEVER
@@ -1108,44 +1107,6 @@ class TestFlashVersionRule(object):
 
         # raw_crash should be unchanged
         assert raw_crash == canonical_standard_raw_crash
-
-
-class TestWinsock_LSPRule(object):
-    def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_crash.Winsock_LSP = 'really long string'
-        expected_raw_crash = copy.deepcopy(raw_crash)
-        raw_dumps = {}
-        processed_crash = copy.deepcopy(canonical_processed_crash)
-        processor_meta = get_basic_processor_meta()
-
-        rule = Winsock_LSPRule(config)
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert processed_crash.Winsock_LSP == 'really long string'
-
-        # raw_crash should be unchanged
-        assert raw_crash == expected_raw_crash
-
-    def test_missing_key(self):
-        config = get_basic_config()
-
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        del raw_crash.Winsock_LSP
-        expected_raw_crash = copy.deepcopy(raw_crash)
-        raw_dumps = {}
-        processed_crash = copy.deepcopy(canonical_processed_crash)
-        processor_meta = get_basic_processor_meta()
-
-        rule = Winsock_LSPRule(config)
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
-
-        assert processed_crash.Winsock_LSP is None
-
-        # raw_crash should be unchanged
-        assert raw_crash == expected_raw_crash
 
 
 class TestTopMostFilesRule(object):


### PR DESCRIPTION
There was a processor rule for copying the `Winsock_LSP` value from the
raw crash to the processed crash, but nothing can use or access it
in the processed crash.

This removes that rule.