### PR TITLE
bug 1529342: redo logging in socorro apps

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -12,7 +12,7 @@
 # logging
 # -------
 
-# Set to 10 - DEBUG for local development
+# Set logging level to DEBUG for local development
 resource.logging.level=DEBUG
 
 # postgres

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -13,7 +13,7 @@
 # -------
 
 # Set to 10 - DEBUG for local development
-resource.logging.level=10
+resource.logging.level=DEBUG
 
 # postgres
 # --------

--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -27,7 +27,6 @@ sending new crash records to Postgres; sending the processed crash to HBase;
 the the submission of the crash_id to Elastic Search."""
 
 from functools import partial
-import logging
 import signal
 
 from configman import Namespace
@@ -35,9 +34,6 @@ from configman.converters import class_converter
 
 from socorro.lib.task_manager import respond_to_SIGTERM
 from socorro.app.socorro_app import App
-
-
-logger = logging.getLogger(__name__)
 
 
 class FetchTransformSaveApp(App):
@@ -86,7 +82,7 @@ class FetchTransformSaveApp(App):
     )
 
     def __init__(self, config):
-        super(FetchTransformSaveApp, self).__init__(config)
+        super().__init__(config)
         self.waiting_func = None
         # select the iterator type based on the "number_of_submissions" config
         self.source_iterator = {
@@ -234,12 +230,7 @@ class FetchTransformSaveApp(App):
                 # we're running all in the same thread, a failure here could
                 # derail the the whole processor. Best just log the problem
                 # so that we can continue.
-                logger.error(
-                    'Error completing job %s: %s',
-                    crash_id,
-                    x,
-                    exc_info=True
-                )
+                self.logger.error('Error completing job %s: %s', crash_id, x, exc_info=True)
 
     def _transform(self, crash_id):
         """this default transform function only transfers raw data from the
@@ -249,39 +240,23 @@ class FetchTransformSaveApp(App):
         try:
             raw_crash = self.source.get_raw_crash(crash_id)
         except Exception as x:
-            logger.error(
-                "reading raw_crash: %s",
-                str(x),
-                exc_info=True
-            )
+            self.logger.error("reading raw_crash: %s", str(x), exc_info=True)
             raw_crash = {}
         try:
             dumps = self.source.get_raw_dumps(crash_id)
         except Exception as x:
-            logger.error(
-                "reading dump: %s",
-                str(x),
-                exc_info=True
-            )
+            self.logger.error("reading dump: %s", str(x), exc_info=True)
             dumps = {}
         try:
             self.destination.save_raw_crash(raw_crash, dumps, crash_id)
-            logger.info('saved - %s', crash_id)
+            self.logger.info('saved - %s', crash_id)
         except Exception as x:
-            logger.error(
-                "writing raw: %s",
-                str(x),
-                exc_info=True
-            )
+            self.logger.error("writing raw: %s", str(x), exc_info=True)
         else:
             try:
                 self.source.remove(crash_id)
             except Exception as x:
-                logger.error(
-                    "removing raw: %s",
-                    str(x),
-                    exc_info=True
-                )
+                self.logger.error("removing raw: %s", str(x), exc_info=True)
 
     def quit_check(self):
         self.task_manager.quit_check()
@@ -299,10 +274,7 @@ class FetchTransformSaveApp(App):
                 quit_check_callback=self.quit_check
             )
         except Exception:
-            logger.critical(
-                'Error in creating crash source',
-                exc_info=True
-            )
+            self.logger.critical('Error in creating crash source', exc_info=True)
             raise
         try:
             self.destination = self.config.destination.crashstorage_class(
@@ -311,16 +283,13 @@ class FetchTransformSaveApp(App):
                 quit_check_callback=self.quit_check
             )
         except Exception:
-            logger.critical(
-                'Error in creating crash destination',
-                exc_info=True
-            )
+            self.logger.critical('Error in creating crash destination', exc_info=True)
             raise
 
     def _setup_task_manager(self):
         """instantiate the threaded task manager to run the producer/consumer
         queue that is the heart of the processor."""
-        logger.info('installing signal handers')
+        self.logger.info('installing signal handers')
         # set up the signal handler for dealing with SIGTERM. the target should
         # be this app instance so the signal handler can reach in and set the
         # quit flag to be True.  See the 'respond_to_SIGTERM' method for the
@@ -360,7 +329,7 @@ class FetchTransformSaveApp(App):
         self._setup_source_and_destination()
         self.task_manager.blocking_start(waiting_func=self.waiting_func)
         self.close()
-        logger.info('done.')
+        self.logger.info('done.')
 
 
 class FetchTransformSaveWithSeparateNewCrashSourceApp(FetchTransformSaveApp):

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -40,6 +40,8 @@ from socorro.lib.revision_data import get_revision_data
 # for use with SIGHUP for apps that run as daemons
 restart = True
 
+logger = logging.getLogger(__name__)
+
 
 def respond_to_SIGHUP(signal_number, frame, logger=None):
     """raise the KeyboardInterrupt which will cause the app to effectively
@@ -80,7 +82,7 @@ def klass_to_pypath(klass):
     return "%s.%s" % (module_name, klass.__name__)
 
 
-class SocorroApp(RequiredConfig):
+class App(RequiredConfig):
     """The base class for all Socorro applications"""
     app_name = 'SocorroAppBaseClass'
     app_version = "1.0"
@@ -92,11 +94,45 @@ class SocorroApp(RequiredConfig):
     config_defaults = None
 
     required_config = Namespace()
+    required_config.add_option(
+        'host_id',
+        doc='host id',
+        default='',
+    )
+    required_config.namespace('logging')
+    required_config.logging.add_option(
+        'level',
+        doc='logging level: DEBUG, INFO, WARNING, ERROR, or CRITICAL',
+        default='INFO',
+        reference_value_from='resource.logging',
+    )
+
+    required_config.namespace('metricscfg')
+    required_config.metricscfg.add_option(
+        'statsd_host',
+        doc='host for statsd server',
+        default='localhost',
+        reference_value_from='resource.metrics'
+    )
+    required_config.metricscfg.add_option(
+        'statsd_port',
+        doc='port for statsd server',
+        default=8125,
+        reference_value_from='resource.metrics'
+    )
+    required_config.metricscfg.add_option(
+        'markus_backends',
+        doc='comma separated list of Markus backends to use',
+        default='markus.backends.datadog.DatadogMetrics',
+        reference_value_from='resource.metrics',
+        from_string_converter=str_to_list,
+    )
 
     def __init__(self, config):
         self.config = config
         # give a name to this running instance of the program.
         self.app_instance_name = self._app_instance_name()
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def main(self):  # pragma: no cover
         """derived classes must override this function with business logic"""
@@ -130,13 +166,6 @@ class SocorroApp(RequiredConfig):
 
     @classmethod
     def _do_run(klass, config_path=None, values_source_list=None):
-        # while this method is defined here, only derived classes are allowed
-        # to call it.
-        if klass is SocorroApp:
-            raise NotImplementedError(
-                "The SocorroApp class has no useable 'main' method"
-            )
-
         if config_path is None:
             config_path = os.environ.get(
                 'DEFAULT_SOCORRO_CONFIG_PATH',
@@ -195,6 +224,9 @@ class SocorroApp(RequiredConfig):
             return code
 
         with config_manager.context() as config:
+            setup_logging(config)
+            setup_metrics(config)
+
             config.executor_identity = (
                 lambda: threading.currentThread().getName()
             )
@@ -202,7 +234,7 @@ class SocorroApp(RequiredConfig):
             # Log revision information
             revision_data = get_revision_data()
             revision_items = sorted(revision_data.items())
-            config.logger.info(
+            logger.info(
                 'version.json: {%s}',
                 ', '.join(
                     ['%r: %r' % (key, val) for key, val in revision_items]
@@ -210,10 +242,10 @@ class SocorroApp(RequiredConfig):
             )
 
             try:
-                config_manager.log_config(config.logger)
+                config_manager.log_config(logger)
                 respond_to_SIGHUP_with_logging = functools.partial(
                     respond_to_SIGHUP,
-                    logger=config.logger
+                    logger=logger
                 )
                 # install the signal handler with logging
                 signal.signal(signal.SIGHUP, respond_to_SIGHUP_with_logging)
@@ -231,28 +263,11 @@ class SocorroApp(RequiredConfig):
             return return_code
 
 
-def setup_logger(config, local_unused, args_unused):
-    """Initialize logging infrastructure and returns app logger
-
-    This method is sets up and initializes the logger objects. It is a function
-    in the form appropriate for a configiman aggregation. When given to
-    Configman, that library will setup and initialize the logging system
-    automatically and then offer the logger as an object within the
-    configuration object.
-
-    """
-    try:
-        app_name = config.application.app_name
-    except KeyError:
-        app_name = 'a_socorro_app'
-
+def setup_logging(config):
+    """Initialize Python logging."""
     logging_level = config.logging.level
-    logging_root_level = config.logging.root_level
-    logging_format = config.logging.format_string
 
-    # FIXME(willkg): we should check config for a friendly host name and
-    # degrade to socket.gethostname()
-    host_id = socket.gethostname()
+    host_id = config.host_id or socket.gethostname()
 
     class AddHostID(logging.Filter):
         def filter(self, record):
@@ -269,7 +284,7 @@ def setup_logger(config, local_unused, args_unused):
         },
         'formatters': {
             'socorroapp': {
-                'format': logging_format
+                'format': '%(asctime)s %(levelname)s - %(name)s - %(threadName)s - %(message)s',
             },
             'mozlog': {
                 '()': 'dockerflow.logging.JsonLogFormatter',
@@ -306,10 +321,6 @@ def setup_logger(config, local_unused, args_unused):
                 'handlers': ['console'],
                 'level': logging_level,
             },
-            app_name: {
-                'handlers': ['console'],
-                'level': logging_level,
-            },
         }
 
     else:
@@ -319,35 +330,13 @@ def setup_logger(config, local_unused, args_unused):
                 'handlers': ['mozlog'],
                 'level': logging_level,
             },
-            app_name: {
-                'handlers': ['mozlog'],
-                'level': logging_level,
-            },
         }
-
-    # If the user is setting the root level to something below or equal to
-    # logging level, then we want to stop propagating some loggers. This only
-    # happens in local development environments.
-    if logging_root_level <= logging_level:
-        logging_config['root'] = {
-            'handlers': ['console'],
-            'level': logging_root_level,
-        }
-        logging_config['loggers']['socorro']['propagate'] = 0
-        logging_config['loggers'][app_name]['propagate'] = 0
 
     logging.config.dictConfig(logging_config)
 
-    logger = logging.getLogger(app_name)
-    return logger
 
-
-def setup_metrics(config, local_unused, args_unused):
-    """Sets up markus and adds a metrics client to config
-
-    :returns: Markus MetricsInterface
-
-    """
+def setup_metrics(config):
+    """Set up Markus."""
     backends = []
 
     for backend in config.metricscfg.markus_backends:
@@ -375,64 +364,3 @@ def setup_metrics(config, local_unused, args_unused):
             raise ValueError('Invalid markus backend "%s"' % backend)
 
     markus.configure(backends=backends)
-
-    return markus.get_metrics('')
-
-
-class App(SocorroApp):
-    """The base class from which Socorro apps are based"""
-    required_config = Namespace()
-    required_config.namespace('logging')
-    required_config.logging.add_option(
-        'format_string',
-        doc='format string for logging',
-        default='%(asctime)s %(levelname)s - %(name)s - %(threadName)s - %(message)s',
-        reference_value_from='resource.logging',
-    )
-    required_config.logging.add_option(
-        'level',
-        doc=(
-            'logging level '
-            '(10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)'
-        ),
-        default=20,
-        reference_value_from='resource.logging',
-    )
-    required_config.logging.add_option(
-        'root_level',
-        doc=(
-            'logging level for everything not Socorro '
-            '(10 - DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)'
-        ),
-        default=30,
-        reference_value_from='resource.logging',
-    )
-    required_config.add_aggregation(
-        'logger',
-        setup_logger
-    )
-
-    required_config.namespace('metricscfg')
-    required_config.metricscfg.add_option(
-        'statsd_host',
-        doc='host for statsd server',
-        default='localhost',
-        reference_value_from='resource.metrics'
-    )
-    required_config.metricscfg.add_option(
-        'statsd_port',
-        doc='port for statsd server',
-        default=8125,
-        reference_value_from='resource.metrics'
-    )
-    required_config.metricscfg.add_option(
-        'markus_backends',
-        doc='comma separated list of Markus backends to use',
-        default='markus.backends.datadog.DatadogMetrics',
-        reference_value_from='resource.metrics',
-        from_string_converter=str_to_list,
-    )
-    required_config.add_aggregation(
-        'metrics',
-        setup_metrics
-    )

--- a/socorro/cron/base.py
+++ b/socorro/cron/base.py
@@ -5,6 +5,7 @@
 import collections
 import datetime
 import functools
+import logging
 import re
 
 from configman import Namespace, RequiredConfig
@@ -156,6 +157,7 @@ class BaseCronApp(RequiredConfig):
     def __init__(self, config, job_information):
         self.config = config
         self.job_information = job_information
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def main(self, function=None, once=True):
         if not function:
@@ -187,7 +189,7 @@ class BaseCronApp(RequiredConfig):
         # case 3: either it has never run successfully or it was previously run
         #   before the 'first_run' key was added (legacy).
         if not last_success:
-            self.config.logger.warning(
+            self.logger.warning(
                 'No previous last_success information available'
             )
             # just run it for the time 'now'

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -6,7 +6,6 @@
 import datetime
 import inspect
 import json
-import logging
 import re
 import sys
 import time
@@ -688,9 +687,8 @@ class CronTabberApp(App, RequiredConfig):
     )
 
     def __init__(self, config):
-        super(CronTabberApp, self).__init__(config)
+        super().__init__(config)
         self.database_class = self.config.crontabber.database_class(config.crontabber)
-        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def main(self):
         if self.config.get('list-jobs'):

--- a/socorro/cron/jobs/archivescraper.py
+++ b/socorro/cron/jobs/archivescraper.py
@@ -168,7 +168,7 @@ class ArchiveScraperCronApp(BaseCronApp):
         }
 
         if self.config.verbose:
-            self.config.logger.info('INSERTING: %s' % list(sorted(params.items())))
+            self.logger.info('INSERTING: %s' % list(sorted(params.items())))
 
         with transaction_context(self.database) as conn:
             cursor = conn.cursor()
@@ -189,7 +189,7 @@ class ArchiveScraperCronApp(BaseCronApp):
                 # If it's an IntegrityError, we already have it and everything is fine
                 pass
             except psycopg2.Error:
-                self.config.logger.exception('failed to insert')
+                self.logger.exception('failed to insert')
 
     def get_links(self, content):
         """Retrieves valid links on the page
@@ -224,12 +224,12 @@ class ArchiveScraperCronApp(BaseCronApp):
         """
         url = urljoin(self.config.base_url, url_path)
         if self.config.verbose:
-            self.config.logger.info('downloading: %s', url)
+            self.logger.info('downloading: %s', url)
         resp = self.session.get(url)
         if resp.status_code != 200:
             if self.config.verbose:
                 # Most of these are 404s because we guessed a url wrong which is fine
-                self.config.logger.warning('Bad status: %s: %s', url, resp.status_code)
+                self.logger.warning('Bad status: %s: %s', url, resp.status_code)
             return ''
 
         return resp.content
@@ -306,9 +306,7 @@ class ArchiveScraperCronApp(BaseCronApp):
         # greater than (major_version - 4) and esr builds
         if major_version:
             major_version_minus_4 = major_version - 4
-            self.config.logger.info(
-                'Skipping anything before %s and not esr', major_version_minus_4
-            )
+            self.logger.info('Skipping anything before %s and not esr', major_version_minus_4)
             version_links = [
                 link for link in version_links
                 if (
@@ -345,7 +343,7 @@ class ArchiveScraperCronApp(BaseCronApp):
                 # platforms that ahve them
                 json_links = self.get_json_links(build_link['path'])
                 if not json_links:
-                    self.config.logger.warning(
+                    self.logger.warning(
                         'could not find json files in: %s', build_link['path']
                     )
                     continue
@@ -451,4 +449,4 @@ class ArchiveScraperCronApp(BaseCronApp):
             archive_directory='mobile'
         )
 
-        self.config.logger.info('Inserted %s builds.', self.successful_inserts)
+        self.logger.info('Inserted %s builds.', self.successful_inserts)

--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -133,7 +133,7 @@ class BugzillaCronApp(BaseCronApp):
 
     def update_bug_data(self, bug_id, signature_set):
         with transaction_context(self.database) as connection:
-            self.config.logger.debug('bug %s: %s', bug_id, signature_set)
+            self.logger.debug('bug %s: %s', bug_id, signature_set)
 
             # If there's no associated signatures, delete everything for this bug id
             if not signature_set:
@@ -157,7 +157,7 @@ class BugzillaCronApp(BaseCronApp):
                         WHERE signature = %s and bug_id = %s
                         """
                         execute_no_results(connection, sql, (signature, bug_id))
-                        self.config.logger.info('association removed: %s - "%s"', bug_id, signature)
+                        self.logger.info('association removed: %s - "%s"', bug_id, signature)
 
             except SQLDidNotReturnSingleRow:
                 signatures_db = []
@@ -169,7 +169,7 @@ class BugzillaCronApp(BaseCronApp):
                     VALUES (%s, %s)
                     """
                     execute_no_results(connection, sql, (signature, bug_id))
-                    self.config.logger.info('association added: %s - "%s"', bug_id, signature)
+                    self.logger.info('association added: %s - "%s"', bug_id, signature)
 
     def _iterator(self, from_date):
         # Fetch all the bugs that have been created or had the crash_signature

--- a/socorro/cron/jobs/monitoring.py
+++ b/socorro/cron/jobs/monitoring.py
@@ -124,9 +124,9 @@ class DependencySecurityCheckCronApp(BaseCronApp):
         client.captureMessage('Dependency security check failed')
 
     def alert_log(self, vulnerabilities):
-        self.config.logger.error('Vulnerabilities found in dependencies!')
+        self.logger.error('Vulnerabilities found in dependencies!')
         for vuln in vulnerabilities:
-            self.config.logger.error('%s: %s' % (vuln.key, vuln.summary))
+            self.logger.error('%s: %s' % (vuln.key, vuln.summary))
 
     def get_python_vulnerabilities(self):
         """Check Python dependencies via Pyup's safety command.

--- a/socorro/cron/jobs/update_signatures.py
+++ b/socorro/cron/jobs/update_signatures.py
@@ -101,7 +101,7 @@ class UpdateSignaturesCronApp(BaseCronApp):
         all_fields = SuperSearchFields(config=self.config).get()
         api = SuperSearch(config=self.config)
         start_datetime = end_datetime - datetime.timedelta(minutes=self.config.period)
-        self.config.logger.info('Looking at %s to %s', start_datetime, end_datetime)
+        self.logger.info('Looking at %s to %s', start_datetime, end_datetime)
 
         params = {
             'date': [
@@ -162,7 +162,7 @@ class UpdateSignaturesCronApp(BaseCronApp):
         # Save signature data to the db
         for item in signature_data:
             if self.config.dry_run:
-                self.config.logger.info(
+                self.logger.info(
                     'Inserting/updating signature (%s, %s, %s)',
                     item['signature'],
                     item['date'],
@@ -175,4 +175,4 @@ class UpdateSignaturesCronApp(BaseCronApp):
                     report_build=item['build_id'],
                 )
 
-        self.config.logger.info('Inserted/updated %d signatures.', len(signature_data))
+        self.logger.info('Inserted/updated %d signatures.', len(signature_data))

--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
+
 from socorro.lib import external_common, MissingArgumentError, BadArgumentError, ooid
 from socorro.external.boto.crashstorage import (
     BotoS3CrashStorage,
@@ -28,6 +30,7 @@ class SimplifiedCrashData(BotoS3CrashStorage):
         # leaf point we want to NOT return a DotDict but just a plain
         # python dict.
         self.config.json_object_hook = dict
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def get(self, **kwargs):
         """Return JSON data of a crash report, given its uuid. """
@@ -62,7 +65,7 @@ class SimplifiedCrashData(BotoS3CrashStorage):
             else:
                 return get(params.uuid)
         except CrashIDNotFound as cidnf:
-            self.config.logger.error('%s not found: %s' % (params.datatype, cidnf))
+            self.logger.error('%s not found: %s' % (params.datatype, cidnf))
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message
             # contains information about buckets and prefix keys.
@@ -93,7 +96,7 @@ class TelemetryCrashData(TelemetryBotoS3CrashStorage):
         try:
             return self.get_unredacted_processed(params.uuid)
         except CrashIDNotFound as cidnf:
-            self.config.logger.error('telemetry crash not found: %s' % cidnf)
+            self.logger.error('telemetry crash not found: %s' % cidnf)
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message contains
             # information about buckets and prefix keys. Re-wrap it here so the

--- a/socorro/external/boto/upload_telemetry_schema.py
+++ b/socorro/external/boto/upload_telemetry_schema.py
@@ -66,7 +66,7 @@ class UploadTelemetrySchema(App):
             bucket = connection_context._get_bucket(connection, self.config.telemetry.bucket_name)
         except S3ResponseError:
             # If there's no bucket--fail out here
-            self.config.logger.error(
+            self.logger.error(
                 'Failure: The %s S3 bucket must be created first.',
                 self.config.telemetry.bucket_name
             )
@@ -77,7 +77,7 @@ class UploadTelemetrySchema(App):
             key = bucket.new_key(self.config.telemetry.json_filename)
         key.set_contents_from_string(CRASH_REPORT_JSON_SCHEMA_AS_STRING)
 
-        self.config.logger.info('Success: Schema uploaded!')
+        self.logger.info('Success: Schema uploaded!')
         return 0
 
 

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -9,6 +9,7 @@ saving, fetching and iterating over raw crashes, dumps and processed crashes.
 import datetime
 import collections
 import copy
+import logging
 import os
 import sys
 
@@ -189,9 +190,9 @@ class CrashStorageBase(RequiredConfig):
             self.quit_check = quit_check_callback
         else:
             self.quit_check = lambda: False
-        self.logger = config.logger
         self.exceptions_eligible_for_retry = ()
         self.redactor = config.redactor_class(config)
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def close(self):
         """some implementations may need explicit closing."""
@@ -606,6 +607,7 @@ class BenchmarkingCrashStorage(CrashStorageBase):
         self.tag = config.benchmark_tag
         self.start_timer = datetime.datetime.now
         self.end_timer = datetime.datetime.now
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def close(self):
         """some implementations may need explicit closing."""
@@ -615,60 +617,60 @@ class BenchmarkingCrashStorage(CrashStorageBase):
         start_time = self.start_timer()
         self.wrapped_crashstore.save_raw_crash(raw_crash, dumps, crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s save_raw_crash %s', self.tag, end_time - start_time)
+        self.logger.debug('%s save_raw_crash %s', self.tag, end_time - start_time)
 
     def save_processed(self, processed_crash):
         start_time = self.start_timer()
         self.wrapped_crashstore.save_processed(processed_crash)
         end_time = self.end_timer()
-        self.config.logger.debug('%s save_processed %s', self.tag, end_time - start_time)
+        self.logger.debug('%s save_processed %s', self.tag, end_time - start_time)
 
     def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
         start_time = self.start_timer()
         self.wrapped_crashstore.save_raw_and_processed(raw_crash, dumps, processed_crash, crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s save_raw_and_processed %s', self.tag, end_time - start_time)
+        self.logger.debug('%s save_raw_and_processed %s', self.tag, end_time - start_time)
 
     def get_raw_crash(self, crash_id):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_raw_crash(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s get_raw_crash %s', self.tag, end_time - start_time)
+        self.logger.debug('%s get_raw_crash %s', self.tag, end_time - start_time)
         return result
 
     def get_raw_dump(self, crash_id, name=None):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_raw_dump(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s get_raw_dump %s', self.tag, end_time - start_time)
+        self.logger.debug('%s get_raw_dump %s', self.tag, end_time - start_time)
         return result
 
     def get_raw_dumps(self, crash_id):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_raw_dumps(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s get_raw_dumps %s', self.tag, end_time - start_time)
+        self.logger.debug('%s get_raw_dumps %s', self.tag, end_time - start_time)
         return result
 
     def get_raw_dumps_as_files(self, crash_id):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_raw_dumps_as_files(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s get_raw_dumps_as_files %s', self.tag, end_time - start_time)
+        self.logger.debug('%s get_raw_dumps_as_files %s', self.tag, end_time - start_time)
         return result
 
     def get_unredacted_processed(self, crash_id):
         start_time = self.start_timer()
         result = self.wrapped_crashstore.get_unredacted_processed(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s get_unredacted_processed %s', self.tag, end_time - start_time)
+        self.logger.debug('%s get_unredacted_processed %s', self.tag, end_time - start_time)
         return result
 
     def remove(self, crash_id):
         start_time = self.start_timer()
         self.wrapped_crashstore.remove(crash_id)
         end_time = self.end_timer()
-        self.config.logger.debug('%s remove %s', self.tag, end_time - start_time)
+        self.logger.debug('%s remove %s', self.tag, end_time - start_time)
 
 
 class MetricsEnabledBase(RequiredConfig):

--- a/socorro/external/es/clear_indices_app.py
+++ b/socorro/external/es/clear_indices_app.py
@@ -33,7 +33,7 @@ class ClearESIndicesApp(App):
         cleaner = self.config.elasticsearch_cleaner_class(self.config)
         deleted_indices = cleaner.delete_indices()
         for index in deleted_indices:
-            self.config.logger.info('Deleted elasticsearch index %s' % (index,))
+            self.logger.info('Deleted elasticsearch index %s' % (index,))
         return SUCCESS
 
 

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -281,7 +281,7 @@ class ESCrashStorage(CrashStorageBase):
         except Exception:
             # NOTE(willkg): An error here shouldn't screw up saving data. Log it so we can fix it
             # later.
-            self.config.logger.exception('something went wrong when capturing raw_crash_size')
+            self.logger.exception('something went wrong when capturing raw_crash_size')
 
         try:
             self.metrics.histogram(
@@ -291,7 +291,7 @@ class ESCrashStorage(CrashStorageBase):
         except Exception:
             # NOTE(willkg): An error here shouldn't screw up saving data. Log it so we can fix it
             # later.
-            self.config.logger.exception('something went wrong when capturing processed_crash_size')
+            self.logger.exception('something went wrong when capturing processed_crash_size')
 
     def _index_crash(self, connection, es_index, es_doctype, crash_document, crash_id):
         try:
@@ -357,7 +357,7 @@ class ESCrashStorage(CrashStorageBase):
                 if not field_name:
                     # We are unable to parse which field to remove, we cannot
                     # try to fix the document. Let it raise.
-                    self.config.logger.critical(
+                    self.logger.critical(
                         'Submission to Elasticsearch failed for %s (%s)',
                         crash_id,
                         e,
@@ -391,7 +391,7 @@ class ESCrashStorage(CrashStorageBase):
                     crash_document['removed_fields'] = field_name
 
             except elasticsearch.exceptions.ElasticsearchException as exc:
-                self.config.logger.critical(
+                self.logger.critical(
                     'Submission to Elasticsearch failed for %s (%s)',
                     crash_id,
                     exc,

--- a/socorro/external/es/index_creator.py
+++ b/socorro/external/es/index_creator.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+import logging
 
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
@@ -56,6 +57,7 @@ class IndexCreator(RequiredConfig):
     def __init__(self, config):
         super(IndexCreator, self).__init__()
         self.config = config
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
         self.es_context = self.config.elasticsearch.elasticsearch_class(
             config=self.config.elasticsearch
         )
@@ -101,10 +103,10 @@ class IndexCreator(RequiredConfig):
                 index=es_index,
                 body=es_settings,
             )
-            self.config.logger.info('Created new elasticsearch index: %s', es_index)
+            self.logger.info('Created new elasticsearch index: %s', es_index)
         except elasticsearch.exceptions.RequestError as e:
             # If this index already exists, swallow the error.
             # NOTE! This is NOT how the error looks like in ES 2.x
             if 'IndexAlreadyExistsException' not in str(e):
                 raise
-            self.config.logger.info('Index exists: %s', es_index)
+            self.logger.info('Index exists: %s', es_index)

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+import logging
 
 import elasticsearch
 
@@ -117,6 +118,7 @@ class SuperSearchFields(object):
 
     def __init__(self, config):
         self.config = config
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
         self.es_context = self.config.elasticsearch.elasticsearch_class(
             self.config.elasticsearch
         )
@@ -185,7 +187,7 @@ class SuperSearchFields(object):
                 all_existing_fields.update(parse_mapping(properties, None))
             except elasticsearch.exceptions.NotFoundError as e:
                 # If an index does not exist, this should not fail
-                self.config.logger.warning(
+                self.logger.warning(
                     'Missing index in elasticsearch while running '
                     'SuperSearchFields.get_missing_fields, error is: %s',
                     str(e)

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -265,11 +265,11 @@ class FSPermanentStorage(CrashStorageBase):
             try:
                 os.unlink(cand)
             except OSError:
-                self.config.logger.error("could not delete: %s", cand, exc_info=True)
+                self.logger.error("could not delete: %s", cand, exc_info=True)
 
         # If the directory is empty, clean it up
         if len(os.listdir(parent_dir)) == 0:
             try:
                 os.rmdir(parent_dir)
             except OSError:
-                self.config.logger.error("could not delete: %s", parent_dir, exc_info=True)
+                self.logger.error("could not delete: %s", parent_dir, exc_info=True)

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import contextlib
+import logging
 import os
 import socket
 
@@ -77,6 +78,7 @@ class ConnectionContext(RequiredConfig):
         """
         super(ConnectionContext, self).__init__()
         self.config = config
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
         if local_config is None:
             local_config = config
         if local_config['database_port'] is None:
@@ -105,7 +107,7 @@ class ConnectionContext(RequiredConfig):
         try:
             yield conn
         finally:
-            # self.config.logger.debug('connection closed')
+            # self.logger.debug('connection closed')
             self.close_connection(conn)
 
     def close_connection(self, connection, force=False):

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -107,7 +107,6 @@ class ConnectionContext(RequiredConfig):
         try:
             yield conn
         finally:
-            # self.logger.debug('connection closed')
             self.close_connection(conn)
 
     def close_connection(self, connection, force=False):

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -81,14 +81,14 @@ class RabbitMQCrashStorage(CrashStorageBase):
                 raw_crash.legacy_processing == 0
             )
         except KeyError:
-            self.config.logger.debug(
+            self.logger.debug(
                 'RabbitMQCrashStorage legacy_processing key absent in crash '
                 '%s', crash_id
             )
             return
 
         if this_crash_should_be_queued:
-            self.config.logger.debug('RabbitMQCrashStorage saving crash %s', crash_id)
+            self.logger.debug('RabbitMQCrashStorage saving crash %s', crash_id)
             retry(
                 self.rabbitmq,
                 self.quit_check,
@@ -97,7 +97,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
             )
             return True
         else:
-            self.config.logger.debug(
+            self.logger.debug(
                 'RabbitMQCrashStorage not saving crash %s, legacy processing '
                 'flag is %s', crash_id, raw_crash.legacy_processing
             )
@@ -166,7 +166,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
         to let the caller know to skip on to the next crash."""
         if crash_id in self.acknowledgement_token_cache:
             # reject this crash - it's already being processsed
-            self.config.logger.info('duplicate job: %s is already in progress', crash_id)
+            self.logger.info('duplicate job: %s is already in progress', crash_id)
             # ack this
             retry(
                 self.rabbitmq,
@@ -200,14 +200,14 @@ class RabbitMQCrashStorage(CrashStorageBase):
                     )
                     del self.acknowledgement_token_cache[crash_id_to_be_acknowledged]
                 except KeyError:
-                    self.config.logger.warning(
+                    self.logger.warning(
                         'RabbitMQCrashStorage tried to acknowledge crash %s'
                         ', which was not in the cache',
                         crash_id_to_be_acknowledged,
                         exc_info=True
                     )
                 except Exception:
-                    self.config.logger.error(
+                    self.logger.error(
                         'RabbitMQCrashStorage unexpected failure on %s',
                         crash_id_to_be_acknowledged,
                         exc_info=True
@@ -218,7 +218,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
 
     def _ack_crash(self, connection, crash_id, acknowledgement_token):
         connection.channel.basic_ack(delivery_tag=acknowledgement_token.delivery_tag)
-        self.config.logger.debug(
+        self.logger.debug(
             'RabbitMQCrashStorage acking %s with delivery_tag %s',
             crash_id,
             acknowledgement_token.delivery_tag

--- a/socorro/lib/transaction.py
+++ b/socorro/lib/transaction.py
@@ -29,10 +29,9 @@ def transaction_context(connection_context):
 
       Rolls the transaction back.
 
-    * ``config.logger.exception``
+    * ``logger``
 
-      ``config`` is a configman ``DotDict`` that has a logger that implements
-      ``exception``.
+      Python logger.
 
     :arg connection_context: the connection context to use
 
@@ -51,7 +50,7 @@ def transaction_context(connection_context):
                 # NOTE(willkg): This exception is effectively getting
                 # swallowed. We're assuming it's a red herring for whatever
                 # threw the original exception. In Python 3, we can chain them.
-                conn.config.logger.exception('cannot rollback')
+                conn.logger.exception('cannot rollback')
             six.reraise(*excinfo)
 
 

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -105,7 +105,7 @@ class ExternalProcessRule(Rule):
         try:
             return json.loads(data)
         except Exception as x:
-            self.config.logger.error(
+            self.logger.error(
                 '%s non-json output: "%s"' % (self.config.command_pathname, data[:100])
             )
             processor_meta.processor_notes.append(
@@ -281,12 +281,12 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
         if return_code == 124:
             msg = 'MDSW terminated with SIGKILL due to timeout'
             processor_meta.processor_notes.append(msg)
-            self.config.logger.warning(msg)
+            self.logger.warning(msg)
 
         elif return_code != 0 or not stackwalker_data.success:
             msg = 'MDSW failed with %s: %s' % (return_code, stackwalker_data.mdsw_status_string)
             processor_meta.processor_notes.append(msg)
-            self.config.logger.warning(msg)
+            self.logger.warning(msg)
 
         return stackwalker_data, return_code
 

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -649,7 +649,7 @@ class BetaVersionRule(Rule):
                 processed_crash['version'] = real_version
                 return
 
-            self.config.logger.info(
+            self.logger.info(
                 'betaversionrule: failed lookup %s %s %s %s',
                 processed_crash.get('uuid'),
                 product,
@@ -797,7 +797,7 @@ class SignatureGeneratorRule(Rule):
         """Captures errors from signature generation"""
         extra['uuid'] = crash_data.get('uuid', None)
         raven_client.capture_error(
-            self.sentry_dsn, self.config.logger, exc_info=exc_info, extra=extra
+            self.sentry_dsn, self.logger, exc_info=exc_info, extra=extra
         )
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -7,6 +7,7 @@ crash.  In this latest version, all transformations have been reimplemented
 as sets of loadable rules.  The rules are applied one at a time, each doing
 some small part of the transformation process."""
 
+import logging
 import os
 import tempfile
 
@@ -190,6 +191,7 @@ class Processor2015(RequiredConfig):
     def __init__(self, config, rules=None, quit_check_callback=None):
         super(Processor2015, self).__init__()
         self.config = config
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
         # the quit checks are components of a system of callbacks used
         # primarily by the TaskManager system.  This is the system that
         # controls the execution model.  If the ThreadedTaskManager is in use,
@@ -259,7 +261,7 @@ class Processor2015(RequiredConfig):
         # the processor to be responsive to requests to shut down.
         self.quit_check()
 
-        start_time = self.config.logger.info('starting transform for crash: %s', crash_id)
+        start_time = self.logger.info('starting transform for crash: %s', crash_id)
         processor_meta_data.started_timestamp = start_time
 
         # Apply rules; if a rule fails, capture the error and continue onward
@@ -272,7 +274,7 @@ class Processor2015(RequiredConfig):
                 # processor notes
                 raven_client.capture_error(
                     sentry_dsn=self.sentry_dsn,
-                    logger=self.config.logger,
+                    logger=self.logger,
                     extra={'crash_id': crash_id}
                 )
                 # NOTE(willkg): notes are public, so we can't put exception
@@ -297,7 +299,7 @@ class Processor2015(RequiredConfig):
         # For backwards compatibility
         processed_crash.completeddatetime = completed_datetime
 
-        self.config.logger.info(
+        self.logger.info(
             "finishing %s transform for crash: %s",
             'successful' if processed_crash.success else 'failed',
             crash_id
@@ -305,9 +307,9 @@ class Processor2015(RequiredConfig):
         return processed_crash
 
     def reject_raw_crash(self, crash_id, reason):
-        self.config.logger.warning('%s rejected: %s', crash_id, reason)
+        self.logger.warning('%s rejected: %s', crash_id, reason)
 
     def close(self):
-        self.config.logger.debug('closing rules')
+        self.logger.debug('closing rules')
         for rule in self.rules:
             rule.close()

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -6,6 +6,7 @@
 """the processor_app converts raw_crashes into processed_crashes"""
 
 import collections
+import logging
 import os
 import sys
 
@@ -170,6 +171,10 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         reference_value_from='secrets.sentry',
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
+
     def _capture_error(self, crash_id, exc_info):
         """Capture an error in sentry if able
 
@@ -184,7 +189,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
 
         raven_client.capture_error(
             sentry_dsn,
-            self.config.logger,
+            self.logger,
             exc_info,
             extra={'crash_id': crash_id}
         )
@@ -209,7 +214,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         except Exception as x:
             # We don't know what this error is, so we should capture it
             self._capture_error(crash_id, sys.exc_info())
-            self.config.logger.warning('error loading crash %s', crash_id, exc_info=True)
+            self.logger.warning('error loading crash %s', crash_id, exc_info=True)
             self.processor.reject_raw_crash(crash_id, 'error in loading: %s' % x)
             return
 
@@ -236,7 +241,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
             # the raw_crash or not.
 
             self.destination.save_raw_and_processed(raw_crash, None, processed_crash, crash_id)
-            self.config.logger.info('saved - %s', crash_id)
+            self.logger.info('saved - %s', crash_id)
         except Exception:
             # Capture the exception so we don't lose it as we do other things
             exc_type, exc_value, exc_tb = sys.exc_info()
@@ -250,10 +255,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
 
             for exc_info_item in exc_info:
                 self._capture_error(crash_id, exc_info_item)
-                self.config.logger.warning(
-                    'error in processing or saving crash %s',
-                    crash_id
-                )
+                self.logger.warning('error in processing or saving crash %s', crash_id)
 
             # Re-raise the original exception with the correct traceback
             six.reraise(exc_type, exc_value, exc_tb)
@@ -265,7 +267,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
                     try:
                         os.unlink(a_dump_pathname)
                     except OSError as x:
-                        self.config.logger.info('deletion of dump failed: %s', x)
+                        self.logger.info('deletion of dump failed: %s', x)
 
     def _setup_source_and_destination(self):
         """Instantiates classes necessary for processing"""

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -6,7 +6,6 @@
 """the processor_app converts raw_crashes into processed_crashes"""
 
 import collections
-import logging
 import os
 import sys
 
@@ -170,10 +169,6 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         default='',
         reference_value_from='secrets.sentry',
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def _capture_error(self, crash_id, exc_info):
         """Capture an error in sentry if able

--- a/socorro/processor/rules/base.py
+++ b/socorro/processor/rules/base.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
+
 from configman import RequiredConfig
 import markus
 
@@ -20,6 +22,7 @@ class Rule(RequiredConfig):
     def __init__(self, config=None, quit_check_callback=None):
         self.config = config
         self.quit_check_callback = quit_check_callback
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, processor_meta_data):
         """Determines whether to run the action for this crash

--- a/socorro/processor/rules/memory_report_extraction.py
+++ b/socorro/processor/rules/memory_report_extraction.py
@@ -41,12 +41,10 @@ class MemoryReportExtraction(Rule):
         try:
             measures = self._get_memory_measures(memory_report, pid)
         except ValueError as e:
-            self.config.logger.info(
-                'Unable to extract measurements from memory report: {}'.format(e)
-            )
+            self.logger.info('Unable to extract measurements from memory report: {}'.format(e))
             return
         except KeyError as e:
-            self.config.logger.info(
+            self.logger.info(
                 'Unable to extract measurements from memory report: '
                 'key {} is missing from a report'.format(e)
             )

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from collections import OrderedDict
+import logging
 import os
 import sys
 import tempfile
@@ -50,7 +51,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('D')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('D  %s', event.pathname)
+                self.monitor.debug('D  %s', event.pathname)
             self.monitor._remove_cached(event.pathname)
 
     def process_IN_CREATE(self, event):
@@ -59,7 +60,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('C')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('C  %s', event.pathname)
+                self.monitor.debug('C  %s', event.pathname)
             self.monitor._update_cache(event.pathname)
 
     def process_IN_MOVED_FROM(self, event):
@@ -68,7 +69,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('M')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('M> %s', event.pathname)
+                self.monitor.debug('M> %s', event.pathname)
             self.monitor._remove_cached(event.pathname)
 
     def process_IN_MOVED_TO(self, event):
@@ -77,7 +78,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('M')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('M< %s', event.pathname)
+                self.monitor.logger.debug('M< %s', event.pathname)
             self.monitor._update_cache(event.pathname)
 
     def process_IN_OPEN(self, event):
@@ -86,7 +87,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('O')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('O  %s', event.pathname)
+                self.monitor.logger.debug('O  %s', event.pathname)
             self.monitor._update_cache(event.pathname)
 
     def process_IN_MODIFY(self, event):
@@ -95,7 +96,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('M')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.config.logger.debug('M  %s', event.pathname)
+                self.monitor.logger.debug('M  %s', event.pathname)
             self.monitor._update_cache(event.pathname, update_size=True)
 
 
@@ -148,6 +149,7 @@ class SymbolLRUCacheManager(RequiredConfig):
         """constructor for a registration object that runs an LRU cache
        cleaner"""
         self.config = config
+        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
         self.directory = os.path.abspath(config.symbol_cache_path)
         self.max_size = config.symbol_cache_size
@@ -199,9 +201,7 @@ class SymbolLRUCacheManager(RequiredConfig):
             try:
                 size = os.stat(path).st_size
             except OSError:
-                self.config.logger.warning(
-                    'file was not found while cleaning cache: %s', path
-                )
+                self.logger.warning('file was not found while cleaning cache: %s', path)
                 return
 
             self.total_size += size
@@ -213,7 +213,7 @@ class SymbolLRUCacheManager(RequiredConfig):
                 os.unlink(rm_path)
                 self._rm_empty_dirs(rm_path)
                 if self.verbosity >= 2:
-                    self.config.logger.debug('RM %s', rm_path)
+                    self.logger.debug('RM %s', rm_path)
         self._lru[path] = size
 
     def _remove_cached(self, path):

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -51,7 +51,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('D')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.debug('D  %s', event.pathname)
+                self.monitor.logger.debug('D  %s', event.pathname)
             self.monitor._remove_cached(event.pathname)
 
     def process_IN_CREATE(self, event):
@@ -60,7 +60,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('C')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.debug('C  %s', event.pathname)
+                self.monitor.logger.debug('C  %s', event.pathname)
             self.monitor._update_cache(event.pathname)
 
     def process_IN_MOVED_FROM(self, event):
@@ -69,7 +69,7 @@ class EventHandler(ProcessEvent):
                 sys.stdout.write('M')
                 sys.stdout.flush()
             elif self.verbosity == 2:
-                self.monitor.debug('M> %s', event.pathname)
+                self.monitor.logger.debug('M> %s', event.pathname)
             self.monitor._remove_cached(event.pathname)
 
     def process_IN_MOVED_TO(self, event):

--- a/socorro/unittest/__init__.py
+++ b/socorro/unittest/__init__.py
@@ -2,10 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import contextlib
 from functools import total_ordering
-import logging
-import mock
 
 
 @total_ordering
@@ -20,10 +17,3 @@ class EqualAnything(object):
 #: Sentinel that is equal to anything; simplifies assertions in cases where
 #: part of the value changes from test to test
 WHATEVER = EqualAnything()
-
-
-@contextlib.contextmanager
-def mock_logging(logger_name, fun_name):
-    logger = logging.getLogger(logger_name)
-    with mock.patch.object(logger, fun_name) as mock_logging_fun:
-        yield mock_logging_fun

--- a/socorro/unittest/__init__.py
+++ b/socorro/unittest/__init__.py
@@ -2,7 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import contextlib
 from functools import total_ordering
+import logging
+import mock
 
 
 @total_ordering
@@ -17,3 +20,10 @@ class EqualAnything(object):
 #: Sentinel that is equal to anything; simplifies assertions in cases where
 #: part of the value changes from test to test
 WHATEVER = EqualAnything()
+
+
+@contextlib.contextmanager
+def mock_logging(logger_name, fun_name):
+    logger = logging.getLogger(logger_name)
+    with mock.patch.object(logger, fun_name) as mock_logging_fun:
+        yield mock_logging_fun

--- a/socorro/unittest/conftest.py
+++ b/socorro/unittest/conftest.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import os
 
 from markus.testing import MetricsMock
@@ -63,3 +64,18 @@ def db_conn():
     for table_name in tables:
         cursor.execute('TRUNCATE %s CASCADE' % table_name)
     conn.commit()
+
+
+@pytest.yield_fixture
+def caplogpp(caplog):
+    """Fix logger propagation values, return caplog fixture, and unfix when done."""
+    changed_loggers = []
+    for logger in logging.Logger.manager.loggerDict.values():
+        if getattr(logger, 'propagate', True) is False:
+            logger.propagate = True
+            changed_loggers.append(logger)
+
+    yield caplog
+
+    for logger in changed_loggers:
+        logger.propagate = False

--- a/socorro/unittest/external/rabbitmq/test_connection_context.py
+++ b/socorro/unittest/external/rabbitmq/test_connection_context.py
@@ -119,7 +119,6 @@ class TestConnectionContextPooled(object):
         config.priority_queue_name = 'wilma'
         config.reprocessing_queue_name = 'betty'
         config.rabbitmq_connection_wrapper_class = Connection
-        config.logger = Mock()
 
         config.executor_identity = lambda: 'MainThread'
 

--- a/socorro/unittest/external/rabbitmq/test_reprocessing.py
+++ b/socorro/unittest/external/rabbitmq/test_reprocessing.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from configman.dotdict import DotDict
-from mock import Mock, MagicMock
+from mock import MagicMock
 
 from socorro.external.crashstorage_base import Redactor
 from socorro.external.rabbitmq.crashstorage import ReprocessingOneRabbitMQCrashStore
@@ -15,7 +15,6 @@ class TestReprocessing(object):
         config = DotDict()
         self.transaction_executor = MagicMock()
         config.transaction_executor_class = self.transaction_executor
-        config.logger = Mock()
         config.rabbitmq_class = ConnectionContext
         config.routing_key = 'socorro.reprocessing'
         config.filter_on_legacy_processing = True

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -416,11 +416,10 @@ class TestRedactor(object):
 
 
 class TestBench(object):
-    def test_benchmarking_crashstore(self):
-        required_config = Namespace()
+    def test_benchmarking_crashstore(self, caplogpp):
+        caplogpp.set_level('DEBUG')
 
-        mock_logging = mock.Mock()
-        required_config.add_option('logger', default=mock_logging)
+        required_config = Namespace()
         required_config.update(BenchmarkingCrashStorage.get_required_config())
         fake_crash_store = mock.Mock()
 
@@ -430,7 +429,6 @@ class TestBench(object):
             app_version='1.0',
             app_description='app description',
             values_source_list=[{
-                'logger': mock_logging,
                 'wrapped_crashstore': fake_crash_store,
                 'benchmark_tag': 'test'
             }],
@@ -455,23 +453,15 @@ class TestBench(object):
                 'payload',
                 'ooid'
             )
-            mock_logging.debug.assert_called_with(
-                '%s save_raw_crash %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            assert 'test save_raw_crash 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.save_processed({})
             crashstorage.wrapped_crashstore.save_processed.assert_called_with(
                 {}
             )
-            mock_logging.debug.assert_called_with(
-                '%s save_processed %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            assert 'test save_processed 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.save_raw_and_processed({}, 'payload', {}, 'ooid')
             crashstorage.wrapped_crashstore.save_raw_and_processed.assert_called_with(
@@ -480,67 +470,32 @@ class TestBench(object):
                 {},
                 'ooid'
             )
-            mock_logging.debug.assert_called_with(
-                '%s save_raw_and_processed %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            assert 'test save_raw_and_processed 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.get_raw_crash('uuid')
-            crashstorage.wrapped_crashstore.get_raw_crash.assert_called_with(
-                'uuid'
-            )
-            mock_logging.debug.assert_called_with(
-                '%s get_raw_crash %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            crashstorage.wrapped_crashstore.get_raw_crash.assert_called_with('uuid')
+            assert 'test get_raw_crash 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.get_raw_dump('uuid')
-            crashstorage.wrapped_crashstore.get_raw_dump.assert_called_with(
-                'uuid'
-            )
-            mock_logging.debug.assert_called_with(
-                '%s get_raw_dump %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            crashstorage.wrapped_crashstore.get_raw_dump.assert_called_with('uuid')
+            assert 'test get_raw_dump 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.get_raw_dumps('uuid')
-            crashstorage.wrapped_crashstore.get_raw_dumps.assert_called_with(
-                'uuid'
-            )
-            mock_logging.debug.assert_called_with(
-                '%s get_raw_dumps %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            crashstorage.wrapped_crashstore.get_raw_dumps.assert_called_with('uuid')
+            assert 'test get_raw_dumps 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.get_raw_dumps_as_files('uuid')
-            crashstorage.wrapped_crashstore.get_raw_dumps_as_files.assert_called_with(
-                'uuid'
-            )
-            mock_logging.debug.assert_called_with(
-                '%s get_raw_dumps_as_files %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            crashstorage.wrapped_crashstore.get_raw_dumps_as_files.assert_called_with('uuid')
+            assert 'test get_raw_dumps_as_files 1' in [rec.message for rec in caplogpp.records]
+            caplogpp.clear()
 
             crashstorage.get_unredacted_processed('uuid')
-            crashstorage.wrapped_crashstore.get_unredacted_processed.assert_called_with(
-                'uuid'
-            )
-            mock_logging.debug.assert_called_with(
-                '%s get_unredacted_processed %s',
-                'test',
-                1
-            )
-            mock_logging.debug.reset_mock()
+            crashstorage.wrapped_crashstore.get_unredacted_processed.assert_called_with('uuid')
+            assert 'test get_unredacted_processed 1' in [rec.message for rec in caplogpp.records]
 
 
 class TestDumpsMappings(object):

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
-
 from configman.dotdict import DotDict
 from mock import Mock
 
@@ -11,54 +9,36 @@ from socorro.lib.task_manager import TaskManager, default_task_func
 
 
 class TestTaskManager(object):
-    def setup_method(self, method):
-        self.logger = logging.getLogger(__name__)
-
     def test_constuctor1(self):
         config = DotDict()
-        config.logger = self.logger
         config.quit_on_empty_queue = False
 
         tm = TaskManager(config)
         assert tm.config == config
-        assert tm.logger == self.logger
         assert tm.task_func == default_task_func
         assert tm.quit is False
 
     def test_executor_identity(self):
         config = DotDict()
-        config.logger = self.logger
-        tm = TaskManager(
-            config,
-            job_source_iterator=range(1),
-
-        )
+        tm = TaskManager(config, job_source_iterator=range(1))
         tm._pid = 666
         assert tm.executor_identity() == '666-MainThread'
 
     def test_get_iterator(self):
         config = DotDict()
-        config.logger = self.logger
         config.quit_on_empty_queue = False
 
-        tm = TaskManager(
-            config,
-            job_source_iterator=range(1),
-        )
+        tm = TaskManager(config, job_source_iterator=range(1))
         assert list(tm._get_iterator()) == [0]
 
         def an_iter(self):
             for i in range(5):
                 yield i
 
-        tm = TaskManager(
-            config,
-            job_source_iterator=an_iter,
-        )
+        tm = TaskManager(config, job_source_iterator=an_iter)
         assert list(tm._get_iterator()) == [0, 1, 2, 3, 4]
 
         class X(object):
-
             def __init__(self, config):
                 self.config = config
 
@@ -66,26 +46,16 @@ class TestTaskManager(object):
                 for key in self.config:
                     yield key
 
-        tm = TaskManager(
-            config,
-            job_source_iterator=X(config)
-        )
+        tm = TaskManager(config, job_source_iterator=X(config))
         assert list(tm._get_iterator()) == list(config.keys())
 
     def test_blocking_start(self):
         config = DotDict()
-        config.logger = self.logger
         config.idle_delay = 1
         config.quit_on_empty_queue = False
 
         class MyTaskManager(TaskManager):
-
-            def _responsive_sleep(
-                self,
-                seconds,
-                wait_log_interval=0,
-                wait_reason=''
-            ):
+            def _responsive_sleep(self, seconds, wait_log_interval=0, wait_reason=''):
                 try:
                     if self.count >= 2:
                         self.quit = True
@@ -93,10 +63,7 @@ class TestTaskManager(object):
                 except AttributeError:
                     self.count = 0
 
-        tm = MyTaskManager(
-            config,
-            task_func=Mock()
-        )
+        tm = MyTaskManager(config, task_func=Mock())
 
         waiting_func = Mock()
 
@@ -107,14 +74,10 @@ class TestTaskManager(object):
 
     def test_blocking_start_with_quit_on_empty(self):
         config = DotDict()
-        config.logger = self.logger
         config.idle_delay = 1
         config.quit_on_empty_queue = True
 
-        tm = TaskManager(
-            config,
-            task_func=Mock()
-        )
+        tm = TaskManager(config, task_func=Mock())
 
         waiting_func = Mock()
 

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
 import time
 
 from configman.dotdict import DotDict
@@ -16,18 +15,13 @@ from socorro.lib.threaded_task_manager import (
 
 
 class TestThreadedTaskManager(object):
-    def setup_method(self, method):
-        self.logger = logging.getLogger(__name__)
-
     def test_constuctor1(self):
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 1
         config.maximum_queue_size = 1
         ttm = ThreadedTaskManager(config)
         try:
             assert ttm.config == config
-            assert ttm.logger == self.logger
             assert ttm.task_func == default_task_func
             assert not ttm.quit
         finally:
@@ -36,7 +30,6 @@ class TestThreadedTaskManager(object):
 
     def test_start1(self):
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 1
         config.maximum_queue_size = 1
         ttm = ThreadedTaskManager(config)
@@ -54,7 +47,6 @@ class TestThreadedTaskManager(object):
 
     def test_doing_work_with_one_worker(self):
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 1
         config.maximum_queue_size = 1
         my_list = []
@@ -62,9 +54,7 @@ class TestThreadedTaskManager(object):
         def insert_into_list(anItem):
             my_list.append(anItem)
 
-        ttm = ThreadedTaskManager(config,
-                                  task_func=insert_into_list
-                                  )
+        ttm = ThreadedTaskManager(config, task_func=insert_into_list)
         try:
             ttm.start()
             time.sleep(0.2)
@@ -78,7 +68,6 @@ class TestThreadedTaskManager(object):
 
     def test_doing_work_with_two_workers_and_generator(self):
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 2
         config.maximum_queue_size = 2
         my_list = []
@@ -86,11 +75,11 @@ class TestThreadedTaskManager(object):
         def insert_into_list(anItem):
             my_list.append(anItem)
 
-        ttm = ThreadedTaskManager(config,
-                                  task_func=insert_into_list,
-                                  job_source_iterator=(((x,), {}) for x in
-                                                       range(10))
-                                  )
+        ttm = ThreadedTaskManager(
+            config,
+            task_func=insert_into_list,
+            job_source_iterator=(((x,), {}) for x in range(10))
+        )
         try:
             ttm.start()
             time.sleep(0.2)
@@ -113,7 +102,6 @@ class TestThreadedTaskManager(object):
             my_list.append(anItem)
 
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 2
         config.maximum_queue_size = 2
         config.job_source_iterator = new_iter
@@ -152,7 +140,6 @@ class TestThreadedTaskManager(object):
             my_list.append(anItem)
 
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 1
         config.maximum_queue_size = 1
         config.job_source_iterator = new_iter
@@ -171,7 +158,6 @@ class TestThreadedTaskManager(object):
 
     def test_blocking_start_with_quit_on_empty(self):
         config = DotDict()
-        config.logger = self.logger
         config.number_of_threads = 2
         config.maximum_queue_size = 2
         config.quit_on_empty_queue = True
@@ -181,10 +167,7 @@ class TestThreadedTaskManager(object):
         def task_func(index):
             calls.append(index)
 
-        tm = ThreadedTaskManager(
-            config,
-            task_func=task_func
-        )
+        tm = ThreadedTaskManager(config, task_func=task_func)
 
         waiting_func = Mock()
 

--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -2,10 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
-
 from configman.dotdict import DotDict as DotDict
-from mock import Mock
 
 from socorro.signature.rules import CSignatureTool
 
@@ -20,19 +17,16 @@ c_signature_tool = CSignatureTool(csig_config)
 
 
 def create_basic_fake_processor():
-    """Creates fake processor configuration"""
+    """Create fake processor configuration."""
     fake_processor = DotDict()
     fake_processor.c_signature_tool = c_signature_tool
     fake_processor.config = DotDict()
-    fake_processor.config.logger = logging.getLogger(__name__)
     fake_processor.processor_notes = []
     return fake_processor
 
 
 def get_basic_config():
-    config = DotDict()
-    config.logger = Mock()
-    return config
+    return DotDict()
 
 
 def get_basic_processor_meta():

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -8,7 +8,7 @@ import json
 
 from configman.dotdict import DotDict
 from markus.testing import MetricsMock
-from mock import Mock, patch
+from mock import patch
 
 from socorro.processor.breakpad_transform_rules import (
     BreakpadStackwalkerRule2015,
@@ -504,7 +504,6 @@ class TestBreakpadTransformRule2015(object):
 class TestJitCrashCategorizeRule(object):
     def get_basic_config(self):
         config = DotDict()
-        config.logger = Mock()
         config.dump_field = 'upload_file_minidump'
         config.command_line = JitCrashCategorizeRule.required_config.command_line.default
         config.result_key = 'classifications.jit.category'

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -727,7 +727,6 @@ class TestMozCrashReasonRule(object):
 class TestOutOfMemoryBinaryRule(object):
     def test_extract_memory_info(self):
         config = DotDict()
-        config.logger = Mock()
 
         processor_meta = get_basic_processor_meta()
 
@@ -743,7 +742,6 @@ class TestOutOfMemoryBinaryRule(object):
 
     def test_extract_memory_info_too_big(self):
         config = DotDict()
-        config.logger = Mock()
 
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
@@ -784,7 +782,6 @@ class TestOutOfMemoryBinaryRule(object):
     def test_extract_memory_info_with_trouble(self):
         config = DotDict()
         config.max_size_uncompressed = 1024
-        config.logger = Mock()
 
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
@@ -807,7 +804,6 @@ class TestOutOfMemoryBinaryRule(object):
     def test_extract_memory_info_with_json_trouble(self):
         config = DotDict()
         config.max_size_uncompressed = 1024
-        config.logger = Mock()
 
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"

--- a/socorro/unittest/processor/test_processor_2015.py
+++ b/socorro/unittest/processor/test_processor_2015.py
@@ -26,7 +26,6 @@ class TestProcessor2015(object):
             values_source_list=[],
         )
         config = cm.get_config()
-        config.logger = Mock()
         config.database_class = Mock()
         config.sentry = Mock()
         config.processor_name = 'dwight'


### PR DESCRIPTION
This nixes the `config.logger` and `config.metrics` items. This adds instance loggers to many components that are logging. One nice thing about this is that it means logged messages have a more helpfully named logger.

This also fixes all the logging-related tests to use pytest's caplog.

This is a first pass on removing configman--we had to switch to using a logger that's not carried around in config.