### PR TITLE
bug 1545446: Remove Fira-Sans, reduce font list

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/fonts.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/fonts.less
@@ -1,5 +1,3 @@
-@import "https://code.cdn.mozilla.net/fonts/fira.css";
-
 @font-face {
     font-family: 'icons';
     src: url('/static/crashstats/fonts/icons.eot?#iefix2013') format('embedded-opentype'),

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/variables.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/variables.less
@@ -3,7 +3,7 @@
 @image-path: "/static/img";
 
 
-@base-font: "Fira Sans", "Helvetica Neue For Number", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
+@base-font: Helvetica, Arial, sans-serif;
 @base-font-size: 12px;
 @base-line-height: 1.7;
 @base-link-color: @primary;


### PR DESCRIPTION
Stop loading Fira Sans from the CDN, rather than add a CSP exception, as tried and discussed in PR #4927. 

Reduce the default font list to a boring set. Here's what Helvetica looks like:

<img width="1386" alt="PR 4931 - Helvetica" src="https://user-images.githubusercontent.com/286017/57389186-455cb680-717f-11e9-9f97-942e9c337435.png">
