### PR TITLE
bug 1544919: Remove incorrect "no ids" message

### DIFF
--- a/socorro/scripts/pubsub.py
+++ b/socorro/scripts/pubsub.py
@@ -145,8 +145,6 @@ def publish_crashid(config, queue, crashids):
         future = publisher.publish(topic_path, data=crash_id.encode('utf-8'))
         future.result()
         print('Published: %s' % crash_id)
-    else:
-        print('No crash ids provided.')
 
 
 def list_from_arg_or_pipe(arg):


### PR DESCRIPTION
As mentioned in https://github.com/mozilla-services/socorro/pull/4894#pullrequestreview-228362039, in a ``for``/``else`` statement, the ``else`` clause is called when the ``for`` loop completes without breaking, but the code was written as if it was called for an empty loop. I believe I was confused with [Jinja's for / else loop](http://jinja.pocoo.org/docs/2.10/templates/#for) 🤦‍♂️.

Since the "no crashids" case is [handled in ``main``](https://github.com/jwhitlock/socorro/blob/d33376d6a8b67d531839ba5a350aac885eb32c6a/socorro/scripts/pubsub.py#L203-L207) (by printing usage help), it doesn't need to be handled here as well.