### PR TITLE
bug 1540858: fix /api/Reprocessing timeouts

### DIFF
--- a/socorro/external/pubsub/crashqueue.py
+++ b/socorro/external/pubsub/crashqueue.py
@@ -170,6 +170,11 @@ class PubSubCrashQueue(RequiredConfig):
         topic_name = self.config['%s_topic_name' % queue]
         topic_path = publisher.topic_path(project_id, topic_name)
 
+        # Queue up the batch
+        futures = []
         for crash_id in crash_ids:
-            future = publisher.publish(topic_path, data=crash_id.encode('utf-8'))
+            futures.append(publisher.publish(topic_path, data=crash_id.encode('utf-8')))
+
+        # Wait for everything in this group to get sent out
+        for future in futures:
             future.result()


### PR DESCRIPTION
Previously, the code published crash ids one at a time waiting for each
to go through. This fixes it to send them in a batch, then make sure
they all went through.