### PR TITLE
Bug 1553665 - Add libc to the signature prefixes.

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -37,8 +37,8 @@ google_breakpad::ReceivePort::WaitForMessage
 KiFastSystemCallRet
 libandroid_runtime\.so@0x
 libbinder\.so@0x
-libc\.so@
-libc-2\.5\.so@
+libc\.so(\.\d+)?@0x
+libc-\d+\.\d+(\.\d+)?\.so@0x
 libEGL\.so@
 libdvm\.so\s*@\s*0x
 libgui\.so@0x


### PR DESCRIPTION
See crashes like:

 * https://bugzilla.mozilla.org/show_bug.cgi?id=1549316
 * https://bugzilla.mozilla.org/show_bug.cgi?id=1553665

I did try to test this manually but the `make shell` stuff ends up abruptly
with:

  /app/docker/socorro_entrypoint.sh: Permission denied

And I tried a bunch of things without luck.

So I hope someone can poke at it for me instead