### PR TITLE
bug 1601223: add moz_malloc_size_of to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -138,6 +138,7 @@ MessageLoop::PostTask
 mozalloc_abort
 mozalloc_handle_oom
 moz_free
+moz_malloc_size_of
 mozilla::AndroidBridge::AutoLocalJNIFrame::~AutoLocalJNIFrame
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-456817ac-baef-4ecf-a79d-f2bb30191203 bp-0457571e-65d7-46a1-a7e9-801dd0191203 bp-d89453bc-36e7-4d93-9e18-d814b0191203
Crash id: 456817ac-baef-4ecf-a79d-f2bb30191203
Original: shutdownhang | moz_malloc_size_of
New:      shutdownhang | moz_malloc_size_of | ICUReporter::Free
Same?:    False
Crash id: 0457571e-65d7-46a1-a7e9-801dd0191203
Original: moz_malloc_size_of
New:      moz_malloc_size_of | mozilla::EventListenerManager::SizeOfIncludingThis
Same?:    False
Crash id: d89453bc-36e7-4d93-9e18-d814b0191203
Original: moz_malloc_size_of
New:      moz_malloc_size_of | sqlite3DbFree
Same?:    False
```