### PR TITLE
bug 1544919: Add note for API token permissions for crash data

### DIFF
--- a/webapp-django/crashstats/tokens/jinja2/tokens/home.html
+++ b/webapp-django/crashstats/tokens/jinja2/tokens/home.html
@@ -26,7 +26,10 @@
           You need <b>API Tokens to be able to connect to the API</b> so that
           the API knows who you are and thus what permissions you have. <br>
           Using any <b>valid API Token</b> with your API calls means a <b>much
-          higher rate limit</b>.
+          higher rate limit</b>. <br>
+          An API token for downloading crash data requires
+          the permissions <code>View Personal Identifiable Information</code>
+          and <code>View Raw Dumps</code>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
As suggested on https://github.com/mozilla-services/socorro/pull/4894#discussion_r276246228, add a note that to download crash data, an API token needs both the ``View Personal
Identifiable Information`` and ``View Raw Dumps ``permissions.

![Screenshot 2019-04-18 14 35 34](https://user-images.githubusercontent.com/286017/56386627-e6db9280-61e7-11e9-9e1b-11cd4f93a8c9.png)

I was tempted to also change ``<b>`` to ``<strong>`` and ``<br>`` to separate ``<p>`` elements. I resisted.