### PR TITLE
Change Buildhub base URL

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -387,7 +387,7 @@ ENGAGE_ROBOTS = False
 BZAPI_BASE_URL = 'https://bugzilla.mozilla.org/rest'
 
 # Base URL for Buildhub
-BUILDHUB_BASE_URL = 'https://mozilla-services.github.io/buildhub/'
+BUILDHUB_BASE_URL = 'https://buildhub.moz.tools/'
 
 # The index schema used in our elasticsearch databases, used in the
 # Super Search Custom Query page.


### PR DESCRIPTION
The old link points to the old web UI for Buildhub1. Changing it to the new one, which incidentally, isn't operating on a path prefix. 

This change would resolve https://github.com/mozilla/buildhub2/issues/366