### PR TITLE
Move "pip check" from lint step to build step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN cd /webapp-frontend-deps/ && npm install
 # Install Socorro Python requirements
 COPY ./requirements /app/requirements
 RUN pip install -U 'pip>=8' && \
-    pip install --no-cache-dir -r requirements/default.txt -c requirements/constraints.txt
+    pip install --no-cache-dir -r requirements/default.txt -c requirements/constraints.txt && \
+    pip check --disable-pip-version-check
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/docker/run_lint.sh
+++ b/docker/run_lint.sh
@@ -29,8 +29,4 @@ else
     echo ">>> eslint (js)"
     cd /app/webapp-django
     /webapp-frontend-deps/node_modules/.bin/eslint .
-
-    echo ">>> pip check"
-    cd /app
-    pip check --disable-pip-version-check
 fi


### PR DESCRIPTION
Moving "pip check" to the build step makes it fail faster if there are
issues.