### PR TITLE
bug 1604317: remove missing processed check from admin

### DIFF
--- a/webapp-django/crashstats/crashstats/admin.py
+++ b/webapp-django/crashstats/crashstats/admin.py
@@ -153,7 +153,6 @@ class MissingProcessedCrashAdmin(admin.ModelAdmin):
         "created",
         "collected_date",
         "is_processed",
-        "check_processed",
         "report_url_linked",
     ]
     actions = [process_crashes]

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -228,23 +228,6 @@ class MissingProcessedCrash(models.Model):
     def report_url(self):
         return reverse("crashstats:report_index", args=(self.crash_id,))
 
-    def check_processed(self):
-        """Check whether this crash id was processed.
-
-        :returns: True, False, or a str of the exception.
-
-        """
-        processed_api = ProcessedCrash()
-        try:
-            processed_api.get(
-                crash_id=self.crash_id, dont_cache=True, refresh_cache=True
-            )
-            return True
-        except CrashIDNotFound:
-            return False
-        except Exception as exc:
-            return str(exc)
-
     class Meta:
         verbose_name = "missing processed crash"
         verbose_name_plural = "missing processed crashes"

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -20,7 +20,6 @@ from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.encoding import iri_to_uri
 
-from socorro.external.crashstorage_base import CrashIDNotFound
 from socorro.lib import BadArgumentError
 from socorro.lib.requestslib import session_with_retries
 from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData


### PR DESCRIPTION
This removes the check to see if a missing processed crash is still
missing from the Django admin page. The check only checked S3 and not
elasticsearch, so it wasn't right. Further, it took FOREVER to run
making the Django admin page super slow.