### PR TITLE
bug 1545446: Allow CDN for fira-sans in CSP

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -751,6 +751,7 @@ CSP_SCRIPT_SRC = (
 CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",
+    'https://code.cdn.mozilla.net',
 )
 CSP_IMG_SRC = (
     "'self'",
@@ -760,6 +761,10 @@ CSP_IMG_SRC = (
 )
 CSP_CONNECT_SRC = (
     "'self'",
+)
+CSP_FONT_SRC = (
+    "'self'",
+    'https://code.cdn.mozilla.net',
 )
 
 CSP_REPORT_URI = (


### PR DESCRIPTION
Loading Fira Sans requires a stylesheet and fonts, so https://code.cdn.mozilla.net is added to the CSP expected paths.

In local testing, this causes the pages to use Fira Sans. Once the font is loaded into Firefox, it is also used in production, although with CSP violations.

The font seems OK if thin to me, and the navigation text gets blurry on my normal DPI external monitor. We may want to adjust weights and sizes to those suggested on https://design.firefox.com/photon/visuals/typography.html