### PR TITLE
bug 1550028: Switch to crash-stats.mozilla.org

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -17,7 +17,7 @@
         "report": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro"
     },
     "urls": {
-        "prod": "https://crash-stats.mozilla.com/",
+        "prod": "https://crash-stats.mozilla.org/",
         "stage": "https://crash-stats.allizom.org/"
     },
     "keywords": [

--- a/docker/config/my.env.dist
+++ b/docker/config/my.env.dist
@@ -19,13 +19,13 @@
 producer_consumer.number_of_threads=2
 
 # ---------------------------------------------
-# crash-stats.mozilla.com settings
+# crash-stats.mozilla.org settings
 # ---------------------------------------------
 
-# API token from crash-stats.mozilla.com that has access to download raw
+# API token from crash-stats.mozilla.org that has access to download raw
 # dumps.
 # SOCORRO_API_TOKEN=
 
-# API token from crash-stats.mozilla.com that has access to reprocess
+# API token from crash-stats.mozilla.org that has access to reprocess
 # crashes.
 # SOCORRO_REPROCESS_API_TOKEN=

--- a/docs/crashstorage/elasticsearch.rst
+++ b/docs/crashstorage/elasticsearch.rst
@@ -7,35 +7,21 @@ Crash storage: Elasticsearch
 Features
 ========
 
-Socorro uses Elasticsearch as a back-end for several intensive features in the
-web app. Here is a list of those features:
+Socorro uses Elasticsearch as a back-end for several search and report features
+in the web app:
 
-* **Super Search**
-
-  Probably the most important one, Super Search is an improved search page
-  that allows users to search through any field they like in the database. It
-  exposes convenient and powerful operators and allows to build complex
-  queries. It is also accessible via the public API, allowing users to build
-  their own tools.
-
-* **Custom Queries**
-
-  Based on Super Search, this feature allows users to write JSON queries that
-  are executed directly against Elasticsearch. This is a very sensitive
-  feature that gives unrestricted access to your data. Specific permissions
-  are needed for users to have access to it.
-
-* **Signature Report**
-
-  A replacement for the old ``/report/list/`` page. It is heavily based
-  on Super Search, and provides useful information about crashes that
-  share a signature. Features include listing crash reports, listing user
-  comments and showing aggregation on any field of the database.
-
-* **Profile page**
-
-  On the profile page, Super Search is used to show the recent crash
-  reports that contain the user's email address.
+* **Super Search** allows users to search through any field in the database. It
+  exposes powerful operators to build complex queries. It is accessible via the
+  public API, allowing users to build their own tools. It is used to implement
+  the other search features.
+* **Custom Queries** allow users to write JSON queries that are executed
+  directly against Elasticsearch. This gives unrestricted access to the data,
+  and requires additional permissions.
+* **Signature Reports** provide useful information about crashes that share a
+  signature. This includes aggregation on any database field, exploring
+  crash reports, and generating graphs.
+* **Profile pages** show the recent crash reports that contain the user's email
+  address.
 
 
 Supported versions of Elasticsearch

--- a/docs/crashstorage/elasticsearch.rst
+++ b/docs/crashstorage/elasticsearch.rst
@@ -18,16 +18,12 @@ web app. Here is a list of those features:
   queries. It is also accessible via the public API, allowing users to build
   their own tools.
 
-  Example: https://crash-stats.mozilla.org/search/
-
 * **Custom Queries**
 
   Based on Super Search, this feature allows users to write JSON queries that
   are executed directly against Elasticsearch. This is a very sensitive
   feature that gives unrestricted access to your data. Specific permissions
   are needed for users to have access to it.
-
-  Example: nope, this is not publicly accessible :)
 
 * **Signature Report**
 
@@ -36,14 +32,10 @@ web app. Here is a list of those features:
   share a signature. Features include listing crash reports, listing user
   comments and showing aggregation on any field of the database.
 
-  Example: https://crash-stats.mozilla.org/signature/?signature=nsTimeout::~nsTimeout%28%29
-
 * **Profile page**
 
   On the profile page, Super Search is used to show the recent crash
   reports that contain the user's email address.
-
-  Example: https://crash-stats.mozilla.org/profile/
 
 
 Supported versions of Elasticsearch

--- a/docs/crashstorage/elasticsearch.rst
+++ b/docs/crashstorage/elasticsearch.rst
@@ -18,7 +18,7 @@ web app. Here is a list of those features:
   queries. It is also accessible via the public API, allowing users to build
   their own tools.
 
-  Example: https://crash-stats.mozilla.com/search/
+  Example: https://crash-stats.mozilla.org/search/
 
 * **Custom Queries**
 
@@ -36,14 +36,14 @@ web app. Here is a list of those features:
   share a signature. Features include listing crash reports, listing user
   comments and showing aggregation on any field of the database.
 
-  Example: https://crash-stats.mozilla.com/signature/?signature=nsTimeout::~nsTimeout%28%29
+  Example: https://crash-stats.mozilla.org/signature/?signature=nsTimeout::~nsTimeout%28%29
 
 * **Profile page**
 
   On the profile page, Super Search is used to show the recent crash
   reports that contain the user's email address.
 
-  Example: https://crash-stats.mozilla.com/profile/
+  Example: https://crash-stats.mozilla.org/profile/
 
 
 Supported versions of Elasticsearch
@@ -146,7 +146,7 @@ Here is an explanation of each properties of a field:
     Brief description of the field.
 
     This shows up in the `Super Search API documentation
-    <https://crash-stats.mozilla.com/documentation/supersearch/api/>`_.
+    <https://crash-stats.mozilla.org/documentation/supersearch/api/>`_.
 
 **namespace**
     The dotted name space for the source of the value of this field.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,13 +5,13 @@ Socorro - Crash ingestion pipeline
 Socorro is a set of components for collecting, processing, and analyzing crash
 data. It is used by Mozilla for analyzing crash data for Mozilla products.
 Mozilla's crash analysis tool is hosted at
-`<https://crash-stats.mozilla.com/>`_.
+`<https://crash-stats.mozilla.org/>`_.
 
 
 :Free software: Mozilla Public License version 2.0
 :Code: https://github.com/mozilla-services/socorro/ and https://github.com/mozilla-services/antenna
 :Documentation: https://socorro.readthedocs.io/
-:Documentation: https://crash-stats.mozilla.com/documentation/
+:Documentation: https://crash-stats.mozilla.org/documentation/
 :Mailing list: https://lists.mozilla.org/listinfo/tools-socorro
 :IRC: `<irc://irc.mozilla.org/breakpad>`_
 :New bugs: https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro
@@ -31,7 +31,7 @@ Mozilla's crash analysis tool is hosted at
 
 
 Crash Stats site documentation covering API docs, getting access to memory dumps,
-and Supersearch is located at `<https://crash-stats.mozilla.com/documentation/>`_.
+and Supersearch is located at `<https://crash-stats.mozilla.org/documentation/>`_.
 
 
 .. toctree::

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -240,16 +240,16 @@ saved to several places:
 Investigated with Webapp aka Crash Stats (Python, Django)
 ---------------------------------------------------------
 
-The webapp is located at `<https://crash-stats.mozilla.com>`_.
+The webapp is located at `<https://crash-stats.mozilla.org>`_.
 
 The webapp lets you search through crash reports and facet on aspects of them
 with `Super Search
-<https://crash-stats.mozilla.com/search/?product=Firefox&_dont_run=1>`_.
+<https://crash-stats.mozilla.org/search/?product=Firefox&_dont_run=1>`_.
 
 The webapp shows `top crashers
-<https://crash-stats.mozilla.com/topcrashers/?product=Firefox>`_.
+<https://crash-stats.mozilla.org/topcrashers/?product=Firefox>`_.
 
-The webapp has a `set of APIs <https://crash-stats.mozilla.com/api/>`_ for
+The webapp has a `set of APIs <https://crash-stats.mozilla.org/api/>`_ for
 accessing data.
 
 You can create an account in the webapp by logging in.
@@ -268,13 +268,13 @@ user was visiting when Firefox crashed.
      https://socorro.readthedocs.io/
 
    **Crash Stats user documentation**
-     https://crash-stats.mozilla.com/documentation/
+     https://crash-stats.mozilla.org/documentation/
 
    **Crash Stats Super search**
-     https://crash-stats.mozilla.com/search/?product=&_dont_run=1
+     https://crash-stats.mozilla.org/search/?product=&_dont_run=1
 
    **Crash Stats APIs**
-     https://crash-stats.mozilla.com/api/
+     https://crash-stats.mozilla.org/api/
 
    **Privacy policy**
      https://www.mozilla.org/en-US/privacy/websites/

--- a/docs/service/processor.rst
+++ b/docs/service/processor.rst
@@ -45,7 +45,7 @@ All helper scripts run in the shell in the container::
     $ make shell
 
 Some of the scripts require downloading production data from
-`crash-stats.mozilla.com <https://crash-stats.mozilla.com>`_, and it is
+`crash-stats.mozilla.org <https://crash-stats.mozilla.org>`_, and it is
 useful to add an API token with higher permissions before entering the shell.
 
 
@@ -64,7 +64,7 @@ using an API token with these permissions:
 * View Personal Identifiable Information
 * View Raw Dumps
 
-You can generate API tokens at `<https://crash-stats.mozilla.com/api/tokens/>`_.
+You can generate API tokens at `<https://crash-stats.mozilla.org/api/tokens/>`_.
 
 .. Note::
 
@@ -111,7 +111,7 @@ below.
 fetch_crashids
 --------------
 
-This will generate a list of crash ids from crash-stats.mozilla.com that meet
+This will generate a list of crash ids from crash-stats.mozilla.org that meet
 specified criteria. Crash ids are printed to stdout, so you can use this in
 conjunction with other scripts or redirect to a file.
 
@@ -132,7 +132,7 @@ copy and pasted:
 
 .. code-block:: shell
 
-   app@socorro:/app$ socorro-cmd fetch_crashids "--url=https://crash-stats.mozilla.com/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform"
+   app@socorro:/app$ socorro-cmd fetch_crashids "--url=https://crash-stats.mozilla.org/search/?product=Firefox&date=%3E%3D2017-09-05T15%3A09%3A00.000Z&date=%3C2017-09-12T15%3A09%3A00.000Z&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform"
 
 You can get command help:
 
@@ -144,7 +144,7 @@ You can get command help:
 fetch_crash_data
 ----------------
 
-This will fetch raw crash data from crash-stats.mozilla.com and save it in the
+This will fetch raw crash data from crash-stats.mozilla.org and save it in the
 appropriate directory structure rooted at outputdir. If you have access to
 memory dumps and use a valid `API token`_, then memory dumps will be fetched
 for processing as well.

--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -73,13 +73,13 @@ Information (PII). There are three main classes of users:
 
 * Anonymous visitors and basic users do not have access to memory dumps or PII.
 * Users in the "Hackers" group can view memory dumps and PII.
-  `Memory Dump Access <https://crash-stats.mozilla.com/documentation/memory_dump_access/>`_
+  `Memory Dump Access <https://crash-stats.mozilla.org/documentation/memory_dump_access/>`_
   has the details for requesting access to this group.
 * Superusers maintain the site, set group membership in the Django admin, and
   have full access.
 
 A logged-in user can view their detailed permissions on the
-`Your Permissions <https://crash-stats.mozilla.com/permissions/>`_ page.
+`Your Permissions <https://crash-stats.mozilla.org/permissions/>`_ page.
 
 The groups and their permissions are defined in
 ``webapp-django/crashstats/crashstats/signals.py``. These are applied to

--- a/docs/tests/system_checklist.rst
+++ b/docs/tests/system_checklist.rst
@@ -46,7 +46,7 @@ Checklist
 
     * local dev: http://localhost:8000/api/Status
     * -stage: https://crash-stats.allizom.org/api/Status
-    * -prod: https://crash-stats.mozilla.com/api/Status
+    * -prod: https://crash-stats.mozilla.org/api/Status
 
 
     Migrations

--- a/scripts/deploy_bug.py
+++ b/scripts/deploy_bug.py
@@ -21,7 +21,7 @@ import requests
 
 
 GITHUB_API = 'https://api.github.com/'
-HOST = 'https://crash-stats.mozilla.com'
+HOST = 'https://crash-stats.mozilla.org'
 
 
 def fetch(url, is_json=True):

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -183,7 +183,7 @@ class Processor2015(RequiredConfig):
     required_config.add_option(
         'version_string_api',
         doc='url for the version string api endpoint in the webapp',
-        default='https://crash-stats.mozilla.com/api/VersionString'
+        default='https://crash-stats.mozilla.org/api/VersionString'
     )
 
     def __init__(self, config, rules=None, quit_check_callback=None):

--- a/socorro/schemas/README.rst
+++ b/socorro/schemas/README.rst
@@ -117,5 +117,5 @@ those crashes with your local ``crash_report.json`` file.
    .. code-block:: shell
 
       $ python socorro/schemas/validate_and_test.py \
-            "https://crash-stats.mozilla.com/search/?dom_ipc_enabled=%21__null__&memory_images=%3E10&version=54.0a1" \
-            "https://crash-stats.mozilla.com/api/SuperSearch/?memory_private=%3E100&product=Firefox&date=%3E%3D2017-02-24T16%3A14%3A00.000Z&date=%3C2017-03-03T16%3A14%3A00.000Z"
+            "https://crash-stats.mozilla.org/search/?dom_ipc_enabled=%21__null__&memory_images=%3E10&version=54.0a1" \
+            "https://crash-stats.mozilla.org/api/SuperSearch/?memory_private=%3E100&product=Firefox&date=%3E%3D2017-02-24T16%3A14%3A00.000Z&date=%3C2017-03-03T16%3A14%3A00.000Z"

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -14,7 +14,7 @@ import requests
 from socorro.external.boto.crashstorage import TelemetryBotoS3CrashStorage
 
 
-API_BASE = 'https://crash-stats.mozilla.com/api/{}/'
+API_BASE = 'https://crash-stats.mozilla.org/api/{}/'
 HERE = os.path.dirname(__file__)
 
 

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -15,7 +15,7 @@ from socorro.scripts import (FallbackToPipeAction,
 
 
 DESCRIPTION = """
-Fetches crash data from crash-stats.mozilla.com system
+Fetches crash data from crash-stats.mozilla.org system
 """
 
 EPILOG = """
@@ -29,11 +29,11 @@ identifiable information::
 
 To create an API token for Socorro in -prod, visit:
 
-    https://crash-stats.mozilla.com/api/tokens/
+    https://crash-stats.mozilla.org/api/tokens/
 
 """
 
-HOST = 'https://crash-stats.mozilla.com'
+HOST = 'https://crash-stats.mozilla.org'
 
 
 class CrashDoesNotExist(Exception):

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -24,7 +24,7 @@ The second is to just specify command line arguments and the query will be based
 
 """
 
-DEFAULT_HOST = 'https://crash-stats.mozilla.com'
+DEFAULT_HOST = 'https://crash-stats.mozilla.org'
 
 MAX_PAGE = 1000
 

--- a/socorro/scripts/reprocess.py
+++ b/socorro/scripts/reprocess.py
@@ -28,7 +28,7 @@ they should increase the number of processor nodes.
 
 """
 
-DEFAULT_HOST = 'https://crash-stats.mozilla.com'
+DEFAULT_HOST = 'https://crash-stats.mozilla.org'
 CHUNK_SIZE = 50
 SLEEP_DEFAULT = 1
 

--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -24,7 +24,7 @@ Socorro that has "View Personally Identifiable Information" permission.
 """
 
 # FIXME(willkg): This hits production. We might want it configurable.
-API_URL = 'https://crash-stats.mozilla.com/api'
+API_URL = 'https://crash-stats.mozilla.org/api'
 
 
 class OutputBase:

--- a/webapp-django/crashstats/documentation/jinja2/documentation/memory_dump_access.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/memory_dump_access.html
@@ -26,14 +26,14 @@
 * Access is conditional on employment and will be revoked upon departure from Mozilla
 * Access will be removed after a year of inactivity
 
-The most recent copy of this agreement is at: https://crash-stats.mozilla.com/documentation/memory_dump_access/</pre>
+The most recent copy of this agreement is at: https://crash-stats.mozilla.org/documentation/memory_dump_access/</pre>
 
     <h1 id="requestaccess">How to request memory dump access</h1>
     <p>
       To request access to memory dumps, please:
     </p>
     <ol>
-      <li>Log into <a href="https://crash-stats.mozilla.com/">Crash Stats</a>
+      <li>Log into <a href="https://crash-stats.mozilla.org/">Crash Stats</a>
           using your LDAP account.
       </li>
       <li>Fill out a


### PR DESCRIPTION
Switch the preferred production domain from crash-stats.mozilla.com to .org in code and docs.