### PR TITLE
bug 1581800: add __memcpy_sse2_unaligned_erms to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -91,6 +91,7 @@ _MD_
 memcmp
 __memcmp16
 memcpy
+__memcpy_sse2_unaligned_erms
 memmove
 _platform_memmove\$VARIANT\$
 __platform_memmove\$VARIANT\$


### PR DESCRIPTION
Example:

```
app@socorro:/app$ socorro-cmd signature 5067a98a-741e-4fed-bdda-f18010190915
Crash id: 5067a98a-741e-4fed-bdda-f18010190915
Original: __memcpy_sse2_unaligned_erms
New:      __memcpy_sse2_unaligned_erms | mozilla::AudioBufferWriter::Write
Same?:    False
```