### PR TITLE
bug 1546978: Update permissions, refresh LogEntry admin view

### DIFF
--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -59,19 +59,10 @@ class LogEntryAdmin(admin.ModelAdmin):
         return False
 
     def has_change_permission(self, request, obj=None):
-        # FIXME(willkg): If this always returned False, then this modeladmin
-        # doesn't show up in the index. However, this means you get a change
-        # page that suggests you can change it, but errors out when saving.
-        #
-        # We can nix this and use has_view_permission when we upgrade to
-        # Django 2.1.
-        return request.method != 'POST'
+        return False
 
     def has_delete_permission(self, request, obj=None):
         return False
-
-    def has_module_permission(self, request):
-        return True
 
 
 @admin.register(BugAssociation)

--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.contrib.auth.models import User
+from django.urls import reverse, NoReverseMatch
 from django.utils.html import format_html
 
 from crashstats.crashstats.models import (
@@ -35,16 +36,20 @@ class LogEntryAdmin(admin.ModelAdmin):
 
     list_display = [
         'action_time',
-        'user_email',
-        'get_edited_object',
-        'action_name',
-        'get_change_message'
+        'admin',
+        'object_link',
+        'action',
+        'get_change_message',
+    ]
+    list_display_links = [
+        'action_time',
+        'get_change_message',
     ]
 
-    def user_email(self, obj):
+    def admin(self, obj):
         return obj.user.email
 
-    def action_name(self, obj):
+    def action(self, obj):
         return ACTION_TO_NAME[obj.action_flag]
 
     def obj_repr(self, obj):
@@ -54,6 +59,30 @@ class LogEntryAdmin(admin.ModelAdmin):
             # For user objects, return the email address as an identifier
             return edited_obj.email
         return edited_obj
+
+    def object_link(self, obj):
+        object_link = self.obj_repr(obj)  # Default to just name
+        content_type = obj.content_type
+
+        if obj.action_flag != DELETION and content_type is not None:
+            # try returning an actual link instead of object repr string
+            try:
+                url = reverse(
+                    'admin:{}_{}_change'.format(content_type.app_label,
+                                                content_type.model),
+                    args=[obj.object_id]
+                )
+                object_link = format_html('<a href="{}">{}</a>',
+                                          url, object_link)
+            except NoReverseMatch:
+                pass
+        return object_link
+    object_link.admin_order_field = 'object_repr'
+    object_link.short_description = 'object'
+
+    def get_change_message(self, obj):
+        return obj.get_change_message()
+    get_change_message.short_description = 'change message'
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
The ``LogEntry`` view allows seeing admin actions (either manual or from tools) as a list. It should be read-only, for auditing purposes, but until Django 2.1, there wasn't a supported way to mark a view as read-only.

Use Django 2.1's default ``has_view_permission`` to drop the ``has_change_permission`` hack, and drop the unneeded ``has_module_permission`` method.

Borrow some ideas from [yprez/django-logentry-admin](https://github.com/yprez/django-logentry-admin/blob/master/logentry_admin/admin.py):

* Change the ``user_email`` column name to "Admin"
* Change the ``get_edited_object`` column to "Object", use the email address when the object is a ``User``, and link to admin details page if available
* Change the ``action_name`` column to "Action"
* Change the ``get_change_message`` column to "Change Message", and link to details

Here's the view on my local box:

![Screenshot 2019-04-25 10 18 04](https://user-images.githubusercontent.com/286017/56747359-6ebf2080-6743-11e9-9a34-dbda3fb626c0.png)

