### PR TITLE
fix bug 1530674: fix version sorting to ignore invalid versions

### DIFF
--- a/socorro/lib/versionutil.py
+++ b/socorro/lib/versionutil.py
@@ -8,8 +8,26 @@ class VersionParseError(Exception):
     pass
 
 
+def validate_version(version):
+    """Validate a version."""
+    if not (version and isinstance(version, str)):
+        return False
+
+    version = version.split('.')
+
+    # Versions should have at least two parts: X.Y
+    if len(version) < 2:
+        return False
+
+    # First part should consist of one or more ascii digits
+    if not (len(version[0]) > 0 and version[0].isdigit()):
+        return False
+
+    return True
+
+
 def generate_version_key(version):
-    """Serializes the version into a string that can sort with other versions
+    """Serialize version into a string that can sort with other versions.
 
     :arg str version: the version string; e.g. "62.0.3b15rc1"
 
@@ -22,6 +40,9 @@ def generate_version_key(version):
     '062000002b005001'
 
     """
+    if not validate_version(version):
+        raise VersionParseError('Version %s does not validate' % version)
+
     orig_version = version
     try:
         if 'rc' in version:
@@ -65,7 +86,5 @@ def generate_version_key(version):
 
     except (ValueError, IndexError, TypeError) as exc:
         raise VersionParseError(
-            'Version %s does not parse: %s' % (
-                repr(orig_version), str(exc)
-            )
+            'Version %s does not parse: %s' % (repr(orig_version), str(exc))
         )

--- a/socorro/unittest/lib/test_versionutil.py
+++ b/socorro/unittest/lib/test_versionutil.py
@@ -6,8 +6,24 @@ import pytest
 
 from socorro.lib.versionutil import (
     generate_version_key,
+    validate_version,
     VersionParseError
 )
+
+
+@pytest.mark.parametrize('version, expected', [
+    # Valid versions
+    ('67.01a', True),
+    ('65.0.1', True),
+    ('3.7a5pre', True),
+
+    # Invalid versions
+    ('', False),
+    ('67', False),
+    ('45_0_1', False)
+])
+def test_validate_version(version, expected):
+    assert validate_version(version) == expected
 
 
 @pytest.mark.parametrize('version, expected', [


### PR DESCRIPTION
This adds a really basic "version validator" and tweaks the version
sorting code to ignore invalid versions.