### PR TITLE
bug 1503344: remove java_stack_trace_full

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2246,25 +2246,6 @@ FIELDS = {
             "type": "string",
         },
     },
-    # FIXME(willkg): Remove java_stack_trace_full after January 2020.
-    "java_stack_trace_full": {
-        "data_validation_type": "str",
-        "description": "(Deprecated) Raw JavaStackTrace value.",
-        "form_field_choices": [],
-        "has_full_version": True,
-        "in_database_name": "java_stack_trace_full",
-        "is_exposed": True,
-        "is_returned": True,
-        "name": "java_stack_trace_full",
-        "namespace": "processed_crash",
-        "permissions_needed": ["crashstats.view_pii"],
-        "query_type": "string",
-        "storage_mapping": {
-            "fields": {"full": {"index": "not_analyzed", "type": "string"}},
-            "index": "analyzed",
-            "type": "string",
-        },
-    },
     "java_stack_trace_raw": {
         "data_validation_type": "str",
         "description": "Raw JavaStackTrace value.",

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -219,8 +219,6 @@ class JavaProcessRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         # This can contain PII in the exception message
         processed_crash["java_stack_trace_raw"] = raw_crash["JavaStackTrace"]
-        # FIXME(willkg): Remove java_stack_trace_full after January 2020.
-        processed_crash["java_stack_trace_full"] = raw_crash["JavaStackTrace"]
 
         try:
             java_exception = javautil.parse_java_stack_trace(

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -338,12 +338,11 @@
                   <td>{{ report.address }}</td>
                 </tr>
                 {% if request.user.has_perm('crashstats.view_pii') or your_crash %}
-                  {# FIXME(willkg): switch this to java_stack_trace_raw after January 2020 #}
-                  {% if report.java_stack_trace_full %}
-                    <tr title="{{ fields_desc['processed_crash.java_stack_trace_full'] }}">
-                      <th scope="row">Java Stack Trace (Full)</th>
+                  {% if report.java_stack_trace_raw %}
+                    <tr title="{{ fields_desc['processed_crash.java_stack_trace_raw'] }}">
+                      <th scope="row">Java Stack Trace (Raw)</th>
                       <td>
-                        <pre>{{ report.java_stack_trace_full }}</pre>
+                        <pre>{{ report.java_stack_trace_raw }}</pre>
                       </td>
                     </tr>
                   {% endif %}


### PR DESCRIPTION
This finishes the transition from `java_stack_trace_full` (which was poorly
named and caused problems in the Elasticsearch crash storage code) to
`java_stack_trace_raw` (which doesn't).