### PR TITLE
Bug 1544449 - Fix NoteXPCOMChild class name.

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -45,7 +45,7 @@ fastzero_I
 _files_getaddrinfo
 .*free
 free_impl
-GCGraphBuilder::NoteXPCOMChild
+CCGraphBuilder::NoteXPCOMChild
 gfxPlatform::Init
 getanswer
 gkrust_shared::oom_hook::hook


### PR DESCRIPTION
GCGraphBuilder got renamed to CCGraphBuilder a long time ago, but the prefix list was never updated.