### PR TITLE
bug 1544543: Add uuid to allowed keys for RawCrash

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -864,6 +864,7 @@ class RawCrash(SocorroMiddleware):
         'TotalVirtualMemory',
         'upload_file_minidump_*',
         'useragent_locale',
+        'uuid',
         'Vendor',
         'version',
         'Version',


### PR DESCRIPTION
The processor requires this key to process raw crash files, and it doesn't contain PII. The crash report won't include a useful signature or a thread, but this may allow some contributions.