### PR TITLE
bug 1599506: add NXMapRemove to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -212,6 +212,7 @@ nsTHashtable<.*>::
 nsTSubstring<.*>::Assign
 nsThread::Shutdown
 NtUser
+NXMapRemove
 objc_exception_rethrow
 objc_exception_throw
 objc_addExceptionHandler


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 0b794045-87ec-4649-9ce1-73ec10191120 6f80238c-83ef-4eee-8b0a-06ee60191121 da9f75f7-852b-4e30-90cd-1fb0c0191126
Crash id: 0b794045-87ec-4649-9ce1-73ec10191120
Original: NXMapRemove
New:      NXMapRemove | -[NSControl sendAction:to:]
Same?:    False

Crash id: 6f80238c-83ef-4eee-8b0a-06ee60191121
Original: NXMapRemove
New:      NXMapRemove | +[NSEvent isSwipeTrackingFromScrollEventsEnabled]
Same?:    False

Crash id: da9f75f7-852b-4e30-90cd-1fb0c0191126
Original: NXMapRemove
New:      NXMapRemove | __CFCSetMakeBitmap
Same?:    False
```