### PR TITLE
bug 1600951: add AllocInfo::Get<T> to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -14,6 +14,7 @@ __aeabi_memcpy
 __aeabi_memmove
 .*alloc_impl
 Allocator<T>::malloc
+AllocInfo::Get<T>
 alloc::oom::default_oom_handler
 alloc::oom::oom
 alloc::raw_vec::capacity_overflow


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 88d033b1-11f3-40d6-a3ee-f11000191202 338f872c-8846-41fe-9791-28f280191202 ad3aabd7-09be-43a2-a03c-bdeb80191202
Crash id: 88d033b1-11f3-40d6-a3ee-f11000191202
Original: AllocInfo::Get<T>
New:      AllocInfo::Get<T> | moz_malloc_size_of
Same?:    False

Crash id: 338f872c-8846-41fe-9791-28f280191202
Original: shutdownhang | AllocInfo::Get<T>
New:      shutdownhang | AllocInfo::Get<T> | TransformPassParameter_dtor
Same?:    False

Crash id: ad3aabd7-09be-43a2-a03c-bdeb80191202
Original: AllocInfo::Get<T>
New:      AllocInfo::Get<T> | _msize
Same?:    False
```