### PR TITLE
bug 1544552: Add `BaseAllocator` to the prefix signature list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -16,6 +16,7 @@ alloc::raw_vec::capacity_overflow
 _alloca_probe
 __android_log_assert
 arena_
+BaseAllocator
 BaseGetNamedObjectDirectory
 __clear_cache
 .*calloc


### PR DESCRIPTION
It avoid crash reports signatures stopping at e.g. `BaseAllocator::malloc`. (e.g. bug 1544552)