### PR TITLE
bug 1563230: wrap cronrun in a timeout

### DIFF
--- a/docker/run_crontabber.sh
+++ b/docker/run_crontabber.sh
@@ -8,12 +8,16 @@
 
 set -e
 
+# Number of seconds to let cronrun run before determining it's hung.
+KILL_TIMEOUT=3600
+
 # Run cronrun sleeping 5 minutes between runs
 while true
 do
-    # NOTE(willkg): We don't want cronrun to exit weird and then have that
-    # kill the container, but this is a lousy thing to do.
-    ./webapp-django/manage.py cronrun || true
+    # NOTE(willkg): cronrun can probably hang, so we wrap it in a timeout.
+    # Also, we don't want cronrun to die and then have that kill the container,
+    # so we do the || true thing.
+    timeout --signal KILL "${KILL_TIMEOUT}" ./webapp-django/manage.py cronrun || true
     echo "Sleep 5 minutes..."
     sleep 300
 done

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -81,7 +81,7 @@ class ProcessorPipeline(RequiredConfig):
         "command_line",
         doc="template for the command to invoke the external program; uses Python format syntax",
         default=(
-            "timeout -s KILL {kill_timeout} {command_pathname} "
+            "timeout --signal KILL {kill_timeout} {command_pathname} "
             "--raw-json {raw_crash_pathname} "
             "{symbols_urls} "
             "--symbols-cache {symbol_cache_path} "
@@ -91,7 +91,7 @@ class ProcessorPipeline(RequiredConfig):
     )
     required_config.breakpad.add_option(
         "kill_timeout",
-        doc="amount of time to let mdsw run before declaring it hung",
+        doc="amount of time in seconds to let mdsw run before declaring it hung",
         default=600,
     )
     required_config.breakpad.add_option(


### PR DESCRIPTION
This prevents cronrun from hanging for more than an hour.