### PR TITLE
bug 1541090: add __clear_cache to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -17,6 +17,7 @@ _alloca_probe
 __android_log_assert
 arena_
 BaseGetNamedObjectDirectory
+__clear_cache
 .*calloc
 cert_
 CERT_


### PR DESCRIPTION
Signature generation examples:

```
app@0c19f53ebd15:/app$ socorro-cmd fetch_crashids --url="https://crash-stats.mozilla.com/search/?signature=%3D__clear_cache&product=FennecAndroid&date=%3E%3D2019-03-29T18%3A36%3A00.000Z&date=%3C2019-04-05T18%3A36%3A00.000Z&_facets=signature&_sort=-date&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature" --num=5 | socorro-cmd signature
Crash id: 9a38cdc3-d98f-4296-94c0-0ed830190405
Original: __clear_cache
New:      __clear_cache | __clear_cache | Gecko_StartBulkWriteString
Same?:    False

Crash id: d24ab32c-71aa-428e-950f-2ba210190405
Original: __clear_cache
New:      __clear_cache | __clear_cache | base.apk@0x143ce5d
Same?:    False

Crash id: bbe160b2-603b-4444-86f9-4db4a0190405
Original: __clear_cache
New:      __clear_cache
Same?:    True

Crash id: 1aab12d1-a1fa-4af7-b845-e082e0190405
Original: __clear_cache
New:      __clear_cache | js::jit::MaybeEnterJit
Same?:    False

Crash id: 97f6dd75-b210-4d3b-90cf-3f7c80190405
Original: __clear_cache
New:      __clear_cache | js::GeneratorObject::create
Same?:    False
```