### PR TITLE
bug 1562665: Use nip.io to avoid /etc/hosts change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       - pubsub
       - memcached
       - oidcprovider
+    links:
+      - "oidcprovider:oidcprovider.127.0.0.1.nip.io"
     command: ["webapp", "--dev"]
     ports:
       - "8000:8000"

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -107,9 +107,9 @@ OVERVIEW_VERSION_URLS=http://localhost:8000/__version__
 # ------------
 OIDC_RP_CLIENT_ID=1
 OIDC_RP_CLIENT_SECRET=bd01adf93cfb
-OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidcprovider:8080/openid/authorize
-OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider:8080/openid/token
-OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
+OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/authorize
+OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/token
+OIDC_OP_USER_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/userinfo
 
 # antenna
 # -------

--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -44,13 +44,8 @@ You can do this as many times as you like.
 Setting up the webapp for OpenID Connect Login
 ----------------------------------------------
 
-In order to authenticate in the webapp using the "Login" button, you
-need to add the following entry to your ``/etc/hosts`` (or equivalent) file::
-
-  127.0.0.1 oidcprovider
-
-This allows your host machine to properly handle the authentication provided by
-the `oidcprovider` docker container.
+A test OpenID Connect (OIDC) provider is served from the container
+``oidcprovider``, and is available at http://oidcprovider.127.0.0.1.nip.io:8080.
 
 When logging in with ``oidcprovider``, use the "Sign up" workflow to create a
 fake account:


### PR DESCRIPTION
The [nip.io DNS service](https://nip.io), plus a [docker-compose links alias](https://docs.docker.com/compose/compose-file/compose-file-v2/#links), allows the OIDC provider to work without updating ``/etc/hosts``.