### PR TITLE
bug 1563261: fix /monitoring/heartbeat/ Elasticsearch connection

### DIFF
--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -97,7 +97,10 @@ def dockerflow_heartbeat(request):
         ['resource']['elasticsearch']
     )
     es = elasticsearch.Elasticsearch(
-        hosts=es_settings['elasticsearch_urls']
+        hosts=es_settings['elasticsearch_urls'],
+        timeout=30,
+        connection_class=elasticsearch.connection.RequestsHttpConnection,
+        verify_certs=True
     )
     es.info()  # will raise an error if there's a problem with the cluster
 


### PR DESCRIPTION
Previously, the webapp and the crash storage connection context built
Elasticsearch clients differently. When we updated urllib3 to 1.25.3, the one
the webapp built for `/monitoring/heartbeat/` started failing with SSL handshake
errors. This fixes that one to use `RequestsHttpConnection` which the rest
of Socorro uses.