### PR TITLE
bug 1563222: Optionally create OIDC account

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,8 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile.oidcprovider
     image: local/socorro_oidcprovider
+    env_file:
+      - my.env
     ports:
       - "8080:8080"
 

--- a/docker/Dockerfile.oidcprovider
+++ b/docker/Dockerfile.oidcprovider
@@ -6,3 +6,4 @@
 FROM mozillaparsys/oidc_testprovider
 
 COPY ./docker/config/oidcprovider-fixtures.json /code/fixtures.json
+COPY ./docker/run_oidcprovider.sh /code/bin/run.sh

--- a/docker/config/my.env.dist
+++ b/docker/config/my.env.dist
@@ -19,6 +19,15 @@
 producer_consumer.number_of_threads=2
 
 # ---------------------------------------------
+# webapp settings
+# ---------------------------------------------
+
+# Auto-created user when starting the development-only OpenID Connect (OIDC) provider
+# OIDC_EMAIL=admin@example.com
+# OIDC_USERNAME=admin
+# OIDC_PASSWORD=password
+
+# ---------------------------------------------
 # crash-stats.mozilla.org settings
 # ---------------------------------------------
 

--- a/docker/run_oidcprovider.sh
+++ b/docker/run_oidcprovider.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Replaces the original run script at:
+# https://github.com/mozilla-parsys/docker-test-mozilla-django-oidc/blob/master/testprovider/bin/run.sh
+# Changes:
+# - Print commnds as the execute
+# - Optionally creates a user, if specified in the environment.
+
+set -x
+
+python manage.py migrate --noinput
+python manage.py loaddata fixtures.json
+
+if [ -n "$OIDC_USERNAME" ] && [ -n "$OIDC_PASSWORD" ] && [ -n "$OIDC_EMAIL" ]
+then
+    # Command must start on the first line, required by ./manage.py shell
+    ./manage.py shell -c "\
+from django.contrib.auth.models import User; \
+user, _ = User.objects.get_or_create(email=\"${OIDC_EMAIL}\", defaults={\"username\": \"${OIDC_USERNAME}\"}); \
+user.set_password(\"${OIDC_PASSWORD}\"); \
+user.save()"
+fi
+
+python manage.py runserver 0.0.0.0:8080

--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -57,6 +57,14 @@ fake account:
 The OIDC user is stored in the ``oidcprovider`` docker container, and will need
 to be recreated on restart.
 
+To automatically create an OIDC account when running ``oidcprovider``, add the
+details in ``my.env``::
+
+    OIDC_EMAIL=admin@example.com
+    OIDC_USERNAME=admin
+    OIDC_PASSWORD=password
+
+You can then skip the "Sign up" workflow and use the "Log in" workflow.
 
 Permissions
 ===========


### PR DESCRIPTION
Update the ``oidcprovider`` run script to create an account if the variables ``OIDC_EMAIL``, ``OIDC_USERNAME``, and ``OIDC_PASSWORD`` are defined in ``my.env``. This allows a developer to skip the "Sign Up" process when logging in locally.

I tried to write this as a script that could be run from the command line. This works well for the ``webapp`` because its database persists between restarts, but the ``oidcprovider`` container throws away the database when it is is shut down. To implement the command, I needed to 1) start the container, 2) wait for migrations to complete, and 3) use ``docker-compose exec`` to run in the running container. Integrating the user creation in the run script was easier and less error prone.

One alternate method would be to add a test user to ``oidcprovider``'s ``fixtures.json``, which would create the user at startup as well. This would mean a developer could use the documented test user to get started, but that test user wouldn't have the developer's email. "Sign up" could still be used to create a user with their email.

To test this PR out, add some variables to ``my.env``:

```
OIDC_EMAIL=admin@example.com
OIDC_USERNAME=admin
OIDC_PASSWORD=password
```

Then rebuild and restart:
```
docker-compose stop
docker-compose build --pull oidcprovider
make runservices run
```

In another terminal window, you can see the account created with ``docker-compose logs -f oidcprovider``:

```
...
oidcprovider_1    | + python manage.py loaddata fixtures.json
oidcprovider_1    | Installed 9 object(s) from 1 fixture(s)
oidcprovider_1    | + '[' -n admin ']'
oidcprovider_1    | + '[' -n password ']'
oidcprovider_1    | + '[' -n admin@example.com ']'
oidcprovider_1    | + ./manage.py shell -c 'from django.contrib.auth.models import User; user, _ = User.objects.get_or_create(email="admin@example.com", defaults={"username": "admin"}); user.set_password("password"); user.save()'
oidcprovider_1    | + python manage.py runserver 0.0.0.0:8080
oidcprovider_1    | Watching for file changes with StatReloader
```

