### PR TITLE
bug 1536903: improve bulk processing performance

### DIFF
--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -164,7 +164,7 @@ class SignatureAdmin(admin.ModelAdmin):
 def process_crashes(modeladmin, request, queryset):
     """Process selected missing processed crashes from admin page."""
     priority_api = PriorityJob()
-    crash_ids = [obj.crash_id for obj in queryset]
+    crash_ids = list(queryset.values_list('crash_id', flatten=True))
     priority_api.post(crash_ids=crash_ids)
     messages.add_message(request, messages.INFO, 'Sent %s crashes for processing.' % len(crash_ids))
 


### PR DESCRIPTION
This fixes the query so that it pulls the list of crash ids rather than
all the information, then create a bunch of instances, and then take
the crash ids from those instances. That's a lot of extra work.