### PR TITLE
Move markus configuration to settings

### DIFF
--- a/webapp-django/crashstats/crashstats/apps.py
+++ b/webapp-django/crashstats/crashstats/apps.py
@@ -15,36 +15,5 @@ class CrashstatsConfig(AppConfig):
         # Import signals kicking off signal registration
         from crashstats.crashstats import signals  # noqa
 
-        # Set up markus
-        if settings.LOCAL_DEV_ENV:
-            # If we're in the local development environment, then use the
-            # logging and statsd backends
-            backends = [
-                {
-                    'class': 'markus.backends.logging.LoggingMetrics',
-                },
-                {
-                    'class': 'markus.backends.statsd.StatsdMetrics',
-                    'options': {
-                        'statsd_host': settings.STATSD_HOST,
-                        'statsd_port': settings.STATSD_PORT,
-                        'statsd_prefix': settings.STATSD_PREFIX,
-                    }
-                }
-            ]
-        else:
-            # Otherwise we're in a server environment and we use the datadog
-            # backend there
-            backends = [
-                {
-                    # Log metrics to Datadog
-                    'class': 'markus.backends.datadog.DatadogMetrics',
-                    'options': {
-                        'statsd_host': settings.STATSD_HOST,
-                        'statsd_port': settings.STATSD_PORT,
-                        'statsd_namespace': settings.STATSD_PREFIX,
-                    }
-                }
-            ]
-
-        markus.configure(backends=backends)
+        # Set up markus metrics
+        markus.configure(backends=settings.MARKUS_BACKENDS)

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -477,7 +477,7 @@ if LOCAL_DEV_ENV:
 else:
     # Otherwise we're in a server environment and we use the datadog
     # backend there
-    MARKUS_BACKENS = [
+    MARKUS_BACKENDS = [
         {
             # Log metrics to Datadog
             'class': 'markus.backends.datadog.DatadogMetrics',

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -459,6 +459,37 @@ STATSD_HOST = config('STATSD_HOST', 'localhost')
 STATSD_PORT = config('STATSD_PORT', 8125, cast=int)
 STATSD_PREFIX = config('STATSD_PREFIX', None)
 
+# set up markus backends for metrics
+if LOCAL_DEV_ENV:
+    MARKUS_BACKENDS = [
+        {
+            'class': 'markus.backends.logging.LoggingMetrics',
+        },
+        {
+            'class': 'markus.backends.statsd.StatsdMetrics',
+            'options': {
+                'statsd_host': STATSD_HOST,
+                'statsd_port': STATSD_PORT,
+                'statsd_prefix': STATSD_PREFIX,
+            }
+        }
+    ]
+else:
+    # Otherwise we're in a server environment and we use the datadog
+    # backend there
+    MARKUS_BACKENS = [
+        {
+            # Log metrics to Datadog
+            'class': 'markus.backends.datadog.DatadogMetrics',
+            'options': {
+                'statsd_host': STATSD_HOST,
+                'statsd_port': STATSD_PORT,
+                'statsd_namespace': STATSD_PREFIX,
+            }
+        }
+    ]
+
+
 CACHES = {
     'default': {
         'BACKEND': config(


### PR DESCRIPTION
For some reason, when I added markus, I put the configuration where it
configures markus. That should be in settings so it's clearer what's going
on from settings. This fixes that.