### PR TITLE
bug 1536147: make archivescraper faster

### DIFF
--- a/socorro/unittest/cron/jobs/test_archivescraper.py
+++ b/socorro/unittest/cron/jobs/test_archivescraper.py
@@ -119,6 +119,8 @@ def config():
         jobs='socorro.cron.jobs.archivescraper.ArchiveScraperCronApp|1h',
         overrides={
             'crontabber.class-ArchiveScraperCronApp.base_url': HOST + '/pub/',
+            # Use 1 worker which keeps it synchronous and single-process
+            'crontabber.class-ArchiveScraperCronApp.num_workers': 1,
         }
     )
     with config_manager.context() as config:
@@ -299,12 +301,12 @@ class TestArchiveScraperCronApp(object):
 
         # Scrape a first time with an empty db and assert that it inserted all
         # the versions we expected
-        archive_scraper.scrape_candidates('Firefox', 'firefox')
+        archive_scraper.scrape_and_insert_build_info('Firefox', 'firefox')
         data = self.fetch_data(db_conn)
         assert data == expected_data
 
         # Scrape it a second time and assert that the contents haven't
         # changed
-        archive_scraper.scrape_candidates('Firefox', 'firefox')
+        archive_scraper.scrape_and_insert_build_info('Firefox', 'firefox')
         data = self.fetch_data(db_conn)
         assert data == expected_data

--- a/webapp-django/crashstats/crashstats/management/__init__.py
+++ b/webapp-django/crashstats/crashstats/management/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapp-django/crashstats/crashstats/management/commands/__init__.py
+++ b/webapp-django/crashstats/crashstats/management/commands/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapp-django/crashstats/crashstats/management/commands/dumppv.py
+++ b/webapp-django/crashstats/crashstats/management/commands/dumppv.py
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Dump the crashstats_productversion table as CSV.
+"""
+
+import csv
+import io
+
+from django.core.management.base import BaseCommand
+
+from crashstats.crashstats.models import ProductVersion
+
+
+class Command(BaseCommand):
+    help = 'Dump crashstats_productversion table as csv.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'outputfile', type=str,
+            help='path to outputfile'
+        )
+
+    def handle(self, **options):
+        fn = options['outputfile']
+
+        pvs = ProductVersion.objects.order_by('id').values_list(
+            'product_name',
+            'release_channel',
+            'major_version',
+            'release_version',
+            'version_string',
+            'build_id',
+            'archive_url'
+        )
+
+        string_buffer = io.StringIO()
+        writer = csv.writer(string_buffer)
+        for pv in pvs:
+            writer.writerow(list(pv))
+
+        lines = string_buffer.getvalue().splitlines()
+        lines.sort()
+
+        with open(fn, 'w') as fp:
+            fp.write('\n'.join(lines) + '\n')


### PR DESCRIPTION
This switches verifyprocessed to use `concurrent.futures` and then restructures archivescraper to also use `concurrent.futures`.

The end result of this on a fresh local dev environment is a massive performance improvement:

* **before**: between 30 and 40 min
* **after**: under 3 min

This will significantly improve development. I slick my environment once a week, so this will save me 30 minutes a week.

archivescraper runs every hour in server environments and takes about 10 min. Since crontabber is synchronous and only runs one job at a time, this blocks all other jobs from running. Improving performance in server environments will improve crontabber job start times.

Using `concurrent.futures` should fix our error handling, too. With the previous implementation using just multiprocessing, we had to have child processes report errors to sentry. I'm pretty sure with this new architecture, the child processes will report exceptions back to the parent which will send them to sentry.