### PR TITLE
bug 1553251: Remove bad params from mdsw command

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -200,7 +200,7 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
             '{symbols_urls} '
             '--symbols-cache {symbol_cache_path} '
             '--symbols-tmp {symbol_tmp_path} '
-            '{dump_file_pathname} '
+            '{dump_file_pathname}'
         )
     )
     required_config.add_option(

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -150,8 +150,7 @@ class Processor2015(RequiredConfig):
             '{symbols_urls} '
             '--symbols-cache {symbol_cache_path} '
             '--symbols-tmp {symbol_tmp_path} '
-            '{dump_file_pathname} '
-            '2> /dev/null'
+            '{dump_file_pathname}'
         )
     )
     required_config.add_option(


### PR DESCRIPTION
Remove ``>2 /dev/null`` from the commmand_line parameter, which is used to call mini dump stack walk (mdsw). This would be valid for a bash command, but they are passed as symbol directories to mdsw when called by Python's ``subprocess.Popen``.

This code didn't work the way I expected. I expected that the default value for ``command_line`` in ``BreakpadStackwalkerRule2015`` would be used to call ``stackwalker``, but instead it is the config from ``Processor2015`` that is used. What is the purpose of ``required_config`` in rules?