### PR TITLE
bug 1553314: default to old keys for environment variables

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -81,7 +81,7 @@ class ProcessorPipeline(RequiredConfig):
         doc='comma-delimited ordered list of urls for symbol lookup',
         default='https://localhost',
         from_string_converter=str_to_list,
-        likely_to_be_changed=True
+        reference_value_from='processor'
     )
     required_config.breakpad.add_option(
         'command_line',
@@ -107,6 +107,7 @@ class ProcessorPipeline(RequiredConfig):
             'on the same filesystem as symbols-cache'
         ),
         default=os.path.join(tempfile.gettempdir(), 'symbols-tmp'),
+        reference_value_from='processor'
     ),
     required_config.breakpad.add_option(
         'symbol_cache_path',
@@ -115,6 +116,7 @@ class ProcessorPipeline(RequiredConfig):
             'readable and writeable (quote path with embedded spaces)'
         ),
         default=os.path.join(tempfile.gettempdir(), 'symbols'),
+        reference_value_from='processor'
     )
     required_config.breakpad.add_option(
         'tmp_storage_path',
@@ -152,7 +154,8 @@ class ProcessorPipeline(RequiredConfig):
     required_config.betaversion.add_option(
         'version_string_api',
         doc='url for the version string api endpoint in the webapp',
-        default='https://crash-stats.mozilla.org/api/VersionString'
+        default='https://crash-stats.mozilla.org/api/VersionString',
+        reference_value_from='processor'
     )
 
     def __init__(self, config, rules=None, quit_check_callback=None):


### PR DESCRIPTION
This defaults to the old keys for environment variables that got changed until
we can change them in stage/prod.