### PR TITLE
Remove vestiges of Python 3 migration

### DIFF
--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -101,7 +101,6 @@ docker run \
        --env-file ./docker/config/local_dev.env \
        --env-file ./docker/config/never_on_a_server.env \
        --env-file ./docker/config/test.env \
-       -e USEPYTHON="${USEPYTHON}" \
        --tty \
        --interactive \
        --entrypoint= \


### PR DESCRIPTION
When we were doing the Python3 migration, we added a USEPYTHON
environment variable to determine which Python binary to use. We don't
need that anymore--all the related machinery is gone.