### PR TITLE
bug 1544919: Refresh webapp service docs

### DIFF
--- a/docs/localdevenvironment.rst
+++ b/docs/localdevenvironment.rst
@@ -10,6 +10,7 @@ development environment.
 If you're interested in running Socorro in a server environment, then check out
 :ref:`deploying-socorro-chapter`.
 
+.. _setup-quickstart:
 
 Setup Quickstart
 ================

--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -150,7 +150,9 @@ and any changes there disappear when you stop the container.
 
 If you are on macOS or Windows, then Docker uses a shared file system that
 creates files with your user ID. This makes it safe to persist static assets,
-at the cost of slower file system performance.
+at the cost of slower file system performance. Linux users can manually set
+the uid and gid to match their account, for the same effect. See "Set UID and
+GID for Docker container user" in :ref:`setup-quickstart`.
 
 If you want static assets to persist between container restarts, then you
 can override ``STATIC_ROOT`` in ``my.env`` to return it to the ``app`` folder::


### PR DESCRIPTION
Update the docs to reflect my best guess at current workflows:

* Add note for signing up with ``oidcprovider`` in dev. I have further changes I want to make, but I first filed as issues in [mozilla-parsys](https://github.com/mozilla-parsys/docker-test-mozilla-django-oidc).
* Move static assets note into new section, with example ``docker-compose.override.yml`` and macOS note. Move instructions for production-like assets as a subsection.
* Simplify and organize the permission sections, which felt like an introduction to django.contrib.auth. Add a link to the official docs to cover content I removed.
* Permissions and default groups are now in ``signal.py``. I think they should be in a data migration, but that can be a future discussion / PR, depending on how often permissions are changed.
* Drop the "Troubleshooting" section, which referred to removed views and emailing tracebacks (it is easier to view the webapp logs for tracebacks).