### PR TITLE
bug 1599779: support other crashid forms in signature command

### DIFF
--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -10,7 +10,7 @@ import sys
 import requests
 
 from .generator import SignatureGenerator
-from .utils import convert_to_crash_data
+from .utils import convert_to_crash_data, parse_crashid
 
 
 DESCRIPTION = """
@@ -160,7 +160,7 @@ def main(argv=None):
 
     with outputter() as out:
         for crash_id in crashids_iterable:
-            crash_id = crash_id.strip()
+            crash_id = parse_crashid(crash_id.strip())
 
             resp = fetch("/RawCrash/", crash_id, api_token)
             if resp.status_code == 404:

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -8,6 +8,7 @@ from ..utils import (
     collapse,
     drop_bad_characters,
     drop_prefix_and_return_type,
+    parse_crashid,
     parse_source_file,
 )
 
@@ -250,3 +251,26 @@ def test_collapse(function, expected):
 )
 def test_drop_prefix_and_return_type(function, expected):
     assert drop_prefix_and_return_type(function) == expected
+
+
+@pytest.mark.parametrize(
+    "item, expected",
+    [
+        ("", None),
+        ("foo", None),
+        (
+            "0b794045-87ec-4649-9ce1-73ec10191120",
+            "0b794045-87ec-4649-9ce1-73ec10191120",
+        ),
+        (
+            "bp-0b794045-87ec-4649-9ce1-73ec10191120",
+            "0b794045-87ec-4649-9ce1-73ec10191120",
+        ),
+        (
+            "https://crash-stats.mozilla.org/report/index/0b794045-87ec-4649-9ce1-73ec10191120",
+            "0b794045-87ec-4649-9ce1-73ec10191120",
+        ),
+    ],
+)
+def test_parse_crashid(item, expected):
+    assert parse_crashid(item) == expected

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -3,6 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+import re
+from urllib.parse import urlparse
+
 from glom import glom
 
 
@@ -304,3 +307,58 @@ def drop_prefix_and_return_type(function):
         tokens = tokens[:-2] + [" ".join(tokens[-2:])]
 
     return tokens[-1]
+
+
+CRASH_ID_RE = re.compile(
+    r"""
+    ^
+    [a-f0-9]{8}-
+    [a-f0-9]{4}-
+    [a-f0-9]{4}-
+    [a-f0-9]{4}-
+    [a-f0-9]{6}
+    [0-9]{6}      # date in YYMMDD
+    $
+""",
+    re.VERBOSE,
+)
+
+
+def is_crash_id_valid(crash_id):
+    """Returns whether this is a valid crash id
+
+    :arg str crash_id: the crash id in question
+
+    :returns: True if it's valid, False if not
+
+    """
+    return bool(CRASH_ID_RE.match(crash_id))
+
+
+def parse_crashid(item):
+    """Returns a crashid from a number of formats.
+
+    This handles the following three forms of crashids:
+
+    * CRASHID
+    * bp-CRASHID
+    * http[s]://HOST[:PORT]/report/index/CRASHID
+
+    :arg str item: the thing to parse a crash id from
+
+    :returns: crashid as str or None
+
+    """
+    if is_crash_id_valid(item):
+        return item
+
+    if item.startswith("bp-") and is_crash_id_valid(item[3:]):
+        return item[3:]
+
+    if item.startswith("http"):
+        parsed = urlparse(item)
+        path = parsed.path
+        if path.startswith("/report/index"):
+            crash_id = path.split("/")[-1]
+            if is_crash_id_valid(crash_id):
+                return crash_id


### PR DESCRIPTION
This only affects the signature command line utility and doesn't affect
signature generation. It makes it easier to copy/paste crash ids from
various sources (bugzilla, urls, etc) to test signature generation.

To test:

```
app@socorro:/app$ socorro-cmd signature https://crash-stats.mozilla.org/report/index/0b794045-87ec-4649-9ce1-73ec10191120
Crash id: 0b794045-87ec-4649-9ce1-73ec10191120
Original: NXMapRemove
New:      NXMapRemove | -[NSControl sendAction:to:]
Same?:    False
```