### PR TITLE
bug 1552973: Log missing boto files as warnings

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -65,7 +65,8 @@ class SimplifiedCrashData(BotoS3CrashStorage):
             else:
                 return get(params.uuid)
         except CrashIDNotFound as cidnf:
-            self.logger.error('%s not found: %s' % (params.datatype, cidnf))
+            self.logger.warning('%(datatype)s not found: %(exception)s',
+                                {'datatype': params.datatype, 'exception': cidnf})
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message
             # contains information about buckets and prefix keys.
@@ -96,7 +97,8 @@ class TelemetryCrashData(TelemetryBotoS3CrashStorage):
         try:
             return self.get_unredacted_processed(params.uuid)
         except CrashIDNotFound as cidnf:
-            self.logger.error('telemetry crash not found: %s' % cidnf)
+            self.logger.warning('telemetry crash not found: %(exception)s',
+                                {'exception': cidnf})
             # The CrashIDNotFound exception that happens inside the
             # crashstorage is too revealing as exception message contains
             # information about buckets and prefix keys. Re-wrap it here so the


### PR DESCRIPTION
When a file is missing when using the boto crashstorage, log as a warning, using a dictionary of log format parameters, rather than as a pre-formated error. Changing from ``.error`` to ``.warning`` avoids creating a Sentry issue when logging, and changing to a format string avoids string formatting if the log isn't picked up by a handler.