### PR TITLE
bug 1564551: Validation error for null characters, plus API view updates

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -873,10 +873,9 @@ class TestMultipleStringField:
         """A list with one string arguments is valid."""
         assert MultipleStringField().clean(["one"]) == ["one"]
 
-    @pytest.mark.xfail
     def test_null_arg(self):
         """A embedded null character is a validation error."""
         field = MultipleStringField()
-        value = "Embeded_Null_\0"
+        value = "Embeded_Null_\x00"
         with pytest.raises(ValidationError):
             field.clean([value])

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -119,15 +119,11 @@ def has_permissions(user, permissions):
 
 
 def is_valid_model_class(model):
-    try:
-        return (
-            issubclass(model, models.SocorroMiddleware) and
-            model is not models.SocorroMiddleware and
-            model is not supersearch_models.ESSocorroMiddleware
-        )
-    except TypeError:
-        # issubclass throws a TypeError if the model is not a class.
-        return False
+    return (
+        issubclass(model, models.SocorroMiddleware) and
+        model is not models.SocorroMiddleware and
+        model is not supersearch_models.ESSocorroMiddleware
+    )
 
 
 @csrf_exempt
@@ -307,13 +303,9 @@ def api_models_and_names():
         if model_name.endswith('Middleware'):
             model_name = model_name[:-10]
 
-        try:
-            if not is_valid_model_class(model):
-                continue
-            if model_name in API_DONT_SERVE_LIST:
-                continue
-        except TypeError:
-            # most likely a builtin class or something
+        if not is_valid_model_class(model):
+            continue
+        if model_name in API_DONT_SERVE_LIST:
             continue
 
         models_with_names.append((model, model_name))

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -79,7 +79,7 @@ TYPE_MAP = {
     datetime.datetime: forms.DateTimeField,
     int: forms.IntegerField,
     # NOTE: Not used in any API models
-    bool: forms.BooleanField,
+    bool: forms.NullBooleanField,
 }
 
 
@@ -95,29 +95,6 @@ class MiddlewareModelForm(forms.Form):
             name = parameter['name']
             field_class = TYPE_MAP[parameter['type']]
             self.fields[name] = field_class(required=required)
-
-    def clean(self):
-        cleaned_data = super().clean()
-
-        for field in self.fields:
-            # Because the context for all of this is the API,
-            # and we're using django forms there's a mismatch to how
-            # boolean fields should be handled.
-            # Django forms are meant for HTML forms. A key principle
-            # functionality of a HTML form and a checkbox is that
-            # if the user choses to NOT check a checkbox, the browser
-            # will not send `mybool=false` or `mybool=''`. It will simply
-            # not send anything and then the server has to assume the user
-            # chose to NOT check it because it was offerend.
-            # On a web API, however, the user doesn't use checkboxes.
-            # He uses `?mybool=truthy` or `&mybool=falsy`.
-            # Therefore, for our boolean fields, if the value is not
-            # present at all, we have to assume it to be None.
-            # That makes it possible to actually set `mybool=false`
-            if isinstance(self.fields[field], forms.BooleanField):
-                if field not in self.data:
-                    self.cleaned_data[field] = None
-        return cleaned_data
 
 
 # Names of models we don't want to serve at all

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -111,13 +111,6 @@ API_DONT_SERVE_LIST = (
 )
 
 
-def has_permissions(user, permissions):
-    for permission in permissions:
-        if not user.has_perm(permission):
-            return False
-    return True
-
-
 def is_valid_model_class(model):
     return (
         issubclass(model, models.SocorroMiddleware) and
@@ -161,7 +154,7 @@ def model_wrapper(request, model_name):
         required_permissions and
         (
             not request.user.is_active or
-            not has_permissions(request.user, required_permissions)
+            not request.user.has_perms(required_permissions)
         )
     ):
         permission_names = []
@@ -229,7 +222,7 @@ def model_wrapper(request, model_name):
         if binary_response:
             # if you don't have all required permissions, you'll get a 403
             required_permissions = model.API_BINARY_PERMISSIONS
-            if required_permissions and not has_permissions(request.user, required_permissions):
+            if required_permissions and not request.user.has_perms(required_permissions):
                 permission_names = []
                 for permission in required_permissions:
                     codename = permission.split('.', 1)[1]
@@ -323,7 +316,7 @@ def documentation(request, default_context=None):
         model_inst = model()
         if (
             model_inst.API_REQUIRED_PERMISSIONS and
-            not has_permissions(request.user, model_inst.API_REQUIRED_PERMISSIONS)
+            not request.user.has_perms(model_inst.API_REQUIRED_PERMISSIONS)
         ):
             continue
         endpoints.append(_describe_model(model_name, model))

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -13,7 +13,6 @@ from django.urls import reverse
 from csp.decorators import csp_update
 from socorro.lib import BadArgumentError
 
-from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.decorators import pass_default_context
 from crashstats.crashstats.utils import SignatureStats, render_exception, urlencode_obj
@@ -95,7 +94,7 @@ def signature_report(request, params, default_context=None):
         for x in SuperSearchFields().get().values()
         if x['is_exposed'] and
         x['is_returned'] and
-        has_permissions(request.user, x['permissions_needed']) and
+        request.user.has_perms(x['permissions_needed']) and
         x['name'] != 'signature'  # exclude the signature field
     )
     context['fields'] = [
@@ -441,9 +440,7 @@ def signature_summary(request, params):
 
     # If the user has permissions, show exploitability.
     all_fields = SuperSearchFields().get()
-    if has_permissions(
-        request.user, all_fields['exploitability']['permissions_needed']
-    ):
+    if request.user.has_perms(all_fields['exploitability']['permissions_needed']):
         params['_histogram.date'] = ['exploitability']
 
     api = SuperSearchUnredacted()

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -17,7 +17,6 @@ from django.views.decorators.http import require_POST
 
 from ratelimit.decorators import ratelimit
 
-from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.utils import render_exception, urlencode_obj
 from crashstats.crashstats.views import pass_default_context
@@ -60,7 +59,7 @@ def get_allowed_fields(user):
     return tuple(
         x['name']
         for x in SuperSearchFields().get().values()
-        if x['is_exposed'] and has_permissions(user, x['permissions_needed'])
+        if x['is_exposed'] and user.has_perms(x['permissions_needed'])
     )
 
 


### PR DESCRIPTION
When an API endpoint has a parameter that takes a list of strings, a null character (``\x00``) in the strings will cause an Internal Server Error:

```
/api/Bugs/?signatures=null%00
```

After this change, it will become a validation error, returning a 400:
```
{
  "errors": {
    "signatures": [
      "Null characters are not allowed."
    ]
  }
}
```

While I was reading the API code and determining how to test this change, I found several untested code paths, and code that can be better written in Python 3. I believe the first three commits fix this particular bug, and the remaining 5 commits improve the existing code. If this is too much for one PR, I can split it, or abandon the refactor.