### PR TITLE
bug 1552898: fix product details url

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -203,7 +203,9 @@ LOGGING_LEVEL = config('LOGGING_LEVEL', 'INFO')
 host_id = socket.gethostname()
 
 # GitHub repo url base
-PRODUCT_DETAILS_BASE_URL = 'https://github.com/mozilla-services/socorro/master/product_details'
+PRODUCT_DETAILS_BASE_URL = (
+    'https://raw.githubusercontent.com/mozilla-services/socorro/master/product_details'
+)
 
 
 class AddHostID(logging.Filter):


### PR DESCRIPTION
This fixes the `PRODUCT_DETAILS_BASE_URL`. I fixed part of it in the previous PR, but missed the domain, so it's returning 404s right now.