### PR TITLE
bug 1513346: Convert six to native Python 3

### DIFF
--- a/scripts/update_siggen.py
+++ b/scripts/update_siggen.py
@@ -9,8 +9,6 @@ import shutil
 import subprocess
 import sys
 
-import six
-
 
 DESCRIPTION = """
 Updates socorro-siggen extracted library with files from Socorro's
@@ -75,7 +73,7 @@ def main(argv=None):
     else:
         print('No previous sha to determine git commits.')
 
-    confirm = six.moves.input('Continue to copy? [y/N]: ')
+    confirm = input('Continue to copy? [y/N]: ')
     if confirm.strip().lower() != 'y':
         print('Exiting...')
         return 1

--- a/socorro-cmd
+++ b/socorro-cmd
@@ -17,12 +17,9 @@ Run "socorro-cmd --help" for help.
 import argparse
 import importlib
 import inspect
-import os
 import sys
 import textwrap
 import types
-
-import six
 
 from socorro.app.socorro_app import App
 
@@ -45,7 +42,7 @@ def showcommands_cmd(argv):
     for group in COMMANDS:
         print('%s:' % group.name)
         for cmd, runner in group:
-            if not isinstance(runner, six.string_types):
+            if not isinstance(runner, str):
                 runner = '%s in %s' % (runner.__name__, inspect.getfile(runner))
             print('  %-24s %s' % (cmd, runner))
         print('')

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -14,7 +14,6 @@ import boto.s3.connection
 from configman import Namespace, RequiredConfig, class_converter
 from configman.converters import str_to_boolean
 import markus
-import six
 
 from socorro.lib.ooid import date_from_ooid
 
@@ -177,7 +176,7 @@ class ConnectionContextBase(RequiredConfig):
     def submit(self, id, name_of_thing, thing):
         """submit something to boto"""
         # can only submit binary to boto
-        assert isinstance(thing, six.binary_type), type(thing)
+        assert isinstance(thing, bytes), type(thing)
         try:
             start_time = time.time()
 

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -10,7 +10,6 @@ from configman import Namespace
 from configman.converters import class_converter, list_converter
 import elasticsearch
 import markus
-import six
 
 from socorro.external.crashstorage_base import CrashStorageBase, Redactor
 from socorro.external.es.super_search_fields import FIELDS
@@ -156,7 +155,7 @@ def truncate_keyword_field_values(fields, data):
             continue
 
         value = data.get(field_name)
-        if isinstance(value, six.string_types) and len(value) > MAX_KEYWORD_FIELD_VALUE_SIZE:
+        if isinstance(value, str) and len(value) > MAX_KEYWORD_FIELD_VALUE_SIZE:
             data[field_name] = value[:MAX_KEYWORD_FIELD_VALUE_SIZE]
 
             # FIXME(willkg): When we get metrics throughout the processor, we should

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -267,7 +267,7 @@ class SuperSearch(RequiredConfig, SearchBase):
                     if len(param.value) == 1:
                         val = param.value[0]
 
-                        if not isinstance(val, six.string_types) or ' ' not in val:
+                        if not isinstance(val, str) or ' ' not in val:
                             # There's only one term and no white space, this
                             # is a simple term filter.
                             filter_value = val

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -5,11 +5,11 @@
 from contextlib import contextmanager, closing
 import gzip
 import json
+from io import BytesIO
 import os
 
 from configman import Namespace
 from configman.dotdict import DotDict
-from six import BytesIO
 
 from socorro.external.crashstorage_base import (
     CrashStorageBase,

--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -7,7 +7,6 @@ import json
 import re
 
 import isodate
-import six
 
 
 UTC = isodate.UTC
@@ -75,7 +74,7 @@ def string_to_datetime(date):
         return date
     if isinstance(date, list):
         date = 'T'.join(date)
-    if isinstance(date, six.string_types):
+    if isinstance(date, str):
         if len(date) <= len('2000-01-01'):
             return datetime.datetime.strptime(date, '%Y-%m-%d').replace(tzinfo=UTC)
         else:

--- a/socorro/lib/external_common.py
+++ b/socorro/lib/external_common.py
@@ -10,7 +10,6 @@ import datetime
 import json
 
 from configman.dotdict import DotDict
-import six
 
 from socorro.lib import BadArgumentError
 import socorro.lib.datetimeutil as dtutil
@@ -140,7 +139,7 @@ def check_type(param, datatype):
             'int': int,
         }[datatype]
 
-    if datatype is str and not isinstance(param, six.string_types):
+    if datatype is str and not isinstance(param, str):
         try:
             param = str(param)
         except ValueError:
@@ -173,7 +172,7 @@ def check_type(param, datatype):
         except ValueError:
             param = None
 
-    elif datatype == "json" and isinstance(param, six.string_types):
+    elif datatype == "json" and isinstance(param, str):
         try:
             param = json.loads(param)
         except ValueError:

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -9,8 +9,6 @@ Common functions for search-related external modules.
 import datetime
 import json
 
-import six
-
 from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
@@ -198,7 +196,7 @@ class SearchBase(object):
                         OPERATORS_MAP['default']
                     )
 
-                    if isinstance(value, six.string_types):
+                    if isinstance(value, str):
                         if value.startswith(OPERATOR_NOT):
                             operator_not = True
                             value = value[1:]
@@ -431,10 +429,10 @@ class SearchBase(object):
 
 
 def convert_to_type(value, data_type):
-    if data_type == 'str' and not isinstance(value, six.string_types):
+    if data_type == 'str' and not isinstance(value, str):
         value = str(value)
     # yes, 'enum' is being converted to a string
-    elif data_type == 'enum' and not isinstance(value, six.string_types):
+    elif data_type == 'enum' and not isinstance(value, str):
         value = str(value)
     elif data_type == 'int' and not isinstance(value, int):
         value = int(value)
@@ -444,7 +442,7 @@ def convert_to_type(value, data_type):
         value = datetimeutil.string_to_datetime(value)
     elif data_type == 'date' and not isinstance(value, datetime.date):
         value = datetimeutil.string_to_datetime(value).date()
-    elif data_type == 'json' and isinstance(value, six.string_types):
+    elif data_type == 'json' and isinstance(value, str):
         value = json.loads(value)
     return value
 

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -4,8 +4,6 @@
 
 import collections
 
-import six
-
 
 def dotdict_to_dict(sdotdict):
     """Takes a DotDict and returns a dict
@@ -17,7 +15,7 @@ def dotdict_to_dict(sdotdict):
     def _dictify(thing):
         if isinstance(thing, collections.Mapping):
             return dict([(key, _dictify(val)) for key, val in thing.items()])
-        elif isinstance(thing, six.string_types):
+        elif isinstance(thing, str):
             # NOTE(willkg): Need to do this because strings are sequences but
             # we don't want to convert them into lists in the next clause
             return thing

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -9,7 +9,6 @@ import re
 import time
 
 import markus
-import six
 from six.moves.urllib.parse import unquote_plus
 
 from socorro.lib import javautil
@@ -165,7 +164,7 @@ class DatesAndTimesRule(Rule):
             'submitted_timestamp',
             date_from_ooid(raw_crash.uuid)
         )
-        if isinstance(processed_crash.submitted_timestamp, six.string_types):
+        if isinstance(processed_crash.submitted_timestamp, str):
             processed_crash.submitted_timestamp = datetime_from_isodate_string(
                 processed_crash.submitted_timestamp
             )
@@ -694,7 +693,7 @@ class OSPrettyVersionRule(Rule):
         processed_crash['os_pretty_version'] = None
 
         pretty_name = processed_crash.get('os_name')
-        if not isinstance(pretty_name, six.string_types):
+        if not isinstance(pretty_name, str):
             # This data is bogus or isn't there, there's nothing we can do.
             return True
 

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -7,9 +7,9 @@ import gzip
 import json
 import re
 import time
+from urllib.parse import unquote_plus
 
 import markus
-from six.moves.urllib.parse import unquote_plus
 
 from socorro.lib import javautil
 from socorro.lib import sentry_client

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -8,8 +8,6 @@ import os
 import sys
 import tempfile
 
-import six
-
 from configman import Namespace, RequiredConfig
 
 
@@ -111,7 +109,7 @@ def from_string_to_parse_size(size_as_string):
         'M': 1024 ** 2,
         'G': 1024 ** 3,
     }
-    if not isinstance(size_as_string, six.string_types) or not size_as_string:
+    if not isinstance(size_as_string, str) or not size_as_string:
         raise ValueError('Bad size value: "%s"' % size_as_string)
 
     if size_as_string[-1].isdigit():

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -6,10 +6,10 @@
 
 import json
 import os
+from urllib.parse import urlparse
 
 import jsonschema
 import requests
-from six.moves.urllib.parse import urlparse
 
 from socorro.external.boto.crashstorage import TelemetryBotoS3CrashStorage
 

--- a/socorro/scripts/db.py
+++ b/socorro/scripts/db.py
@@ -4,10 +4,10 @@
 
 import argparse
 import os
+from urllib.parse import urlparse
 
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from six.moves.urllib.parse import urlparse
 
 from socorro.scripts import WrappedTextHelpFormatter
 

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -5,8 +5,8 @@
 import argparse
 import datetime
 from functools import total_ordering
+from urllib.parse import urlparse, parse_qs
 
-from six.moves.urllib.parse import urlparse, parse_qs
 
 from socorro.lib.datetimeutil import utc_now
 from socorro.lib.requestslib import session_with_retries

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -3,12 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import copy
+from io import BytesIO
 import json
 
 from configman.dotdict import DotDict
 from mock import call, Mock, patch
 import requests_mock
-import six
 
 from socorro.lib.datetimeutil import datetime_from_isodate_string
 from socorro.lib.util import dotdict_to_dict
@@ -731,7 +731,7 @@ class TestOutOfMemoryBinaryRule(object):
 
         with patch('socorro.processor.mozilla_transform_rules.gzip.open') as mocked_gzip_open:
             ret = json.dumps({'mysterious': ['awesome', 'memory']})
-            mocked_gzip_open.return_value = six.BytesIO(ret.encode('utf-8'))
+            mocked_gzip_open.return_value = BytesIO(ret.encode('utf-8'))
             rule = OutOfMemoryBinaryRule(config)
             # Stomp on the value to make it easier to test with
             rule.MAX_SIZE_UNCOMPRESSED = 1024

--- a/webapp-django/crashstats/api/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/api/templatetags/jinja_helpers.py
@@ -8,14 +8,13 @@ import warnings
 
 from django_jinja import library
 import jinja2
-import six
 
 from django.forms.widgets import RadioSelect
 
 
 @library.global_function
 def describe_friendly_type(type_):
-    if type_ is six.text_type:
+    if type_ is str:
         return "String"
     if type_ is int:
         return "Integer"
@@ -59,10 +58,10 @@ def make_test_input(parameter, defaults):
         data['type'] = 'date'
     else:
         data['type'] = 'text'
-    if parameter['type'] is not six.text_type:
+    if parameter['type'] is not str:
         classes.append('validate-%s' % parameter['type'].__name__)
     if defaults.get(parameter['name']):
-        data['value'] = quote(six.text_type(defaults.get(parameter['name'])))
+        data['value'] = quote(str(defaults.get(parameter['name'])))
     else:
         data['value'] = ''
 

--- a/webapp-django/crashstats/api/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/api/templatetags/jinja_helpers.py
@@ -3,12 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+from urllib.parse import quote
 import warnings
 
 from django_jinja import library
 import jinja2
 import six
-from six.moves.urllib.parse import quote
 
 from django.forms.widgets import RadioSelect
 

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -66,7 +66,7 @@ class MultipleStringField(forms.TypedMultipleChoiceField):
 
 
 TYPE_MAP = {
-    six.text_type: forms.CharField,
+    str: forms.CharField,
     list: MultipleStringField,
     datetime.date: forms.DateField,
     datetime.datetime: forms.DateTimeField,

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -19,7 +19,6 @@ from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 
 from ratelimit.decorators import ratelimit
-import six
 
 from crashstats.api.cleaner import Cleaner
 from crashstats.crashstats import models
@@ -95,8 +94,7 @@ class FormWrapperMeta(DeclarativeFieldsMetaclass):
         return super(FormWrapperMeta, cls).__new__(cls, name, bases, attrs)
 
 
-@six.add_metaclass(FormWrapperMeta)
-class FormWrapper(forms.Form):
+class FormWrapper(forms.Form, metaclass=FormWrapperMeta):
     def clean(self):
         cleaned_data = super(FormWrapper, self).clean()
 

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -185,7 +185,7 @@ def model_wrapper(request, model_name):
         raise http.Http404('no service called `%s`' % model_name)
 
     required_permissions = getattr(model(), 'API_REQUIRED_PERMISSIONS', None)
-    if isinstance(required_permissions, six.string_types):
+    if isinstance(required_permissions, str):
         required_permissions = [required_permissions]
     if (
         required_permissions and
@@ -270,7 +270,7 @@ def model_wrapper(request, model_name):
         if binary_response:
             # if you don't have all required permissions, you'll get a 403
             required_permissions = model.API_BINARY_PERMISSIONS
-            if isinstance(required_permissions, six.string_types):
+            if isinstance(required_permissions, str):
                 required_permissions = [required_permissions]
             if required_permissions and not has_permissions(request.user, required_permissions):
                 permission_names = []
@@ -404,7 +404,7 @@ def _describe_model(model_name, model):
     required_permissions = []
     if model_inst.API_REQUIRED_PERMISSIONS:
         permissions = model_inst.API_REQUIRED_PERMISSIONS
-        if isinstance(permissions, six.string_types):
+        if isinstance(permissions, str):
             permissions = [permissions]
         for permission in permissions:
             codename = permission.split('.', 1)[1]

--- a/webapp-django/crashstats/authentication/management/commands/makesuperuser.py
+++ b/webapp-django/crashstats/authentication/management/commands/makesuperuser.py
@@ -9,10 +9,10 @@ environment.
 
 from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
 
 
 def get_input(text):
+    """Get user input, or mock it for tests."""
     return input(text).strip()
 
 

--- a/webapp-django/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp-django/crashstats/authentication/tests/test_auditgroups.py
@@ -3,8 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
-
-import six
+from io import StringIO
 
 from django.contrib.auth.models import Group, User
 from django.core.management import call_command
@@ -18,7 +17,7 @@ class TestAuditGroupsCommand(object):
     """Test auditgroups command."""
 
     def test_no_users(self, db):
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', stdout=buffer)
         assert 'Removing:' not in buffer.getvalue()
 
@@ -33,7 +32,7 @@ class TestAuditGroupsCommand(object):
 
         assert hackers_group.user_set.count() == 1
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@mozilla.com (!is_active)' in buffer.getvalue()
@@ -48,7 +47,7 @@ class TestAuditGroupsCommand(object):
         bob.groups.add(hackers_group)
         bob.save()
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@mozilla.com (inactive 366d, no tokens)' in buffer.getvalue()
@@ -61,7 +60,7 @@ class TestAuditGroupsCommand(object):
         bob.groups.add(hackers_group)
         bob.save()
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == []
         assert 'Removing: bob@example.com (not employee or exception)' in buffer.getvalue()
@@ -77,7 +76,7 @@ class TestAuditGroupsCommand(object):
         policyexception = PolicyException.objects.create(user=bob, comment='friend')
         policyexception.save()
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@example.com']
         assert 'Removing:' not in buffer.getvalue()
@@ -93,7 +92,7 @@ class TestAuditGroupsCommand(object):
         token = Token.objects.create(user=bob)
         token.save()
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert (
@@ -108,7 +107,7 @@ class TestAuditGroupsCommand(object):
         bob.groups.add(hackers_group)
         bob.save()
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=True, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert 'Removing:' not in buffer.getvalue()
@@ -123,7 +122,7 @@ class TestAuditGroupsCommand(object):
 
         assert hackers_group.user_set.count() == 1
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('auditgroups', persist=False, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ['bob@mozilla.com']
         assert 'Removing: bob@mozilla.com (inactive 366d, no tokens)' in buffer.getvalue()

--- a/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
+++ b/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
@@ -2,9 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from io import StringIO
+
 import mock
 import pytest
-import six
 
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -16,7 +17,7 @@ from crashstats.authentication.management.commands import makesuperuser
 class TestMakeSuperuserCommand(object):
     def test_make_existing_user(self, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('makesuperuser', 'BOB@mozilla.com', stdout=buffer)
         assert 'bob@mozilla.com is now a superuser/staff' in buffer.getvalue()
 
@@ -31,7 +32,7 @@ class TestMakeSuperuserCommand(object):
         bob.is_superuser = True
         bob.is_staff = True
         bob.save()
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('makesuperuser', 'BOB@mozilla.com', stdout=buffer)
 
         # Assert what got printed
@@ -49,7 +50,7 @@ class TestMakeSuperuserCommand(object):
         bob.save()
         otto = User.objects.create(username='otto', email='otto@mozilla.com')
 
-        buffer = six.StringIO()
+        buffer = StringIO()
         call_command('makesuperuser', 'BOB@mozilla.com', 'oTTo@mozilla.com', stdout=buffer)
         assert 'bob@mozilla.com is now a superuser/staff' in buffer.getvalue()
         assert 'otto@mozilla.com is now a superuser/staff' in buffer.getvalue()
@@ -66,7 +67,7 @@ class TestMakeSuperuserCommand(object):
         assert [g.name for g in otto.groups.all()] == ['Hackers']
 
     def test_nonexisting_user(self, db):
-        buffer = six.StringIO()
+        buffer = StringIO()
         email = 'neverheardof@mozilla.com'
         call_command('makesuperuser', email, stdout=buffer)
         assert '{} is now a superuser/staff'.format(email) in buffer.getvalue()
@@ -83,7 +84,7 @@ class TestMakeSuperuserCommand(object):
     )
     def test_with_raw_input(self, mocked_raw_input, db):
         bob = User.objects.create(username='bob', email='bob@mozilla.com')
-        buffer = six.StringIO()
+        buffer = StringIO()
         cmd = makesuperuser.Command()
         cmd.stdout = buffer
         cmd.handle(emailaddress=[])
@@ -101,7 +102,7 @@ class TestMakeSuperuserCommand(object):
     )
     def test_with_raw_input_but_empty(self, mocked_raw_input, db):
         with pytest.raises(CommandError):
-            buffer = six.StringIO()
+            buffer = StringIO()
             cmd = makesuperuser.Command()
             cmd.stdout = buffer
             cmd.handle(emailaddress=[])

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import functools
+from urllib.parse import urlparse
 
 import markus
-from six.moves.urllib.parse import urlparse
 
 from django.contrib.auth.decorators import (
     REDIRECT_FIELD_NAME,

--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import six
-
 from django import forms
 
 
@@ -11,7 +9,7 @@ class _BaseForm(object):
     def clean(self):
         cleaned_data = super().clean()
         for field in cleaned_data:
-            if isinstance(cleaned_data[field], six.string_types):
+            if isinstance(cleaned_data[field], str):
                 cleaned_data[field] = (
                     cleaned_data[field].replace('\r\n', '\n')
                     .replace(u'\u2018', "'").replace(u'\u2019', "'").strip())

--- a/webapp-django/crashstats/crashstats/management/commands/archivescraper.py
+++ b/webapp-django/crashstats/crashstats/management/commands/archivescraper.py
@@ -58,10 +58,10 @@ import concurrent.futures
 import copy
 from functools import partial
 import json
+from urllib.parse import urljoin
 
 import more_itertools
 from pyquery import PyQuery as pq
-from six.moves.urllib.parse import urljoin
 
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -13,8 +13,6 @@ import hashlib
 import logging
 import time
 
-import six
-
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
@@ -548,7 +546,7 @@ class SocorroMiddleware(SocorroCommon):
             else:
                 if isinstance(value, str) and param['type'] is list:
                     value = [value]
-                elif param['type'] is six.text_type:
+                elif param['type'] is str:
                     # we'll let the url making function later deal with this
                     pass
                 else:
@@ -582,7 +580,7 @@ class SocorroMiddleware(SocorroCommon):
                                 (False, getattr(self, 'possible_params', []))):
             for item in items:
                 if isinstance(item, str):
-                    type_ = six.text_type
+                    type_ = str
                     name = item
                 elif isinstance(item, dict):
                     type_ = item['type']

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -546,7 +546,7 @@ class SocorroMiddleware(SocorroCommon):
                 if isinstance(value, datetime.datetime) and param['type'] is datetime.date:
                     value = value.date()
             else:
-                if isinstance(value, six.string_types) and param['type'] is list:
+                if isinstance(value, str) and param['type'] is list:
                     value = [value]
                 elif param['type'] is six.text_type:
                     # we'll let the url making function later deal with this
@@ -581,7 +581,7 @@ class SocorroMiddleware(SocorroCommon):
         for required, items in ((True, getattr(self, 'required_params', [])),
                                 (False, getattr(self, 'possible_params', []))):
             for item in items:
-                if isinstance(item, six.string_types):
+                if isinstance(item, str):
                     type_ = six.text_type
                     name = item
                 elif isinstance(item, dict):
@@ -1076,7 +1076,7 @@ class BugzillaBugInfo(SocorroCommon):
         return 'buginfo:{}'.format(bug_id)
 
     def get(self, bugs):
-        if isinstance(bugs, six.string_types):
+        if isinstance(bugs, str):
             bugs = [bugs]
         fields = ('summary', 'status', 'id', 'resolution')
         results = []

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -5,6 +5,7 @@
 import datetime
 import json
 import re
+from urllib.parse import urlencode, parse_qs
 
 from django_jinja import library
 import humanfriendly
@@ -12,7 +13,6 @@ import isodate
 import jinja2
 from libgravatar import Gravatar
 import six
-from six.moves.urllib.parse import urlencode, parse_qs
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -12,7 +12,6 @@ import humanfriendly
 import isodate
 import jinja2
 from libgravatar import Gravatar
-import six
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
@@ -36,7 +35,7 @@ def truncatechars(str_, max_length):
 @library.filter
 def digitgroupseparator(number):
     """AKA ``thousands separator'' - 1000000 becomes 1,000,000 """
-    if not isinstance(number, six.integer_types):
+    if not isinstance(number, int):
         return number
     return format(number, ',')
 

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -364,7 +364,7 @@ def url(viewname, *args, **kwargs):
     string values), we have to sanitize the values.
     """
     def clean_argument(s):
-        if isinstance(s, six.string_types):
+        if isinstance(s, str):
             # First remove all proper control characters like '\n',
             # '\r' or '\t'.
             s = ''.join(c for c in s if ord(c) >= 32)

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -23,7 +23,7 @@ from socorro.external.es.super_search_fields import FIELDS
 class Response(object):
     def __init__(self, content=None, status_code=200):
         self.raw = content
-        if not isinstance(content, six.string_types):
+        if not isinstance(content, str):
             content = json.dumps(content)
         self.content = content.strip()
         self.status_code = status_code

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -6,7 +6,6 @@ import copy
 import json
 
 import mock
-import six
 
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
@@ -31,7 +30,7 @@ class Response(object):
     @property
     def text(self):
         # Similar to content but with the right encoding
-        return six.text_type(self.content, 'utf-8')
+        return str(self.content, 'utf-8')
 
     def json(self):
         return self.raw

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -4,8 +4,7 @@
 
 import datetime
 import time
-
-from six.moves.urllib.parse import quote_plus, parse_qs, urlparse
+from urllib.parse import quote_plus, parse_qs, urlparse
 
 from django.core.cache import cache
 from django.test.client import RequestFactory

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import random
+from urllib.parse import urlparse, parse_qs
 
 import mock
 import pytest
-from six.moves.urllib.parse import urlparse, parse_qs
 
 from django.core.cache import cache
 from django.conf import settings

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -9,8 +9,7 @@ import isodate
 import json
 import random
 import re
-
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from django import http
 from django.conf import settings

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -10,7 +10,6 @@ import json
 import random
 import re
 
-import six
 from six.moves.urllib.parse import urlencode
 
 from django import http
@@ -522,7 +521,7 @@ def build_default_context(product=None, versions=None):
     context['active_versions'] = active_versions
 
     if versions is not None:
-        if isinstance(versions, six.string_types):
+        if isinstance(versions, str):
             versions = versions.split(';')
 
         if versions:

--- a/webapp-django/crashstats/exploitability/views.py
+++ b/webapp-django/crashstats/exploitability/views.py
@@ -3,8 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from collections import defaultdict
-
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from django import http
 from django.conf import settings

--- a/webapp-django/crashstats/manage/admin.py
+++ b/webapp-django/crashstats/manage/admin.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import hashlib
-
 from collections import OrderedDict
+import hashlib
+from urllib.parse import urlparse
+
 import requests
-from six.moves.urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib import messages

--- a/webapp-django/crashstats/manage/utils.py
+++ b/webapp-django/crashstats/manage/utils.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import six
-
 from django.utils.encoding import smart_text
 
 
@@ -16,7 +14,7 @@ def string_hex_to_hex_string(snippet):
     we always return a 4 character string preceeded by 0x.
     This function tries to make that conversion.
     """
-    assert isinstance(snippet, six.string_types)
+    assert isinstance(snippet, str)
     return '0x' + format(int(snippet, 16), '04x')
 
 

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import six
-
 
 # This determines what files are copied from npm libraries into the
 # static root when collectstatic runs.
@@ -399,10 +397,10 @@ _used = {}
 for config in PIPELINE_JS, PIPELINE_CSS:  # NOQA
     _trouble = set()
     for k, v in config.items():
-        assert isinstance(k, six.string_types), k
+        assert isinstance(k, str), k
         out = v['output_filename']
         assert isinstance(v['source_filenames'], tuple), v
-        assert isinstance(out, six.string_types), v
+        assert isinstance(out, str), v
         assert not out.split('/')[-1].startswith('.'), k
         assert '_' not in out
         assert out.endswith('.min.css') or out.endswith('.min.js')

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+from urllib.parse import quote
 
 import mock
 import pyquery
-from six.moves.urllib.parse import quote
 
 from django.urls import reverse
 from django.utils.encoding import smart_text

--- a/webapp-django/crashstats/sources/views.py
+++ b/webapp-django/crashstats/sources/views.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from urllib.parse import urlparse
+
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_for_filename, CppLexer
 import requests
 
 from django import http
-
-from six.moves.urllib.parse import urlparse
 
 
 # List of hosts that we will fetch source files from that we syntax highlight and return to the

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -5,7 +5,6 @@
 import operator
 
 import isodate
-from six import text_type
 
 from django import forms
 from django.utils.timezone import utc
@@ -69,7 +68,7 @@ class PrefixedField(object):
         """Return the value as a string. """
         if value is None:
             return None
-        return text_type(value)
+        return str(value)
 
 
 class MultipleValueField(forms.MultipleChoiceField):

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -5,7 +5,7 @@
 import operator
 
 import isodate
-from six import string_types, text_type
+from six import text_type
 
 from django import forms
 from django.utils.timezone import utc
@@ -51,7 +51,7 @@ class PrefixedField(object):
     prefixed_value = None
 
     def to_python(self, value):
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             self.operator, value = split_on_operator(value)
 
         return super().to_python(value)

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -5,8 +5,6 @@
 import copy
 import functools
 
-import six
-
 from django.core.cache import cache
 
 from crashstats.crashstats import models
@@ -122,7 +120,7 @@ class SuperSearch(ESSocorroMiddleware):
                 # Intervals can be strings for dates (like "day" or "1.5h")
                 # and can only be integers for numbers.
                 interval_type = {
-                    'date': six.text_type,
+                    'date': str,
                     'number': int
                 }.get(field['query_type'])
 

--- a/webapp-django/crashstats/supersearch/tests/common.py
+++ b/webapp-django/crashstats/supersearch/tests/common.py
@@ -4,14 +4,12 @@
 
 import json
 
-import six
-
 from crashstats.crashstats.tests.test_models import Response
 
 
 class SuperSearchResponse(Response):
     def __init__(self, content=None, status_code=200, columns=None):
-        if isinstance(content, six.string_types):
+        if isinstance(content, str):
             content = json.loads(content)
 
         if columns is None:

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -4,10 +4,10 @@
 
 import json
 import re
+from urllib.parse import quote
 
 import mock
 import pyquery
-from six.moves.urllib.parse import quote
 
 from django.conf import settings
 from django.urls import reverse

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.utils.http import urlquote
-from six import text_type
 
 from session_csrf import anonymous_csrf
 
@@ -106,7 +105,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
 
     form = TopCrashersForm(request.GET)
     if not form.is_valid():
-        return http.HttpResponseBadRequest(text_type(form.errors))
+        return http.HttpResponseBadRequest(str(form.errors))
 
     product = form.cleaned_data['product']
     versions = form.cleaned_data['version']
@@ -188,7 +187,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         'versions': versions,
         'crash_type': crash_type,
         'os_name': os_name,
-        'result_count': text_type(result_count),
+        'result_count': str(result_count),
         'mode': tcbs_mode,
         'range_type': range_type,
         'end_date': end_date,


### PR DESCRIPTION
Convert most ``six`` usage to native Python 3 code.

The remaining code is for ``six.reraise``. This could be replaced with ``from future.utils import raise_ as reraise``. Reading the code, it appears Python 3's exception chaining would be better for some cases, but I'm not up-to-date on Python 3 exceptions, and need to do my homework.

