### PR TITLE
bug 1606450: truncate long string values for Elasticsearch

### DIFF
--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -943,7 +943,7 @@ class Test_truncate_string_field_values:
     )
     def test_truncate_string_field_values(self, data, expected):
         fields = {
-            "key": {"in_database_name": "key", "storage_mapping": {"type": "string"},}
+            "key": {"in_database_name": "key", "storage_mapping": {"type": "string"}}
         }
 
         # Note: data is modified in place


### PR DESCRIPTION
Elasticsearch gets sad when crash reports contain values which have more than 32,766 utf-8 encoded characters. This adds some code to truncate those fields before saving to Elasticsearch.

This fixes saving `java_stack_trace` and `java_stack_trace_raw` for StackOverflow errors which can get up to 100k characters long and make Elasticsearch sad.

To test:

1. run the processor
2. process a crash report for a Java Stack Overflow error like 844d5678-e15f-4974-bcf1-d51d90191230
3. watch the logs and make sure it saves in Elasticsearch without kicking up a maxbyteslengthexceeded error