### PR TITLE
bug 1603308: move update missing task into updatemissing command

### DIFF
--- a/webapp-django/crashstats/crashstats/management/commands/updatemissing.py
+++ b/webapp-django/crashstats/crashstats/management/commands/updatemissing.py
@@ -6,8 +6,6 @@
 This command checks known missing crashes to see if they've since been processed.
 """
 
-import markus
-
 from django.core.management.base import BaseCommand
 
 from crashstats.crashstats.configman_utils import get_s3_context
@@ -17,13 +15,6 @@ from crashstats.crashstats.management.commands.verifyprocessed import (
 )
 from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.crashstats.models import MissingProcessedCrash
-
-
-# Number of seconds until we decide a worker has stalled
-WORKER_TIMEOUT = 10 * 60
-
-
-metrics = markus.get_metrics("cron.verifyprocessed")
 
 
 class Command(BaseCommand):

--- a/webapp-django/crashstats/crashstats/management/commands/updatemissing.py
+++ b/webapp-django/crashstats/crashstats/management/commands/updatemissing.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This command checks known missing crashes to see if they've since been processed.
+"""
+
+import markus
+
+from django.core.management.base import BaseCommand
+
+from crashstats.crashstats.configman_utils import get_s3_context
+from crashstats.crashstats.management.commands.verifyprocessed import (
+    is_in_s3,
+    is_in_elasticsearch,
+)
+from crashstats.supersearch.models import SuperSearchUnredacted
+from crashstats.crashstats.models import MissingProcessedCrash
+
+
+# Number of seconds until we decide a worker has stalled
+WORKER_TIMEOUT = 10 * 60
+
+
+metrics = markus.get_metrics("cron.verifyprocessed")
+
+
+class Command(BaseCommand):
+    help = "Check known missing crashes to see if they've been processed."
+
+    def check_past_missing(self):
+        """Check the table for missing crashes and check to see if they exist."""
+        s3_context = get_s3_context()
+        bucket = s3_context.config.bucket_name
+        s3_client = s3_context.build_client()
+
+        supersearch = SuperSearchUnredacted()
+
+        crash_ids = []
+
+        crash_ids = MissingProcessedCrash.objects.filter(
+            is_processed=False
+        ).values_list("crash_id", flat=True)
+
+        no_longer_missing = []
+
+        for crash_id in crash_ids:
+            if is_in_s3(s3_client, bucket, crash_id):
+                if is_in_elasticsearch(supersearch, crash_id):
+                    no_longer_missing.append(crash_id)
+
+        updated = 0
+        if no_longer_missing:
+            updated = MissingProcessedCrash.objects.filter(
+                crash_id__in=no_longer_missing
+            ).update(is_processed=True)
+
+        self.stdout.write(
+            "Updated %s missing crashes which have since been processed" % updated
+        )
+
+    def handle(self, **options):
+        self.check_past_missing()
+        self.stdout.write("Done!")

--- a/webapp-django/crashstats/crashstats/tests/test_updatemissing.py
+++ b/webapp-django/crashstats/crashstats/tests/test_updatemissing.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+from crashstats.crashstats.models import MissingProcessedCrash
+from crashstats.crashstats.management.commands.updatemissing import Command
+from socorro.lib.datetimeutil import utc_now
+from socorro.lib.ooid import create_new_ooid, date_from_ooid
+
+
+TODAY = utc_now().strftime("%Y%m%d")
+BUCKET_NAME = os.environ.get("resource.boto.bucket_name")
+
+
+class TestUpdateMissing:
+    def create_raw_crash_in_s3(self, boto_helper, crash_id):
+        boto_helper.upload_fileobj(
+            bucket_name=BUCKET_NAME,
+            key="v2/raw_crash/%s/%s/%s" % (crash_id[0:3], TODAY, crash_id),
+            data=b"test",
+        )
+
+    def create_processed_crash_in_s3(self, boto_helper, crash_id):
+        boto_helper.upload_fileobj(
+            bucket_name=BUCKET_NAME,
+            key="v1/processed_crash/%s" % crash_id,
+            data=b"test",
+        )
+
+    def create_processed_crash_in_es(self, es_conn, crash_id):
+        crash_date = date_from_ooid(crash_id)
+        document = {
+            "crash_id": crash_id,
+            "raw_crash": {},
+            "processed_crash": {
+                "uuid": crash_id,
+                "signature": "OOM | Small",
+                "date_processed": crash_date,
+            },
+        }
+        index_name = crash_date.strftime(es_conn.get_index_template())
+        doctype = es_conn.get_doctype()
+        with es_conn() as conn:
+            conn.index(index=index_name, doc_type=doctype, body=document, id=crash_id)
+        es_conn.refresh()
+
+    def test_past_missing_still_missing(self, capsys, db):
+        # Create a MissingProcessedCrash row, but don't put the processed crash in the
+        # bucket. After check_past_missing() runs, the MissingProcessedCrash should
+        # still have is_processed=False.
+        crash_id = create_new_ooid()
+        mpe = MissingProcessedCrash(crash_id=crash_id, is_processed=False)
+        mpe.save()
+
+        cmd = Command()
+        cmd.check_past_missing()
+
+        mpe = MissingProcessedCrash.objects.get(crash_id=crash_id)
+        assert mpe.is_processed is False
+
+    def test_past_missing_no_longer_missing(self, capsys, db, es_conn, boto_helper):
+        # Create a MissingProcessedCrash row and put the processed crash in the S3
+        # bucket. After check_past_missing() runs, the MissingProcessedCrash should
+        # have is_processed=True.
+        crash_id = create_new_ooid()
+        mpe = MissingProcessedCrash(crash_id=crash_id, is_processed=False)
+        mpe.save()
+
+        self.create_raw_crash_in_s3(boto_helper, crash_id)
+        self.create_processed_crash_in_s3(boto_helper, crash_id)
+        self.create_processed_crash_in_es(es_conn, crash_id)
+
+        cmd = Command()
+        cmd.check_past_missing()
+
+        mpe = MissingProcessedCrash.objects.get(crash_id=crash_id)
+        assert mpe.is_processed is True

--- a/webapp-django/crashstats/cron/__init__.py
+++ b/webapp-django/crashstats/cron/__init__.py
@@ -49,6 +49,12 @@ JOBS = [
         "backfill": True,
     },
     {
+        # Check past missing crashes and update status daily at 3:00am
+        "cmd": "updatemissing",
+        "frequency": "1d",
+        "time": "03:00",
+    },
+    {
         # Scrape archive.mozilla.org for productversion data every hour
         "cmd": "archivescraper",
         "frequency": "1h",


### PR DESCRIPTION
This splits verifyprocessed into two tasks. Checking existing known missing processed crashes to see if they've since been processed only needs to happen once a day and it doesn't need to backfill since it checks all the known missing crashes.

Moving that to a separate task will reduce the runtime for verifyprocessed. Further, because verifyprocessed *is* a backfill task, if it needs to run for a bunch of days, it doesn't repeat the unnecessary work of updatemissing.