### PR TITLE
bug 1539272: switch to 3.6.8-slim-stretch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.7-slim-jessie as socorro_image_base
+FROM python:3.6.8-slim-stretch as socorro_image_base
 
 # Set up user and group
 ARG groupid=10001

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM python:3.6.7-slim-jessie
+FROM python:3.6.8-slim-stretch
 
 ARG groupid=10001
 ARG userid=10001

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -16,7 +16,7 @@
 # Failures should cause setup to fail
 set -v -e -x
 
-echo ">>> pytest"
+echo ">>> set up environment"
 # Set up environment variables
 
 # NOTE(willkg): This has to be "database_url" all lowercase because configman.
@@ -29,11 +29,13 @@ export PYTHONPATH=/app/:$PYTHONPATH
 PYTEST="$(which pytest)"
 PYTHON="$(which python)"
 
+echo ">>> wait for services"
 # Wait for postgres and elasticsearch services to be ready
 urlwait "${DATABASE_URL}" 10
 urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
 urlwait "${ELASTICSEARCH_URL}" 10
 
+echo ">>> build pubsub things and db things"
 # Clear Pub/Sub for tests
 ./socorro-cmd pubsub delete
 ./socorro-cmd pubsub create

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -22,7 +22,7 @@ SOCORRO_GID=${SOCORRO_GID:-"10001"}
 
 # Use the same image we use for building docker images because it's cached.
 # Otherwise this doesn't make any difference.
-BASEIMAGENAME="python:3.6.7-slim-jessie"
+BASEIMAGENAME="python:3.6.8-slim-stretch"
 TESTIMAGE="local/socorro_app"
 
 # Start services in background (this is idempotent)
@@ -107,6 +107,6 @@ docker run \
        --tty \
        --interactive \
        --entrypoint= \
-       "${TESTIMAGE}" sh -c /app/docker/run_tests.sh
+       "${TESTIMAGE}" /app/docker/run_tests.sh
 
 echo "Done!"

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -35,6 +35,7 @@ PACKAGES_TO_INSTALL=(
     libcurl3-gnutls
     libcurl4-gnutls-dev
     wget
+    rsync
 
     # For nodejs and npm
     curl


### PR DESCRIPTION
The last time I attempted this, I hit all kinds of problems with compiling the breakpad client and minidump-stackwalk and abandoned the effort. Since then, one of the breakpad client updates we did must have covered all the problems I had because this update was easy peasy.