### PR TITLE
bug 1599157, 1599162, 1599164, 1599167, 1599168, 1599222: third round of signature generation changes

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -308,6 +308,7 @@ TouchBadMemory
 # the signature rather than dropped
 trunc
 __ulock_wait
+__unlink
 vcruntime140\.dll@0x
 _VEC_memcpy
 _VEC_memzero

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -45,6 +45,7 @@ core::slice::slice_index_order_fail
 core::str::slice_error_fail
 CrashInJS
 CreateFileMappingA
+__cxxabiv1::failed_throw
 __delayLoadHelper2
 dlmalloc
 dlmalloc_trim

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -250,6 +250,7 @@ SEC_.*Item
 seckey_
 SECKEY_
 __security_check_cookie
+__semwait_signal
 send
 setjmp
 sigblock

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -307,6 +307,7 @@ TouchBadMemory
 # so best to keep it in the prefix list where the frame is added to
 # the signature rather than dropped
 trunc
+__ulock_wait
 vcruntime140\.dll@0x
 _VEC_memcpy
 _VEC_memzero

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -161,6 +161,7 @@ mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame
 mozilla::ipc::RPCChannel::EnteredCxxStack
 mozilla::ipc::RPCChannel::Send
 mozilla::ipc::WriteIPDLParam
+mozilla::ipc::IPDLParamTraits<T>::Write
 mozilla::layers::CompositorD3D11::Failed
 mozilla::layers::CompositorD3D11::HandleError
 mozilla::SpinEventLoopUntil<T>

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -309,6 +309,7 @@ TouchBadMemory
 trunc
 __ulock_wait
 __unlink
+unlink
 vcruntime140\.dll@0x
 _VEC_memcpy
 _VEC_memzero


### PR DESCRIPTION
This is a third round of signature generation changes.

https://bugzilla.mozilla.org/show_bug.cgi?id=1599157 : add __cxxabiv1::failed_throw

```
app@socorro:/app$ socorro-cmd signature 70ff8c5d-172d-40f3-8ef7-367050190705
Crash id: 70ff8c5d-172d-40f3-8ef7-367050190705
Original: __cxxabiv1::failed_throw
New:      __cxxabiv1::failed_throw | +[NSObject isMemberOfClass:]
Same?:    False
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1599162 : add __semwait_signal

```
app@socorro:/app$ socorro-cmd signature 449bc42d-da64-4ac1-ba1e-608e30190709
Crash id: 449bc42d-da64-4ac1-ba1e-608e30190709
Original: shutdownhang | __semwait_signal
New:      shutdownhang | __semwait_signal | usleep
Same?:    False
```

This isn't much better, but further improvement can be done in future PRs.

https://bugzilla.mozilla.org/show_bug.cgi?id=1599164 : add __ulock_wait

```
app@socorro:/app$ socorro-cmd signature 45eee9e7-ca72-497a-af1e-33ebe0190702
Crash id: 45eee9e7-ca72-497a-af1e-33ebe0190702
Original: shutdownhang | __ulock_wait
New:      shutdownhang | __ulock_wait | libac.win2unix.multithreading.dylib@0x1b96
Same?:    False
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1599167 : add __unlink

https://bugzilla.mozilla.org/show_bug.cgi?id=1599168 : add unlink

```
app@socorro:/app$ socorro-cmd signature 9d1ad096-2ca9-4a12-9078-0f02f0190705
Crash id: 9d1ad096-2ca9-4a12-9078-0f02f0190705
Original: shutdownhang | __unlink
New:      shutdownhang | __unlink | unlink | nsLocalFile::Remove
Same?:    False
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1599222 : add mozilla::ipc::IPDLParamTraits<T>::Write

cherry-picked from pr #5043 

```
app@socorro:/app$ socorro-cmd signature 33f0a7eb-b9a6-4504-bf30-4a84e0191125
Crash id: 33f0a7eb-b9a6-4504-bf30-4a84e0191125
Original: mozilla::ipc::IPDLParamTraits<T>::Write
New:      mozilla::ipc::IPDLParamTraits<T>::Write | mozilla::dom::PContentChild::SendNotifyMediaActiveChanged
Same?:    False
```