### PR TITLE
bug 1542392: fix depcheck to tell us if it's using a safety api key

### DIFF
--- a/webapp-django/crashstats/monitoring/management/commands/depcheck.py
+++ b/webapp-django/crashstats/monitoring/management/commands/depcheck.py
@@ -105,6 +105,7 @@ class Command(BaseCommand):
         # for any paths.
         cmd = [settings.SAFETY_PATH, 'check', '--json']
         if getattr(settings, 'SAFETY_API_KEY', ''):
+            self.stdout.write('Using safety api key.')
             cmd += ['--key', settings.SAFETY_API_KEY]
 
         process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -125,11 +126,17 @@ class Command(BaseCommand):
                     ) for result in results
                 ]
             except (ValueError, IndexError) as err:
-                raise DependencySecurityCheckFailed(
-                    'Could not parse pyup safety output',
-                    err,
-                    output,
-                )
+                if error_output:
+                    raise DependencySecurityCheckFailed(
+                        'pyup safety returned error',
+                        error_output
+                    )
+                else:
+                    raise DependencySecurityCheckFailed(
+                        'Could not parse pyup safety output',
+                        err,
+                        output,
+                    )
 
         raise DependencySecurityCheckFailed(error_output)
 


### PR DESCRIPTION
This fixes the depcheck command to tell us if it's using a safety api key.
Otherwise we have no idea.

This also fixes what it does if the key is bad. Before it would raise
an error with the text `"b''"`. Now it tells you the api key is invalid.
Isn't that nice.