### PR TITLE
bug 1567528: Filter MozCrashReason with eval msg

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -252,6 +252,7 @@ class MozCrashReasonRule(Rule):
     DISALLOWED_PREFIXES = (
         'Failed to load module',
         'byte index',
+        'do not use eval with system privileges'
     )
 
     def sanitize_reason(self, reason):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -658,6 +658,7 @@ class TestMozCrashReasonRule(object):
         bad_reasons = [
             'byte index 21548 is not a char boundary',
             'Failed to load module "jar:file..."'
+            'do not use eval with system privileges: jar:file...',
         ]
         for reason in bad_reasons:
             raw_crash = {


### PR DESCRIPTION
Filter a ``MozCrashReason`` prefix that may contain sensitive data in the full message.