### PR TITLE
bug 1590096: add more libc functions to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -16,6 +16,8 @@ alloc::oom::oom
 alloc::raw_vec::capacity_overflow
 _alloca_probe
 __android_log_assert
+__assert_fail
+__assert_fail_base
 arena_
 BaseAllocator
 BaseGetNamedObjectDirectory
@@ -46,10 +48,12 @@ EtwEventEnabled
 extent_
 fastcopy_I
 fastzero_I
+__fdelt_chk
 __fdelt_warn
 _files_getaddrinfo
 .*free
 __fortify_fail
+__fortify_fail_abort
 free_impl
 __fsetlocking
 CCGraphBuilder::NoteXPCOMChild
@@ -87,6 +91,7 @@ JS_NewStringCopyZ
 KiUserExceptionDispatcher
 kill
 __libc_android_abort
+__libc_message
 libobjc.A.dylib@0x1568.
 (libxul\.so|xul\.dll|XUL)@0x
 LL_
@@ -246,6 +251,7 @@ ssl3_
 strchr
 strcmp
 strcpy
+__strcpy_chk
 .*strdup
 StringBeginsWith
 StringEndsWith


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 42625bd8-af4b-40da-a23b-26c500191021 e4d195e0-86be-4a40-8ea2-ad6860190907 1012cd66-1ea1-4013-adbe-e46f70191021
Crash id: 42625bd8-af4b-40da-a23b-26c500191021
Original: raise | abort | __assert_fail_base
New:      raise | abort | __assert_fail_base | __assert_fail | std::_Rb_tree<T>::_M_insert_unique<T>
Same?:    False

Crash id: e4d195e0-86be-4a40-8ea2-ad6860190907
Original: raise | abort | mozilla::detail::MutexImpl::lock | __fortify_fail_abort | __chk_fail
New:      raise | abort | mozilla::detail::MutexImpl::lock | __fortify_fail_abort | __chk_fail | g_spawn_sync
Same?:    False

Crash id: 1012cd66-1ea1-4013-adbe-e46f70191021
Original: raise | abort | __libc_message
New:      raise | abort | __libc_message | __fortify_fail_abort | __stack_chk_fail | malloc_init | BaseAllocator::malloc | <name omitted> | <name omitted> | XPCWrappedNative::GetNewOrUsed
Same?:    False
```