### PR TITLE
bug 1557012: add Allocator<T>::malloc to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -10,6 +10,7 @@
 Abort
 .*abort
 .*alloc_impl
+Allocator<T>::malloc
 alloc::oom::default_oom_handler
 alloc::oom::oom
 alloc::raw_vec::capacity_overflow


### PR DESCRIPTION
This is in mozglue and signature generation shouldn't stop on them but rather
continue onwards.