### PR TITLE
bug 1553838: fix JitCrashCategorizeRule

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -229,15 +229,16 @@ class ProcessorPipeline(RequiredConfig):
             TopMostFilesRule(),
             ThemePrettyNameRule(),
             MemoryReportExtraction(),
-            # a set of classifiers to help with jit crashes
+            # generate signature now that we've done all the processing it depends on
+            SignatureGeneratorRule(),
+            # a set of classifiers to help with jit crashes--must be last since it
+            # depends on signature generation
             JitCrashCategorizeRule(
                 dump_field=config.jit.dump_field,
                 command_line=config.jit.command_line,
                 command_pathname=config.jit.command_pathname,
                 kill_timeout=config.jit.kill_timeout
             ),
-            # generate signature now that we've done all the processing it depends on
-            SignatureGeneratorRule(),
         ]
 
     def process_crash(self, raw_crash, raw_dumps, processed_crash):


### PR DESCRIPTION
The JitCrashCategorizeRule only kicks off for crashes with certain
properties including requiring certain things in the signature. If this
runs *before* signature generation, then it'll never do anything since
the predicate will never be met. This fixes that.

To test:

1. process d02ac76e-eee6-4206-8026-c08f10190523 using master branch; then check http://localhost:8000/api/UnredactedCrash/?crash_id=d02ac76e-eee6-4206-8026-c08f10190523 and look for "classifications" key--it's not there
2. process it using this branch and re-check--it is there :tada: