### PR TITLE
Fix db setup

### DIFF
--- a/docker/run_setup_postgres.sh
+++ b/docker/run_setup_postgres.sh
@@ -22,8 +22,8 @@ urlwait "${DATABASE_URL}" 10
 
 # Create the database if it doesn't exist
 echo "Dropping and creating db..."
-python socorro/scripts/db.py drop || true
-python socorro/scripts/db.py create || true
+./socorro-cmd db drop || true
+./socorro-cmd db create || true
 
 # Run Django migrations
 echo "Setting up tables..."


### PR DESCRIPTION
Running "python socorro/scripts/db.py" does nothing--it just loads
the module. We need to run "socorro-cmd db" now. This fixes that.