### PR TITLE
bug 1561697: add mozilla::ipc::WriteIPDLParam to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -121,6 +121,7 @@ mozilla::ipc::RPCChannel::Call
 mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame
 mozilla::ipc::RPCChannel::EnteredCxxStack
 mozilla::ipc::RPCChannel::Send
+mozilla::ipc::WriteIPDLParam
 mozilla::layers::CompositorD3D11::Failed
 mozilla::layers::CompositorD3D11::HandleError
 mozilla::SpinEventLoopUntil<T>


### PR DESCRIPTION
This adds `mozilla::ipc::WriteIPDLParam` to the prefix list so signature generation continues beyond it. By itself, it's too general a bucket.  It'd help to know what the `T` actually is, but that breaks normalization.  Continuing to the next frame should clarify the bucket.