### PR TITLE
bug 1563222: add createuser script to oidcprovider container

### DIFF
--- a/docker/Dockerfile.oidcprovider
+++ b/docker/Dockerfile.oidcprovider
@@ -6,3 +6,7 @@
 FROM mozillaparsys/oidc_testprovider
 
 COPY ./docker/config/oidcprovider-fixtures.json /code/fixtures.json
+RUN mkdir --parents /code/oidcprovider/management/commands/
+RUN touch /code/oidcprovider/management/__init__.py
+RUN touch /code/oidcprovider/management/commands/__init__.py
+COPY ./docker/oidcprovider/createuser.py /code/oidcprovider/management/commands/createuser.py

--- a/docker/oidcprovider/createuser.py
+++ b/docker/oidcprovider/createuser.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Create a user.
+"""
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Create a user."
+
+    def add_arguments(self, parser):
+        parser.add_argument("username", help="account username")
+        parser.add_argument("password", help="account password")
+        parser.add_argument("email", help="account email address")
+
+    def handle(self, **options):
+        username = options["username"]
+        password = options["password"]
+        email = options["email"]
+
+        if User.objects.filter(username=username).exists():
+            self.stdout.write("User {} already exists.".format(username))
+            return
+
+        user = User.objects.create(username=username, email=email)
+        user.set_password(password)
+        user.save()
+        self.stdout.write("User {} created.".format(username))

--- a/docs/service/webapp.rst
+++ b/docs/service/webapp.rst
@@ -31,31 +31,35 @@ Creating a superuser
 --------------------
 
 If you want to do anything in the webapp admin, you'll need to create a
-superuser.
+superuser in the Crash Stats webapp and a OIDC account to authenticate
+against in the oidcprovider service container.
 
-Run this::
+Let's use these credentials:
 
-  $ docker-compose run app shell ./webapp-django/manage.py makesuperuser email@example.com
+* username: willkg
+* password: foo
+* email: willkg@example.com
 
+This creates an account in the oidcprovider service container::
 
-You can do this as many times as you like.
+  $ docker-compose up -d oidcprovider
+  $ docker-compose exec oidcprovider /code/manage.py createuser willkg foo willkg@example.com
 
+This creates a superuser account in the Crash Stats webapp corresponding to the account
+we created in the oidcprovider service container::
 
-Setting up the webapp for OpenID Connect Login
-----------------------------------------------
+  $ docker-compose run app shell ./webapp-django/manage.py makesuperuser willkg@example.com
 
-A test OpenID Connect (OIDC) provider is served from the container
-``oidcprovider``, and is available at http://oidcprovider.127.0.0.1.nip.io:8080.
+Feel free to use different credentials.
 
-When logging in with ``oidcprovider``, use the "Sign up" workflow to create a
-fake account:
+.. Note::
 
-* Username: A non-email username
-* Email: Matches your Socorro account email
-* Password: Any password
+   You will have to recreate both of these accounts any time you do something
+   that recreates the postgres db or restarts the oidcprovider service
+   container.
 
-The OIDC user is stored in the ``oidcprovider`` docker container, and will need
-to be recreated on restart.
+   Best to put account creationg in a shell script so you can recreate both
+   accounts easily.
 
 
 Permissions


### PR DESCRIPTION
This lets you do the following:

```
docker-compose up -d oidcprovider
docker-compose exec oidcprovider /code/manage.py createuser USER PASSWORD EMAIL
```

Then you'll have a user account in the running oidcprovider container. Couple this with `makesuperuser` and that's all you need to script account creation for local dev environment purposes.

This fixes my needs without a lot of mumbo-jumbo. The account that gets created exists only in the running container--it's not persisted to the host or across other oidcprovider containers.

To test:

1. `docker-compose stop oidcprovider`
2. `docker-compose build --no-cache oidcprovider`
3. `docker-compose up -d oidcprovider`
4. `docker-compose exec oidcprovider /code/manage.py USER PASSWORD EMAIL`

This also handles the case where the account already exists--it lets you know and doesn't error out.