### PR TITLE
bug 1539130: redo admin for PolicyException

### DIFF
--- a/webapp-django/crashstats/authentication/admin.py
+++ b/webapp-django/crashstats/authentication/admin.py
@@ -3,10 +3,56 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.html import format_html
 
 from crashstats.authentication.models import PolicyException
+
+
+# Unregister the original UserAdmin and register our better one
+try:
+    admin.site.unregister(User)
+except TypeError:
+    pass
+
+
+@admin.register(User)
+class UserAdminBetter(UserAdmin):
+    """Improved UserAdmin.
+
+    This shows columns we care about and has links to PolicyException manipulation.
+
+    """
+
+    list_display = [
+        'email',
+        'first_name',
+        'last_name',
+        'is_active',
+        'is_hacker',
+        'is_superuser',
+        'date_joined',
+        'last_login',
+        'get_policyexception',
+    ]
+
+    def is_hacker(self, obj):
+        """Return whether user is in the Hackers group and has access to PII."""
+        return obj.groups.filter(name='Hackers').exists()
+    is_hacker.short_description = 'Hacker (PII)'
+
+    def get_policyexception(self, obj):
+        """Return whether user has a PolicyException with links to change/delete or add one."""
+        if hasattr(obj, 'policyexception'):
+            url = reverse(
+                'admin:authentication_policyexception_change', args=(obj.policyexception.id,)
+            )
+            return format_html('YES | <a href="{}">Change/Delete</a>', url)
+        url = reverse('admin:authentication_policyexception_add') + ('?user=%d' % obj.id)
+        return format_html('<a href="{}">Create</a>', url)
+    get_policyexception.short_description = 'PolicyException'
 
 
 @admin.register(PolicyException)
@@ -19,7 +65,6 @@ class PolicyExceptionAdmin(admin.ModelAdmin):
         'created',
         'user_linked',
     ]
-
     search_fields = ['user__email', 'notes']
 
     def get_user_email(self, obj):

--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -4,7 +4,6 @@
 
 from django.contrib import admin
 from django.contrib import messages
-from django.contrib.auth.admin import UserAdmin
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.utils.html import format_html
 
@@ -21,19 +20,6 @@ from crashstats.crashstats.models import (
     # Middleware
     PriorityJob
 )
-
-
-# Fix the Django Admin User list display so it shows the columns we care about
-UserAdmin.list_display = [
-    'email',
-    'first_name',
-    'last_name',
-    'is_superuser',
-    'is_staff',
-    'is_active',
-    'date_joined',
-    'last_login'
-]
 
 
 ACTION_TO_NAME = {


### PR DESCRIPTION
This reworks the `UserAdmin` to make it clearer who has access to what data on
the site. Further, it adds `PolicyException` status and also links to
create/delete/edit policy exceptions.