### PR TITLE
bug 1584951: add memset implementation variations to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -17,6 +17,8 @@ alloc::raw_vec::capacity_overflow
 _alloca_probe
 __android_log_assert
 arena_
+avx::memset16
+avx::memset32
 BaseAllocator
 BaseGetNamedObjectDirectory
 __clear_cache
@@ -134,6 +136,7 @@ MOZ_CrashOOL
 MOZ_CrashPrintf
 msvcr120\.dll@0x
 \<name omitted\>
+neon::memset32
 NP_Shutdown
 (NS_)?(Lossy)?(Copy|Append|Convert).*UTF
 nsACString_internal::Assign
@@ -180,6 +183,7 @@ PLDHashTable::
 PL_
 port_
 PORT_
+portable::memset32
 _PR_
 PR_
 .*ProcessNextEvent
@@ -207,6 +211,9 @@ send
 setjmp
 sigblock
 sigprocmask
+sk_memset32
+sk_memset32_dither
+SK_OPTS_NS::memset32
 SocketAccept
 SocketAcceptRead
 SocketAvailable
@@ -226,6 +233,8 @@ SocketSync
 SocketTransmitFile
 SocketWrite
 SocketWritev
+sse2::memset32
+sse2::memsetT<T>
 ssl_
 SSL_
 std::alloc::rust_oom


### PR DESCRIPTION
This adds a bunch of architecture-specific memset implementations to the
prefix list so that signature generation continues beyond those frames.

```
app@socorro:/app$ socorro-cmd signature 654bc83b-da3b-47f9-afbe-9a5c50190926 c81483f6-ddbe-48de-ab5f-5dbdd0190930 0eadb932-9899-4684-b2fd-b91380190929 d61cf817-4adc-4f05-95bb-ceaf10190927 8b3d254e-b6d4-49ab-853d-06c6d0190901  d1e87e20-62bc-4661-9386-905920190506
Crash id: 654bc83b-da3b-47f9-afbe-9a5c50190926
Original: avx::memset32
New:      avx::memset32 | SkDraw::drawPaint
Same?:    False

Crash id: c81483f6-ddbe-48de-ab5f-5dbdd0190930
Original: sse2::memset32
New:      sse2::memset32 | SkDraw::drawPaint
Same?:    False

Crash id: 0eadb932-9899-4684-b2fd-b91380190929
Original: neon::memset32
New:      neon::memset32 | SkRasterPipelineBlitter::Create::$_4::__invoke
Same?:    False

Crash id: d61cf817-4adc-4f05-95bb-ceaf10190927
Original: sse2::memsetT<T>
New:      sse2::memsetT<T> | sse2::memset32 | D32_Src_BitmapXferProc
Same?:    False

Crash id: 8b3d254e-b6d4-49ab-853d-06c6d0190901
Original: portable::memset32
New:      portable::memset32 | org.chromium.tRIExf (deleted)@0xedf8f
Same?:    False

Crash id: d1e87e20-62bc-4661-9386-905920190506
Original: avx::memset16
New:      avx::memset16 | SkRasterPipelineBlitter::blitRect
Same?:    False
```