### PR TITLE
bug 1529342: remove sighup handling

### DIFF
--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -17,8 +17,6 @@ all the Socorro Apps derive.
 import logging
 import logging.config
 import logging.handlers
-import functools
-import signal
 import os
 import socket
 import sys
@@ -35,22 +33,6 @@ from configman import (
 from configman.converters import py_obj_to_str, str_to_python_object, str_to_list
 import markus
 from socorro.lib.revision_data import get_revision_data
-
-
-# for use with SIGHUP for apps that run as daemons
-restart = True
-
-
-def respond_to_SIGHUP(signal_number, frame, logger=None):
-    """raise the KeyboardInterrupt which will cause the app to effectively
-    shutdown, closing all it resources.  Then, because it sets 'restart' to
-    True, the app will reread all the configuration information, rebuild all
-    of its structures and resources and start running again"""
-    global restart
-    restart = True
-    if logger:
-        logger.info('detected SIGHUP')
-    raise KeyboardInterrupt
 
 
 def cls_to_pypath(cls):
@@ -150,17 +132,10 @@ class App(RequiredConfig):
 
     @classmethod
     def run(cls, config_path=None, values_source_list=None):
-        global restart
-        restart = True
-        while restart:
-            # the SIGHUP handler will change that back to True if it wants
-            # the app to restart and run again.
-            restart = False
-            app_exit_code = cls._do_run(
-                config_path=config_path,
-                values_source_list=values_source_list
-            )
-        return app_exit_code
+        return cls._do_run(
+            config_path=config_path,
+            values_source_list=values_source_list
+        )
 
     @classmethod
     def _do_run(cls, config_path=None, values_source_list=None):
@@ -242,12 +217,6 @@ class App(RequiredConfig):
             )
 
             config_manager.log_config(mylogger)
-            respond_to_SIGHUP_with_logging = functools.partial(
-                respond_to_SIGHUP,
-                logger=mylogger
-            )
-            # install the signal handler with logging
-            signal.signal(signal.SIGHUP, respond_to_SIGHUP_with_logging)
 
             # we finally know what app to actually run, instantiate it
             app_to_run = cls(config)

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -132,13 +132,6 @@ class App(RequiredConfig):
 
     @classmethod
     def run(cls, config_path=None, values_source_list=None):
-        return cls._do_run(
-            config_path=config_path,
-            values_source_list=values_source_list
-        )
-
-    @classmethod
-    def _do_run(cls, config_path=None, values_source_list=None):
         # NOTE(willkg): This is a classmethod, so we need a different logger.
         mylogger = logging.getLogger(__name__ + '.' + cls.__name__)
         if config_path is None:

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -36,14 +36,16 @@ def respond_to_SIGTERM(signal_number, frame, target=None):
     This function is used in registering a signal handler from the signal
     module.  It should be registered for any signal for which the desired
     behavior is to kill the application:
+
         signal.signal(signal.SIGTERM, respondToSIGTERM)
-        signal.signal(signal.SIGHUP, respondToSIGTERM)
 
     parameters:
+
         signal_number - unused in this function but required by the api.
         frame - unused in this function but required by the api.
         target - an instance of a class that has a member called 'task_manager'
                  that is a derivative of the TaskManager class below.
+
     """
     if target:
         target.logger.info('detected SIGTERM')

--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -71,89 +71,89 @@ class TestApp(object):
     def test_do_run(self, setup_logging):
         with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('socorro.app.socorro_app.signal'):
-                class SomeOtherApp(App):
-                    app_name = 'SomeOtherApp'
-                    app_verision = '1.2.3'
-                    app_description = 'a silly app'
 
-                    def main(self):
-                        expected = cm.return_value.context.return_value.__enter__.return_value
-                        assert self.config is expected
-                        return 17
+            class SomeOtherApp(App):
+                app_name = 'SomeOtherApp'
+                app_verision = '1.2.3'
+                app_description = 'a silly app'
 
-                result = SomeOtherApp.run()
-                args = cm.call_args_list
-                args, kwargs = args[0]
-                assert isinstance(args[0], Namespace)
-                assert isinstance(kwargs['values_source_list'], list)
-                assert kwargs['app_name'] == SomeOtherApp.app_name
-                assert kwargs['app_version'] == SomeOtherApp.app_version
-                assert kwargs['app_description'] == SomeOtherApp.app_description
-                assert kwargs['config_pathname'] == './config'
-                assert kwargs['values_source_list'][-1] == command_line
-                assert isinstance(kwargs['values_source_list'][-2], DotDict)
-                assert kwargs['values_source_list'][-3] is ConfigFileFutureProxy
-                assert result == 17
+                def main(self):
+                    expected = cm.return_value.context.return_value.__enter__.return_value
+                    assert self.config is expected
+                    return 17
+
+            result = SomeOtherApp.run()
+            args = cm.call_args_list
+            args, kwargs = args[0]
+            assert isinstance(args[0], Namespace)
+            assert isinstance(kwargs['values_source_list'], list)
+            assert kwargs['app_name'] == SomeOtherApp.app_name
+            assert kwargs['app_version'] == SomeOtherApp.app_version
+            assert kwargs['app_description'] == SomeOtherApp.app_description
+            assert kwargs['config_pathname'] == './config'
+            assert kwargs['values_source_list'][-1] == command_line
+            assert isinstance(kwargs['values_source_list'][-2], DotDict)
+            assert kwargs['values_source_list'][-3] is ConfigFileFutureProxy
+            assert result == 17
 
     @mock.patch('socorro.app.socorro_app.setup_logging')
     def test_do_run_with_alternate_class_path(self, setup_logging):
         with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('socorro.app.socorro_app.signal'):
-                class SomeOtherApp(App):
-                    app_name = 'SomeOtherApp'
-                    app_verision = '1.2.3'
-                    app_description = 'a silly app'
 
-                    def main(self):
-                        expected = cm.return_value.context.return_value.__enter__.return_value
-                        assert self.config is expected
-                        return 17
+            class SomeOtherApp(App):
+                app_name = 'SomeOtherApp'
+                app_verision = '1.2.3'
+                app_description = 'a silly app'
 
-                result = SomeOtherApp.run('my/other/path')
+                def main(self):
+                    expected = cm.return_value.context.return_value.__enter__.return_value
+                    assert self.config is expected
+                    return 17
 
-                args = cm.call_args_list
-                args, kwargs = args[0]
-                assert isinstance(args[0], Namespace)
-                assert isinstance(kwargs['values_source_list'], list)
-                assert kwargs['app_name'] == SomeOtherApp.app_name
-                assert kwargs['app_version'] == SomeOtherApp.app_version
-                assert kwargs['app_description'] == SomeOtherApp.app_description
-                assert kwargs['config_pathname'] == 'my/other/path'
-                assert kwargs['values_source_list'][-1] == command_line
-                assert isinstance(kwargs['values_source_list'][-2], DotDict)
-                assert kwargs['values_source_list'][-3] is ConfigFileFutureProxy
-                assert result == 17
+            result = SomeOtherApp.run('my/other/path')
+
+            args = cm.call_args_list
+            args, kwargs = args[0]
+            assert isinstance(args[0], Namespace)
+            assert isinstance(kwargs['values_source_list'], list)
+            assert kwargs['app_name'] == SomeOtherApp.app_name
+            assert kwargs['app_version'] == SomeOtherApp.app_version
+            assert kwargs['app_description'] == SomeOtherApp.app_description
+            assert kwargs['config_pathname'] == 'my/other/path'
+            assert kwargs['values_source_list'][-1] == command_line
+            assert isinstance(kwargs['values_source_list'][-2], DotDict)
+            assert kwargs['values_source_list'][-3] is ConfigFileFutureProxy
+            assert result == 17
 
     @mock.patch('socorro.app.socorro_app.setup_logging')
     def test_do_run_with_alternate_values_source_list(self, setup_logging):
         with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('socorro.app.socorro_app.signal'):
-                class SomeOtherApp(App):
-                    app_name = 'SomeOtherApp'
-                    app_verision = '1.2.3'
-                    app_description = 'a silly app'
 
-                    def main(self):
-                        expected = cm.return_value.context.return_value.__enter__.return_value
-                        assert self.config is expected
-                        return 17
+            class SomeOtherApp(App):
+                app_name = 'SomeOtherApp'
+                app_verision = '1.2.3'
+                app_description = 'a silly app'
 
-                result = SomeOtherApp.run(
-                    config_path='my/other/path',
-                    values_source_list=[{"a": 1}, {"b": 2}]
-                )
+                def main(self):
+                    expected = cm.return_value.context.return_value.__enter__.return_value
+                    assert self.config is expected
+                    return 17
 
-                args = cm.call_args_list
-                args, kwargs = args[0]
-                assert isinstance(args[0], Namespace)
-                assert kwargs['app_name'] == SomeOtherApp.app_name
-                assert kwargs['app_version'] == SomeOtherApp.app_version
-                assert kwargs['app_description'] == SomeOtherApp.app_description
-                assert kwargs['config_pathname'] == 'my/other/path'
-                assert isinstance(kwargs['values_source_list'], list)
-                assert kwargs['values_source_list'][0] == {"a": 1}
-                assert kwargs['values_source_list'][1] == {"b": 2}
-                assert result == 17
+            result = SomeOtherApp.run(
+                config_path='my/other/path',
+                values_source_list=[{"a": 1}, {"b": 2}]
+            )
+
+            args = cm.call_args_list
+            args, kwargs = args[0]
+            assert isinstance(args[0], Namespace)
+            assert kwargs['app_name'] == SomeOtherApp.app_name
+            assert kwargs['app_version'] == SomeOtherApp.app_version
+            assert kwargs['app_description'] == SomeOtherApp.app_description
+            assert kwargs['config_pathname'] == 'my/other/path'
+            assert isinstance(kwargs['values_source_list'], list)
+            assert kwargs['values_source_list'][0] == {"a": 1}
+            assert kwargs['values_source_list'][1] == {"b": 2}
+            assert result == 17

--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -21,54 +21,9 @@ class TestApp(object):
 
         with pytest.raises(NotImplementedError):
             sa.main()
-        with pytest.raises(NotImplementedError):
-            sa._do_run()
-
-    def test_run(self):
-        class SomeOtherApp(App):
-            @classmethod
-            def _do_run(klass, config_path=None, values_source_list=None):
-                klass.config_path = config_path
-                return 17
-
-        assert SomeOtherApp._do_run() == 17
-        assert SomeOtherApp.config_path is None
-        x = SomeOtherApp.run()
-        assert x == 17
-
-    def test_run_with_alternate_config_path(self):
-        class SomeOtherApp(App):
-            @classmethod
-            def _do_run(klass, config_path=None, values_source_list=None):
-                klass.values_source_list = values_source_list
-                klass.config_path = config_path
-                return 17
-
-        assert SomeOtherApp._do_run('my/path') == 17
-        assert SomeOtherApp.config_path == 'my/path'
-        x = SomeOtherApp.run('my/other/path')
-        assert x == 17
-        assert SomeOtherApp.config_path == 'my/other/path'
 
     @mock.patch('socorro.app.socorro_app.setup_logging')
-    def test_run_with_alternate_values_source_list(self, setup_logging):
-        class SomeOtherApp(App):
-            @classmethod
-            def _do_run(klass, config_path=None, values_source_list=None):
-                klass.values_source_list = values_source_list
-                klass.config_path = config_path
-                return 17
-
-        assert SomeOtherApp._do_run('my/path', [{}, {}]) == 17
-        assert SomeOtherApp.config_path == 'my/path'
-        assert SomeOtherApp.values_source_list == [{}, {}]
-        x = SomeOtherApp.run('my/other/path', [])
-        assert x == 17
-        assert SomeOtherApp.config_path == 'my/other/path'
-        assert SomeOtherApp.values_source_list == []
-
-    @mock.patch('socorro.app.socorro_app.setup_logging')
-    def test_do_run(self, setup_logging):
+    def test_run(self, setup_logging):
         with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
 
@@ -97,7 +52,39 @@ class TestApp(object):
             assert result == 17
 
     @mock.patch('socorro.app.socorro_app.setup_logging')
-    def test_do_run_with_alternate_class_path(self, setup_logging):
+    def test_run_with_alternate_config_path(self, setup_logging):
+        class SomeOtherApp(App):
+            @classmethod
+            def run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        assert SomeOtherApp.run('my/path') == 17
+        assert SomeOtherApp.config_path == 'my/path'
+        x = SomeOtherApp.run('my/other/path')
+        assert x == 17
+        assert SomeOtherApp.config_path == 'my/other/path'
+
+    @mock.patch('socorro.app.socorro_app.setup_logging')
+    def test_run_with_alternate_values_source_list(self, setup_logging):
+        class SomeOtherApp(App):
+            @classmethod
+            def run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        assert SomeOtherApp.run('my/path', [{}, {}]) == 17
+        assert SomeOtherApp.config_path == 'my/path'
+        assert SomeOtherApp.values_source_list == [{}, {}]
+        x = SomeOtherApp.run('my/other/path', [])
+        assert x == 17
+        assert SomeOtherApp.config_path == 'my/other/path'
+        assert SomeOtherApp.values_source_list == []
+
+    @mock.patch('socorro.app.socorro_app.setup_logging')
+    def test_run_with_alternate_class_path(self, setup_logging):
         with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
 
@@ -124,36 +111,4 @@ class TestApp(object):
             assert kwargs['values_source_list'][-1] == command_line
             assert isinstance(kwargs['values_source_list'][-2], DotDict)
             assert kwargs['values_source_list'][-3] is ConfigFileFutureProxy
-            assert result == 17
-
-    @mock.patch('socorro.app.socorro_app.setup_logging')
-    def test_do_run_with_alternate_values_source_list(self, setup_logging):
-        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
-            cm.return_value.context.return_value = mock.MagicMock()
-
-            class SomeOtherApp(App):
-                app_name = 'SomeOtherApp'
-                app_verision = '1.2.3'
-                app_description = 'a silly app'
-
-                def main(self):
-                    expected = cm.return_value.context.return_value.__enter__.return_value
-                    assert self.config is expected
-                    return 17
-
-            result = SomeOtherApp.run(
-                config_path='my/other/path',
-                values_source_list=[{"a": 1}, {"b": 2}]
-            )
-
-            args = cm.call_args_list
-            args, kwargs = args[0]
-            assert isinstance(args[0], Namespace)
-            assert kwargs['app_name'] == SomeOtherApp.app_name
-            assert kwargs['app_version'] == SomeOtherApp.app_version
-            assert kwargs['app_description'] == SomeOtherApp.app_description
-            assert kwargs['config_pathname'] == 'my/other/path'
-            assert isinstance(kwargs['values_source_list'], list)
-            assert kwargs['values_source_list'][0] == {"a": 1}
-            assert kwargs['values_source_list'][1] == {"b": 2}
             assert result == 17


### PR DESCRIPTION
We no longer run Socorro apps in a way that requires they handle `SIGHUP` and restart with updated configuration. Given that, we can remove this code.