### PR TITLE
bug 1597334: Adjust Dockerfile for size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,10 @@ FROM socorro_image_base as socorro_breakpad
 WORKDIR /mdsw/
 
 # Install some helpful debugging things
-RUN apt-get -y install gdb vim
+RUN apt-get update && apt-get install -y \
+    gdb \
+    vim \
+&& rm -rf /var/lib/apt/lists/*
 
 # Build breakpad client and stackwalker binaries
 COPY ./scripts/build-breakpad.sh /mdsw/scripts/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@ ARG userid=10001
 
 WORKDIR /app/
 RUN groupadd --gid $groupid app && \
-    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app
+    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \
+    chown app.app /app/
 
 # Install OS-level things
 COPY ./docker/set_up_ubuntu.sh /tmp/
@@ -14,13 +15,18 @@ RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
 
 
 FROM socorro_image_base as socorro_breakpad
-
 WORKDIR /mdsw/
 
-# Install some helpful debugging things
+# Install breakpad requirements and some helpful debugging things
 RUN apt-get update && apt-get install -y \
     gdb \
+    libcurl3 \
+    libcurl3-gnutls \
+    libcurl4-gnutls-dev \
+    pkg-config \
+    rsync \
     vim \
+    wget \
 && rm -rf /var/lib/apt/lists/*
 
 # Build breakpad client and stackwalker binaries
@@ -30,8 +36,8 @@ COPY ./minidump-stackwalk/ /mdsw/minidump-stackwalk/
 RUN STACKWALKDIR=/stackwalk SRCDIR=/mdsw /mdsw/scripts/build-stackwalker.sh
 
 # Let app own /mdsw and /stackwalk so it's easier to debug later
-RUN chown -R app.app /mdsw
-RUN chown -R app.app /stackwalk
+RUN chown -R app.app /mdsw /stackwalk
+
 
 FROM socorro_image_base
 WORKDIR /app/
@@ -40,41 +46,36 @@ WORKDIR /app/
 COPY --from=socorro_breakpad /stackwalk/* /stackwalk/
 
 # Install frontend JS deps
-COPY ./webapp-django/package.json /webapp-frontend-deps/package.json
-COPY ./webapp-django/package-lock.json /webapp-frontend-deps/package-lock.json
+COPY ./webapp-django/package*.json /webapp-frontend-deps/
 RUN cd /webapp-frontend-deps/ && npm install
 
 # Install Socorro Python requirements
-COPY ./requirements /app/requirements
+COPY --chown=app:app ./requirements /app/requirements
 RUN pip install -U 'pip>=8' && \
     pip install --no-cache-dir -r requirements/default.txt -c requirements/constraints.txt && \
     pip check --disable-pip-version-check
 
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONPATH /app
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app \
+    LESS_BINARY=/webapp-frontend-deps/node_modules/.bin/lessc \
+    UGLIFYJS_BINARY=/webapp-frontend-deps/node_modules/.bin/uglifyjs \
+    CSSMIN_BINARY=/webapp-frontend-deps/node_modules/.bin/cssmin \
+    NPM_ROOT_PATH=/webapp-frontend-deps/ \
+    NODE_PATH=/webapp-frontend-deps/node_modules/
 
-ENV LESS_BINARY /webapp-frontend-deps/node_modules/.bin/lessc
-ENV UGLIFYJS_BINARY /webapp-frontend-deps/node_modules/.bin/uglifyjs
-ENV CSSMIN_BINARY /webapp-frontend-deps/node_modules/.bin/cssmin
-ENV NPM_ROOT_PATH /webapp-frontend-deps/
-ENV NODE_PATH /webapp-frontend-deps/node_modules/
+# app should own everything under /app in the container
+USER app
 
 # Copy everything over
-COPY . /app/
+COPY --chown=app:app . /app/
+
+# Build tmp directories for minidump stackwalker
+RUN mkdir -p /tmp/symbols/cache /tmp/symbols/tmp
 
 # Run collectstatic in container which puts files in the default place for
 # static files
 RUN cd /app/webapp-django/ && python manage.py collectstatic --noinput
-
-# app should own everything under /app in the container
-RUN chown -R app.app /app
-
-USER app
-
-# Build tmp directories for minidump stackwalker
-RUN mkdir -p /tmp/symbols/cache
-RUN mkdir -p /tmp/symbols/tmp
 
 # Set entrypoint for this image. The entrypoint script takes a service
 # to run as the first argument. See the script for available arguments.

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -29,20 +29,12 @@ PACKAGES_TO_INSTALL=(
     # For sentry-cli
     gawk
 
-    # For building breakpad
-    pkg-config
-    libcurl3
-    libcurl3-gnutls
-    libcurl4-gnutls-dev
-    wget
-    rsync
-
     # For nodejs and npm
     curl
 )
 
 # Install Ubuntu packages
-apt-get install -y ${PACKAGES_TO_INSTALL[@]}
+apt-get install -y "${PACKAGES_TO_INSTALL[@]}"
 
 # Install nodejs and npm from Nodesource's 8.x branch
 curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
@@ -50,6 +42,9 @@ echo 'deb https://deb.nodesource.com/node_10.x jessie main' > /etc/apt/sources.l
 echo 'deb-src https://deb.nodesource.com/node_10.x jessie main' >> /etc/apt/sources.list.d/nodesource.list
 apt-get update
 apt-get install -y nodejs
+
+# Remove apt cache
+rm -rf /var/lib/apt/lists/*
 
 # Stomp on the bash prompt with something more useful
 cat > /etc/bash.bashrc <<EOF
@@ -59,7 +54,7 @@ MYUSER="\$(id -u -n)"
 # Set the prompt to use the username we just figured out plus the container
 # name which is in an environment variable. If there is no CONTAINERNAME,
 # then use the host name.
-PS1="\${MYUSER}@socorro:\w\$ "
+PS1="\${MYUSER}@socorro:\\w\$ "
 
 # Add current directory to path.
 PATH=\${PATH}:.
@@ -67,6 +62,3 @@ EOF
 
 # Remove this bashrc so it doesn't override the global one we created
 rm /home/app/.bashrc
-
-# Clean up apt cache
-rm -rf /var/lib/apt/lists/*

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -67,3 +67,6 @@ EOF
 
 # Remove this bashrc so it doesn't override the global one we created
 rm /home/app/.bashrc
+
+# Clean up apt cache
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Make some changes to the Docker build size:

* Following [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run), remove the apt cache at the end of package installs. This reduced the final image size almost 1%. It does require that `apt-get update` is run again when installing dev tools in the socorro_breakpad build, however, so it can potentially slow down builds without caches.

And, some more suggested by @willkg:

* Move breakpad package installs to ``socorro_breakpad``, to reduce final image size.
* Fix quoting in ``set_up_ubuntu.sh``.
* Combine some commands to reduce layers.
* Run ``collectstatic`` as app user, rather than ``chown`` afterwards, to eliminate a duplicate layer.