### PR TITLE
bug 1393889: add elasticsearch7 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,15 @@ services:
       - "9200:9200"
       - "9300:9300"
 
+  # https://www.docker.elastic.co/
+  elasticsearch7:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.1.0
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9201:9200"
+      - "9301:9300"
+
   # Google Pub/Sub emulator
   pubsub:
     build:


### PR DESCRIPTION
This adds an elasticsearch7 container that listens on port 9201. This allows you to run elasticsearch 1.4 and 7.1 simultaneously so we can implement and test necessary code changes as well as implement and test migration scripts.

The elasticsearch7 container isn't used by anything, so this doesn't affect the local dev environment.

To run the elasticsaerch7 container, you'd do:

```
$ docker-compose up elasticsearch7
```

Once we have this in master, it makes it easier to go back and forth between a master and elasticsearch 1.4 setup and a branch and elasticsearch 7.1 setup.