### PR TITLE
bug 1543988: update breakpad client to 4d550cceca107f36c4bc1ea1126b7d…

### DIFF
--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -15,7 +15,7 @@ set -v -e -x
 
 # Build the revision used in the snapshot unless otherwise specified.
 # Update this if you update the snapshot!
-: BREAKPAD_REV         "${BREAKPAD_REV:=44384d80b32a5bb361c2ec3bee667f7ccee566d7}"
+: BREAKPAD_REV         "${BREAKPAD_REV:=4d550cceca107f36c4bc1ea1126b7d32cc50f424}"
 
 export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
…32cc50f424

This updates the breakpad client to match the crash reporter.