### PR TITLE
bug 1548830: Fix API token examples

### DIFF
--- a/webapp-django/crashstats/tokens/jinja2/tokens/home.html
+++ b/webapp-django/crashstats/tokens/jinja2/tokens/home.html
@@ -137,13 +137,13 @@
         </p>
         <p>Here's an example:</p>
         <p class="example">
-          <code>curl -H "Auth-Token: 58af2acef8a74dbca9580e2bb8ba9c9a" {{ absolute_base_url }}{{ url('api:model_wrapper', 'RawCrash') }}?uuid=fb27d0f3-db8e-4835-9311-288bb0170829</code>
+          <code>curl -H "Auth-Token: 58af2acef8a74dbca9580e2bb8ba9c9a" {{ absolute_base_url }}{{ url('api:model_wrapper', 'RawCrash') }}?crash_id=fb27d0f3-db8e-4835-9311-288bb0170829</code>
         </p>
         <p>Or, if you prefer Python:</p>
         <pre class="example">import requests
 
 headers = {'Auth-Token': '58af2acef8a74dbca9580e2bb8ba9c9x'}
-url = '{{ absolute_base_url }}{{ url('api:model_wrapper', 'RawCrash') }}?uuid=fb27d0f3-db8e-4835-9311-288bb0170829'
+url = '{{ absolute_base_url }}{{ url('api:model_wrapper', 'RawCrash') }}?crash_id=fb27d0f3-db8e-4835-9311-288bb0170829'
 response = requests.get(url, headers=headers)
 print response.json()</pre>
       </div>


### PR DESCRIPTION
The RawCrash API uses ``crash_id``, not ``uuid``, for the querystring parameter. Fix the example to use the correct parameter.