### PR TITLE
bug 1594665: add __pthread_mutex_lock to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -225,6 +225,7 @@ __psynch_cvwait
 _pthread_cond_wait
 pthread_mutex_lock
 __pthread_kill
+__pthread_mutex_lock
 _purecall
 raise
 realloc


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 2927b970-0948-40d2-8511-a16d50191107
Crash id: 2927b970-0948-40d2-8511-a16d50191107
Original: __pthread_mutex_lock
New:      __pthread_mutex_lock | free | core::ptr::real_drop_in_place | servo_arc::Arc<T>::drop_slow
Same?:    False
```