### PR TITLE
Update Fennec Nightly version to 68.0a1

### DIFF
--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,3 +1,3 @@
 {
-    "featured_versions": ["69.0a1", "68.0b", "67.0.2"]
+    "featured_versions": ["68.0a1", "68.0b", "67.0.2"]
 }


### PR DESCRIPTION
Fennec releases are riding the ESR68 train, so the correct Nightly version to use is 68.0a1. We are not officially publishing anything with a newer version.