### PR TITLE
bug 1594468: move libc* lines from irrelevant list to prefix list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -37,8 +37,6 @@ google_breakpad::ReceivePort::WaitForMessage
 KiFastSystemCallRet
 libandroid_runtime\.so@0x
 libbinder\.so@0x
-libc\.so(\.\d+)?@0x
-libc-\d+\.\d+(\.\d+)?\.so@0x
 libEGL\.so@
 libdvm\.so\s*@\s*0x
 libgui\.so@0x

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -100,6 +100,8 @@ KiUserExceptionDispatcher
 kill
 __libc_android_abort
 __libc_message
+libc\.so(\.\d+)?@0x
+libc-\d+\.\d+(\.\d+)?\.so@0x
 libobjc.A.dylib@0x1568.
 (libxul\.so|xul\.dll|XUL)@0x
 LL_


### PR DESCRIPTION
We've done a lot of symbol uploading for libc binaries for Linux
distributions. Instead of skipping these frames, we want to include them
in the signature and move past them.

```
app@socorro:/app$ socorro-cmd signature b206311b-2b61-497c-a0b7-2978b0190522
Crash id: b206311b-2b61-497c-a0b7-2978b0190522
Original: mozilla::layers::MappedYCbCrTextureData::CopyInto
New:      libc-2.29.9000.so@0xa6735 | mozilla::layers::MappedYCbCrTextureData::CopyInto
Same?:    False
```