### PR TITLE
bug 1594508: don't file bugs as "critical"

### DIFF
--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -178,7 +178,6 @@ def bugzilla_submit_url(report, parsed_dump, crashing_thread, bug_product):
     )
 
     kwargs = {
-        "bug_severity": "critical",
         "bug_type": "defect",
         "keywords": "crash",
         "product": bug_product,

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -166,7 +166,6 @@ class TestBugzillaSubmitURL(object):
         assert qs["short_desc"] == ["Crash in [@ $&#;deadbeef]"]
         assert qs["keywords"] == ["crash"]
         assert qs["op_sys"] == ["Windows"]
-        assert qs["bug_severity"] == ["critical"]
         assert qs["bug_type"] == ["defect"]
 
     def test_truncate_short_desc(self):


### PR DESCRIPTION
This removes the severity=critical bit from filing bugs.