### PR TITLE
bug 1544919: Add FallbackToPipeAction

### DIFF
--- a/socorro/scripts/__init__.py
+++ b/socorro/scripts/__init__.py
@@ -99,6 +99,9 @@ class FallbackToPipeAction(argparse.Action):
         if option_strings:
             raise ValueError("This action does not work with named arguments")
         if nargs != '*':
+            # For nargs='*', the action is called with an empty list.
+            # For other values ('?', '+', 1), the action isn't called, so we
+            # can't fallback to reading from stdin.
             raise ValueError("nargs should be '*'")
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -6,11 +6,12 @@ import argparse
 import json
 import os
 import os.path
-import sys
 
 from socorro.lib.datetimeutil import JsonDTEncoder
 from socorro.lib.requestslib import session_with_retries
-from socorro.scripts import FlagAction, WrappedTextHelpFormatter
+from socorro.scripts import (FallbackToPipeAction,
+                             FlagAction,
+                             WrappedTextHelpFormatter)
 
 
 DESCRIPTION = """
@@ -147,7 +148,10 @@ def main(argv=None):
     )
 
     parser.add_argument('outputdir', help='directory to place crash data in')
-    parser.add_argument('crashid', nargs='*', help='one or more crash ids to fetch data for')
+    parser.add_argument('crashid',
+                        help='one or more crash ids to fetch data for',
+                        nargs='*',
+                        action=FallbackToPipeAction)
 
     if argv is None:
         args = parser.parse_args()
@@ -167,10 +171,7 @@ def main(argv=None):
     else:
         print('No api token provided. Skipping dumps and personally identifiable information.')
 
-    # This will pull crash ids from the command line if specified, otherwise it'll pull from stdin
-    crashids_iterable = args.crashid or sys.stdin
-
-    for crash_id in crashids_iterable:
+    for crash_id in args.crashid:
         crash_id = crash_id.strip()
 
         print('Working on %s...' % crash_id)

--- a/socorro/unittest/scripts/test_init.py
+++ b/socorro/unittest/scripts/test_init.py
@@ -10,6 +10,23 @@ import pytest
 from socorro.scripts import FallbackToPipeAction, FlagAction
 
 
+@pytest.fixture
+def parser():
+    return argparse.ArgumentParser()
+
+
+@pytest.fixture
+def fallback_parser(parser):
+    parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
+    return parser
+
+
+@pytest.fixture
+def mock_stdin():
+    with mock.patch('sys.stdin', spec_set=['isatty', '__iter__']) as mock_stdin:
+        yield mock_stdin
+
+
 class TestFlagAction:
     @pytest.mark.parametrize('args, expected', [
         # No args results in default
@@ -23,16 +40,14 @@ class TestFlagAction:
         (['--no-flag', '--flag'], True),
         (['--flag', '--no-flag'], False),
     ])
-    def test_parsing(self, args, expected):
-        parser = argparse.ArgumentParser()
+    def test_parsing(self, args, expected, parser):
         parser.add_argument('--flag', '--no-flag', dest='flag', default=True, action=FlagAction)
 
         args = parser.parse_args(args)
         assert args.flag is expected
 
-    def test_value_error(self):
+    def test_value_error(self, parser):
         """Validate flags--must have a flag and a no-flag"""
-        parser = argparse.ArgumentParser()
         with pytest.raises(ValueError):
             # --flag and no --no-flag
             parser.add_argument('--flag', dest='flag', default=True, action=FlagAction)
@@ -43,68 +58,52 @@ class TestFlagAction:
 
 
 class TestFallbackToPipeAction:
-    def test_named_option_raises(self):
+    def test_named_option_raises(self, parser):
         """Init fails with positional args, since omitting skips the call."""
-        parser = argparse.ArgumentParser()
         with pytest.raises(ValueError):
             parser.add_argument('--name', nargs='*',
                                 action=FallbackToPipeAction)
 
     @pytest.mark.parametrize('nargs', ['?', '+', 1])
-    def test_other_nargs_raises(self, nargs):
+    def test_other_nargs_raises(self, nargs, parser):
         """Init fails nargs!='*', since omitting skips the call."""
-        parser = argparse.ArgumentParser()
         with pytest.raises(ValueError):
             parser.add_argument('name', nargs=nargs,
                                 action=FallbackToPipeAction)
 
-    def test_command_line(self):
+    def test_command_line(self, fallback_parser, mock_stdin):
         """Command line positional arguments are preferred."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
-        with mock.patch('sys.stdin') as mock_stdin:
-            mock_stdin.isatty.side_effect = Exception('should not be called')
-            args = parser.parse_args(['1', '2', '3'])
+        mock_stdin.isatty.side_effect = Exception('should not be called')
+        args = fallback_parser.parse_args(['1', '2', '3'])
         assert args.testid == ['1', '2', '3']
 
-    def test_stdin_fallback(self):
+    def test_stdin_fallback(self, fallback_parser, mock_stdin):
         """If positional arguments are omitted, the stdin is used."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
-        with mock.patch('sys.stdin') as mock_stdin:
-            mock_stdin.isatty.return_value = False
-            mock_stdin.__iter__.return_value = ['a\n', ' b\n', 'c\n']
-            args = parser.parse_args([])
+        mock_stdin.isatty.return_value = False
+        mock_stdin.__iter__.return_value = ['a\n', ' b\n', 'c\n']
+        args = fallback_parser.parse_args([])
         assert args.testid == ['a', ' b', 'c']
 
-    def test_stdin_tty_fails(self):
+    def test_stdin_tty_fails(self, fallback_parser, mock_stdin):
         """An interactive shell fails as a fallback."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
-        with mock.patch('sys.stdin') as mock_stdin:
-            mock_stdin.isatty.return_value = True
-            with pytest.raises(SystemExit):
-                parser.parse_args([])
+        mock_stdin.isatty.return_value = True
+        with pytest.raises(SystemExit):
+            fallback_parser.parse_args([])
 
-    def test_stdin_empty_fails(self):
+    def test_stdin_empty_fails(self, fallback_parser, mock_stdin):
         """An empty pipe fails as a fallback."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
-        with mock.patch('sys.stdin') as mock_stdin:
-            mock_stdin.isatty.return_value = True
-            mock_stdin.__iter__.return_value = []
-            with pytest.raises(SystemExit):
-                parser.parse_args([])
+        mock_stdin.isatty.return_value = True
+        mock_stdin.__iter__.return_value = []
+        with pytest.raises(SystemExit):
+            fallback_parser.parse_args([])
 
-    def test_stdin_type_translation(self):
+    def test_stdin_type_translation(self, parser, mock_stdin):
         """Values from stdin are processed by the type function."""
-        parser = argparse.ArgumentParser()
         parser.add_argument('testid',
                             nargs='*',
                             type=int,
                             action=FallbackToPipeAction)
-        with mock.patch('sys.stdin') as mock_stdin:
-            mock_stdin.isatty.return_value = False
-            mock_stdin.__iter__.return_value = ['1\n', '10\n', '1000\n']
-            args = parser.parse_args([])
+        mock_stdin.isatty.return_value = False
+        mock_stdin.__iter__.return_value = ['1\n', '10\n', '1000\n']
+        args = parser.parse_args([])
         assert args.testid == [1, 10, 1000]

--- a/socorro/unittest/scripts/test_init.py
+++ b/socorro/unittest/scripts/test_init.py
@@ -4,9 +4,10 @@
 
 import argparse
 
+import mock
 import pytest
 
-from socorro.scripts import FlagAction
+from socorro.scripts import FallbackToPipeAction, FlagAction
 
 
 class TestFlagAction:
@@ -39,3 +40,71 @@ class TestFlagAction:
         with pytest.raises(ValueError):
             # --no-flag and no --flag
             parser.add_argument('--no-flag', dest='flag', default=True, action=FlagAction)
+
+
+class TestFallbackToPipeAction:
+    def test_named_option_raises(self):
+        """Init fails with positional args, since omitting skips the call."""
+        parser = argparse.ArgumentParser()
+        with pytest.raises(ValueError):
+            parser.add_argument('--name', nargs='*',
+                                action=FallbackToPipeAction)
+
+    @pytest.mark.parametrize('nargs', ['?', '+', 1])
+    def test_other_nargs_raises(self, nargs):
+        """Init fails nargs!='*', since omitting skips the call."""
+        parser = argparse.ArgumentParser()
+        with pytest.raises(ValueError):
+            parser.add_argument('name', nargs=nargs,
+                                action=FallbackToPipeAction)
+
+    def test_command_line(self):
+        """Command line positional arguments are preferred."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
+        with mock.patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.side_effect = Exception('should not be called')
+            args = parser.parse_args(['1', '2', '3'])
+        assert args.testid == ['1', '2', '3']
+
+    def test_stdin_fallback(self):
+        """If positional arguments are omitted, the stdin is used."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
+        with mock.patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.__iter__.return_value = ['a\n', ' b\n', 'c\n']
+            args = parser.parse_args([])
+        assert args.testid == ['a', ' b', 'c']
+
+    def test_stdin_tty_fails(self):
+        """An interactive shell fails as a fallback."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
+        with mock.patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with pytest.raises(SystemExit):
+                parser.parse_args([])
+
+    def test_stdin_empty_fails(self):
+        """An empty pipe fails as a fallback."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument('testid', nargs='*', action=FallbackToPipeAction)
+        with mock.patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            mock_stdin.__iter__.return_value = []
+            with pytest.raises(SystemExit):
+                parser.parse_args([])
+
+    def test_stdin_type_translation(self):
+        """Values from stdin are processed by the type function."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument('testid',
+                            nargs='*',
+                            type=int,
+                            action=FallbackToPipeAction)
+        with mock.patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.__iter__.return_value = ['1\n', '10\n', '1000\n']
+            args = parser.parse_args([])
+        assert args.testid == [1, 10, 1000]


### PR DESCRIPTION
``FallbackToPipeAction`` centralizes the logic for taking ``crashids`` from either the positional arguments or a piped list, so both work:

```shell
cat crashids.txt | xargs socorro-cmd fetch_crash_data ./crashdata
cat crashids.txt | socorro-cmd fetch_crash_data ./crashdata
```

It works in the ``argparse`` framework so that omitting both is a parsing error, which displays the default usage message.