### PR TITLE
bug 1542392: rewrite monitoring crontabber app as Django command

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -105,8 +105,6 @@ OVERVIEW_VERSION_URLS=http://localhost:8000/__version__
 
 # crontabber
 # ----------
-crontabber.class-DependencySecurityCheckCronApp.safety_path=/usr/local/bin/safety
-crontabber.class-DependencySecurityCheckCronApp.package_json_path=/app/webapp-django/package.json
 crontabber.class-UploadCrashReportJSONSchemaCronApp.bucket_name=telemetry_bucket
 
 # oidcprovider

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -1088,9 +1088,6 @@ DEFAULT_JOBS = ','.join([
     # Product/version maintenance
     'socorro.cron.jobs.archivescraper.ArchiveScraperCronApp|1h',
 
-    # Dependency checking
-    'socorro.cron.jobs.monitoring.DependencySecurityCheckCronApp|1d|05:00',
-
     # Processed crash verification
     'socorro.cron.jobs.verify_processed.VerifyProcessedCronApp|1d|04:00',
 ])

--- a/socorro/unittest/cron/test_crontabber_app.py
+++ b/socorro/unittest/cron/test_crontabber_app.py
@@ -8,7 +8,6 @@ from socorro.cron.crontabber_app import jobs_converter, DEFAULT_JOBS
 class TestJobsConverter(object):
     expected_job_names = [
         'ArchiveScraperCronApp',
-        'DependencySecurityCheckCronApp',
         'ElasticsearchCleanupCronApp',
         'VerifyProcessedCronApp',
     ]

--- a/webapp-django/crashstats/cron/__init__.py
+++ b/webapp-django/crashstats/cron/__init__.py
@@ -36,6 +36,12 @@ JOBS = [
         'frequency': '1h',
         'last_success': True,
         'backfill': True,
+    },
+    {
+        # Check dependencies for security updates every day at 5:00am
+        'cmd': 'depcheck',
+        'frequency': '1d',
+        'time': '05:00',
     }
 ]
 

--- a/webapp-django/crashstats/monitoring/management/__init__.py
+++ b/webapp-django/crashstats/monitoring/management/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapp-django/crashstats/monitoring/management/commands/__init__.py
+++ b/webapp-django/crashstats/monitoring/management/commands/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -721,6 +721,11 @@ CRONTABBER_MAX_ONGOING_AGE_HOURS = 2
 # Number of seconds before we retry a failed job
 CRONTABBER_ERROR_RETRY_TIME = 300
 
+# Configuration for the depcheck command
+NPM_PATH = config('NPM_PATH', '/usr/bin/npm')
+SAFETY_PATH = config('SAFETY_PATH', '/usr/local/bin/safety')
+SAFETY_API_KEY = config('SAFETY_API_KEY', '')
+PACKAGE_JSON_PATH = config('PACKAGE_JSON_PATH', '/app/webapp-django/package.json')
 
 # OIDC credentials are needed to be able to connect with OpenID Connect.
 # Credentials for local development are set in /docker/config/oidcprovider-fixtures.json.


### PR DESCRIPTION
This rewrites the monitoring crontabber app as a Django command.  "monitoring"
wasn't very descriptive of what it did, so I renamed it to depcheck.