### PR TITLE
bug 1581800: add __memcpy.* to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -91,7 +91,7 @@ _MD_
 memcmp
 __memcmp16
 memcpy
-__memcpy_sse2_unaligned_erms
+__memcpy.*
 memmove
 _platform_memmove\$VARIANT\$
 __platform_memmove\$VARIANT\$


### PR DESCRIPTION
This replaces the previous change with a more general one that catches more `__memcpy` things.

Example:

```
app@socorro:/app$ socorro-cmd signature 5067a98a-741e-4fed-bdda-f18010190915 c1d99ea6-4e00-42d2-b2dc-e892b0190917 0e8d5ad2-3382-4e6d-be37-bf7cf0190917
Crash id: 5067a98a-741e-4fed-bdda-f18010190915
Original: __memcpy_sse2_unaligned_erms
New:      __memcpy_sse2_unaligned_erms | mozilla::AudioBufferWriter::Write
Same?:    False

Crash id: c1d99ea6-4e00-42d2-b2dc-e892b0190917
Original: __memcpy_sse2_unaligned
New:      __memcpy_sse2_unaligned | libxul.so@0x2c61875 | org.chromium.5DpjkS (deleted)@0xc92f
Same?:    False

Crash id: 0e8d5ad2-3382-4e6d-be37-bf7cf0190917
Original: __memcpy_ssse3
New:      __memcpy_ssse3 | soundtouch::FIFOProcessor::receiveSamples
Same?:    False
```