### PR TITLE
bug 1544497: fix comments tab in signature report

### DIFF
--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -65,7 +65,9 @@
         <li><a href="#reports" class="reports" data-tab-name="reports">Reports</a></li>
         <li><a href="#graphs" class="graphs" data-tab-name="graphs">Graphs</a></li>
         <li><a href="#bugzilla" class="bugzilla" data-tab-name="bugzilla">Bugzilla</a></li>
-        <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
+        {% if request.user.has_perm('crashstats.view_pii') %}
+          <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
+        {% endif %}
         {% if product in correlations_products %}
           <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
         {% endif %}

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -65,9 +65,7 @@
         <li><a href="#reports" class="reports" data-tab-name="reports">Reports</a></li>
         <li><a href="#graphs" class="graphs" data-tab-name="graphs">Graphs</a></li>
         <li><a href="#bugzilla" class="bugzilla" data-tab-name="bugzilla">Bugzilla</a></li>
-        {% if request.user.has_perm('crashstats.view_pii') %}
-          <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
-        {% endif %}
+        <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
         {% if product in correlations_products %}
           <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
         {% endif %}

--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -78,9 +78,17 @@ SignatureReport.init = function() {
     var errorMsg;
 
     try {
-      errorDetails = $(jqXHR.responseText); // This might fail
-      errorTitle = 'Oops, an error occured';
-      errorMsg = 'Please fix the following issues: ';
+      if (jqXHR.status === 403) {
+        // Handle the HTTP 403 case explicitly
+        errorDetails = '';
+        errorTitle = 'Forbidden';
+        errorMsg = 'You do not have access to view this data.';
+      } else {
+        // It's some other problem
+        errorDetails = $(jqXHR.responseText); // This might fail
+        errorTitle = 'Oops, an error occured';
+        errorMsg = 'Please fix the following issues: ';
+      }
 
       errorContent.append($('<h3>', { text: errorTitle }));
       errorContent.append($('<p>', { text: errorMsg }));

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -318,7 +318,10 @@ def signature_graphs(request, params, field):
 
 @pass_validated_params
 def signature_comments(request, params):
-    '''Return a list of non-empty comments. '''
+    """Return a list of non-empty comments."""
+    # Users can't see comments unless they have view_pii permissions.
+    if not request.user.has_perm('crashstats.view_pii'):
+        return http.HttpResponseForbidden()
 
     signature = params['signature'][0]
 
@@ -353,7 +356,7 @@ def signature_comments(request, params):
     params['_sort'] = '-date'
     params['_results_number'] = results_per_page
     params['_results_offset'] = context['results_offset']
-    params['_facets'] = []  # We don't need no facets.
+    params['_facets'] = []
 
     context['current_url'] = '%s?%s' % (
         reverse('signature:signature_report'),


### PR DESCRIPTION
Users shouldn't be able to view comments if they don't have `view_pii`
permissions.