### PR TITLE
bug 1559223, 1542964: add modules_in_stack to processed crash

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2730,6 +2730,20 @@ FIELDS = {
         "query_type": "string",
         "storage_mapping": {"type": "string"},
     },
+    "modules_in_stack": {
+        "data_validation_type": "str",
+        "description": "Set of module/debugid strings that show up in stack of the crashing thread.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "modules_in_stack",
+        "is_exposed": True,
+        "is_returned": True,
+        "name": "modules_in_stack",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "string",
+        "storage_mapping": {"analyzer": "semicolon_keywords", "type": "string"},
+    },
     "moz_crash_reason": {
         "data_validation_type": "str",
         "description": (

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -39,6 +39,7 @@ from socorro.processor.rules.mozilla import (
     ExploitablityRule,
     FlashVersionRule,
     JavaProcessRule,
+    ModulesInStackRule,
     MozCrashReasonRule,
     OSPrettyVersionRule,
     OutOfMemoryBinaryRule,
@@ -218,6 +219,7 @@ class ProcessorPipeline(RequiredConfig):
             FlashVersionRule(),
             OSPrettyVersionRule(),
             TopMostFilesRule(),
+            ModulesInStackRule(),
             ThemePrettyNameRule(),
             MemoryReportExtraction(),
             # generate signature now that we've done all the processing it depends on


### PR DESCRIPTION
This adds a new "modules_in_stack" field which is a semicolon-delimited
set of "module/debugid" strings for modules that are in the stack of the
crashing thread.

The value is indexed using the semicolon_analyzer, so each string ends
up as a single term. This allows us to use supersearch "startswith" for
finding crash reports with a specified module in the stack (e.g.
"libfenix.so") and "has term" for finding crash reports with a specified
"module/debugid" in the crashing thread of the stack. The latter helps
us reprocess crash reports for which we just uploaded symbols.