### PR TITLE
bug 1545446: fix input box widths in super search

### DIFF
--- a/webapp-django/crashstats/supersearch/static/supersearch/css/search.less
+++ b/webapp-django/crashstats/supersearch/static/supersearch/css/search.less
@@ -36,11 +36,11 @@
     #simple-search,
     .date-filters {
         text-align: center;
-        display: flex;
         justify-content: space-between;
 
         > div {
             width: 24%;
+            display: inline-block;
 
             label {
                 display: block;

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -408,7 +408,7 @@ $(function() {
     $('input[type=text]', simpleSearchContainer).each(function() {
       var elt = $(this);
       elt.select2({
-        width: 'element',
+        width: '100%',
         tags: elt.data('choices'),
       });
     });
@@ -455,19 +455,19 @@ $(function() {
     sortInput.select2({
       data: sortFields,
       multiple: true,
-      width: 'element',
+      width: '100%',
       sortResults: socorro.search.sortResults,
     });
     facetsInput.select2({
       data: FACETS,
       multiple: true,
-      width: 'element',
+      width: '100%',
       sortResults: socorro.search.sortResults,
     });
     columnsInput.select2({
       data: COLUMNS,
       multiple: true,
-      width: 'element',
+      width: '100%',
       sortResults: socorro.search.sortResults,
     });
 


### PR DESCRIPTION
This fixes the product/version/etc input box widths in super search so they're vaguely responsive
and have more helpful widths.

Full screen (on my machine):

![image](https://user-images.githubusercontent.com/820826/58906732-8e4e4f00-86da-11e9-851d-27fd779eb613.png)

Smaller screen (on my machine):

![image](https://user-images.githubusercontent.com/820826/58906769-a7570000-86da-11e9-9e9a-50290a00c7dd.png)
