### PR TITLE
bug 1513346: remove python 2 bits from signature generation

### DIFF
--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# NOTE(willkg): Need to keep this until we drop Python 2.7 support in siggen
-from __future__ import print_function
-
 import argparse
 import csv
 import os

--- a/socorro/signature/siglists_utils.py
+++ b/socorro/signature/siglists_utils.py
@@ -17,11 +17,7 @@ _SPECIAL_EXTENDED_VALUES = {
     'signature_sentinels': [
         (
             'mozilla::ipc::RPCChannel::Call(IPC::Message*, IPC::Message*)',
-            lambda x: (
-                'CrashReporter::CreatePairedMinidumps(void*, '
-                'unsigned long, nsAString_internal*, nsILocalFile**, '
-                'nsILocalFile**)'
-            ) in x
+            lambda x: 'CrashReporter::CreatePairedMinidumps(void*, unsigned long, nsAString_internal*, nsILocalFile**, nsILocalFile**)' in x  # noqa
         ),
     ],
 }
@@ -68,6 +64,4 @@ def _get_file_content(source):
 IRRELEVANT_SIGNATURE_RE = _get_file_content('irrelevant_signature_re')
 PREFIX_SIGNATURE_RE = _get_file_content('prefix_signature_re')
 SIGNATURE_SENTINELS = _get_file_content('signature_sentinels')
-SIGNATURES_WITH_LINE_NUMBERS_RE = _get_file_content(
-    'signatures_with_line_numbers_re'
-)
+SIGNATURES_WITH_LINE_NUMBERS_RE = _get_file_content('signatures_with_line_numbers_re')

--- a/socorro/signature/tests/siglists/test-invalid-sig-list.txt
+++ b/socorro/signature/tests/siglists/test-invalid-sig-list.txt
@@ -1,4 +1,4 @@
 # Test Signatures List.
 # Contains an invalid regular expression.
 
-lol[[wut\]
+lol[wut\]

--- a/socorro/signature/tests/test_siglists.py
+++ b/socorro/signature/tests/test_siglists.py
@@ -7,7 +7,6 @@ import importlib
 import mock
 from pkg_resources import resource_stream
 import pytest
-import six
 
 # NOTE(willkg): We do this so that we can extract signature generation into its
 # own namespace as an external library. This allows the tests to run if it's in
@@ -35,7 +34,9 @@ class TestSigLists:
 
             for line in content:
                 assert line
-                if isinstance(line, six.string_types):
+                # Some items can be tuples; for the str lines, make sure they
+                # don't start with a #
+                if isinstance(line, str):
                     assert not line.startswith('#')
 
     @mock.patch(base_module + '.siglists_utils.resource_stream')

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -4,7 +4,6 @@
 
 
 from glom import glom
-import six
 
 
 def int_or_none(data):
@@ -93,18 +92,11 @@ def drop_bad_characters(text):
     """Takes a text and drops all non-printable and non-ascii characters and
     also any whitespace characters that aren't space.
 
-    :arg str/unicode text: the text to fix
+    :arg str text: the text to fix
 
     :returns: text with all bad characters dropped
 
     """
-    if six.PY2:
-        if isinstance(text, str):
-            # Convert to unicode to handle encoded sequences
-            text = text.decode('unicode_escape')
-        # Convert to a Python 2 str and drop any non-ascii characters
-        text = text.encode('ascii', 'ignore')
-
     # Strip all non-ascii and non-printable characters
     text = ''.join([c for c in text if c in ALLOWED_CHARS])
     return text


### PR DESCRIPTION
This removes Python 2 bits from signature generation. We no longer need to
support Python 2 with siggen.