### PR TITLE
bug 1553314: remove configuration from Rules

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -70,15 +70,15 @@ resource.boto.resource_class=socorro.external.boto.connection_context.HostPortS3
 # there's only one processor node. For server environments, we probably want to store that
 # in a volume. These three vars are all affected.
 companion_process.symbol_cache_path=/tmp/symbols/cache
-processor.symbol_cache_path=/tmp/symbols/cache
-processor.symbol_tmp_path=/tmp/symbols/tmp
+processor.breakpad.symbol_cache_path=/tmp/symbols/cache
+processor.breakpad.symbol_tmp_path=/tmp/symbols/tmp
 
 # Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
 # a long time
 processor.kill_timeout=30
 
 # Set symbols_urls to something helpful for local dev
-processor.symbols_urls=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1
+processor.breakpad.symbols_urls=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1
 
 # Stackwalker is in a different place in the new infra and local dev
 processor.command_pathname=/stackwalk/stackwalker

--- a/scripts/run_mdsw.sh
+++ b/scripts/run_mdsw.sh
@@ -20,7 +20,7 @@ function getenv {
 }
 
 DATADIR=./crashdata_mdsw_tmp
-STACKWALKER="$(getenv 'processor.command_pathname')"
+STACKWALKER="$(getenv 'processor.breakpad.command_pathname')"
 
 if [[ $# -eq 0 ]]; then
     if [ -t 0 ]; then

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -58,87 +58,32 @@ from socorro.processor.rules.mozilla import (
     UserDataRule,
 )
 
-DEFAULT_RULES = [
-    # fix the raw crash removing null characters
-    DeNullRule,
-    # rules to change the internals of the raw crash
-    ProductRewrite,
-    ESRVersionRewrite,
-    PluginContentURL,
-    PluginUserComment,
-    # rules to transform a raw crash into a processed crash
-    IdentifierRule,
-    MinidumpSha256Rule,
-    BreakpadStackwalkerRule2015,
-    ProductRule,
-    UserDataRule,
-    EnvironmentRule,
-    PluginRule,
-    AddonsRule,
-    DatesAndTimesRule,
-    OutOfMemoryBinaryRule,
-    JavaProcessRule,
-    MozCrashReasonRule,
-    # post processing of the processed crash
-    CrashingThreadRule,
-    CPUInfoRule,
-    OSInfoRule,
-    BetaVersionRule,
-    ExploitablityRule,
-    FlashVersionRule,
-    OSPrettyVersionRule,
-    TopMostFilesRule,
-    ThemePrettyNameRule,
-    MemoryReportExtraction,
-    # a set of classifiers to help with jit crashes
-    JitCrashCategorizeRule,
-    # generate signature now that we've done all the processing it depends on
-    SignatureGeneratorRule,
-]
-
 
 class ProcessorPipeline(RequiredConfig):
-    """this class is a generalization of the Processor into a rule processing
-    framework. This class is suitable for use in the 'processor_app'
-    introducted in 2012."""
+    """Processor pipeline for Mozilla crash ingestion."""
 
     required_config = Namespace('transform_rules')
-    required_config.add_option(
+
+    # BreakpadStackwalkerRule2015 configuration
+    required_config.breakpad = Namespace()
+    required_config.breakpad.add_option(
         'dump_field',
         doc='the default name of a dump',
         default='upload_file_minidump',
     )
-    required_config.add_option(
+    required_config.breakpad.add_option(
         'command_pathname',
         doc='the full pathname to the external program to run (quote path with embedded spaces)',
-        # NOTE(willkg): This is the path for the RPM-based Socorro deploy. When
-        # we switch to Docker, we should change this.
-        default='/data/socorro/stackwalk/bin/stackwalker',
+        default='/stackwalk/stackwalker',
     )
-    required_config.add_option(
-        'result_key',
-        doc=(
-            'the key where the external process result should be stored '
-            'in the processed crash'
-        ),
-        default='stackwalker_result',
-    )
-    required_config.add_option(
-        'return_code_key',
-        doc=(
-            'the key where the external process return code should be stored '
-            'in the processed crash'
-        ),
-        default='stackwalker_return_code',
-    )
-    required_config.add_option(
+    required_config.breakpad.add_option(
         name='symbols_urls',
         doc='comma-delimited ordered list of urls for symbol lookup',
         default='https://localhost',
         from_string_converter=str_to_list,
         likely_to_be_changed=True
     )
-    required_config.add_option(
+    required_config.breakpad.add_option(
         'command_line',
         doc='template for the command to invoke the external program; uses Python format syntax',
         default=(
@@ -150,12 +95,12 @@ class ProcessorPipeline(RequiredConfig):
             '{dump_file_pathname}'
         )
     )
-    required_config.add_option(
+    required_config.breakpad.add_option(
         'kill_timeout',
         doc='amount of time to let mdsw run before declaring it hung',
         default=600
     )
-    required_config.add_option(
+    required_config.breakpad.add_option(
         'symbol_tmp_path',
         doc=(
             'directory to use as temp space for downloading symbols--must be '
@@ -163,7 +108,7 @@ class ProcessorPipeline(RequiredConfig):
         ),
         default=os.path.join(tempfile.gettempdir(), 'symbols-tmp'),
     ),
-    required_config.add_option(
+    required_config.breakpad.add_option(
         'symbol_cache_path',
         doc=(
             'the path where the symbol cache is found, this location must be '
@@ -171,12 +116,40 @@ class ProcessorPipeline(RequiredConfig):
         ),
         default=os.path.join(tempfile.gettempdir(), 'symbols'),
     )
-    required_config.add_option(
-        'temporary_file_system_storage_path',
+    required_config.breakpad.add_option(
+        'tmp_storage_path',
         doc='a path where temporary files may be written',
         default=tempfile.gettempdir(),
     )
-    required_config.add_option(
+
+    # JitClassCategorizationRule configuration
+    required_config.jit = Namespace()
+    required_config.jit.add_option(
+        'kill_timeout',
+        doc='amount of time to let command run before declaring it hung',
+        default=600
+    )
+    required_config.jit.add_option(
+        'dump_field',
+        doc='the default name of a dump',
+        default='upload_file_minidump',
+    )
+    required_config.jit.add_option(
+        'command_pathname',
+        doc='full pathname to external program; quote path with embedded spaces',
+        default='/stackwalk/jit-crash-categorize'
+    )
+    required_config.jit.add_option(
+        'command_line',
+        doc='template for command line; uses Python format syntax',
+        default=(
+            'timeout -s KILL {kill_timeout} {command_pathname} {dump_file_pathname}'
+        )
+    )
+
+    # BetaVersionRule configuration
+    required_config.betaversion = Namespace()
+    required_config.betaversion.add_option(
         'version_string_api',
         doc='url for the version string api endpoint in the webapp',
         default='https://crash-stats.mozilla.org/api/VersionString'
@@ -201,11 +174,71 @@ class ProcessorPipeline(RequiredConfig):
         else:
             self.quit_check = lambda: False
 
-        rule_set = rules or list(DEFAULT_RULES)
+        self.rules = rules or self.get_ruleset(config)
+        for rule in self.rules:
+            self.logger.info('Loaded rule: %r' % rule)
 
-        self.rules = []
-        for a_rule_class in rule_set:
-            self.rules.append(a_rule_class(config))
+    def get_ruleset(self, config):
+        """Generate rule set for Mozilla crash processing.
+
+        :arg config: configman DotDict config instance
+
+        :returns: pipeline of rules
+
+        """
+        return [
+            # fix the raw crash removing null characters
+            DeNullRule(),
+            # rules to change the internals of the raw crash
+            ProductRewrite(),
+            ESRVersionRewrite(),
+            PluginContentURL(),
+            PluginUserComment(),
+            # rules to transform a raw crash into a processed crash
+            IdentifierRule(),
+            MinidumpSha256Rule(),
+            BreakpadStackwalkerRule2015(
+                dump_field=config.breakpad.dump_field,
+                symbols_urls=config.breakpad.symbols_urls,
+                command_line=config.breakpad.command_line,
+                command_pathname=config.breakpad.command_pathname,
+                kill_timeout=config.breakpad.kill_timeout,
+                symbol_tmp_path=config.breakpad.symbol_tmp_path,
+                symbol_cache_path=config.breakpad.symbol_cache_path,
+                tmp_storage_path=config.breakpad.tmp_storage_path
+            ),
+            ProductRule(),
+            UserDataRule(),
+            EnvironmentRule(),
+            PluginRule(),
+            AddonsRule(),
+            DatesAndTimesRule(),
+            OutOfMemoryBinaryRule(),
+            JavaProcessRule(),
+            MozCrashReasonRule(),
+            # post processing of the processed crash
+            CrashingThreadRule(),
+            CPUInfoRule(),
+            OSInfoRule(),
+            BetaVersionRule(
+                version_string_api=config.betaversion.version_string_api
+            ),
+            ExploitablityRule(),
+            FlashVersionRule(),
+            OSPrettyVersionRule(),
+            TopMostFilesRule(),
+            ThemePrettyNameRule(),
+            MemoryReportExtraction(),
+            # a set of classifiers to help with jit crashes
+            JitCrashCategorizeRule(
+                dump_field=config.jit.dump_field,
+                command_line=config.jit.command_line,
+                command_pathname=config.jit.command_pathname,
+                kill_timeout=config.jit.kill_timeout
+            ),
+            # generate signature now that we've done all the processing it depends on
+            SignatureGeneratorRule(),
+        ]
 
     def process_crash(self, raw_crash, raw_dumps, processed_crash):
         """Take a raw_crash and its associated raw_dumps and return a processed_crash

--- a/socorro/processor/rules/base.py
+++ b/socorro/processor/rules/base.py
@@ -4,14 +4,13 @@
 
 import logging
 
-from configman import RequiredConfig
 import markus
 
 
 metrics = markus.get_metrics('processor.rule')
 
 
-class Rule(RequiredConfig):
+class Rule:
     """Base class for transform rules
 
     Provides structure for calling rules during the processor pipeline and also
@@ -19,9 +18,7 @@ class Rule(RequiredConfig):
 
     """
 
-    def __init__(self, config=None, quit_check_callback=None):
-        self.config = config
-        self.quit_check_callback = quit_check_callback
+    def __init__(self):
         self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, processor_meta_data):
@@ -67,3 +64,15 @@ class Rule(RequiredConfig):
 
     def close(self):
         pass
+
+    def generate_repr(self, keys=None):
+        keys = keys or []
+        return (
+            '<' +
+            self.__class__.__name__ +
+            ''.join([' %s=%r' % (key, getattr(self, key, None)) for key in keys]) +
+            '>'
+        )
+
+    def __repr__(self):
+        return self.generate_repr()

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -77,8 +77,18 @@ def dot_save(a_mapping, key, value):
     current_mapping[key_parts[-1]] = value
 
 
-def execute_external_process(crash_id, command_pathname, command_line,
-                             processor_meta, interpret_output):
+def execute_external_process(command_pathname, command_line, processor_meta, interpret_output):
+    """Executes an external process, interprets output, and returns output and return_code.
+
+    :arg str command_pathname: the path to the command to run
+    :arg str command_line: the complete command line to run
+    :arg processor_meta: the meta part of the processed crash
+    :arg fun interpret_output: the function to interpret the output; takes a file-pointer,
+        processor_meta, and command_pathname and returns interpreted output
+
+    :returns: (output, return_code)
+
+    """
     # Tokenize the command line into args
     command_line_args = shlex.split(command_line, comments=False, posix=True)
 
@@ -152,7 +162,6 @@ class BreakpadStackwalkerRule2015(Rule):
     def _execute_external_process(self, crash_id, command_pathname, command_line, processor_meta):
         output, return_code = (
             execute_external_process(
-                crash_id=crash_id,
                 command_pathname=command_pathname,
                 command_line=command_line,
                 processor_meta=processor_meta,
@@ -254,10 +263,10 @@ class BreakpadStackwalkerRule2015(Rule):
                 )
 
                 stackwalker_data, return_code = self._execute_external_process(
-                    crash_id,
-                    self.command_pathname,
-                    command_line,
-                    processor_meta
+                    crash_id=crash_id,
+                    command_pathname=self.command_pathname,
+                    command_line=command_line,
+                    processor_meta=processor_meta
                 )
 
                 if dump_name == self.dump_field:
@@ -316,7 +325,6 @@ class JitCrashCategorizeRule(Rule):
             return result
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        crash_id = raw_crash['uuid']
         params = {
             'command_pathname': self.command_pathname,
             'kill_timeout': self.kill_timeout,
@@ -325,7 +333,6 @@ class JitCrashCategorizeRule(Rule):
         command_line = self.command_line.format(**params)
 
         output, return_code = execute_external_process(
-            crash_id=crash_id,
             command_pathname=self.command_pathname,
             command_line=command_line,
             processor_meta=processor_meta,

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -9,10 +9,7 @@ import os
 import shlex
 import subprocess
 import threading
-import tempfile
 
-from configman import Namespace
-from configman.converters import str_to_list
 from configman.dotdict import DotDict
 import markus
 
@@ -63,188 +60,73 @@ class MinidumpSha256Rule(Rule):
         processed_crash['minidump_sha256_hash'] = raw_crash['MinidumpSha256Hash']
 
 
-class ExternalProcessRule(Rule):
-    # FIXME(willkg): command_line and command_pathname are referenced in the
-    # uplifted versions in ProcessorPipeline. The rest of these config values have
-    # no effect on anything and are just here.
-    required_config = Namespace()
-    required_config.add_option(
-        'dump_field',
-        doc='the default name of a dump',
-        default='upload_file_minidump',
-    )
-    required_config.add_option(
-        'command_line',
-        doc='template for the command to invoke the external program; uses Python format syntax',
-        default='timeout -s KILL 30 {command_pathname}',
-    )
-    required_config.add_option(
-        'command_pathname',
-        doc='the full pathname to the external program to run (quote path with embedded spaces)',
-        default='/data/socorro/stackwalk/bin/dumplookup',
-    )
-    required_config.add_option(
-        'result_key',
-        doc='where the external process result should be stored in the processed crash',
-        default='%s_result' % (
-            required_config.command_pathname.default.split('/')[-1].replace('-', '')
-        ),
-    )
-    required_config.add_option(
-        'return_code_key',
-        doc='where the external process return code should be stored in the processed crash',
-        default='%s_return_code' % required_config.command_pathname.default.split('/')[-1],
-    )
+def dot_save(a_mapping, key, value):
+    if '.' not in key or isinstance(a_mapping, DotDict):
+        a_mapping[key] = value
+        return
 
-    def __init__(self, config):
-        super().__init__(config)
-
-    def _interpret_external_command_output(self, fp, processor_meta):
-        data = fp.read()
+    # FIXME(willkg): Replace this with glom
+    current_mapping = a_mapping
+    key_parts = key.split('.')
+    for key_fragment in key_parts[:-1]:
         try:
-            return json.loads(data)
-        except Exception as x:
-            self.logger.error(
-                '%s non-json output: "%s"' % (self.config.command_pathname, data[:100])
-            )
-            processor_meta.processor_notes.append(
-                "%s output failed in json: %s" % (self.config.command_pathname, x)
-            )
-        return {}
+            current_mapping = current_mapping[key_fragment]
+        except KeyError:
+            current_mapping[key_fragment] = {}
+            current_mapping = current_mapping[key_fragment]
+    current_mapping[key_parts[-1]] = value
 
-    def _execute_external_process(self, crash_id, command_line, processor_meta):
-        # Tokenize the command line into args
-        command_line_args = shlex.split(command_line, comments=False, posix=True)
 
-        # Execute the command line sending stderr (debug logging) to devnull and
-        # capturing stdout (JSON blob of output)
-        subprocess_handle = subprocess.Popen(
-            command_line_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-        with closing(subprocess_handle.stdout):
-            external_command_output = self._interpret_external_command_output(
-                subprocess_handle.stdout,
-                processor_meta
-            )
+def execute_external_process(crash_id, command_pathname, command_line,
+                             processor_meta, interpret_output):
+    # Tokenize the command line into args
+    command_line_args = shlex.split(command_line, comments=False, posix=True)
 
-        return_code = subprocess_handle.wait()
-        return external_command_output, return_code
-
-    @staticmethod
-    def dot_save(a_mapping, key, value):
-        if '.' not in key or isinstance(a_mapping, DotDict):
-            a_mapping[key] = value
-            return
-        current_mapping = a_mapping
-        key_parts = key.split('.')
-        for key_fragment in key_parts[:-1]:
-            try:
-                current_mapping = current_mapping[key_fragment]
-            except KeyError:
-                current_mapping[key_fragment] = {}
-                current_mapping = current_mapping[key_fragment]
-        current_mapping[key_parts[-1]] = value
-
-    def _save_results(
-        self,
-        external_command_output,
-        return_code,
-        raw_crash,
-        processed_crash,
-        processor_meta
-    ):
-        # FIXME(willkg): we could replace this with glom
-        self.dot_save(processed_crash, self.config.result_key, external_command_output)
-        self.dot_save(processed_crash, self.config.return_code_key, return_code)
-
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        crash_id = raw_crash['uuid']
-        command_parameters = dict(self.config)
-        command_parameters['dump_file_pathname'] = raw_dumps[self.config['dump_field']]
-        command_line = self.config.command_line.format(**command_parameters)
-
-        external_command_output, external_process_return_code = (
-            self._execute_external_process(crash_id, command_line, processor_meta)
+    # Execute the command line sending stderr (debug logging) to devnull and
+    # capturing stdout (JSON blob of output)
+    subprocess_handle = subprocess.Popen(
+        command_line_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    with closing(subprocess_handle.stdout):
+        external_command_output = interpret_output(
+            fp=subprocess_handle.stdout,
+            processor_meta=processor_meta,
+            command_pathname=command_pathname
         )
 
-        self._save_results(
-            external_command_output,
-            external_process_return_code,
-            raw_crash,
-            processed_crash,
-            processor_meta
-        )
+    return_code = subprocess_handle.wait()
+    return external_command_output, return_code
 
 
-class BreakpadStackwalkerRule2015(ExternalProcessRule):
-    """Executes the minidump stackwalker external process and puts output in processed crash"""
-    # FIXME(willkg): command_line and command_pathname are referenced in the
-    # uplifted versions in ProcessorPipeline. The rest of these config values have
-    # no effect on anything and are just here.
-    required_config = Namespace()
-    required_config.add_option(
-        name='symbols_urls',
-        doc='comma delimited ordered list of urls for symbol lookup',
-        default='https://localhost',
-        from_string_converter=str_to_list,
-        likely_to_be_changed=True
-    )
-    required_config.add_option(
-        'command_line',
-        doc='template for the command to invoke the external program; uses Python format syntax',
-        default=(
-            'timeout -s KILL {kill_timeout} {command_pathname} '
-            '--raw-json {raw_crash_pathname} '
-            '{symbols_urls} '
-            '--symbols-cache {symbol_cache_path} '
-            '--symbols-tmp {symbol_tmp_path} '
-            '{dump_file_pathname}'
-        )
-    )
-    required_config.add_option(
-        'command_pathname',
-        doc='the full pathname to the external program to run (quote path with embedded spaces)',
-        # NOTE(willkg): This is the path for the RPM-based Socorro deploy. When
-        # we switch to Docker, we should change this.
-        default='/data/socorro/stackwalk/bin/stackwalker',
-    )
-    required_config.add_option(
-        'kill_timeout',
-        doc='amount of time to let mdsw run before declaring it hung',
-        default=600
-    )
-    required_config.add_option(
-        'symbol_tmp_path',
-        doc=(
-            'directory to use as temp space for downloading symbols--must be on '
-            'the same filesystem as symbols-cache'
-        ),
-        default=os.path.join(tempfile.gettempdir(), 'symbols-tmp'),
-    ),
-    required_config.add_option(
-        'symbol_cache_path',
-        doc=(
-            'the path where the symbol cache is found, this location must be '
-            'readable and writeable (quote path with embedded spaces)'
-        ),
-        default=os.path.join(tempfile.gettempdir(), 'symbols'),
-    )
-    required_config.add_option(
-        'temporary_file_system_storage_path',
-        doc='a path where temporary files may be written',
-        default=tempfile.gettempdir(),
-    )
+class BreakpadStackwalkerRule2015(Rule):
+    """Executes the minidump stackwalker external process and puts output in processed crash."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, dump_field, symbols_urls, command_pathname, command_line, kill_timeout,
+                 symbol_tmp_path, symbol_cache_path, tmp_storage_path):
+        super().__init__()
+        self.dump_field = dump_field
+        self.symbols_urls = symbols_urls
+        self.command_pathname = command_pathname
+        self.command_line = command_line
+        self.kill_timeout = kill_timeout
+        self.symbol_tmp_path = symbol_tmp_path
+        self.symbol_cache_path = symbol_cache_path
+        self.tmp_storage_path = tmp_storage_path
+
         self.metrics = markus.get_metrics('processor.breakpadstackwalkerrule')
+
+    def __repr__(self):
+        keys = ('dump_field', 'symbols_urls', 'command_pathname', 'command_line',
+                'kill_timeout', 'symbol_tmp_path', 'symbol_cache_path',
+                'tmp_storage_path')
+        return self.generate_repr(keys=keys)
 
     @contextmanager
     def _temp_raw_crash_json_file(self, raw_crash, crash_id):
         file_pathname = os.path.join(
-            self.config.temporary_file_system_storage_path,
+            self.tmp_storage_path,
             '%s.%s.TEMPORARY.json' % (crash_id, threading.currentThread().getName())
         )
         with open(file_pathname, "w") as f:
@@ -254,22 +136,41 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
         finally:
             os.unlink(file_pathname)
 
-    def _execute_external_process(self, crash_id, command_line, processor_meta):
-        stackwalker_output, return_code = (
-            super()._execute_external_process(crash_id, command_line, processor_meta)
+    def _interpret_output(self, fp, processor_meta, command_pathname):
+        data = fp.read()
+        try:
+            return json.loads(data)
+        except Exception as x:
+            self.logger.error(
+                '%s non-json output: "%s"' % (command_pathname, data[:100])
+            )
+            processor_meta.processor_notes.append(
+                "%s output failed in json: %s" % (command_pathname, x)
+            )
+        return {}
+
+    def _execute_external_process(self, crash_id, command_pathname, command_line, processor_meta):
+        output, return_code = (
+            execute_external_process(
+                crash_id=crash_id,
+                command_pathname=command_pathname,
+                command_line=command_line,
+                processor_meta=processor_meta,
+                interpret_output=self._interpret_output
+            )
         )
 
-        if not isinstance(stackwalker_output, Mapping):
-            msg = 'MDSW produced unexpected output: %s (%s)' % str(stackwalker_output)[:20]
+        if not isinstance(output, Mapping):
+            msg = 'MDSW produced unexpected output: %s (%s)' % str(output)[:20]
             processor_meta.processor_notes.append(msg)
             self.logger.warning(msg + ' (%s)' % crash_id)
-            stackwalker_output = {}
+            output = {}
 
         stackwalker_data = DotDict()
-        stackwalker_data.json_dump = stackwalker_output
+        stackwalker_data.json_dump = output
         stackwalker_data.mdsw_return_code = return_code
 
-        stackwalker_data.mdsw_status_string = stackwalker_output.get('status', 'unknown error')
+        stackwalker_data.mdsw_status_string = output.get('status', 'unknown error')
         stackwalker_data.success = stackwalker_data.mdsw_status_string == 'OK'
 
         self.metrics.incr(
@@ -307,22 +208,22 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
 
         symbols_urls = ' '.join([
             '--symbols-url "%s"' % url.strip()
-            for url in self.config.symbols_urls
+            for url in self.symbols_urls
         ])
 
         params = {
             # These come from config
-            'kill_timeout': self.config.kill_timeout,
-            'command_pathname': self.config.command_pathname,
-            'symbol_cache_path': self.config.symbol_cache_path,
-            'symbol_tmp_path': self.config.symbol_tmp_path,
+            'kill_timeout': self.kill_timeout,
+            'command_pathname': self.command_pathname,
+            'symbol_cache_path': self.symbol_cache_path,
+            'symbol_tmp_path': self.symbol_tmp_path,
             'symbols_urls': symbols_urls,
 
             # These are calculated
             'dump_file_pathname': dump_file_pathname,
             'raw_crash_pathname': raw_crash_pathname
         }
-        return self.config.command_line.format(**params)
+        return self.command_line.format(**params)
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         crash_id = raw_crash['uuid']
@@ -341,7 +242,7 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
                 # to differentiate these dump types is by the name of the
                 # dump.  All minidumps targeted for the stackwalker will have
                 # a name with a prefix specified in configuration:
-                if not dump_name.startswith(self.config.dump_field):
+                if not dump_name.startswith(self.dump_field):
                     # dumps not intended for the stackwalker are ignored
                     continue
 
@@ -354,42 +255,29 @@ class BreakpadStackwalkerRule2015(ExternalProcessRule):
 
                 stackwalker_data, return_code = self._execute_external_process(
                     crash_id,
+                    self.command_pathname,
                     command_line,
                     processor_meta
                 )
 
-                if dump_name == self.config.dump_field:
+                if dump_name == self.dump_field:
                     processed_crash.update(stackwalker_data)
                 else:
                     processed_crash.additional_minidumps.append(dump_name)
                     processed_crash[dump_name] = stackwalker_data
 
 
-class JitCrashCategorizeRule(ExternalProcessRule):
-    # FIXME(willkg): command_line and command_pathname are referenced in the
-    # uplifted versions in ProcessorPipeline. The rest of these config values have
-    # no effect on anything and are just here.
-    required_config = Namespace()
-    required_config.add_option(
-        'command_line',
-        doc='template for the command to invoke the external program; uses Python format syntax',
-        default='timeout -s KILL 30 {command_pathname} {dump_file_pathname} '
-    )
-    required_config.add_option(
-        'command_pathname',
-        doc='the full pathname to the external program to run (quote path with embedded spaces)',
-        default='/data/socorro/stackwalk/bin/jit-crash-categorize',
-    )
-    required_config.add_option(
-        'result_key',
-        doc='where the external process result should be stored in the processed crash',
-        default='classifications.jit.category',
-    )
-    required_config.add_option(
-        'return_code_key',
-        doc='where the external process return code should be stored in the processed crash',
-        default='classifications.jit.category_return_code',
-    )
+class JitCrashCategorizeRule(Rule):
+    def __init__(self, dump_field, command_pathname, command_line, kill_timeout):
+        super().__init__()
+        self.dump_field = dump_field
+        self.command_pathname = command_pathname
+        self.command_line = command_line
+        self.kill_timeout = kill_timeout
+
+    def __repr__(self):
+        keys = ('dump_field', 'command_pathname', 'command_line', 'kill_timeout')
+        return self.generate_repr(keys=keys)
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
         if (
@@ -413,15 +301,12 @@ class JitCrashCategorizeRule(ExternalProcessRule):
             processed_crash.signature.endswith('js::irregexp::ExecuteCode<T>')
         )
 
-    def _interpret_external_command_output(self, fp, processor_meta):
+    def _interpret_output(self, fp, processor_meta, command_pathname):
         try:
             result = fp.read()
         except IOError as x:
             processor_meta.processor_notes.append(
-                "%s unable to read external command output: %s" % (
-                    self.config.command_pathname,
-                    x
-                )
+                "%s unable to read external command output: %s" % (command_pathname, x)
             )
             return ''
         try:
@@ -429,3 +314,23 @@ class JitCrashCategorizeRule(ExternalProcessRule):
         except AttributeError:
             # there's no strip method
             return result
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        crash_id = raw_crash['uuid']
+        params = {
+            'command_pathname': self.command_pathname,
+            'kill_timeout': self.kill_timeout,
+            'dump_file_pathname': raw_dumps[self.dump_field]
+        }
+        command_line = self.command_line.format(**params)
+
+        output, return_code = execute_external_process(
+            crash_id=crash_id,
+            command_pathname=self.command_pathname,
+            command_line=command_line,
+            processor_meta=processor_meta,
+            interpret_output=self._interpret_output
+        )
+
+        dot_save(processed_crash, 'classifications.jit.category', output)
+        dot_save(processed_crash, 'classifications.jit.category_return_code', return_code)

--- a/socorro/processor/rules/memory_report_extraction.py
+++ b/socorro/processor/rules/memory_report_extraction.py
@@ -16,7 +16,9 @@ UNITS_BYTES = 0
 
 class MemoryReportExtraction(Rule):
     """Extract key measurements from the memory_report object into a more
-    comprehensible and usable dictionary. """
+    comprehensible and usable dictionary.
+
+    """
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
         try:
@@ -107,9 +109,7 @@ class MemoryReportExtraction(Rule):
             if path.startswith('explicit/'):
                 if units != UNITS_BYTES:
                     raise ValueError(
-                        'bad units for an explicit/ report: {}, {}'.format(
-                            path, str(units)
-                        )
+                        'bad units for an explicit/ report: {}, {}'.format(path, str(units))
                     )
 
                 if kind == KIND_NONHEAP:
@@ -118,9 +118,7 @@ class MemoryReportExtraction(Rule):
                     explicit_heap += amount
                 else:
                     raise ValueError(
-                        'bad kind for an explicit/ report: {}, {}'.format(
-                            path, str(kind)
-                        )
+                        'bad kind for an explicit/ report: {}, {}'.format(path, str(kind))
                     )
 
                 if path.startswith('explicit/images/'):

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -13,7 +13,7 @@ from socorro.processor.rules.general import (
     IdentifierRule,
     OSInfoRule,
 )
-from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
+from socorro.unittest.processor import get_basic_processor_meta
 
 
 canonical_standard_raw_crash = DotDict({
@@ -116,8 +116,7 @@ class TestDeNullRule(object):
         (b'a\0bc\0', b'abc'),
     ])
     def test_de_null(self, data, expected):
-        config = get_basic_config()
-        rule = DeNullRule(config)
+        rule = DeNullRule()
         assert rule.de_null(data) == expected
 
     def test_rule_with_dict(self):
@@ -127,8 +126,7 @@ class TestDeNullRule(object):
             '\0key3': '\0val3'
         }
 
-        config = get_basic_config()
-        rule = DeNullRule(config)
+        rule = DeNullRule()
         rule.act(raw_crash, {}, {}, get_basic_processor_meta())
 
         assert raw_crash == {
@@ -145,8 +143,7 @@ class TestDeNullRule(object):
             '\0key3': '\0val3'
         })
 
-        config = get_basic_config()
-        rule = DeNullRule(config)
+        rule = DeNullRule()
         rule.act(raw_crash, {}, {}, get_basic_processor_meta())
 
         assert raw_crash == DotDict({
@@ -158,8 +155,6 @@ class TestDeNullRule(object):
 
 class TestIdentifierRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         uuid = '00000000-0000-0000-0000-000002140504'
         raw_crash = {
             'uuid': uuid
@@ -168,21 +163,19 @@ class TestIdentifierRule(object):
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = IdentifierRule(config)
+        rule = IdentifierRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash['crash_id'] == uuid
         assert processed_crash['uuid'] == uuid
 
     def test_uuid_missing(self):
-        config = get_basic_config()
-
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = IdentifierRule(config)
+        rule = IdentifierRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # raw crash and processed crashes should be unchanged
@@ -192,14 +185,12 @@ class TestIdentifierRule(object):
 
 class TestCPUInfoRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.copy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
-        rule = CPUInfoRule(config)
+        rule = CPUInfoRule()
 
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
@@ -212,8 +203,6 @@ class TestCPUInfoRule(object):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_cpu_count(self):
-        config = get_basic_config()
-
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
         system_info = copy.copy(canonical_processed_crash['json_dump']['system_info'])
@@ -224,7 +213,7 @@ class TestCPUInfoRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = CPUInfoRule(config)
+        rule = CPUInfoRule()
 
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
@@ -236,14 +225,12 @@ class TestCPUInfoRule(object):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_json_dump(self):
-        config = get_basic_config()
-
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = CPUInfoRule(config)
+        rule = CPUInfoRule()
 
         # the call to be tested
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
@@ -257,7 +244,6 @@ class TestCPUInfoRule(object):
 
 class TestOSInfoRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
         raw_crash = {}
         processed_crash = DotDict({
             'json_dump': {
@@ -269,7 +255,7 @@ class TestOSInfoRule(object):
         })
         processor_meta = get_basic_processor_meta()
 
-        rule = OSInfoRule(config)
+        rule = OSInfoRule()
 
         # the call to be tested
         rule.act(raw_crash, {}, processed_crash, processor_meta)
@@ -281,12 +267,11 @@ class TestOSInfoRule(object):
         assert raw_crash == {}
 
     def test_stuff_missing(self):
-        config = get_basic_config()
         raw_crash = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = OSInfoRule(config)
+        rule = OSInfoRule()
 
         # the call to be tested
         rule.act(raw_crash, {}, processed_crash, processor_meta)

--- a/socorro/unittest/processor/rules/test_memory_report_extraction.py
+++ b/socorro/unittest/processor/rules/test_memory_report_extraction.py
@@ -6,7 +6,6 @@ import os
 import json
 
 from socorro.processor.rules.memory_report_extraction import MemoryReportExtraction
-from socorro.unittest.processor import create_basic_fake_processor
 
 
 HERE = os.path.dirname(__file__)
@@ -19,13 +18,8 @@ def get_example_file_data(filename):
 
 
 class TestMemoryReportExtraction(object):
-    def get_config(self):
-        fake_processor = create_basic_fake_processor()
-        return fake_processor.config
-
     def test_predicate_success(self):
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         processed_crash = {}
         processed_crash['memory_report'] = {
@@ -39,8 +33,7 @@ class TestMemoryReportExtraction(object):
         assert predicate_result
 
     def test_predicate_no_match(self):
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         processed_crash = {}
 
@@ -58,8 +51,7 @@ class TestMemoryReportExtraction(object):
         assert not predicate_result
 
     def test_predicate_failure_bad_unrecognizable(self):
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('bad_unrecognizable.json')
 
@@ -71,8 +63,7 @@ class TestMemoryReportExtraction(object):
         assert not predicate_result
 
     def test_action_success(self):
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('good.json')
 
@@ -132,8 +123,7 @@ class TestMemoryReportExtraction(object):
     def test_action_failure_bad_kind(self, caplogpp):
         caplogpp.set_level('DEBUG')
 
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('bad_kind.json')
 
@@ -153,8 +143,7 @@ class TestMemoryReportExtraction(object):
     def test_action_failure_bad_units(self, caplogpp):
         caplogpp.set_level('DEBUG')
 
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('bad_units.json')
 
@@ -174,8 +163,7 @@ class TestMemoryReportExtraction(object):
     def test_action_failure_bad_pid(self, caplogpp):
         caplogpp.set_level('DEBUG')
 
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('good.json')
 
@@ -195,8 +183,7 @@ class TestMemoryReportExtraction(object):
     def test_action_failure_key_error(self, caplogpp):
         caplogpp.set_level('DEBUG')
 
-        config = self.get_config()
-        rule = MemoryReportExtraction(config)
+        rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data('bad_missing_key.json')
 

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -36,7 +36,7 @@ from socorro.processor.rules.mozilla import (
 )
 from socorro.signature.generator import SignatureGenerator
 from socorro.unittest import WHATEVER
-from socorro.unittest.processor import get_basic_config, get_basic_processor_meta
+from socorro.unittest.processor import get_basic_processor_meta
 
 
 canonical_standard_raw_crash = DotDict({
@@ -154,15 +154,12 @@ canonical_processed_crash = DotDict({
 
 class TestProductRule(object):
     def test_everything_we_hoped_for(self):
-        # does it even instantiate?
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ProductRule(config)
+        rule = ProductRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.product == "Firefox"
@@ -172,9 +169,6 @@ class TestProductRule(object):
         assert processed_crash.build == "20120420145725"
 
     def test_stuff_missing(self):
-        # does it even instantiate?
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.Version
         del raw_crash.Distributor
@@ -185,7 +179,7 @@ class TestProductRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ProductRule(config)
+        rule = ProductRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.product == "Firefox"
@@ -197,14 +191,12 @@ class TestProductRule(object):
 
 class TestUserDataRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = UserDataRule(config)
+        rule = UserDataRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.url == "http://www.mozilla.com"
@@ -213,8 +205,6 @@ class TestUserDataRule(object):
         assert processed_crash.user_id == ""
 
     def test_stuff_missing(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.URL
         del raw_crash.Comments
@@ -224,7 +214,7 @@ class TestUserDataRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = UserDataRule(config)
+        rule = UserDataRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.url is None
@@ -234,21 +224,17 @@ class TestUserDataRule(object):
 
 class TestEnvironmentRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = EnvironmentRule(config)
+        rule = EnvironmentRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.app_notes == raw_crash.Notes
 
     def test_stuff_missing(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.Notes
 
@@ -256,7 +242,7 @@ class TestEnvironmentRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = EnvironmentRule(config)
+        rule = EnvironmentRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.app_notes == ""
@@ -264,8 +250,6 @@ class TestEnvironmentRule(object):
 
 class TestPluginRule(object):
     def test_plugin_hang(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginHang = 1
         raw_crash.Hang = 0
@@ -277,7 +261,7 @@ class TestPluginRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginRule(config)
+        rule = PluginRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.hangid == 'fake-00000000-0000-0000-0000-000002140504'
@@ -288,8 +272,6 @@ class TestPluginRule(object):
         assert processed_crash.PluginVersion == '0.0'
 
     def test_browser_hang(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.Hang = 1
         raw_crash.ProcessType = 'browser'
@@ -297,7 +279,7 @@ class TestPluginRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginRule(config)
+        rule = PluginRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.hangid is None
@@ -310,14 +292,12 @@ class TestPluginRule(object):
 
 class TestAddonsRule(object):
     def test_action_nothing_unexpected(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        addons_rule = AddonsRule(config)
+        addons_rule = AddonsRule()
         addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # the raw crash & raw_dumps should not have changed
@@ -341,8 +321,6 @@ class TestAddonsRule(object):
         assert processed_crash.addons_checked
 
     def test_action_colon_in_addon_version(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'adblockpopups@jessehakanen.net:0:3:1'
         raw_crash['EMCheckCompatibility'] = 'Nope'
@@ -350,7 +328,7 @@ class TestAddonsRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        addons_rule = AddonsRule(config)
+        addons_rule = AddonsRule()
         addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected_addon_list = [
@@ -360,15 +338,13 @@ class TestAddonsRule(object):
         assert not processed_crash.addons_checked
 
     def test_action_addon_is_nonsense(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['Add-ons'] = 'naoenut813teq;mz;<[`19ntaotannn8999anxse `'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        addons_rule = AddonsRule(config)
+        addons_rule = AddonsRule()
         addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected_addon_list = [
@@ -424,14 +400,12 @@ class TestDatesAndTimesRule(object):
         assert processor_notes == expected
 
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -445,15 +419,13 @@ class TestDatesAndTimesRule(object):
         assert processed_crash.last_crash == 86985
 
     def test_bad_timestamp(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -468,8 +440,6 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == ['non-integer value of "timestamp"']
 
     def test_bad_timestamp_and_no_crash_time(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.CrashTime
@@ -477,7 +447,7 @@ class TestDatesAndTimesRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -497,8 +467,6 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == expected
 
     def test_no_startup_time_bad_timestamp(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.timestamp = 'hi there'
         del raw_crash.StartupTime
@@ -506,7 +474,7 @@ class TestDatesAndTimesRule(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -525,15 +493,13 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == expected
 
     def test_no_startup_time(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash.StartupTime
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -548,15 +514,13 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == []
 
     def test_bad_startup_time(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.StartupTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -571,15 +535,13 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == ['non-integer value of "StartupTime"']
 
     def test_bad_install_time(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.InstallTime = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -594,15 +556,13 @@ class TestDatesAndTimesRule(object):
         assert processor_meta.processor_notes == ['non-integer value of "InstallTime"']
 
     def test_bad_seconds_since_last_crash(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.SecondsSinceLastCrash = 'feed the goats'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = DatesAndTimesRule(config)
+        rule = DatesAndTimesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash.submitted_timestamp)
@@ -619,8 +579,6 @@ class TestDatesAndTimesRule(object):
 
 class TestJavaProcessRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = {
             'JavaStackTrace': (
                 'Exception: some messge\n'
@@ -633,7 +591,7 @@ class TestJavaProcessRule(object):
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = JavaProcessRule(config)
+        rule = JavaProcessRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # The entire JavaStackTrace blob
@@ -647,8 +605,6 @@ class TestJavaProcessRule(object):
         )
 
     def test_malformed(self):
-        config = get_basic_config()
-
         raw_crash = {
             'JavaStackTrace': 'junk\n\tat org.File.function\njunk'
         }
@@ -657,7 +613,7 @@ class TestJavaProcessRule(object):
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = JavaProcessRule(config)
+        rule = JavaProcessRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # The entire JavaStackTrace blob
@@ -672,20 +628,16 @@ class TestJavaProcessRule(object):
 
 class TestMozCrashReasonRule(object):
     def test_no_mozcrashreason(self):
-        config = get_basic_config()
-
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = MozCrashReasonRule(config)
+        rule = MozCrashReasonRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash == {}
 
     def test_good_mozcrashreason(self):
-        config = get_basic_config()
-
         raw_crash = {
             'MozCrashReason': 'MOZ_CRASH(OOM)'
         }
@@ -693,7 +645,7 @@ class TestMozCrashReasonRule(object):
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
-        rule = MozCrashReasonRule(config)
+        rule = MozCrashReasonRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
         assert processed_crash == {
             'moz_crash_reason_raw': 'MOZ_CRASH(OOM)',
@@ -701,8 +653,7 @@ class TestMozCrashReasonRule(object):
         }
 
     def test_bad_mozcrashreason(self):
-        config = get_basic_config()
-        rule = MozCrashReasonRule(config)
+        rule = MozCrashReasonRule()
 
         bad_reasons = [
             'byte index 21548 is not a char boundary',
@@ -725,14 +676,12 @@ class TestMozCrashReasonRule(object):
 
 class TestOutOfMemoryBinaryRule(object):
     def test_extract_memory_info(self):
-        config = DotDict()
-
         processor_meta = get_basic_processor_meta()
 
         with patch('socorro.processor.rules.mozilla.gzip.open') as mocked_gzip_open:
             ret = json.dumps({'mysterious': ['awesome', 'memory']})
             mocked_gzip_open.return_value = BytesIO(ret.encode('utf-8'))
-            rule = OutOfMemoryBinaryRule(config)
+            rule = OutOfMemoryBinaryRule()
             # Stomp on the value to make it easier to test with
             rule.MAX_SIZE_UNCOMPRESSED = 1024
             memory = rule._extract_memory_info('a_pathname', processor_meta.processor_notes)
@@ -740,8 +689,6 @@ class TestOutOfMemoryBinaryRule(object):
             assert memory == {'mysterious': ['awesome', 'memory']}
 
     def test_extract_memory_info_too_big(self):
-        config = DotDict()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
@@ -759,7 +706,7 @@ class TestOutOfMemoryBinaryRule(object):
                 return opened
 
             mocked_gzip_open.side_effect = gzip_open
-            rule = OutOfMemoryBinaryRule(config)
+            rule = OutOfMemoryBinaryRule()
 
             # Stomp on the value to make it easier to test with
             rule.MAX_SIZE_UNCOMPRESSED = 5
@@ -779,9 +726,6 @@ class TestOutOfMemoryBinaryRule(object):
             assert processed_crash.memory_report_error == expected_error_message
 
     def test_extract_memory_info_with_trouble(self):
-        config = DotDict()
-        config.max_size_uncompressed = 1024
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
@@ -790,7 +734,7 @@ class TestOutOfMemoryBinaryRule(object):
 
         with patch('socorro.processor.rules.mozilla.gzip.open') as mocked_gzip_open:
             mocked_gzip_open.side_effect = IOError
-            rule = OutOfMemoryBinaryRule(config)
+            rule = OutOfMemoryBinaryRule()
 
             memory = rule._extract_memory_info('a_pathname', processor_meta.processor_notes)
             assert memory['ERROR'] == 'error in gzip for a_pathname: OSError()'
@@ -801,9 +745,6 @@ class TestOutOfMemoryBinaryRule(object):
             assert processed_crash.memory_report_error == 'error in gzip for a_pathname: OSError()'
 
     def test_extract_memory_info_with_json_trouble(self):
-        config = DotDict()
-        config.max_size_uncompressed = 1024
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
@@ -816,7 +757,7 @@ class TestOutOfMemoryBinaryRule(object):
             ) as mocked_json_loads:
                 mocked_json_loads.side_effect = ValueError
 
-                rule = OutOfMemoryBinaryRule(config)
+                rule = OutOfMemoryBinaryRule()
                 memory = rule._extract_memory_info('a_pathname', processor_meta.processor_notes)
                 mocked_gzip_open.assert_called_with('a_pathname', 'rb')
                 assert memory == {"ERROR": "error in json for a_pathname: ValueError()"}
@@ -830,8 +771,6 @@ class TestOutOfMemoryBinaryRule(object):
                 assert processed_crash.memory_report_error == expected
 
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {'memory_report': 'a_pathname'}
@@ -846,20 +785,18 @@ class TestOutOfMemoryBinaryRule(object):
                 return 'mysterious-awesome-memory'
 
         with patch('socorro.processor.rules.mozilla.temp_file_context'):
-            rule = MyOutOfMemoryBinaryRule(config)
+            rule = MyOutOfMemoryBinaryRule()
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
             assert processed_crash.memory_report == 'mysterious-awesome-memory'
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.JavaStackTrace = "this is a Java Stack trace"
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = OutOfMemoryBinaryRule(config)
+        rule = OutOfMemoryBinaryRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert 'memory_report' not in processed_crash
@@ -867,14 +804,13 @@ class TestOutOfMemoryBinaryRule(object):
 
 class TestProductRewriteRule(object):
     def test_product_map_rewrite(self):
-        config = get_basic_config()
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash['ProductName'] = 'Fennec'
         raw_crash['ProductID'] = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ProductRewrite(config)
+        rule = ProductRewrite()
         rule.act(raw_crash, {}, processed_crash, processor_meta)
 
         assert raw_crash.ProductName == 'FennecAndroid'
@@ -889,15 +825,13 @@ class TestProductRewriteRule(object):
 
 class TestESRVersionRewrite(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ESRVersionRewrite(config)
+        rule = ESRVersionRewrite()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.Version == "12.0esr"
@@ -906,15 +840,13 @@ class TestESRVersionRewrite(object):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'not_esr'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ESRVersionRewrite(config)
+        rule = ESRVersionRewrite()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.Version == "12.0"
@@ -923,8 +855,6 @@ class TestESRVersionRewrite(object):
         assert processed_crash == DotDict()
 
     def test_this_is_really_broken(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.ReleaseChannel = 'esr'
         del raw_crash.Version
@@ -932,7 +862,7 @@ class TestESRVersionRewrite(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ESRVersionRewrite(config)
+        rule = ESRVersionRewrite()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert "Version" not in raw_crash
@@ -944,8 +874,6 @@ class TestESRVersionRewrite(object):
 
 class TestPluginContentURL(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginContentURL = 'http://mozilla.com'
         raw_crash.URL = 'http://google.com'
@@ -953,7 +881,7 @@ class TestPluginContentURL(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginContentURL(config)
+        rule = PluginContentURL()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.URL == "http://mozilla.com"
@@ -962,15 +890,13 @@ class TestPluginContentURL(object):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.URL = 'http://google.com'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginContentURL(config)
+        rule = PluginContentURL()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.URL == "http://google.com"
@@ -981,8 +907,6 @@ class TestPluginContentURL(object):
 
 class TestPluginUserComment(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.PluginUserComment = 'I hate it when this happens'
         raw_crash.Comments = 'I wrote something here, too'
@@ -990,7 +914,7 @@ class TestPluginUserComment(object):
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginUserComment(config)
+        rule = PluginUserComment()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.Comments == 'I hate it when this happens'
@@ -999,15 +923,13 @@ class TestPluginUserComment(object):
         assert processed_crash == DotDict()
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.Comments = 'I wrote something here'
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = PluginUserComment(config)
+        rule = PluginUserComment()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert raw_crash.Comments == 'I wrote something here'
@@ -1018,14 +940,12 @@ class TestPluginUserComment(object):
 
 class TestExploitablityRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
-        rule = ExploitablityRule(config)
+        rule = ExploitablityRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.exploitability == 'high'
@@ -1034,14 +954,12 @@ class TestExploitablityRule(object):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ExploitablityRule(config)
+        rule = ExploitablityRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.exploitability == 'unknown'
@@ -1052,9 +970,7 @@ class TestExploitablityRule(object):
 
 class TestFlashVersionRule(object):
     def test_get_flash_version(self):
-        config = get_basic_config()
-
-        rule = FlashVersionRule(config)
+        rule = FlashVersionRule()
 
         assert rule._get_flash_version(filename='NPSWF32_1_2_3.dll', version='1.2.3') == '1.2.3'
         assert rule._get_flash_version(filename='NPSWF32_1_2_3.dll') == '1.2.3'
@@ -1088,14 +1004,12 @@ class TestFlashVersionRule(object):
         assert ret == '9.0.16.0'
 
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
-        rule = FlashVersionRule(config)
+        rule = FlashVersionRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.flash_version == '9.1.3.08'
@@ -1106,8 +1020,6 @@ class TestFlashVersionRule(object):
 
 class TestTopMostFilesRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
@@ -1141,7 +1053,7 @@ class TestTopMostFilesRule(object):
 
         processor_meta = get_basic_processor_meta()
 
-        rule = TopMostFilesRule(config)
+        rule = TopMostFilesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.topmost_filenames == 'wilma.cpp'
@@ -1150,15 +1062,13 @@ class TestTopMostFilesRule(object):
         assert raw_crash == canonical_standard_raw_crash
 
     def test_missing_key(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         expected_raw_crash = copy.deepcopy(raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = TopMostFilesRule(config)
+        rule = TopMostFilesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.topmost_filenames is None
@@ -1167,8 +1077,6 @@ class TestTopMostFilesRule(object):
         assert raw_crash == expected_raw_crash
 
     def test_missing_key_2(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
@@ -1187,7 +1095,7 @@ class TestTopMostFilesRule(object):
 
         processor_meta = get_basic_processor_meta()
 
-        rule = TopMostFilesRule(config)
+        rule = TopMostFilesRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         assert processed_crash.topmost_filenames is None
@@ -1199,15 +1107,13 @@ class TestTopMostFilesRule(object):
 class TestBetaVersionRule(object):
     API_URL = 'http://example.com/api/VersionString'
 
-    def get_config(self):
-        config = get_basic_config()
-        config.version_string_api = self.API_URL
-        return config
+    def build_rule(self):
+        return BetaVersionRule(
+            version_string_api=self.API_URL
+        )
 
     def test_beta_channel_known_version(self):
         # Beta channel with known version gets converted correctly
-        config = self.get_config()
-
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1218,7 +1124,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker() as req_mock:
             req_mock.get(
                 self.API_URL + '?product=Firefox&channel=beta&build_id=20001001101010',
@@ -1233,7 +1139,6 @@ class TestBetaVersionRule(object):
 
     def test_release_channel(self):
         """Release channel doesn't trigger rule"""
-        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1244,7 +1149,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker():
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
@@ -1253,7 +1158,6 @@ class TestBetaVersionRule(object):
 
     def test_nightly_channel(self):
         """Nightly channel doesn't trigger rule"""
-        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1264,7 +1168,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker():
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
@@ -1273,7 +1177,6 @@ class TestBetaVersionRule(object):
 
     def test_bad_buildid(self):
         """Invalid buildids don't cause errors"""
-        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1284,7 +1187,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker() as req_mock:
             # NOTE(willkg): Is it possible to validate the buildid and
             # reject it without doing an HTTP round-trip?
@@ -1305,7 +1208,6 @@ class TestBetaVersionRule(object):
 
     def test_beta_channel_unknown_version(self):
         """Beta crash that Buildhub doesn't know about gets b0"""
-        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1316,7 +1218,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker() as req_mock:
             req_mock.get(
                 self.API_URL + '?product=Firefox&channel=beta&build_id=220000101101011',
@@ -1335,7 +1237,6 @@ class TestBetaVersionRule(object):
 
     def test_aurora_channel(self):
         """Test aurora channel lookup"""
-        config = self.get_config()
         raw_crash = {}
         raw_dumps = {}
         processed_crash = {
@@ -1346,7 +1247,7 @@ class TestBetaVersionRule(object):
         }
         processor_meta = get_basic_processor_meta()
 
-        rule = BetaVersionRule(config)
+        rule = self.build_rule()
         with requests_mock.Mocker() as req_mock:
             req_mock.get(
                 self.API_URL + '?product=Firefox&channel=aurora&build_id=20001001101010',
@@ -1362,14 +1263,12 @@ class TestBetaVersionRule(object):
 
 class TestOsPrettyName(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
 
         processor_meta = get_basic_processor_meta()
 
-        rule = OSPrettyVersionRule(config)
+        rule = OSPrettyVersionRule()
 
         # A known Windows version.
         processed_crash = DotDict()
@@ -1450,8 +1349,6 @@ class TestOsPrettyName(object):
 
 class TestThemePrettyNameRule(object):
     def test_everything_we_hoped_for(self):
-        config = get_basic_config()
-
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = DotDict()
@@ -1470,7 +1367,7 @@ class TestThemePrettyNameRule(object):
             'elemhidehelper@adblockplus.org:1.2.1',
         ]
 
-        rule = ThemePrettyNameRule(config)
+        rule = ThemePrettyNameRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
         # the raw crash & raw_dumps should not have changed
@@ -1493,12 +1390,10 @@ class TestThemePrettyNameRule(object):
         assert processed_crash.addons == expected_addon_list
 
     def test_missing_key(self):
-        config = get_basic_config()
-
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
 
-        rule = ThemePrettyNameRule(config)
+        rule = ThemePrettyNameRule()
 
         # Test with missing key.
         res = rule.predicate({}, {}, processed_crash, processor_meta)
@@ -1518,8 +1413,7 @@ class TestThemePrettyNameRule(object):
         assert res is False
 
     def test_with_malformed_addons_field(self):
-        config = get_basic_config()
-        rule = ThemePrettyNameRule(config)
+        rule = ThemePrettyNameRule()
 
         processed_crash = DotDict()
         processor_meta = get_basic_processor_meta()
@@ -1541,7 +1435,7 @@ class TestThemePrettyNameRule(object):
 
 class TestSignatureGeneratorRule:
     def test_signature(self):
-        rule = SignatureGeneratorRule(get_basic_config())
+        rule = SignatureGeneratorRule()
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         processed_crash = DotDict({
             'json_dump': {
@@ -1576,7 +1470,7 @@ class TestSignatureGeneratorRule:
         assert processor_meta['processor_notes'] == []
 
     def test_empty_raw_and_processed_crashes(self):
-        rule = SignatureGeneratorRule(get_basic_config())
+        rule = SignatureGeneratorRule()
         raw_crash = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -1602,8 +1496,7 @@ class TestSignatureGeneratorRule:
             def predicate(self, raw_crash, processed_crash):
                 raise exc_value
 
-        config = get_basic_config()
-        rule = SignatureGeneratorRule(config)
+        rule = SignatureGeneratorRule()
 
         # Override the regular SigntureGenerator with one with a BadRule
         # in the pipeline

--- a/socorro/unittest/processor/test_processor_pipeline.py
+++ b/socorro/unittest/processor/test_processor_pipeline.py
@@ -42,7 +42,7 @@ class TestProcessorPipeline(object):
         }
         processed_crash = DotDict()
 
-        processor = ProcessorPipeline(config, rules=[BadRule])
+        processor = ProcessorPipeline(config, rules=[BadRule()])
         processor.process_crash(raw_crash, {}, processed_crash)
 
         # Notes were added
@@ -76,7 +76,7 @@ class TestProcessorPipeline(object):
         }
         processed_crash = DotDict()
 
-        processor = ProcessorPipeline(config, rules=[BadRule])
+        processor = ProcessorPipeline(config, rules=[BadRule()])
         processor.process_crash(raw_crash, {}, processed_crash)
 
         # Notes were added again
@@ -97,8 +97,8 @@ class TestProcessorPipeline(object):
         })
 
         p = ProcessorPipeline(self.get_config(), rules=[
-            CPUInfoRule,
-            OSInfoRule,
+            CPUInfoRule(),
+            OSInfoRule(),
         ])
         with patch('socorro.processor.processor_pipeline.utc_now') as faked_utcnow:
             faked_utcnow.return_value = '2015-01-01T00:00:00'


### PR DESCRIPTION
This adjusts the `ProcessorPipeline` to own configuration of the rules in the
pipeline. Configuration is now defined on that class and it passes in necessary
data through init args to the rules that require it.  In this way, rules are
just transformation classes and aren't configman-style classes.

This adds logging of the pipeline rules and their configuration. This will
make it a lot easier to notice and debug rules problems in the future.

Doing this also fixed configuration for the `JitCrashCategorizeRule` which was
totally busted and probably has been for some time. Now rule configuration is
namespaced which allows us to configure both the `BreakpadStackwalkerRule2015`
and `JitCrashCategorizeRule`.

This also removed all the confusing duplicated (and triplicated in some places)
configuration which was confusing and causing problems.

I also nixed the `ExternalProcessRule` and folded it into the rules that subclassed it. Those three rules were hard to follow because of all the back and forth between super/subclasses and selective overriding. It was way easier to just break them up and move the shared bits to a function.

To test:

1. run tests
2. process some crashes
   1. does the rule output on startup look sane?
   2. did BreakpadStackwalkerRule2015 run? do crashes get signatures?
   3. did the BetaVersionRule run? you need to make sure to process a Firefox beta channel crash to check this.

Note that the `JitCrashCategorizeRule` isn't quite fixed, yet. It still won't do anything because it's kicking off before signature generation, but depends on the signature to run. I want to fix that in a follow-up PR because it hasn't run in so long that I don't know what it's supposed to do or whether it works at all.