### PR TITLE
fix bug 1527346: switch webapp to use Pub/Sub

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -3,6 +3,26 @@
 # put filesystem crashstorage stuff in /tmp/test_crashes
 resource.fs.fs_root=/tmp/test_crashes
 
+# Statsd
+STATSD_CLIENT=django_statsd.clients.null
+
+# Sentry
+SENTRY_DSN=
+RAVEN_DSN=
+
+# Boto
+AWS_ACCESS_KEY=something
+AWS_SECRET_ACCESS_KEY=something
+# NOTE(willkg): We want boto to use connect_to_region, so we make this an
+# empty string
+AWS_HOST=
+# Use test buckets
+resource.boto.bucket_name=crashstats-test
+TELEMETRY_BUCKET_NAME=telemetry-test
+
+# Elasticsearch configuration
+ELASTICSEARCH_URLS=http://example.com:9123
+
 # Postgres configuration
 database_url=postgres://postgres:aPassword@postgresql:5432/socorro_test
 DATABASE_URL=postgres://postgres:aPassword@postgresql:5432/socorro_test
@@ -24,6 +44,7 @@ resource.pubsub.reprocessing_subscription_name=test_reprocessing_sub
 # Django tests are meant to run with debug mode disabled.
 DEBUG=False
 
-# Use test buckets
-resource.boto.bucket_name=crashstats-test
-TELEMETRY_BUCKET_NAME=telemetry-test
+CACHE_IMPLEMENTATION_FETCHES=True
+DEFAULT_PRODUCT=WaterWolf
+BZAPI_BASE_URL=http://bugzilla.example.com/rest
+SECRET_KEY=fakekey

--- a/scripts/process_crashes.sh
+++ b/scripts/process_crashes.sh
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Pulls down crash data for specified crash ids, syncs to the S3 bucket, and
-# sends the crash ids to the rabbitmq queue.
+# sends the crash ids to the Pub/Sub queue.
 #
 # Usage:
 #
@@ -45,8 +45,7 @@ mkdir "${DATADIR}" || echo "${DATADIR} already exists."
 ./scripts/socorro_aws_s3.sh ls --recursive s3://dev_bucket/
 
 # Add crash ids to queue
-./socorro-cmd add_crashid_to_queue socorro.normal $@
-# ./socorro-cmd pubsub publish $@
+./socorro-cmd pubsub publish $@
 
 # Print urls to make it easier to look at them
 for crashid in "$@"

--- a/socorro/external/pubsub/crashqueue.py
+++ b/socorro/external/pubsub/crashqueue.py
@@ -148,3 +148,16 @@ class PubSubCrashQueue(RequiredConfig):
 
     def __call__(self):
         return self.__iter__()
+
+    def publish(self, queue, crash_ids):
+        """Publish crash ids to specified queue."""
+        assert queue in ['standard', 'priority', 'reprocessing']
+
+        publisher = pubsub_v1.PublisherClient()
+        project_id = self.config.project_id
+        topic_name = self.config['%s_topic_name' % queue]
+        topic_path = publisher.topic_path(project_id, topic_name)
+
+        for crash_id in crash_ids:
+            future = publisher.publish(topic_path, data=crash_id.encode('utf-8'))
+            future.result()

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -24,7 +24,7 @@ CONFIG_DEFAULTS = {
     'always_ignore_mismatches': True,
 
     'queue': {
-        'crashqueue_class': 'socorro.external.rabbitmq.crashqueue.RabbitMQCrashQueue',
+        'crashqueue_class': 'socorro.external.pubsub.crashqueue.PubSubCrashQueue',
     },
 
     'source': {

--- a/socorro/unittest/external/pubsub/__init__.py
+++ b/socorro/unittest/external/pubsub/__init__.py
@@ -1,0 +1,116 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from configman import ConfigurationManager
+from google.api_core.exceptions import AlreadyExists
+from google.cloud import pubsub_v1
+
+from socorro.external.pubsub.crashqueue import PubSubCrashQueue
+
+
+# Socorro uses three queues. Each is implemented as a Pub/Sub topic and subscription.
+QUEUES = ['standard', 'priority', 'reprocessing']
+
+# Pub/Sub acknowledgement deadline in seconds
+ACK_DEADLINE = 2
+
+
+class PubSubHelper:
+    """Helper class for setting up, tearing down, and publishing to Pub/Sub."""
+
+    def __init__(self, config):
+        # NOTE(willkg): This (lazily) uses the same config as PubSubCrashQueue.
+        self.config = config
+
+    def setup_topics(self):
+        publisher = pubsub_v1.PublisherClient()
+        subscriber = pubsub_v1.SubscriberClient()
+
+        project_id = self.config.project_id
+
+        for queue in QUEUES:
+            topic_name = self.config['%s_topic_name' % queue]
+            topic_path = publisher.topic_path(project_id, topic_name)
+
+            try:
+                publisher.create_topic(topic_path)
+            except AlreadyExists:
+                pass
+
+            subscription_name = self.config['%s_subscription_name' % queue]
+            subscription_path = subscriber.subscription_path(project_id, subscription_name)
+            try:
+                subscriber.create_subscription(
+                    name=subscription_path,
+                    topic=topic_path,
+                    ack_deadline_seconds=ACK_DEADLINE
+                )
+            except AlreadyExists:
+                pass
+
+    def teardown_topics(self):
+        publisher = pubsub_v1.PublisherClient()
+        subscriber = pubsub_v1.SubscriberClient()
+        project_id = self.config.project_id
+
+        for queue in QUEUES:
+            topic_name = self.config['%s_topic_name' % queue]
+            topic_path = publisher.topic_path(project_id, topic_name)
+
+            # Delete all subscriptions
+            for sub_path in publisher.list_topic_subscriptions(topic_path):
+                subscriber.delete_subscription(sub_path)
+
+            # Delete topic
+            publisher.delete_topic(topic_path)
+
+    def __enter__(self):
+        self.setup_topics()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.teardown_topics()
+
+    def get_crash_ids(self, queue_name):
+        subscriber = pubsub_v1.SubscriberClient()
+        project_id = self.config.project_id
+        sub_name = self.config['%s_subscription_name' % queue_name]
+        sub_path = subscriber.subscription_path(project_id, sub_name)
+
+        ack_ids = []
+        crash_ids = []
+        while True:
+            response = subscriber.pull(sub_path, max_messages=1, return_immediately=True)
+            if not response.received_messages:
+                break
+
+            for msg in response.received_messages:
+                crash_ids.append(msg.message.data.decode('utf-8'))
+                ack_ids.append(msg.ack_id)
+
+        if ack_ids:
+            # Set the ack deadlines to 0 so they go back in the queue
+            subscriber.acknowledge(sub_path, ack_ids)
+
+        return crash_ids
+
+    def publish(self, queue_name, crash_id):
+        publisher = pubsub_v1.PublisherClient()
+        project_id = self.config.project_id
+
+        topic_name = self.config['%s_topic_name' % queue_name]
+        topic_path = publisher.topic_path(project_id, topic_name)
+
+        future = publisher.publish(topic_path, data=crash_id.encode('utf-8'))
+        future.result()
+
+
+def get_config_manager():
+    pubsub_config = PubSubCrashQueue.get_required_config()
+    return ConfigurationManager(
+        [pubsub_config],
+        app_name='test-pubsub',
+        app_description='',
+        argv_source=[]
+    )

--- a/socorro/unittest/external/rabbitmq/test_reprocessing.py
+++ b/socorro/unittest/external/rabbitmq/test_reprocessing.py
@@ -6,7 +6,7 @@ from configman.dotdict import DotDict
 from mock import MagicMock
 
 from socorro.external.crashstorage_base import Redactor
-from socorro.external.rabbitmq.crashstorage import ReprocessingOneRabbitMQCrashStore
+from socorro.external.rabbitmq.crashstorage import ReprocessingRabbitMQCrashStore
 from socorro.external.rabbitmq.connection_context import ConnectionContext
 
 
@@ -24,18 +24,18 @@ class TestReprocessing(object):
 
     def test_post(self):
         config = self._setup_config()
-        reprocessing = ReprocessingOneRabbitMQCrashStore(config)
+        reprocessing = ReprocessingRabbitMQCrashStore(config)
 
         def mocked_save_raw_crash(raw_crash, dumps, crash_id):
             assert crash_id == 'some-crash-id'
             return True
 
         reprocessing.save_raw_crash = mocked_save_raw_crash
-        assert reprocessing.reprocess('some-crash-id')
+        assert reprocessing.process('some-crash-id')
 
     def test_post_multiple_one_fails(self):
         config = self._setup_config()
-        reprocessing = ReprocessingOneRabbitMQCrashStore(config)
+        reprocessing = ReprocessingRabbitMQCrashStore(config)
 
         def mocked_save_raw_crash(raw_crash, dumps, crash_id):
             if crash_id == 'crash-id-1':
@@ -45,4 +45,4 @@ class TestReprocessing(object):
             raise NotImplementedError(crash_id)
 
         reprocessing.save_raw_crash = mocked_save_raw_crash
-        assert not reprocessing.reprocess(['crash-id-1', 'crash-id-2'])
+        assert not reprocessing.process(['crash-id-1', 'crash-id-2'])

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -129,7 +129,7 @@ BLACKLIST = (
     # because it's very sensitive and we don't want to expose it
     'Query',
     # because it's an internal thing only
-    'Priorityjob',
+    'PriorityJob',
     'Products',
     'TelemetryCrash',
 )

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1476,11 +1476,11 @@ class TestViews(BaseTestViews):
 
         models.UnredactedCrash.implementation().get.side_effect = mocked_processed_crash_get
 
-        def mocked_priority_job_process(**params):
+        def mocked_publish(**params):
             assert params['crash_ids'] == [crash_id]
             return True
 
-        models.Priorityjob.implementation().process.side_effect = mocked_priority_job_process
+        models.PriorityJob.implementation().publish.side_effect = mocked_publish
 
         url = reverse('crashstats:report_index', args=[crash_id])
         response = self.client.get(url)

--- a/webapp-django/crashstats/crashstats/tests/testbase.py
+++ b/webapp-django/crashstats/crashstats/tests/testbase.py
@@ -43,6 +43,10 @@ class DjangoTestCase(django.test.TestCase):
             # string 'MagicMock' in it no matter which class it came from.
             klass.implementation().__class__.__name__ = klass.__name__
 
+    def undo_implementation_mock(self, cls):
+        """Undoes a single implementation mock."""
+        cls.implementation = self._mockeries[cls]
+
     def tearDown(self):
         for klass in classes_with_implementation:
             klass.implementation = self._mockeries[klass]

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -108,7 +108,7 @@ def report_index(request, crash_id, default_context=None):
         # ...if we haven't already done so.
         cache_key = 'priority_job:{}'.format(crash_id)
         if not cache.get(cache_key):
-            priority_api = models.Priorityjob()
+            priority_api = models.PriorityJob()
             priority_api.post(crash_ids=[crash_id])
             cache.set(cache_key, True, 60)
         return render(request, 'crashstats/report_index_pending.html', context)

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -384,7 +384,7 @@ CRASH_ID_PREFIX = 'bp-'
 ENGAGE_ROBOTS = False
 
 # Base URL for when we use the Bugzilla API
-BZAPI_BASE_URL = 'https://bugzilla.mozilla.org/rest'
+BZAPI_BASE_URL = config('BZAPI_BASE_URL', 'https://bugzilla.mozilla.org/rest')
 
 # Base URL for Buildhub
 BUILDHUB_BASE_URL = 'https://buildhub.moz.tools/'
@@ -657,6 +657,21 @@ SOCORRO_IMPLEMENTATIONS_CONFIG = {
             'calling_format': config(
                 'resource.boto.calling_format', 'boto.s3.connection.OrdinaryCallingFormat'
             ),
+        },
+        'pubsub': {
+            'project_id': config('resource.pubsub.project_id', None),
+            'standard_topic_name': config('resource.pubsub.standard_topic_name', None),
+            'standard_subscription_name': config(
+                'resource.pubsub.standard_subscription_name', None
+            ),
+            'priority_topic_name': config('resource.pubsub.priority_topic_name', None),
+            'priority_subscription_name': config(
+                'resource.pubsub.priority_subscription_name', None
+            ),
+            'reprocessing_topic_name': config('resource.pubsub.reprocessing_topic_name', None),
+            'reprocessing_subscription_name': config(
+                'resource.pubsub.reprocessing_subscription_name', None
+            )
         }
     },
     'telemetrydata': {

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -2,21 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
-Settings for running tests. These override settings in base.py.
-"""
+"""Settings for running tests. These override settings in base.py."""
 
 from crashstats.settings.base import *  # noqa
-
-CACHE_IMPLEMENTATION_FETCHES = True
-
-DEFAULT_PRODUCT = 'WaterWolf'
-
-# here we deliberately "destroy" the BZAPI URL so running tests that are
-# badly mocked never accidentally actually use a real working network address
-BZAPI_BASE_URL = 'https://bugzilla.example.com/rest'
-
-STATSD_CLIENT = 'django_statsd.clients.null'
 
 SECRET_KEY = 'fakekey'
 
@@ -35,37 +23,9 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
 
-
-# don't accidentally send anything to sentry whilst running tests
-RAVEN_CONFIG = {}
-SENTRY_DSN = None
-
-
-# Make sure these have something but something not right
-# so the tests never accidentally manage to connect to AWS
-# for realz.
-AWS_ACCESS_KEY = 'something'
-AWS_SECRET_ACCESS_KEY = 'anything'
-SYMBOLS_BUCKET_DEFAULT_NAME = 'my-lovely-bucket'
-SYMBOLS_FILE_PREFIX = 'v99'
-SYMBOLS_BUCKET_DEFAULT_LOCATION = 'us-west-2'
-# We want AWS to use connect_to_region, so we make AWS_HOST an empty string
-AWS_HOST = ''
-
-
-# Test-specific Socorro configuration
-SOCORRO_IMPLEMENTATIONS_CONFIG = {
-    'resource': {
-        'elasticsearch': {
-            'elasticsearch_urls': ['http://example.com:9123'],
-        },
-        'boto': {
-            'bucket_name': 'crashstats-test'
-        }
-    },
-    'telemetrydata': {
-        'bucket_name': 'telemetry-test'
-    }
+# Fix some implementations configuration
+SOCORRO_IMPLEMENTATIONS_CONFIG['resource']['boto'] = {  # noqa
+    'bucket_name': 'crashstats-test'
 }
 
 # Remove SessionRefresh middleware so that tests don't need to have a non-expired OIDC token

--- a/webapp-django/pytest.ini
+++ b/webapp-django/pytest.ini
@@ -5,4 +5,12 @@
 addopts = -rsxX --tb=native
 DJANGO_SETTINGS_MODULE = crashstats.settings.test
 # Transform all warnings into errors
-filterwarnings = error
+filterwarnings =
+    error
+    # grpcio kicks this up for some reason in pytest
+    ignore::ImportWarning
+    ignore:::grpcio[.*]
+    ignore:::google[.*]
+    # configman kicks up errors if there's configuration stuff that isn't used
+    # and that breaks the webapp's configman glue
+    ignore:::configman[.*]


### PR DESCRIPTION
This implements the necessary Pub/Sub bits in the webapp. I tried to keep it similar to how RabbitMQ was used with the hope that we could switch back and forth, but that didn't work out so well. The webapp is pretty hard-coded to use one or the other and I didn't want to put the work into abstracting it out since this is an interim problem that will go away soon.

Because the webapp is in Pub/Sub mode, this adjusts the processor to also be in Pub/Sub mode. That means we need to:

1. do the configuration changes in the infra
2. switch Antenna to Pub/Sub mode
3. land this
4. nix socorro-pigeon

all around the same time.