### PR TITLE
bug 1599152, 1599155, 1599156, 1599165: second pass on signature generation changes

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -24,6 +24,7 @@ __assert_fail_base
 arena_
 BaseAllocator
 BaseGetNamedObjectDirectory
+CALayerRetain
 __clear_cache
 .*calloc
 cert_

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -213,6 +213,7 @@ objc_exception_throw
 objc_addExceptionHandler
 objc_msgSend
 objc_release
+objc_retain
 operator new
 o_strcat_s
 <.*>::operator()

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -229,6 +229,7 @@ PR_
 .*ProcessNextEvent
 __psynch_cvwait
 _pthread_cond_wait
+pthread_cond_signal_thread_np
 pthread_mutex_lock
 __pthread_kill
 __pthread_mutex_lock

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -24,6 +24,7 @@ __assert_fail_base
 arena_
 BaseAllocator
 BaseGetNamedObjectDirectory
+CALayerRelease
 CALayerRetain
 __clear_cache
 .*calloc


### PR DESCRIPTION
This covers four more bugs:

https://bugzilla.mozilla.org/show_bug.cgi?id=1599152 : add objc_retain

https://crash-stats.mozilla.org/report/index/7e836f20-bdd7-4776-854d-d69b30190909

```
app@socorro:/app$ socorro-cmd signature 7e836f20-bdd7-4776-854d-d69b30190909
Crash id: 7e836f20-bdd7-4776-854d-d69b30190909
Original: objc_retain
New:      objc_retain | CoreFoundation@0x9d8d8
Same?:    False
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1599155 : add CALayerRetain

https://crash-stats.mozilla.org/report/index/cf7f771e-f5aa-4230-9e7e-825bf0190903

```
app@socorro:/app$ socorro-cmd signature cf7f771e-f5aa-4230-9e7e-825bf0190903
Crash id: cf7f771e-f5aa-4230-9e7e-825bf0190903
Original: CALayerRetain
New:      CALayerRetain | CA::Layer::thread_flags_
Same?:    False
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1599156 : add CALayerRelease

No example crash reports for `CALayerRelease`.

https://bugzilla.mozilla.org/show_bug.cgi?id=1599165 : add pthread_cond_signal_thread_np

https://crash-stats.mozilla.org/report/index/3412d26e-3236-4586-95a3-c8cad0190701

```
app@socorro:/app$ socorro-cmd signature 3412d26e-3236-4586-95a3-c8cad0190701
Crash id: 3412d26e-3236-4586-95a3-c8cad0190701
Original: shutdownhang | __psynch_cvwait | _pthread_cond_wait | pthread_cond_signal_thread_np
New:      shutdownhang | __psynch_cvwait | _pthread_cond_wait | pthread_cond_signal_thread_np | <name omitted> | arena_t::MallocSmall | CopyHostent
Same?:    False
```