### PR TITLE
bug 1549540: surface signal issues from minidump-stackwalk

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -289,9 +289,9 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
             msg = 'MDSW failed with %s: %s' % (
                 return_code, stackwalker_data.mdsw_status_string
             )
+            # subprocess.Popen with shell=False returns negative exit codes
+            # where the number is the signal that got kicked up
             if return_code == -6:
-                # subprocess.Popen with shell=False returns negative exit codes
-                # where the number is the signal that got kicked up
                 msg = msg + ' (SIGABRT)'
 
             processor_meta.processor_notes.append(msg)

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -439,9 +439,9 @@ class TestBreakpadTransformRule2015(object):
 
             assert processed_crash.json_dump == {}
             assert processed_crash.mdsw_return_code == 124
-            assert processed_crash.mdsw_status_string == "unknown error"
+            assert processed_crash.mdsw_status_string == 'unknown error'
             assert processed_crash.success is False
-            assert processor_meta.processor_notes == ["MDSW terminated with SIGKILL due to timeout"]
+            assert processor_meta.processor_notes == ['MDSW timeout (SIGKILL)']
 
             assert mm.has_record(
                 'incr',


### PR DESCRIPTION
This adds `SIGKILL` and `SIGABRT` to logging and processor notes so we can more
easily find crash reports which didn't process well.

We can add other signals as they pop up in the exit code graphs on Datadog.