### PR TITLE
bug 1553327: Fix exception handler in cronrun

### DIFF
--- a/webapp-django/crashstats/cron/management/commands/cronrun.py
+++ b/webapp-django/crashstats/cron/management/commands/cronrun.py
@@ -166,8 +166,8 @@ class Command(BaseCommand):
                 )
 
                 # Send error to sentry, log it, and remember the failure
-                sentry_sdk.capture_error()
-                logger.error('error when running %s (%s): %s', cmd, run_time, single_line_tb)
+                sentry_sdk.capture_exception()
+                logger.warning('error when running %s (%s): %s', cmd, run_time, single_line_tb)
                 self._remember_failure(
                     cmd,
                     end_time - start_time,


### PR DESCRIPTION
Use ``sentry_sdk.capture_exception`` to capture the exception, instead of ``.capture_error``, which is what our ``sentry_client`` calls it.

Change the logging to Warning level, so that it won't send a second event to Sentry.

Add a test to confirm handling of exceptions.