### PR TITLE
bug 1552898: implement manual featured versions

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -42,7 +42,8 @@ resource.pubsub.reprocessing_subscription_name=test_reprocessing_sub
 # Django tests are meant to run with debug mode disabled.
 DEBUG=False
 
+BZAPI_BASE_URL=http://bugzilla.example.com/rest
+PRODUCT_DETAILS_BASE_URL=http://github.example.com
 CACHE_IMPLEMENTATION_FETCHES=True
 DEFAULT_PRODUCT=WaterWolf
-BZAPI_BASE_URL=http://bugzilla.example.com/rest
 SECRET_KEY=fakekey

--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,3 +1,3 @@
 {
-    "active_versions": ["69.0a1", "68.0b", "67.0.2"]
+    "featured_versions": ["69.0a1", "68.0b", "67.0.2"]
 }

--- a/product_details/README.rst
+++ b/product_details/README.rst
@@ -41,7 +41,7 @@ How to update product details files
 To make a change to one of these files, edit it in the GitHub
 interface and then create a pull request.
 
-GitHub interface: https://github.com/mozilla-services/socorro/tree/master/product-details
+GitHub interface: https://github.com/mozilla-services/socorro/tree/master/product_details
 
 The pull request will be reviewed and merged by a developer.
 

--- a/product_details/README.rst
+++ b/product_details/README.rst
@@ -15,13 +15,13 @@ Here's an example:
 .. code-block:: json
 
    {
-       "active_versions": ["69.0a1", "68.0b8", "67.0.2"]
+       "featured_versions": ["69.0a1", "68.0b8", "67.0.2"]
    }
 
 Keys:
 
-``active_versions``
-    List of one or more versions of this product that are currently active.
+``featured_versions``
+    List of one or more versions of this product that are currently featured.
 
     If you want an option for "all beta versions", end the version with ``b``
     and omit the beta number. For example, ``68.0b8`` covers just ``b8``
@@ -33,6 +33,9 @@ Keys:
 
     For all other products, version strings should match the ``Version``
     annotation in the crash report.
+
+    This affects the listed featured versions on the product home page and the
+    "Current Versions" drop down navigation menu in the Crash Stats website.
 
 
 How to update product details files

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/product_home.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/product_home.html
@@ -50,6 +50,12 @@
         </div>
         <br class="clear" />
       </div>
+      <div class="body">
+        Note: Featured versions are calculated from the crash reports collected
+        and processed by Crash Stats or they're manually maintained in files in
+        GitHub. To edit featured versions, see
+        <a href="https://github.com/mozilla-services/socorro/tree/master/product_details">the product_details README</a>
+      </div>
     </div>
     <br class="clear" />
   </div>

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
@@ -81,7 +81,7 @@
           <li class="version_select">
             <label for="product_version_select" class="visually-hidden">Select Version:</label>
             <select id="product_version_select" >
-              <optgroup label="Active">
+              <optgroup label="Featured">
                 <option value="Current Versions">Current Versions</option>
                 {% set pvs = filter_featured_versions(active_versions[product]) %}
                 {% if pvs %}

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -36,15 +36,15 @@ def test_product_details_files(fn):
     except json.decoder.JSONDecoderError as exc:
         raise Exception('%s: invalid JSON: %s' % (fn_basename, exc))
 
-    if 'active_versions' not in data:
-        raise Exception('%s: missing "active_versions" key' % fn_basename)
+    if 'featured_versions' not in data:
+        raise Exception('%s: missing "featured_versions" key' % fn_basename)
 
-    if not isinstance(data['active_versions'], list):
+    if not isinstance(data['featured_versions'], list):
         raise Exception(
-            '%s: "active_versions" value is not a list of strings' % fn_basename
+            '%s: "featured_versions" value is not a list of strings' % fn_basename
         )
 
-    for item in data['active_versions']:
+    for item in data['featured_versions']:
         if not isinstance(item, str):
             raise Exception(
                 '%s: value %r is not a str' % (fn_basename, item)

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -8,47 +8,14 @@ import os
 import os.path
 
 import pytest
+import requests
+import requests_mock
 
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.encoding import smart_text
 
 from crashstats.crashstats import utils
-
-
-def get_product_details_files():
-    product_details_path = os.path.join(settings.SOCORRO_ROOT, 'product_details')
-    return [
-        os.path.join(product_details_path, fn)
-        for fn in os.listdir(product_details_path)
-        if fn.endswith('.json')
-    ]
-
-
-@pytest.mark.parametrize('fn', get_product_details_files())
-def test_product_details_files(fn):
-    """Validate product_details/ JSON files."""
-    fn_basename = os.path.basename(fn)
-
-    try:
-        with open(fn, 'r') as fp:
-            data = json.load(fp)
-    except json.decoder.JSONDecoderError as exc:
-        raise Exception('%s: invalid JSON: %s' % (fn_basename, exc))
-
-    if 'featured_versions' not in data:
-        raise Exception('%s: missing "featured_versions" key' % fn_basename)
-
-    if not isinstance(data['featured_versions'], list):
-        raise Exception(
-            '%s: "featured_versions" value is not a list of strings' % fn_basename
-        )
-
-    for item in data['featured_versions']:
-        if not isinstance(item, str):
-            raise Exception(
-                '%s: value %r is not a str' % (fn_basename, item)
-            )
 
 
 def test_enhance_frame():
@@ -475,3 +442,79 @@ class TestUtils:
         assert signature_stats.is_startup_window_crash is True
         assert signature_stats.is_hang_crash is False
         assert signature_stats.is_plugin_crash is False
+
+
+def get_product_details_files():
+    product_details_path = os.path.join(settings.SOCORRO_ROOT, 'product_details')
+    return [
+        os.path.join(product_details_path, fn)
+        for fn in os.listdir(product_details_path)
+        if fn.endswith('.json')
+    ]
+
+
+@pytest.mark.parametrize('fn', get_product_details_files())
+def test_product_details_files(fn):
+    """Validate product_details/ JSON files."""
+    fn_basename = os.path.basename(fn)
+
+    try:
+        with open(fn, 'r') as fp:
+            data = json.load(fp)
+    except json.decoder.JSONDecoderError as exc:
+        raise Exception('%s: invalid JSON: %s' % (fn_basename, exc))
+
+    if 'featured_versions' not in data:
+        raise Exception('%s: missing "featured_versions" key' % fn_basename)
+
+    if not isinstance(data['featured_versions'], list):
+        raise Exception(
+            '%s: "featured_versions" value is not a list of strings' % fn_basename
+        )
+
+    for item in data['featured_versions']:
+        if not isinstance(item, str):
+            raise Exception(
+                '%s: value %r is not a str' % (fn_basename, item)
+            )
+
+
+class Test_get_manually_maintained_featured_versions:
+    # Note that these tests are mocked and contrived and if the url changes or
+    # something along those lines, these tests can pass, but it might not work
+    # in stage/prod.
+
+    def test_exists(self):
+        with requests_mock.Mocker() as req_mock:
+            url = '%s/Firefox.json' % settings.PRODUCT_DETAILS_BASE_URL
+            req_mock.get(url, json={'featured_versions': ['68.0a1', '67.0b', '66.0']})
+
+            featured = utils.get_manually_maintained_featured_versions('Firefox')
+            assert featured == ['68.0a1', '67.0b', '66.0']
+
+    def test_invalid_file(self):
+        """Not JSON or no featured_versions returns None."""
+        # Not JSON
+        with requests_mock.Mocker() as req_mock:
+            url = '%s/Firefox.json' % settings.PRODUCT_DETAILS_BASE_URL
+            req_mock.get(url, text='this is not json')
+
+            featured = utils.get_manually_maintained_featured_versions('Firefox')
+            assert featured is None
+
+        # No featured_versions
+        with requests_mock.Mocker() as req_mock:
+            url = '%s/Firefox.json' % settings.PRODUCT_DETAILS_BASE_URL
+            req_mock.get(url, json={})
+
+            featured = utils.get_manually_maintained_featured_versions('Firefox')
+            assert featured is None
+
+    def test_github_down(self):
+        """Connection error returns None."""
+        with requests_mock.Mocker() as req_mock:
+            url = '%s/Firefox.json' % settings.PRODUCT_DETAILS_BASE_URL
+            req_mock.get(url, exc=requests.exceptions.ConnectionError)
+
+            featured = utils.get_manually_maintained_featured_versions('Firefox')
+            assert featured is None

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -202,6 +202,9 @@ LOGGING_LEVEL = config('LOGGING_LEVEL', 'INFO')
 
 host_id = socket.gethostname()
 
+# GitHub repo url base
+PRODUCT_DETAILS_BASE_URL = 'https://github.com/mozilla-services/socorro/master/product_details'
+
 
 class AddHostID(logging.Filter):
     def filter(self, record):


### PR DESCRIPTION
This implements manually-curated featured versions. They exist in the
`product_details/` directory. People can edit and create pull requests using the
GitHub interface. Using GitHub for process flow significantly reduces the
complexity of the implementation. This is probably a good enough first pass
and we can adjust that as needs necessitate.
    
If a file exists, Crash Stats will use that to set the featured versions which
show up on the product home page and in the "featured version" part of the
current versions drop down in the menu. If a file does not exist or can't be
retrieved, Crash Stats will calculate the featured versions based on the
existing crash report data. Featured versions are cached for an hour after
which they're figured again, so if anything goes wrong, we just have to wait
a bit.
