### PR TITLE
bug 1544919: fix scripts/process_crashes.sh to take from stdin

### DIFF
--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -64,3 +64,6 @@ PS1="\${MYUSER}@socorro:\w\$ "
 # Add current directory to path.
 PATH=\${PATH}:.
 EOF
+
+# Remove this bashrc so it doesn't override the global one we created
+rm /home/app/.bashrc

--- a/docs/service/processor.rst
+++ b/docs/service/processor.rst
@@ -92,13 +92,13 @@ For example:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./scripts/process_crashes.sh ed35821d-3af5-4fe9-bfa3-dc4dc0181128
+   app@socorro:/app$ scripts/process_crashes.sh ed35821d-3af5-4fe9-bfa3-dc4dc0181128
 
 You can also use it with ``fetch_crashids``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids --num=1 | ./scripts/process_crashes.sh
+   app@socorro:/app$ socorro-cmd fetch_crashids --num=1 | scripts/process_crashes.sh
 
 After running ``scripts/process_crashes.sh``, you will need to run the
 processor which will do the actual processing.
@@ -119,26 +119,26 @@ This pulls 100 crash ids from yesterday for Firefox product:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids
+   app@socorro:/app$ socorro-cmd fetch_crashids
 
 This pulls 5 crash ids from 2017-09-01:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids --num=5 --date=2017-09-01
+   app@socorro:/app$ socorro-cmd fetch_crashids --num=5 --date=2017-09-01
 
 This pulls 100 crash ids for criteria specified with a Super Search url that we
 copy and pasted:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform"
+   app@socorro:/app$ socorro-cmd fetch_crashids "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform"
 
 You can get command help:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids --help
+   app@socorro:/app$ socorro-cmd fetch_crashids --help
 
 
 fetch_crash_data
@@ -153,14 +153,14 @@ Usage from host:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crash_data <outputdir> <crashid> [<crashid> ...]
+   app@socorro:/app$ socorro-cmd fetch_crash_data <outputdir> <crashid> [<crashid> ...]
 
 
 For example (assumes this crash exists):
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crash_data ./testdata 5c9cecba-75dc-435f-b9d0-289a50170818
+   app@socorro:/app$ socorro-cmd fetch_crash_data ./testdata 5c9cecba-75dc-435f-b9d0-289a50170818
 
 
 Use with ``fetch_crashids`` to fetch crash data from 100 crashes from yesterday
@@ -168,14 +168,14 @@ for Firefox:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids | ./socorro-cmd fetch_crash_data ./testdata
+   app@socorro:/app$ socorro-cmd fetch_crashids | socorro-cmd fetch_crash_data ./testdata
 
 
 You can get command help:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crash_data --help
+   app@socorro:/app$ socorro-cmd fetch_crash_data --help
 
 
 scripts/socorro_aws_s3.sh
@@ -188,28 +188,28 @@ For example, this creates an S3 bucket named ``dev_bucket``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev_bucket/
 
 
 This copies the contents of ``./testdata`` into the ``dev_bucket``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./scripts/socorro_aws_s3.sh sync ./testdata s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./testdata s3://dev_bucket/
 
 
 This lists the contents of the bucket:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./scripts/socorro_aws_s3.sh ls s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh ls s3://dev_bucket/
 
 
 Since this is just a wrapper, you can get help:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./scripts/socorro_aws_s3.sh help
+   app@socorro:/app$ scripts/socorro_aws_s3.sh help
 
 
 pubsub
@@ -225,14 +225,14 @@ For example:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd pubsub publish ed35821d-3af5-4fe9-bfa3-dc4dc0181128
+   app@socorro:/app$ socorro-cmd pubsub publish ed35821d-3af5-4fe9-bfa3-dc4dc0181128
 
 
 For help:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd pubsub publish --help
+   app@socorro:/app$ socorro-cmd pubsub publish --help
 
 
 .. Note::
@@ -252,20 +252,20 @@ Let's process crashes for Firefox from yesterday. We'd do this:
   $ make shell
 
   # Generate a file of crashids--one per line
-  app@socorro:/app$ ./socorro-cmd fetch_crashids > crashids.txt
+  app@socorro:/app$ socorro-cmd fetch_crashids > crashids.txt
 
   # Pull raw crash data from -prod for each crash id and put it in the
   # "crashdata" directory on the host
-  app@socorro:/app$ cat crashids.txt | ./socorro-cmd fetch_crash_data ./crashdata
+  app@socorro:/app$ cat crashids.txt | socorro-cmd fetch_crash_data ./crashdata
 
   # Create a dev_bucket in localstack-s3
-  app@socorro:/app$ ./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+  app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev_bucket/
 
   # Copy that data from the host into the localstack-s3 container
   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./crashdata s3://dev_bucket/
 
   # Add all the crash ids to the queue
-  app@socorro:/app$ cat crashids.txt | ./socorro-cmd pubsub publish
+  app@socorro:/app$ cat crashids.txt | socorro-cmd pubsub publish
 
   # Then exit the container
   app@socorro:/app$ exit

--- a/docs/service/processor.rst
+++ b/docs/service/processor.rst
@@ -98,7 +98,7 @@ You can also use it with ``fetch_crashids``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ socorro-cmd fetch_crashids --num=1 | xargs scripts/process_crashes.sh
+   app@socorro:/app$ ./socorro-cmd fetch_crashids --num=1 | ./scripts/process_crashes.sh
 
 After running ``scripts/process_crashes.sh``, you will need to run the
 processor which will do the actual processing.
@@ -168,7 +168,7 @@ for Firefox:
 
 .. code-block:: shell
 
-   app@socorro:/app$ ./socorro-cmd fetch_crashids | socorro-cmd fetch_crash_data ./testdata
+   app@socorro:/app$ ./socorro-cmd fetch_crashids | ./socorro-cmd fetch_crash_data ./testdata
 
 
 You can get command help:
@@ -252,11 +252,11 @@ Let's process crashes for Firefox from yesterday. We'd do this:
   $ make shell
 
   # Generate a file of crashids--one per line
-  app@socorro:/app$ socorro-cmd fetch_crashids > crashids.txt
+  app@socorro:/app$ ./socorro-cmd fetch_crashids > crashids.txt
 
   # Pull raw crash data from -prod for each crash id and put it in the
   # "crashdata" directory on the host
-  app@socorro:/app$ cat crashids.txt | socorro-cmd fetch_crash_data ./crashdata
+  app@socorro:/app$ cat crashids.txt | ./socorro-cmd fetch_crash_data ./crashdata
 
   # Create a dev_bucket in localstack-s3
   app@socorro:/app$ ./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
@@ -265,7 +265,7 @@ Let's process crashes for Firefox from yesterday. We'd do this:
   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./crashdata s3://dev_bucket/
 
   # Add all the crash ids to the queue
-  app@socorro:/app$ cat crashids.txt | socorro-cmd pubsub publish
+  app@socorro:/app$ cat crashids.txt | ./socorro-cmd pubsub publish
 
   # Then exit the container
   app@socorro:/app$ exit

--- a/scripts/process_crashes.sh
+++ b/scripts/process_crashes.sh
@@ -13,7 +13,7 @@
 #
 # You can use it with fetch_crashids:
 #
-#    app@socorro:/app$ socorro-cmd fetch_crashids --num=1 | xargs ./scripts/process_crashes.sh
+#    app@socorro:/app$ socorro-cmd fetch_crashids --num=1 | ./scripts/process_crashes.sh
 #
 # Make sure to run the processor to do the actual processing.
 
@@ -30,8 +30,14 @@ function cleanup {
 trap cleanup EXIT
 
 if [[ $# -eq 0 ]]; then
-    echo "Usage: process_crashes.sh CRASHID [CRASHID ...]"
-    exit 1
+    if [ -t 0 ]; then
+        # If stdin is a terminal, then there's no input
+        echo "Usage: process_crashes.sh CRASHID [CRASHID ...]"
+        exit 1
+    fi
+
+    # stdin is not a terminal, so pull the args from there
+    set -- ${@:-$(</dev/stdin)}
 fi
 
 mkdir "${DATADIR}" || echo "${DATADIR} already exists."


### PR DESCRIPTION
This fixes `./scripts/process_crashes.sh` to pull from stdin if there are no crashid args and stdin is not a tty.

```shell
$ make shell
app@afdfe895c928:/app$ ./scripts/process_crashes.sh 
Usage: process_crashes.sh CRASHID [CRASHID ...]
app@afdfe895c928:/app$ echo 4854438d-dd83-44d5-967b-155d70190418 | scripts/process_crashes.sh 
<copious output>
app@afdfe895c928:/app$ scripts/process_crashes.sh 4854438d-dd83-44d5-967b-155d70190418
<copious output>
```