### PR TITLE
bug 1592208: add more c functions to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -9,6 +9,9 @@
 .*CrashAtUnhandlableOOM
 Abort
 .*abort
+__aeabi_memcpy4
+__aeabi_memcpy
+__aeabi_memmove
 .*alloc_impl
 Allocator<T>::malloc
 alloc::oom::default_oom_handler
@@ -44,6 +47,7 @@ __delayLoadHelper2
 dlmalloc
 dlmalloc_trim
 dvm
+__entry_from_strcat_in_strcpy
 EtwEventEnabled
 extent_
 fastcopy_I
@@ -57,8 +61,12 @@ __fortify_fail_abort
 free_impl
 __fsetlocking
 CCGraphBuilder::NoteXPCOMChild
-gfxPlatform::Init
 getanswer
+GetTickCount64
+gfxPlatform::Init
+__GI___strlen_sse2
+__GI_memcpy
+__GI_strlen
 gkrust_shared::oom_hook::hook
 gsignal
 HandleInvalidParameter
@@ -87,6 +95,7 @@ JSAutoCompartment::JSAutoCompartment
 JS_DHashTableEnumerate
 JS_DHashTableOperate
 JS_NewStringCopyZ
+js_strlen
 KiUserExceptionDispatcher
 kill
 __libc_android_abort
@@ -94,14 +103,27 @@ __libc_message
 libobjc.A.dylib@0x1568.
 (libxul\.so|xul\.dll|XUL)@0x
 LL_
+lstrcatA
+lstrlenA
 malloc
 mbrtoc32
 _MD_
 memcmp
+__memcmp_avx2_movbe
+__memcmp_ia32
+__memcmp_sse2
+__memcmp_sse4_1
+__memcmp_ssse3
 __memcmp16
+_platform_memcmp
+__platform_memcmp
 memcpy
 __memcpy.*
 memmove
+__memmove_avx_unaligned_erms
+__memmove_avx_unaligned
+__memmove_ssse3_back
+__memmove_ssse3
 _platform_memmove\$VARIANT\$
 __platform_memmove\$VARIANT\$
 memset
@@ -119,7 +141,6 @@ mozilla::MozPromise<T>::ThenInternal
 SleepConditionVariableCS
 SleepConditionVariableSRW
 mozilla::TimeStamp::Now
-GetTickCount64
 mozilla::detail::MutexImpl::
 mozilla::detail::nsStringRepr::First
 mozilla::detail::nsStringRepr::Last
@@ -153,8 +174,10 @@ nsAString_internal::Assign
 nsACString_internal::BeginWriting
 nsAString_internal::BeginWriting
 nsACString_internal::SetCapacity
+nsCRT::strcmp
 nsTArrayInfallibleAllocator
 NS_strcmp
+NS_strlen
 nsBaseHashtable<.*>::
 nsClassHashtable<.*>::
 nsCOMPtr
@@ -186,6 +209,7 @@ objc_exception_throw
 objc_msgSend
 objc_release
 operator new
+o_strcat_s
 <.*>::operator()
 pages_commit
 PLDHashTable::
@@ -258,6 +282,9 @@ __strcpy_chk
 StringBeginsWith
 StringEndsWith
 strlen
+__strlen_avx2
+__strlen_sse2_bsf
+_platform_strlen
 strncpy
 strzcmp16
 strstr
@@ -274,6 +301,7 @@ _VEC_memzero
 .*WaitFor
 wcslen
 wcsrtombs
+wcscpy_s
 # NOTE(willkg): continue past wayland symbols
 wl_(array|proxy)_.*
 __wrap_realloc
@@ -302,9 +330,11 @@ sse2::memsetT<T>
 # platform-specific strcmp implementations
 __strcmp_avx2
 __strcmp_sse2_unaligned
+__strcmp_sse4_2
 __strcmp_ssse3
 __GI_strcmp
 __GI___strcmp_ssse3
+g_strcmp0
 _platform_strcmp
 lstrcmpA
 lstrcmpW


### PR DESCRIPTION
```
socorro-cmd signature 43d8524c-7ab9-4f65-b220-caf710190501 465e3022-1e37-4dd8-80bc-da15c0190614 16bafed3-c66e-4b98-ba6e-9dfcc0190913 3faed5f6-1f83-45e9-8f6c-cac080190611
f44243f3-3d83-46f2-b760-248470190524 0b9dbbf4-8926-40fa-be1c-d71ef0190501 c739d507-2dbe-4ff2-ab8e-fa14c0190502 ebdead20-fc46-4b86-8d31-4a68e0190810 49d8181e-8b4a-4355-bda4-40d9d0191026 81699798-498d-44ee-93d1-7d9430190731 3cb984b0-e93d-4181-a289-5b4540190607 b2db67a2-4081-4d85-b839-0893e0191018 c7551462-4fe6-4dfb-b016-418b60190531 c7551462-4fe6-4dfb-b016-418b60190531 9049638d-4066-4e91-923f-dc3060190625 9049638d-4066-4e91-923f-dc3060190625 feee4cef-45b0-4c44-a798-ea1040191025
1a8a4124-23a5-4b0a-8203-29b740191029 1c305869-da99-4298-8ff9-01cc70190702 31ac5a8a-763b-4342-b234-9cf280190916 b490cfa5-d08f-446b-bfc4-321ca0190503 c3f57220-4062-4bc5-bbf4-805970190501 5a8bf4af-cf5c-41ad-bd1a-ac7880191028 6e79ae80-bd61-4435-a0eb-36d5c0190518 64b022c6-814d-4f2c-80ff-d99220190918 37f54e86-1f7a-41c8-96d1-74eb20190905 d29be862-ce45-4b16-a759-2dcc90190503 4c411759-9a3d-4c9a-95cc-0fa610190430 ed2633c8-644c-4c27-b3ca-2f40a0191029
Crash id: 43d8524c-7ab9-4f65-b220-caf710190501
Original: NS_strlen
New:      NS_strlen | nsClipboard::GetNativeDataOffClipboard
Same?:    False

Crash id: 465e3022-1e37-4dd8-80bc-da15c0190614
Original: __GI___strlen_sse2
New:      __GI___strlen_sse2 | libxul.so@0x3e123e1 | libxul.so@0x1fd8ee0 | libxul.so@0x680103f | libxul.so@0x680101f | libxul.so@0x1fddb92 | libxul.so@0x1847c13 | libxul.so@0x1847b0f | libxul.so@0x1fe1a89 | libxul.so@0x67fd0df | libxul.so@0x1fe6424 | libxul.so@0...
Same?:    False
Notes:    (1)
          SigTruncate: SigTrunc: signature truncated due to length

Crash id: 16bafed3-c66e-4b98-ba6e-9dfcc0190913
Original: __GI_memcpy
New:      __GI_memcpy | org.chromium.bWqHCM (deleted)@0x17dbcf
Same?:    False

Crash id: 3faed5f6-1f83-45e9-8f6c-cac080190611
Original: __GI_strlen
New:      __GI_strlen | libxul.so@0xa3a110 | libxul.so@0xa3ad18 | libstdc++.so.6.0.21@0x136304
Same?:    False

Crash id: f44243f3-3d83-46f2-b760-248470190524
Original: __aeabi_memcpy4
New:      __aeabi_memcpy4 | <style::values::generics::basic_shape::BasicShape<H, V, LengthPercentage, NonNegativeLengthPercentage> as core::clone::Clone>::clone
Same?:    False

Crash id: 0b9dbbf4-8926-40fa-be1c-d71ef0190501
Original: __aeabi_memmove
New:      __aeabi_memmove | std::__ndk1::basic_string<T>::assign
Same?:    False

Crash id: c739d507-2dbe-4ff2-ab8e-fa14c0190502
Original: __entry_from_strcat_in_strcpy
New:      __entry_from_strcat_in_strcpy | mozilla::gl::GLLibraryLoader::LoadSymbols
Same?:    False

Crash id: ebdead20-fc46-4b86-8d31-4a68e0190810
Original: __memcmp_avx2_movbe
New:      __memcmp_avx2_movbe | libxul.so@0x10fcacf | libxul.so@0x10fecba | libxul.so@0xd5ecdb | libxul.so@0x5cdbd9f | libxul.so@0x3b4ef8a | libxul.so@0x3c45427 | libxul.so@0x3c4436e | libxul.so@0x3c44a26 | libxul.so@0x1094aa7 | libxul.so@0x108bf54 | libxul.so@0...
Same?:    False
Notes:    (1)
          SigTruncate: SigTrunc: signature truncated due to length

Crash id: 49d8181e-8b4a-4355-bda4-40d9d0191026
Original: libxul.so@0x2a547f3 | __memcmp_ia32
New:      libxul.so@0x2a547f3 | __memcmp_ia32 | libxul.so@0x34447d | libxul.so@0x4bde6af | libxul.so@0x4ba584b | libxul.so@0x344453 | libxul.so@0x729cea3 | libxul.so@0x28b5447 | libxul.so@0x7485fff | libxul.so@0x3c0970 | __pthread_mutex_lock
Same?:    False

Crash id: 81699798-498d-44ee-93d1-7d9430190731
Original: __memcmp_sse2
New:      __memcmp_sse2 | libxul.so@0x83f77e | libxul.so@0x9dbdb0 | libxul.so@0x9e56d8 | libxul.so@0x9b54d8 | libxul.so@0x8ec62c | libxul.so@0x9b58c6 | libxul.so@0x8e143e | libxul.so@0x8e3ae7 | libxul.so@0x9a6ba5 | libxul.so@0x8e143e | firefox@0x129cf
Same?:    False

Crash id: 3cb984b0-e93d-4181-a289-5b4540190607
Original: __memcmp_sse4_1
New:      __memcmp_sse4_1 | libmozsqlite3.so@0x47c0a
Same?:    False

Crash id: b2db67a2-4081-4d85-b839-0893e0191018
Original: __memcmp_ssse3
New:      __memcmp_ssse3 | libxul.so@0x106e422 | omni.ja@0x398da
Same?:    False

Crash id: c7551462-4fe6-4dfb-b016-418b60190531
Original: __memmove_avx_unaligned_erms
New:      __memmove_avx_unaligned_erms | libxul.so@0x23edb7b | libxul.so@0x23eda18 | libxul.so@0x23ee1ea | libxul.so@0x528b134 | libxul.so@0x23ed34f | libxul.so@0x23ed34f | libxul.so@0x52a01d9 | __pthread_mutex_unlock_usercnt
Same?:    False

Crash id: c7551462-4fe6-4dfb-b016-418b60190531
Original: __memmove_avx_unaligned_erms
New:      __memmove_avx_unaligned_erms | libxul.so@0x23edb7b | libxul.so@0x23eda18 | libxul.so@0x23ee1ea | libxul.so@0x528b134 | libxul.so@0x23ed34f | libxul.so@0x23ed34f | libxul.so@0x52a01d9 | __pthread_mutex_unlock_usercnt
Same?:    False

Crash id: 9049638d-4066-4e91-923f-dc3060190625
Original: __memmove_ssse3_back
New:      __memmove_ssse3_back | SkSpriteBlitter_Memcpy::blitRect
Same?:    False

Crash id: 9049638d-4066-4e91-923f-dc3060190625
Original: __memmove_ssse3_back
New:      __memmove_ssse3_back | SkSpriteBlitter_Memcpy::blitRect
Same?:    False

Crash id: feee4cef-45b0-4c44-a798-ea1040191025
Original: __platform_memcmp
New:      __platform_memcmp | nsTArray_Impl<T>::Compare<T> | NS_QuickSort
Same?:    False

Crash id: 1a8a4124-23a5-4b0a-8203-29b740191029
Original: __strcmp_sse4_2
New:      __strcmp_sse4_2 | libxul.so@0x15507ad
Same?:    False

Crash id: 1c305869-da99-4298-8ff9-01cc70190702
Original: __strlen_avx2
New:      __strlen_avx2 | libical.so.3.0.4@0x345e5
Same?:    False

Crash id: 31ac5a8a-763b-4342-b234-9cf280190916
Original: __strlen_sse2_bsf
New:      __strlen_sse2_bsf | libavutil.so.54.20.100@0x2aec2
Same?:    False

Crash id: b490cfa5-d08f-446b-bfc4-321ca0190503
Original: _platform_memcmp
New:      _platform_memcmp | nsZipArchive::GetItem
Same?:    False

Crash id: c3f57220-4062-4bc5-bbf4-805970190501
Original: _platform_strlen
New:      _platform_strlen | nsImapServerResponseParser::msg_fetch_literal
Same?:    False

Crash id: 5a8bf4af-cf5c-41ad-bd1a-ac7880191028
Original: g_strcmp0
New:      g_strcmp0 | libgtk-3.so.0.1000.8@0x18ba3a
Same?:    False

Crash id: 6e79ae80-bd61-4435-a0eb-36d5c0190518
Original: js_strlen
New:      js_strlen | nsClipboard::GetNativeDataOffClipboard
Same?:    False

Crash id: 64b022c6-814d-4f2c-80ff-d99220190918
Original: contfilt.dll | RtlConsoleMultiByteToUnicodeN | RtlConsoleMultiByteToUnicodeN | contfilt.dll | lstrcatA
New:      contfilt.dll | RtlConsoleMultiByteToUnicodeN | RtlConsoleMultiByteToUnicodeN | contfilt.dll | lstrcatA | lstrlenA
Same?:    False

Crash id: 37f54e86-1f7a-41c8-96d1-74eb20190905
Original: nsCRT::strcmp
New:      nsCRT::strcmp | js::JitFrameIter::JitFrameIter
Same?:    False

Crash id: d29be862-ce45-4b16-a759-2dcc90190503
Original: xul.dll | o_strcat_s
New:      xul.dll | o_strcat_s | RtlWakeAllConditionVariable | RtlpWakeByAddress | RtlLeaveCriticalSection | RtlEnterCriticalSection | xul.dll | thread_start<T>
Same?:    False

Crash id: 4c411759-9a3d-4c9a-95cc-0fa610190430
Original: xul.dll | mozglue.dll | xul.dll | mozglue.dll | xul.dll | wcscpy_s
New:      xul.dll | mozglue.dll | xul.dll | mozglue.dll | xul.dll | wcscpy_s | UserCallWinProcCheckWow
Same?:    False

Crash id: ed2633c8-644c-4c27-b3ca-2f40a0191029
Original: __aeabi_memcpy
New:      __aeabi_memcpy | mozilla::dom::ipc::WritableSharedMap::Serialize
Same?:    False
```