### PR TITLE
bug 1552709: Escape surrogates on report index

### DIFF
--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -9,7 +9,9 @@ from django import http
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.core.cache import cache
+from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from django.template import loader
 from django.urls import reverse
 from django.utils.http import urlquote
 
@@ -238,7 +240,9 @@ def report_index(request, crash_id, default_context=None):
             ':'.join(x) for x in context['report']['addons']
         ]
 
-    return render(request, 'crashstats/report_index.html', context)
+    content = loader.render_to_string('crashstats/report_index.html', context, request)
+    utf8_content = content.encode('utf-8', errors='backslashreplace')
+    return HttpResponse(utf8_content, charset='utf-8')
 
 
 @pass_default_context


### PR DESCRIPTION
A processed dump may contain a surrogate character in the range U+DC80 to U+DCFF, used to represent non-decodable bytes on POSIX systems (see [PEP 0383](https://www.python.org/dev/peps/pep-0383/)). By default, these can not be encoded in UTF-8, and an error handler is needed. This escapes the characters, so (for example) U+DF03 becomes the string "\udf03" in the UTF-8 encoding.

There are a number of possible [error handlers](https://docs.python.org/3/library/codecs.html#error-handlers), and I picked ``backslashreplace``, which makes the surrogate easy to see for humans. I tried ``surrogatepass`` first, but it is meant for use with ``surrogateescape`` for round-trip encoding of unicode with surrogates. Browsers seem to be happy to ignore the surrogates, but tests and ``smart_text`` were more demanding.

I was able to duplicate [bug 1552709](https://bugzilla.mozilla.org/show_bug.cgi?id=1552709) locally with crash ``244c4ff6-6879-45f1-aaa8-74ad20190519``. Attempting to view the processed report results in a series of server errors, which are even slower in developments as Django repeatedly fails to generate a debug page. With this PR, the report renders, and you can see the encoded "\udf03" on the Modules and Raw Dump tabs.