### PR TITLE
bug 1543097: Sanitize ELB headers 

### DIFF
--- a/webapp-django/crashstats/sentrylib.py
+++ b/webapp-django/crashstats/sentrylib.py
@@ -30,7 +30,7 @@ def get_before_send():
             SanitizeSQLQueryCrumb(('email', 'username', 'password', 'session_data', 'session_key',
                                    'tokens_token.key', 'auth_user.id')),
         )),
-        SanitizeHeaders(('Auth-Token',)),
+        SanitizeHeaders(('Auth-Token', 'X-Forwarded-For', 'X-Real-Ip')),
         SanitizePostData(('csrfmiddlewaretoken',)),
         SanitizeQueryString(('code', 'state')),
     )

--- a/webapp-django/crashstats/tests/test_sentrylib.py
+++ b/webapp-django/crashstats/tests/test_sentrylib.py
@@ -296,7 +296,7 @@ class TestBeforeSend:
     @pytest.mark.parametrize(
         'names, url, headers, expected_headers',
         TestSanitizeHeaders.CASES,
-        ids=tuple(case[0] for case in TestSanitizePostData.CASES))
+        ids=tuple(case[0] for case in TestSanitizeHeaders.CASES))
     def test_event_headers_sanitized(self, names, url, headers, expected_headers):
         """Request headers are sanitized of sensitive values."""
         event = {'request': {'url': url, 'headers': deepcopy(headers)}}

--- a/webapp-django/crashstats/tests/test_sentrylib.py
+++ b/webapp-django/crashstats/tests/test_sentrylib.py
@@ -163,6 +163,25 @@ class TestSanitizeHeaders:
                 'Host': 'example.com'
             }
         ),
+        # Deployed behind an AWS Elastic Load Balancer (ELB)
+        (
+            'X-Forwarded-For,X-Real-IP',
+            'https://example.com/siteadmin/crash-me-now/',
+            {
+                'Host': 'example.com',
+                'X-Forwarded-For': '203.0.113.19, 203.0.113.19',
+                'X-Forwarded-Port': '443',
+                'X-Forwarded-Proto': 'https',
+                'X-Real-Ip': '203.0.113.19'
+            },
+            {
+                'Host': 'example.com',
+                'X-Forwarded-For': '[filtered]',  # Sensitive
+                'X-Forwarded-Port': '443',
+                'X-Forwarded-Proto': 'https',
+                'X-Real-Ip': '[filtered]'  # Also sensitive
+            }
+        )
     )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The ELB adds several headers, including ``X-Forwarded-For`` and ``X-Real-IP``, that include the user's IP address. They are moved to ``sentry.interfaces.Http`` when saved in Sentry (load the JSON for a Sentry issue to see).