### PR TITLE
bug 1602121: add queue consuming and publishing for AWS SQS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - my.env
     depends_on:
       - localstack-s3
+      - localstack-sqs
       - pubsub
       - statsd
     expose:

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -62,6 +62,9 @@ resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.region=us-west-2
 
 resource.boto.sqs_endpoint_url=http://localstack-sqs:4576/
+resource.boto.standard_queue=local_dev_standard
+resource.boto.priority_queue=local_dev_priority
+resource.boto.reprocessing_queue=local_dev_reprocessing
 
 # processor
 # ---------

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -30,6 +30,11 @@ resource.pubsub.priority_subscription_name=test_priority_sub
 resource.pubsub.reprocessing_topic_name=test_reprocessing
 resource.pubsub.reprocessing_subscription_name=test_reprocessing_sub
 
+# SQS configuration
+resource.boto.standard_queue=test_standard
+resource.boto.priority_queue=test_priority
+resource.boto.reprocessing_queue=test_reprocessing
+
 # Django tests are meant to run with debug mode disabled.
 DEBUG=False
 

--- a/docker/run_setup.sh
+++ b/docker/run_setup.sh
@@ -4,10 +4,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-set -e
-
 # Run scripts for setting up data sources for the local development environment.
 # This assumes that it is running in the webapp docker container.
+
+set -e
 
 # Drop and re-create the breakpad database with tables, stored procedures,
 # types, indexes, and keys; also bulk-loads static data for some lookup tables
@@ -23,6 +23,10 @@ set -e
 # Delete and create Pub/Sub topics and subscriptions
 /app/socorro-cmd pubsub delete
 /app/socorro-cmd pubsub create
+
+# Delete and create SQS queues
+/app/socorro-cmd sqs delete-all
+/app/socorro-cmd sqs create-all
 
 # Initialize the cronrun bookkeeping for all configured jobs to success
 /app/webapp-django/manage.py cronmarksuccess all

--- a/socorro/external/pubsub/crashqueue.py
+++ b/socorro/external/pubsub/crashqueue.py
@@ -12,7 +12,7 @@ from google.api_core.exceptions import DeadlineExceeded
 
 from socorro.external.crashqueue_base import CrashQueueBase
 
-# Maximum number of messages to pull from a Pub/Sub topic in a single pull
+# Maximum number of messages to pull from a Google Pub/Sub topic in a single pull
 # request
 PUBSUB_MAX_MESSAGES = 5
 
@@ -21,9 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 class PubSubCrashQueue(CrashQueueBase):
-    """Crash queue that uses Pub/Sub.
+    """Crash queue that uses Google Pub/Sub.
 
-    This requires three Pub/Sub topics:
+    This requires three Google Pub/Sub topics:
 
     * **standard topic**: processing incoming crashes from the collector
     * **priority topic**: processing crashes right now because someone/something
@@ -110,7 +110,7 @@ class PubSubCrashQueue(CrashQueueBase):
         logger.debug("ack %s from %s", ack_id, sub_path)
 
     def __iter__(self):
-        """Return iterator over crash ids from Pub/Sub.
+        """Return iterator over crash ids from Google Pub/Sub.
 
         Each returned crash is a ``(crash_id, {kwargs})`` tuple with
         ``finished_func`` as the only key in ``kwargs``. The caller should call

--- a/socorro/external/sqs/__init__.py
+++ b/socorro/external/sqs/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/socorro/external/sqs/crashqueue.py
+++ b/socorro/external/sqs/crashqueue.py
@@ -1,0 +1,263 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from functools import partial
+import logging
+import random
+import time
+
+import boto3
+from botocore.client import ClientError
+from configman import Namespace
+from more_itertools import chunked
+
+from socorro.external.crashqueue_base import CrashQueueBase
+from socorro.lib.util import retry
+
+
+# Maximum number of messages to pull from an SQS queue in a single pull request
+SQS_MAX_MESSAGES = 5
+
+
+logger = logging.getLogger(__name__)
+
+
+class CrashIdsFailedToPublish(Exception):
+    """Crash ids that failed to publish."""
+
+
+def wait_times_connect():
+    """Return generator for wait times with jitter between failed connection attempts."""
+    for i in [5] * 5:
+        yield i + random.uniform(-2, 2)  # nosec
+
+
+class SQSCrashQueue(CrashQueueBase):
+    """Crash queue that uses AWS SQS.
+
+    This requires three AWS SQS queues:
+
+    * **standard queue**: processing incoming crashes from the collector
+    * **priority queue**: processing crashes right now because someone/something
+      is trying to view them
+    * **reprocessing queue**: reprocessing crashes after a change to the processor
+      that have (probably) already been processed
+
+    When configuring credentials for this crashqueue object, you can do one of two
+    things:
+
+    1. provide ``ACCESS_KEY`` and ``SECRET_ACCESS_KEY`` in the configuration, OR
+    2. use one of the other methods described in the boto3 docs
+       http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+
+    You also need to have three AWS SQS queues:
+
+    * standard
+    * priority
+    * reprocessing
+
+    and they need the following settings:
+
+    ==========================  =========
+    Setting                     Value
+    ==========================  =========
+    Default Visibility Timeout  5 minutes
+    Message Retention Period    *default*
+    Maximum Message Size        *default*
+    Delivery Delay              *default*
+    Receive Message Wait Time   *default*
+    ==========================  =========
+
+    The AWS credentials that Socorro is configured with must have the following
+    Amazon SQS permissions on the SQS queue you created:
+
+    * ``sqs:GetQueueUrl``
+
+      Socorro needs to convert a queue name to a queue url. This requires the
+      ``sqs:GetQueueUrl``
+
+    * ``sqs:SendMessage``
+
+      Socorro sends messages to a queue--this is how the webapp publishes crash ids
+      to the priority and reprocessing queues. This requires the ``sqs:SendMessage``
+      permission.
+
+    * ``sqs:DeleteMessage``
+
+      Once Socorro processor has processed a crash report, it needs to delete the
+      message from the queue. This requires the ``sqs:DeleteMessage`` permission.
+
+    * ``sqs:ReceiveMessage``
+
+      The Socorro processor has to receive messages from the queue in order to
+      process the related crash reports. This requires teh ``sqs:ReceiveMessage``
+      permission.
+
+    If something isn't configured correctly, then the Socorro processor will be unable
+    to process crashes and the webapp will be unable to publish crash ids for
+    processing.
+
+    """
+
+    required_config = Namespace()
+    required_config.add_option(
+        "access_key", doc="access key", reference_value_from="resource.boto",
+    )
+    required_config.add_option(
+        "secret_access_key",
+        doc="secret access key",
+        secret=True,
+        reference_value_from="secrets.boto",
+    )
+    required_config.add_option(
+        "region",
+        doc="Name of the S3 region (e.g. us-west-2)",
+        default="us-west-2",
+        reference_value_from="resource.boto",
+    )
+    required_config.add_option(
+        "sqs_endpoint_url",
+        doc=(
+            "endpoint url to connect to; None if you are connecting to AWS. For "
+            "example, ``http://localhost:4572/``."
+        ),
+        default="",
+        reference_value_from="resource.boto",
+    )
+    required_config.add_option(
+        "standard_queue",
+        doc="The name for the standard queue.",
+        reference_value_from="resource.boto",
+    )
+    required_config.add_option(
+        "priority_queue",
+        doc="The name for the priority queue.",
+        reference_value_from="resource.boto",
+    )
+    required_config.add_option(
+        "reprocessing_queue",
+        doc="The name for the reprocessing queue.",
+        reference_value_from="resource.boto",
+    )
+
+    def __init__(self, config, namespace="", quit_check_callback=None):
+        super().__init__(config, namespace, quit_check_callback)
+
+        self.client = self.build_client()
+        self.standard_queue_url = self.get_queue_url(self.config.standard_queue)
+        self.priority_queue_url = self.get_queue_url(self.config.priority_queue)
+        self.reprocessing_queue_url = self.get_queue_url(self.config.reprocessing_queue)
+        self.queue_to_queue_url = {
+            "standard": self.standard_queue_url,
+            "priority": self.priority_queue_url,
+            "reprocessing": self.reprocessing_queue_url,
+        }
+
+    def get_queue_url(self, queue_name):
+        return self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+
+    @retry(
+        retryable_exceptions=[
+            # FIXME(willkg): Seems like botocore always raises ClientError
+            # which is unhelpful for granularity purposes.
+            ClientError,
+            # This raises a ValueError "invalid endpoint" if it has problems
+            # getting the s3 credentials and then tries "s3..amazonaws.com"--we
+            # want to retry that, too.
+            ValueError,
+        ],
+        wait_time_generator=wait_times_connect,
+        sleep_function=time.sleep,
+        module_logger=logger,
+    )
+    def build_client(self):
+        """Returns a Boto3 SQS Client."""
+        # Either they provided ACCESS_KEY and SECRET_ACCESS_KEY in which case
+        # we use those, or they didn't in which case boto3 pulls credentials
+        # from one of a myriad of other places.
+        # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+        session_kwargs = {}
+        if self.config.access_key and self.config.secret_access_key:
+            session_kwargs["aws_access_key_id"] = self.config.access_key
+            session_kwargs["aws_secret_access_key"] = self.config.secret_access_key
+        session = boto3.session.Session(**session_kwargs)
+
+        kwargs = {
+            "service_name": "sqs",
+            "region_name": self.config.region,
+        }
+        if self.config.sqs_endpoint_url:
+            kwargs["endpoint_url"] = self.config.sqs_endpoint_url
+
+        return session.client(**kwargs)
+
+    def ack_crash(self, queue_url, handle):
+        self.client.delete_message(QueueUrl=queue_url, ReceiptHandle=handle)
+        logger.debug("ack %s from %s", handle, queue_url)
+
+    def __iter__(self):
+        """Return iterator over crash ids from AWS SQS.
+
+        Each returned crash is a ``(crash_id, {kwargs})`` tuple with
+        ``finished_func`` as the only key in ``kwargs``. The caller should call
+        ``finished_func`` when it's done processing the crash.
+
+        """
+        queue_urls = [
+            self.priority_queue_url,
+            self.standard_queue_url,
+            self.reprocessing_queue_url,
+        ]
+
+        while True:
+            has_msgs = False
+            for queue_url in queue_urls:
+                resp = self.client.receive_message(
+                    QueueUrl=queue_url,
+                    WaitTimeSeconds=0,
+                    MaxNumberOfMessages=SQS_MAX_MESSAGES,
+                )
+                msgs = resp.get("Messages", [])
+
+                if not msgs:
+                    continue
+
+                has_msgs = True
+                for msg in msgs:
+                    crash_id = msg["Body"]
+                    handle = msg["ReceiptHandle"]
+                    logger.debug("got %s from %s", crash_id, queue_url)
+                    if crash_id == "test":
+                        # Ack and drop any test crash ids
+                        self.ack_crash(queue_url, handle)
+                        continue
+                    yield (
+                        (crash_id,),
+                        {"finished_func": partial(self.ack_crash, queue_url, handle)},
+                    )
+
+            if not has_msgs:
+                # There's nothing to process, so return
+                return
+
+    def publish(self, queue, crash_ids):
+        """Publish crash ids to specified queue."""
+        failed = []
+
+        queue_url = self.queue_to_queue_url[queue]
+        for batch in chunked(crash_ids, 10):
+            entry_list = [
+                {"Id": str(i), "MessageBody": crash_id}
+                for i, crash_id in enumerate(batch)
+            ]
+            resp = self.client.send_message_batch(
+                QueueUrl=queue_url, Entries=entry_list
+            )
+            for item in resp.get("Failed", []):
+                failed.append(entry_list[int(item["Id"])])
+
+        if failed:
+            raise CrashIdsFailedToPublish(
+                "Crashids failed to publish: %s", ",".join(failed)
+            )

--- a/socorro/scripts/sqs_cli.py
+++ b/socorro/scripts/sqs_cli.py
@@ -87,11 +87,11 @@ def list_messages(ctx, queue):
         click.echo("Queue %s is empty." % queue)
 
 
-@sqs_group.command("send_message")
+@sqs_group.command("publish")
 @click.argument("queue")
 @click.argument("message")
 @click.pass_context
-def send_message(ctx, queue, message):
+def publish(ctx, queue, message):
     """Add a message to a queue."""
     conn = get_client()
     try:
@@ -139,6 +139,15 @@ def create(ctx, queue):
     click.echo("Queue %s created." % queue)
 
 
+@sqs_group.command("create-all")
+@click.pass_context
+def create_all(ctx):
+    """Create SQS queues related to processing."""
+    ctx.invoke(create, queue=os.environ["resource.boto.standard_queue"])
+    ctx.invoke(create, queue=os.environ["resource.boto.priority_queue"])
+    ctx.invoke(create, queue=os.environ["resource.boto.reprocessing_queue"])
+
+
 @sqs_group.command("delete")
 @click.argument("queue")
 @click.pass_context
@@ -159,6 +168,15 @@ def delete(ctx, queue):
     queue_url = resp["QueueUrl"]
     conn.delete_queue(QueueUrl=queue_url)
     click.echo("Queue %s deleted." % queue)
+
+
+@sqs_group.command("delete-all")
+@click.pass_context
+def delete_all(ctx):
+    """Delete SQS queues related to processing."""
+    ctx.invoke(delete, queue=os.environ["resource.boto.standard_queue"])
+    ctx.invoke(delete, queue=os.environ["resource.boto.priority_queue"])
+    ctx.invoke(delete, queue=os.environ["resource.boto.reprocessing_queue"])
 
 
 def main(argv=None):

--- a/socorro/unittest/external/sqs/__init__.py
+++ b/socorro/unittest/external/sqs/__init__.py
@@ -7,6 +7,10 @@ from configman import ConfigurationManager, environment
 from socorro.external.sqs.crashqueue import SQSCrashQueue
 
 
+# Visibility timeout for the AWS SQS queue in seconds
+VISIBILITY_TIMEOUT = 1
+
+
 def get_sqs_config():
     sqs_config = SQSCrashQueue.get_required_config()
     config_manager = ConfigurationManager(

--- a/socorro/unittest/external/sqs/__init__.py
+++ b/socorro/unittest/external/sqs/__init__.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from configman import ConfigurationManager, environment
+
+from socorro.external.sqs.crashqueue import SQSCrashQueue
+
+
+def get_sqs_config():
+    sqs_config = SQSCrashQueue.get_required_config()
+    config_manager = ConfigurationManager(
+        [sqs_config],
+        app_name="test-sqs",
+        app_description="",
+        values_source_list=[environment],
+        argv_source=[],
+    )
+    return config_manager.get_config()

--- a/socorro/unittest/external/sqs/conftest.py
+++ b/socorro/unittest/external/sqs/conftest.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import boto3
+import pytest
+
+from socorro.unittest.external.sqs import get_sqs_config
+
+
+# Socorro uses three queues. Each is implemented as a SQS queue.
+QUEUES = ["standard", "priority", "reprocessing"]
+
+
+class SQSHelper:
+    """Helper class for setting up, tearing down, and publishing to Pub/Sub.
+
+    Note: This uses the same config as SQSCrashQueue.
+
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.client = self.build_client()
+        self._queues = []
+
+        self.queue_to_queue_name = {
+            "standard": self.config.standard_queue,
+            "priority": self.config.priority_queue,
+            "reprocessing": self.config.reprocessing_queue,
+        }
+
+    def build_client(self):
+        session = boto3.session.Session(
+            aws_access_key_id=self.config.access_key,
+            aws_secret_access_key=self.config.secret_access_key,
+        )
+        client = session.client(
+            service_name="sqs",
+            region_name=self.config.region,
+            endpoint_url=self.config.sqs_endpoint_url,
+        )
+        return client
+
+    def setup_queues(self):
+        for queue_name in self.queue_to_queue_name.values():
+            self.create_queue(queue_name)
+
+    def teardown_queues(self):
+        for queue_name in self._queues:
+            queue_url = self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+            self.client.delete_queue(QueueUrl=queue_url)
+
+    def __enter__(self):
+        self.setup_queues()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.teardown_queues()
+
+    def create_queue(self, queue_name):
+        self.client.create_queue(QueueName=queue_name)
+        self._queues.append(queue_name)
+
+    def get_published_crashids(self, queue):
+        queue_name = self.queue_to_queue_name[queue]
+        queue_url = self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        all_crashids = []
+        while True:
+            resp = self.client.receive_message(
+                QueueUrl=queue_url, WaitTimeSeconds=0, VisibilityTimeout=1,
+            )
+            msgs = resp.get("Messages", [])
+            if not msgs:
+                break
+            all_crashids.extend([msg["Body"] for msg in msgs])
+
+        return all_crashids
+
+    def publish(self, queue, crash_id):
+        queue_name = self.queue_to_queue_name[queue]
+        queue_url = self.client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        self.client.send_message(QueueUrl=queue_url, MessageBody=crash_id)
+
+
+@pytest.yield_fixture
+def sqs_helper():
+    config = get_sqs_config()
+    with SQSHelper(config) as sqs:
+        yield sqs

--- a/socorro/unittest/external/sqs/conftest.py
+++ b/socorro/unittest/external/sqs/conftest.py
@@ -8,10 +8,6 @@ import pytest
 from socorro.unittest.external.sqs import get_sqs_config
 
 
-# Socorro uses three queues. Each is implemented as a SQS queue.
-QUEUES = ["standard", "priority", "reprocessing"]
-
-
 class SQSHelper:
     """Helper class for setting up, tearing down, and publishing to Pub/Sub.
 

--- a/socorro/unittest/external/sqs/conftest.py
+++ b/socorro/unittest/external/sqs/conftest.py
@@ -5,7 +5,7 @@
 import boto3
 import pytest
 
-from socorro.unittest.external.sqs import get_sqs_config
+from socorro.unittest.external.sqs import get_sqs_config, VISIBILITY_TIMEOUT
 
 
 class SQSHelper:
@@ -55,7 +55,10 @@ class SQSHelper:
         self.teardown_queues()
 
     def create_queue(self, queue_name):
-        self.client.create_queue(QueueName=queue_name)
+        self.client.create_queue(
+            QueueName=queue_name,
+            Attributes={"VisibilityTimeout": str(VISIBILITY_TIMEOUT)},
+        )
         self._queues.append(queue_name)
 
     def get_published_crashids(self, queue):

--- a/socorro/unittest/external/sqs/test_crashqueue.py
+++ b/socorro/unittest/external/sqs/test_crashqueue.py
@@ -8,10 +8,7 @@ import pytest
 
 from socorro.external.sqs.crashqueue import SQSCrashQueue
 from socorro.lib.ooid import create_new_ooid
-from socorro.unittest.external.sqs import get_sqs_config
-
-
-VISIBILITY_DEADLINE = 2
+from socorro.unittest.external.sqs import get_sqs_config, VISIBILITY_TIMEOUT
 
 
 class TestSQSCrashQueue:
@@ -61,8 +58,7 @@ class TestSQSCrashQueue:
         for args, kwargs in new_crashes:
             kwargs["finished_func"]()
 
-        # Wait beyond the ack deadline in the grossest way possible
-        time.sleep(VISIBILITY_DEADLINE + 1)
+        time.sleep(VISIBILITY_TIMEOUT + 1)
 
         # Now call it again and make sure we get nothing back
         new_crashes = list(crash_queue.new_crashes())

--- a/socorro/unittest/external/sqs/test_crashqueue.py
+++ b/socorro/unittest/external/sqs/test_crashqueue.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+
+import pytest
+
+from socorro.external.sqs.crashqueue import SQSCrashQueue
+from socorro.lib.ooid import create_new_ooid
+from socorro.unittest.external.sqs import get_sqs_config
+
+
+VISIBILITY_DEADLINE = 2
+
+
+class TestSQSCrashQueue:
+    def test_iter(self, sqs_helper):
+        standard_crash = create_new_ooid()
+        sqs_helper.publish("standard", standard_crash)
+
+        reprocessing_crash = create_new_ooid()
+        sqs_helper.publish("reprocessing", reprocessing_crash)
+
+        priority_crash = create_new_ooid()
+        sqs_helper.publish("priority", priority_crash)
+
+        crash_queue = SQSCrashQueue(get_sqs_config())
+        new_crashes = list(crash_queue.new_crashes())
+
+        # Assert the shape of items in new_crashes
+        for item in new_crashes:
+            assert isinstance(item, tuple)
+            assert isinstance(item[0], tuple)  # *args
+            assert isinstance(item[1], dict)  # **kwargs
+            assert list(item[1].keys()) == ["finished_func"]
+
+        # Assert new_crashes order is the correct order
+        crash_ids = [item[0][0] for item in new_crashes]
+        assert crash_ids == [priority_crash, standard_crash, reprocessing_crash]
+
+    def test_ack(self, sqs_helper):
+        original_crash_id = create_new_ooid()
+
+        # Publish crash id to the queue
+        sqs_helper.publish("standard", original_crash_id)
+
+        crash_queue = SQSCrashQueue(get_sqs_config())
+        new_crashes = list(crash_queue.new_crashes())
+
+        # Assert original_crash_id is in new_crashes
+        crash_ids = [item[0][0] for item in new_crashes]
+        assert crash_ids == [original_crash_id]
+
+        # Now call it again; note that we haven't acked the crash_ids
+        # nor have the leases expired
+        second_new_crashes = list(crash_queue.new_crashes())
+        assert second_new_crashes == []
+
+        # Now ack the crash_id and we don't get it again
+        for args, kwargs in new_crashes:
+            kwargs["finished_func"]()
+
+        # Wait beyond the ack deadline in the grossest way possible
+        time.sleep(VISIBILITY_DEADLINE + 1)
+
+        # Now call it again and make sure we get nothing back
+        new_crashes = list(crash_queue.new_crashes())
+        assert new_crashes == []
+
+    @pytest.mark.parametrize("queue", ["standard", "priority", "reprocessing"])
+    def test_publish_one(self, sqs_helper, queue):
+        crash_id = create_new_ooid()
+
+        crash_queue = SQSCrashQueue(get_sqs_config())
+        crash_queue.publish(queue, [crash_id])
+
+        published_crash_ids = sqs_helper.get_published_crashids(queue)
+        assert published_crash_ids == [crash_id]
+
+    @pytest.mark.parametrize("queue", ["standard", "priority", "reprocessing"])
+    def test_publish_many(self, sqs_helper, queue):
+        crash_id_1 = create_new_ooid()
+        crash_id_2 = create_new_ooid()
+        crash_id_3 = create_new_ooid()
+
+        crash_queue = SQSCrashQueue(get_sqs_config())
+        crash_queue.publish(queue, [crash_id_1, crash_id_2])
+        crash_queue.publish(queue, [crash_id_3])
+
+        published_crash_ids = sqs_helper.get_published_crashids(queue)
+        assert sorted(published_crash_ids) == sorted(
+            [crash_id_1, crash_id_2, crash_id_3]
+        )

--- a/webapp-django/crashstats/crashstats/configman_utils.py
+++ b/webapp-django/crashstats/crashstats/configman_utils.py
@@ -12,13 +12,13 @@ from configman import ConfigurationManager, configuration, Namespace
 from configman.environment import environment
 
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 from socorro.app.socorro_app import App
 from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData
 from socorro.external.es.connection_context import (
     ConnectionContext as ESConnectionContext,
 )
-from socorro.external.pubsub.crashqueue import PubSubCrashQueue
 
 
 def get_s3_context():
@@ -56,7 +56,9 @@ def config_from_configman():
         "elasticsearch_class", default=ESConnectionContext
     )
     definition_source.namespace("queue")
-    definition_source.add_option("crashqueue_class", default=PubSubCrashQueue)
+    definition_source.add_option(
+        "crashqueue_class", default=import_string(settings.CRASHQUEUE)
+    )
     definition_source.namespace("crashdata")
     definition_source.crashdata.add_option(
         "crash_data_class", default=SimplifiedCrashData

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -19,11 +19,11 @@ from django.db import models
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.encoding import iri_to_uri
+from django.utils.module_loading import import_string
 
 from socorro.lib import BadArgumentError
 from socorro.lib.requestslib import session_with_retries
 from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData
-from socorro.external.pubsub.crashqueue import PubSubCrashQueue
 
 from crashstats.crashstats.configman_utils import config_from_configman
 
@@ -1035,7 +1035,7 @@ class Reprocessing(SocorroMiddleware):
     permission.
     """
 
-    implementation = PubSubCrashQueue
+    implementation = import_string(settings.CRASHQUEUE)
 
     API_REQUIRED_PERMISSIONS = ("crashstats.reprocess_crashes",)
 
@@ -1057,7 +1057,7 @@ class Reprocessing(SocorroMiddleware):
 class PriorityJob(SocorroMiddleware):
     """Submit crash ids to priority queue."""
 
-    implementation = PubSubCrashQueue
+    implementation = import_string(settings.CRASHQUEUE)
 
     required_params = (("crash_ids", list),)
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -567,6 +567,12 @@ if not implementations_database_url:
     implementations_database_url = database_url
 implementations_config = dj_database_url.parse(implementations_database_url)
 
+# The CrashQueueBase class to use for submitting priority and reprocessing
+# requests
+CRASHQUEUE = config(
+    "queue.crashqueue_class", "socorro.external.pubsub.crashqueue.PubSubCrashQueue"
+)
+
 # Config for when the models pull directly from socorro.external classes.
 SOCORRO_CONFIG = {
     "secrets": {

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -590,7 +590,6 @@ SOCORRO_CONFIG = {
             "region": config("resource.boto.region", "us-west-2"),
             "resource_class": "socorro.external.boto.connection_context.S3Connection",
             "s3_endpoint_url": config("resource.boto.s3_endpoint_url", None),
-
             # SQS things
             "sqs_endpoint_url": config("resource.boto.sqs_endpoint_url", None),
             "standard_queue": config("resource.boto.standard_queue", None),

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -590,6 +590,12 @@ SOCORRO_CONFIG = {
             "region": config("resource.boto.region", "us-west-2"),
             "resource_class": "socorro.external.boto.connection_context.S3Connection",
             "s3_endpoint_url": config("resource.boto.s3_endpoint_url", None),
+
+            # SQS things
+            "sqs_endpoint_url": config("resource.boto.sqs_endpoint_url", None),
+            "standard_queue": config("resource.boto.standard_queue", None),
+            "priority_queue": config("resource.boto.priority_queue", None),
+            "reprocessing_queue": config("resource.boto.reprocessing_queue", None),
         },
         "pubsub": {
             "service_account_file": config(


### PR DESCRIPTION
This adds the bits to Socorro to consume from and publish to AWS SQS. This adds tests and some configuration, too.

The default continues to be Google Pub/Sub. This makes no changes to how things run in production. After this lands, we'll figure out the migration plan.

Next steps on this:

1. I need to self-review it.
2. I need to set this up with real AWS SQS queues and Antenna and make sure the whole thing works.