### PR TITLE
bug 1563222: Drop confirmation of OIDC provider

### DIFF
--- a/docker/config/oidcprovider-fixtures.json
+++ b/docker/config/oidcprovider-fixtures.json
@@ -51,7 +51,7 @@
         "model": "oidc_provider.client",
         "pk": 1,
         "fields": {
-            "name": "testrpHS256",
+            "name": "Socorro Dev (HS256 algorithm)",
             "owner": null,
             "client_type": "confidential",
             "client_id": "1",
@@ -63,7 +63,7 @@
             "contact_email": "",
             "logo": "",
             "reuse_consent": true,
-            "require_consent": true,
+            "require_consent": false,
             "_redirect_uris": "http://localhost:8000/oidc/callback/",
             "_post_logout_redirect_uris": "",
             "response_types": [
@@ -75,7 +75,7 @@
         "model": "oidc_provider.client",
         "pk": 2,
         "fields": {
-            "name": "testrpRS256",
+            "name": "Socorro Dev (RS256 algorithm)",
             "owner": null,
             "client_type": "confidential",
             "client_id": "2",
@@ -87,7 +87,7 @@
             "contact_email": "",
             "logo": "",
             "reuse_consent": true,
-            "require_consent": true,
+            "require_consent": false,
             "_redirect_uris": "http://localhost:8000/oidc/callback/",
             "_post_logout_redirect_uris": "",
             "response_types": [


### PR DESCRIPTION
Use better names for the OIDC test clients, and skip confirmation entirely, to further streamline local development.

I piggybacked on [bug 1563222](https://bugzilla.mozilla.org/show_bug.cgi?id=1563222), because I noticed the weird test client name on the confirmation screen while reviewing PR #4991. If you'd like to track under a new bug, I can file it.