### PR TITLE
Update release.py

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -13,7 +13,7 @@ both.
 This requires Python 3 to run.
 
 repo: https://github.com/willkg/socorro-release/
-sha: 90da286263152ca86622b9fd848ee884fe653cf2
+sha: 6a6ca14d8fc142e3e86d9ac72283ce209edcd1b1
 
 """
 


### PR DESCRIPTION
This updates `release.py` to the latest. It looks a little goofy. We used black to reformat the python code, so we made the changes in this repo and then copied it back to the socorro-release repo. This mostly picks up the SHA change from the socorro-release repo.