### PR TITLE
bug 1549297: fix android manufacturer faceting

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1204,6 +1204,7 @@ FIELDS = {
         'permissions_needed': [],
         'query_type': 'enum',
         'storage_mapping': {
+            'analyzer': 'keyword',
             'type': 'string'
         }
     },


### PR DESCRIPTION
In the signature report, one of the facets is on android manufacturer. Because
it wasn't being indexed as a keyword, it was getting tokenized and then faceted
on the tokens. This fixes that.