### PR TITLE
Add pip check to linters, update AWS requirements

### DIFF
--- a/docker/run_lint.sh
+++ b/docker/run_lint.sh
@@ -29,4 +29,8 @@ else
     echo ">>> eslint (js)"
     cd /app/webapp-django
     /webapp-frontend-deps/node_modules/.bin/eslint .
+
+    echo ">>> pip check"
+    cd /app
+    pip check --disable-pip-version-check
 fi

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -84,7 +84,7 @@ pyasn1-modules==0.2.4 \
     --hash=sha256:a52090e8c5841ebbf08ae455146792d9ef3e8445b21055d3a3b7ed9c712b7c7c \
     --hash=sha256:c00dad1d69d8592bbbc978f5beb3e992d3bf996e6b97eeec1c8608f81221d922 \
     --hash=sha256:c226b5c17683d98498e157d6ac0098b93f9c475da5bc50072f64bf3f3f6b828f
-# aws-cli 1.16.122 requires >=3.1.2,<=3.5.0
+# aws-cli 1.16.276 requires >=3.1.2,<=3.5.0
 rsa==3.4.2 \
     --hash=sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5 \
     --hash=sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd # pyup: <=3.5.0
@@ -128,9 +128,9 @@ attrs==19.1.0 \
 pluggy==0.12.0 \
     --hash=sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc \
     --hash=sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c
-botocore==1.12.220 \
-    --hash=sha256:748fe4ee5cc8b10ef09e52c740b488402d6f6d4d1f0dde0c936da232b42b1bdd \
-    --hash=sha256:9ffd9264e4ad999d2929cfe1c7e413d4cdf76a8bd92f011dce31874f056d2e18
+botocore==1.13.12 \
+    --hash=sha256:0095818b1f1e2698c3fe0ccc6bd4ed8c735fce37d9a99d7f304047bfd8272ec8 \
+    --hash=sha256:9303675e019b4a7389bfbec264068435d2111739b46baa7ebd08391e64dddfb4
 colorama==0.3.9 \
     --hash=sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda \
     --hash=sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1
@@ -140,9 +140,9 @@ s3transfer==0.2.0 \
 jmespath==0.9.4 \
     --hash=sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6 \
     --hash=sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c
-boto3==1.9.112 \
-    --hash=sha256:267840eafbf5d7bb83f3eec22a2bd5fe4ffccd6b6497ee583ba5cd4ff5c50bf8 \
-    --hash=sha256:4e71a7e782280cb038e25bd33ae5acdbbd728bff83b2e2f37f48fb6e4dc6921e
+boto3==1.10.12 \
+    --hash=sha256:4f231c746d2acba8b458897f7a0a2f4b9d75656eeeba9c78d17f60fa0cc2cb68 \
+    --hash=sha256:e3c67a3b0140b903cc2d64ee9e68a392961a205dc54290000baf928e6a65e25c
 jsondiff==1.1.2 \
     --hash=sha256:7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21
 aws-xray-sdk==2.4.2 \
@@ -320,11 +320,11 @@ cachetools==3.1.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
-cfn-lint==0.19.1 \
-    --hash=sha256:1bd2a71eca128f5cb1c6770d32668294cf6d91dc78dc80f4ecb4f041e2abd3d8 \
-    --hash=sha256:5a723ff791fc23aced78e9cde28f18f9eeae9a24f91db2b7a20f7aa837a613b3
-aws-sam-translator==1.11.0 \
-    --hash=sha256:db872c43bdfbbae9fc8c9201e6a7aeb9a661cda116a94708ab0577b46a38b962
+cfn-lint==0.24.8 \
+    --hash=sha256:1df76ac8c7bd6c9d9d1e70d5081e3ed30757e60ae4dbf9d1af957d6c04ada8b8 \
+    --hash=sha256:5aa1540ee9a7efc23ebe54a22f1a505766a4bb44f64a0f4fe79574a156a9b43e
+aws-sam-translator==1.15.1 \
+    --hash=sha256:11c62c00f37b57c39a55d7a29d93f4704a88549c29a6448ebc953147173fbe85
 jsonpatch==1.23 \
     --hash=sha256:49f29cab70e9068db3b1dc6b656cbe2ee4edf7dfe9bf5a0055f17a4b6804a4b9 \
     --hash=sha256:8bf92fa26bc42c346c03bd4517722a8e4f429225dbe775ac774b2c70d95dbd33
@@ -426,3 +426,5 @@ typed-ast==1.4.0 \
     --hash=sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a \
     --hash=sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66 \
     --hash=sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12
+pyrsistent==0.15.5 \
+    --hash=sha256:eb6545dbeb1aa69ab1fb4809bfbf5a8705e44d92ef8fc7c2361682a47c46c778

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -115,12 +115,9 @@ django-jinja==2.4.1 \
 humanfriendly==4.18 \
     --hash=sha256:23057b10ad6f782e7bc3a20e3cb6768ab919f619bbdc0dd75691121bbde5591d \
     --hash=sha256:33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85
-# cfn-lint and aws-sam-translator require ~=2.6, check in July 2019
-# https://github.com/aws-cloudformation/cfn-python-lint/issues/905
-# https://github.com/awslabs/serverless-application-model/issues/922
-jsonschema==2.6.0 \
-    --hash=sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08 \
-    --hash=sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02 # pyup: ~=2.6
+jsonschema==3.1.1 \
+    --hash=sha256:2fa0684276b6333ff3c0b1b27081f4b2305f0a36cf702a23db50edb141893c3f \
+    --hash=sha256:94c0a13b4a0616458b42529091624e66700a17f847453e52279e35509a5b7631
 requests-mock==1.7.0 \
     --hash=sha256:510df890afe08d36eca5bb16b4aa6308a6f85e3159ad3013bac8b9de7bd5a010 \
     --hash=sha256:88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646
@@ -161,9 +158,9 @@ django-npm==1.0.0 \
 markus==2.1.0 \
     --hash=sha256:3408818d4d78ca0f4085c6ea32b02f4b3d2a2520b169ddec3167b50f0b7c700d \
     --hash=sha256:bfa276c69b25006e37449eed447bc27105bf6f26c9ca27d01ddefbd1077b44ea
-awscli==1.16.271 \
-    --hash=sha256:968991b6b8a75ffbb02acb567efe8901134a45fe9e4b52c740bfb408829039f2 \
-    --hash=sha256:c7884535acecd2bdad8ee24387203e931f2dd016315d457e805ef807c999ca19
+awscli==1.16.276 \
+    --hash=sha256:6ae2d5bcce2e16906ad34bee99f3ba3d7a1633c8f0f53ef97e7575499b5a88eb \
+    --hash=sha256:6c63da10a322f1245f90df99b549074d97b08f0e6f69d8ce7f06330b4822b792
 moto==1.3.13 \
     --hash=sha256:95d48d8ebaad47fb5bb4233854cf1cf8523ec5307d50eb1e4017ce10f1960b66
 mozilla-django-oidc==1.2.2 \


### PR DESCRIPTION
`pip check` reports if there is a mismatch between requirements and the installed packages. This is sometimes missed by auto-update tools, or is too complicated to resolve.

This PR also updates the AWS packages to get consistent versions:

* [jsonschema](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst) 2.6.0 → 3.1.1: Support Draft 6 and 7, ECMA 262 dialect regular expressions
* awscli 1.16.271 → 1.16.276: Bump for botocore

This includes these constraint updates:
* botocore 1.12.239 → 1.13.12: Remove vendored requests, API updates
* boto3 1.9.112 → 1.10.12: Support botocore 1.13
* cfn-lint 0.19.1 → 0.24.8: Support botocore 1.13
* aws-sam-translator 1.11.0 → 1.15.1: Support botocore 1.13 and jsonschema 3.1
* pyrsistent 0.15.5 - New requirement of jsonschema
