### PR TITLE
bug 1473068: Expand OIDC_EXEMPT_URLS for more XHR usage

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -737,7 +737,12 @@ OIDC_EXEMPT_URLS = [
     '/buginfo/bug',
 
     # Used by signature report as an XHR
-    'signature:signature_summary',  # data-urls-summary
+    # TODO: Should include aggregations and graphs, but they include a parameter in the URL
+    'signature:signature_summary',          # data-urls-summary
+    'signature:signature_reports',          # data-urls-reports
+    'signature:signature_bugzilla',         # data-urls-bugzilla
+    'signature:signature_comments',         # data-urls-comments
+    'signature:signature_correlations',     # data-urls-correlations
 ]
 LOGOUT_REDIRECT_URL = '/'
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -730,12 +730,14 @@ OIDC_OP_USER_ENDPOINT = config('OIDC_OP_USER_ENDPOINT', '')
 # contexts and that doesn't handle redirecting.
 OIDC_EXEMPT_URLS = [
     # Used by supersearch page as an XHR
-    '/search/fields/',
-    '/search/results/',
+    'supersearch:search_fields',    # data-fields-url
+    'supersearch:search_results',   # data-results-url
+
+    # Used by bugzilla.js
     '/buginfo/bug',
 
     # Used by signature report as an XHR
-    '/signature/summary/',
+    'signature:signature_summary',  # data-urls-summary
 ]
 LOGOUT_REDIRECT_URL = '/'
 


### PR DESCRIPTION
Add more URLs to ``OIDC_EXEMPT_URLS``, which prevents XHR requests from being checked for session expiration and getting a login redirect.

These are defined as attributes in a block in ``signature_report.html``:

https://github.com/mozilla-services/socorro/blob/750dece05d3877a281e7e401f3cd7fd559340ece/webapp-django/crashstats/signature/jinja2/signature/signature_report.html#L19-L25

I've reworked ``OIDC_EXEMPT_URLS`` to use URL names, which are [reversed once in the middleware](https://github.com/mozilla/mozilla-django-oidc/blob/e780130deacccbafc85a92f48d1407e042f5f955/mozilla_django_oidc/middleware.py#L44-L65), so that the templates will line up with the settings. I've also added the attribute names as comments, to make it easier to find one from the other.

There are two pages, for aggregations and graphs, which should also be exempt. Unfortunately, they include parameters in the URL, so the exact URL match in the middleware can't be used. There's a couple of options:

* Convert our JavaScript and URLs to pass the extra parameter in the querystring instead of the URL
* Update ``mozilla_django_oidc`` to match on a regex or a URL prefix.

Either will be more work, so I'm picking up the easy stuff first.

