### PR TITLE
bug 1534617: add "is_processed" check

### DIFF
--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -162,7 +162,9 @@ class MissingProcessedCrashesAdmin(admin.ModelAdmin):
     list_display = [
         'crash_id',
         'created',
-        'report_url_linked'
+        'collected_date',
+        'is_processed',
+        'report_url_linked',
     ]
 
     def report_url_linked(self, obj):


### PR DESCRIPTION
When looking at `MissingProcessedCrashes`, in the Django admin, this now
shows the collected date as well as whether the crash has been processed.
This will make it easier to deal with missing crashes.