### PR TITLE
Remove IRC references

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,8 +69,8 @@ need to do the following first:
 We can't assign bugs to you until you've done at least those two
 steps.
 
-If you need help, let us know by `asking on IRC or sending an email to the
-mailing list <https://socorro.readthedocs.io/en/latest/#project-info>`_.
+If you need help, let us know by `sending an email to the mailing list
+<https://socorro.readthedocs.io/en/latest/#project-info>`_.
 
 
 Conventions

--- a/README.rst
+++ b/README.rst
@@ -54,5 +54,4 @@ https://lists.mozilla.org/listinfo/tools-socorro
 
 Please help each other.
 
-Devs hang out in the Socorro/Breakpad IRC channel:
-`<irc://irc.mozilla.org/breakpad>`_
+Crash Stats engineers hang out in the ``#breakpad`` channel on Mozilla Slack.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,6 @@ Mozilla's crash analysis tool is hosted at
 :Documentation: https://socorro.readthedocs.io/
 :Documentation: https://crash-stats.mozilla.org/documentation/
 :Mailing list: https://lists.mozilla.org/listinfo/tools-socorro
-:IRC: `<irc://irc.mozilla.org/breakpad>`_
 :New bugs: https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro
 :View all bugs: https://bugzilla.mozilla.org/buglist.cgi?quicksearch=product%3Asocorro
 

--- a/product_details/README.rst
+++ b/product_details/README.rst
@@ -55,4 +55,4 @@ expire, but after that you should be able to see the changes in production.
 Questions
 =========
 
-If you have any questions, please ask in ``#breakpad`` on ``irc.mozilla.org``.
+If you have any questions, please ask in ``#breakpad`` on Mozilla Slack.


### PR DESCRIPTION
irc.mozilla.org is going away soon. This removes references to it.