### PR TITLE
bug 1599146, 1599147, 1599149, 1599151: signature changes pass 1

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -17,6 +17,7 @@ core\.odex@0x
 core::panicking::
 CrashReporter::TerminateHandler
 CrashStatsLogForwarder::CrashAction
+__cxa_rethrow
 __cxa_throw
 _CxxThrowException
 dalvik-heap

--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -90,6 +90,7 @@ SleepConditionVariableSRW
 std::_Atomic_fetch_add_4
 std::panicking::
 std::__terminate
+std::terminate
 system@framework@.*\.jar@classes\.dex@0x
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
 WaitForSingleObjectExImplementation

--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -73,6 +73,7 @@ NtWaitForAlertByThreadId
 nvmap@0x
 objc_begin_catch
 objc_msgLookupSuper2
+objc_terminate
 org\.mozilla\.f.*-\d\.apk@0x
 panic_abort::
 PR_WaitCondVar

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -209,6 +209,7 @@ nsTSubstring<.*>::Assign
 nsThread::Shutdown
 NtUser
 objc_exception_throw
+objc_addExceptionHandler
 objc_msgSend
 objc_release
 operator new

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -208,6 +208,7 @@ nsTHashtable<.*>::
 nsTSubstring<.*>::Assign
 nsThread::Shutdown
 NtUser
+objc_exception_rethrow
 objc_exception_throw
 objc_addExceptionHandler
 objc_msgSend


### PR DESCRIPTION
This covers the first pass of signature generation changes:

bug #1599146: add __cxa_rethrow

Example: https://crash-stats.mozilla.org/report/index/229b74eb-9ef2-4f18-aef2-966ab0191125

```
app@socorro:/app$ socorro-cmd signature 229b74eb-9ef2-4f18-aef2-966ab0191125
Crash id: 229b74eb-9ef2-4f18-aef2-966ab0191125
Original: __cxa_rethrow
New:      objc_addExceptionHandler | -[NSOpenGLLayer drawInOpenGLContext:pixelFormat:forLayerTime:displayTime:]
Same?:    False
```

bug #1599147: add objc_exception_rethrow

Example: https://crash-stats.mozilla.org/report/index/cff884cf-a283-491f-bfe2-d1ff80191125

```
app@socorro:/app$ socorro-cmd signature cff884cf-a283-491f-bfe2-d1ff80191125
Crash id: cff884cf-a283-491f-bfe2-d1ff80191125
Original: __cxa_rethrow
New:      objc_exception_rethrow | -[NSOpenGLLayer drawInOpenGLContext:pixelFormat:forLayerTime:displayTime:]
Same?:    False
```

bug #1599149: add std::terminate

Example: https://crash-stats.mozilla.org/report/index/74fdf9ad-8552-4d59-98b7-3a6470190705

```
app@socorro:/app$ socorro-cmd signature 74fdf9ad-8552-4d59-98b7-3a6470190705
Crash id: 74fdf9ad-8552-4d59-98b7-3a6470190705
Original: std::terminate
New:      objc_exception_rethrow | Foundation@0x2e6d6f
Same?:    False
```
bug #1599151: add objc_terminate

Example: https://crash-stats.mozilla.org/report/index/7b1b7fd4-fe3d-4a45-b1db-1db160190919

```
app@socorro:/app$ socorro-cmd signature 7b1b7fd4-fe3d-4a45-b1db-1db160190919
Crash id: 7b1b7fd4-fe3d-4a45-b1db-1db160190919
Original: std::terminate
New:      _dispatch_client_callout
Same?:    False
```