### PR TITLE
bug 1543097: Do not send DisallowedHost to Sentry

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -600,7 +600,10 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()],
         debug=SENTRY_DEBUG,
         before_send=get_before_send())
-    ignore_logger(SENTRY_LOG_NAME)
+
+    # Do not generate events for some logs (ERROR or above)
+    ignore_logger(SENTRY_LOG_NAME)  # avoid infinite logging loops
+    ignore_logger('django.security.DisallowedHost')  # no fix needed, the system is working
 
     if SENTRY_DEBUG:
         # Add a DEBUG level handler for sentry processing messages


### PR DESCRIPTION
When the requested ``Host`` header is not in ``ALLOWED_HOSTS``, the user gets a ``400 Bad Request``, and a message is logged to ``django.security.DisallowedHost``. This can be useful when setting up a server or monitoring, and then becomes annoying when random requesters set the wrong host.

For local testing, set ``SENTRY_DSN=https://bad-id@sentry.127.0.0.1.nip.io/0``, tail the webapp logs, and make a request via a disallowed hostname, like http://oidcprovider:8000/. Before this PR, the [logging integration](https://docs.sentry.io/platforms/python/logging/) sends it as an event, and after, it does not.
