### PR TITLE
bug 1527345: reduce Pub/Sub pulling

### DIFF
--- a/socorro/external/pubsub/crashqueue.py
+++ b/socorro/external/pubsub/crashqueue.py
@@ -10,6 +10,11 @@ from configman import Namespace, RequiredConfig
 from google.cloud import pubsub_v1
 
 
+# Maximum number of messages to pull from a Pub/Sub topic in a single pull
+# request
+PUBSUB_MAX_MESSAGES = 5
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -118,7 +123,6 @@ class PubSubCrashQueue(RequiredConfig):
             self.priority_path,
             self.standard_path,
             self.reprocessing_path,
-            self.priority_path
         ]
 
         while True:
@@ -126,7 +130,7 @@ class PubSubCrashQueue(RequiredConfig):
             for sub_path in sub_paths:
                 response = self.subscriber.pull(
                     sub_path,
-                    max_messages=1,
+                    max_messages=PUBSUB_MAX_MESSAGES,
                     return_immediately=True
                 )
                 if response.received_messages:


### PR DESCRIPTION
This reduces the number of Pub/Sub pulling operations by changing it to pull up
to 5 messages at a time from each queue. Further, it reduces the number of
times it pulls from the priority queue such that it only pulls from the
priority queue once per pass rather than twice per pass.

The theory is that this will increase the throughput for crash processing
on the standard queue which is where the vast majority of our messages
are.