### PR TITLE
bug 1602342, 1602343, 1602344: siglist changes

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -63,6 +63,7 @@ _files_getaddrinfo
 __fortify_fail
 __fortify_fail_abort
 ___forwarding___
+__forwarding_prep_0___
 free_impl
 __fsetlocking
 CCGraphBuilder::NoteXPCOMChild

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -62,6 +62,7 @@ _files_getaddrinfo
 .*free
 __fortify_fail
 __fortify_fail_abort
+___forwarding___
 free_impl
 __fsetlocking
 CCGraphBuilder::NoteXPCOMChild

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -184,6 +184,7 @@ nsAString_internal::BeginWriting
 nsACString_internal::SetCapacity
 -\[NSApplication _crashOnException:\]
 nsCRT::strcmp
+-\[NSObject doesNotRecognizeSelector:\]
 nsTArrayInfallibleAllocator
 NS_strcmp
 NS_strlen


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-1a9ebfb8-1234-4966-b30a-aa0870191209 bp-d9b67a17-2e1c-4494-9825-e3be60191208
Crash id: 1a9ebfb8-1234-4966-b30a-aa0870191209
Original: objc_exception_throw | -[NSObject doesNotRecognizeSelector:]
New:      objc_exception_throw | -[NSObject doesNotRecognizeSelector:] | ___forwarding___ | __forwarding_prep_0___ | mozilla::gl::GLContextCGL::MigrateToActiveGPU
Same?:    False
Crash id: d9b67a17-2e1c-4494-9825-e3be60191208
Original: objc_exception_throw | -[NSObject doesNotRecognizeSelector:]
New:      objc_exception_throw | -[NSObject doesNotRecognizeSelector:] | ___forwarding___ | __forwarding_prep_0___ | mozilla::gl::GLContextCGL::MigrateToActiveGPU
Same?:    False
```