### PR TITLE
bug 1581567: validate crash ids in /api/Reprocessing

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -632,9 +632,11 @@ class TestViews(BaseTestViews):
         assert response.status_code == 200
 
     def test_Reprocessing(self):
+        crash_id = create_new_ooid()
+
         def mocked_publish(queue, crash_ids):
             assert queue == "reprocessing"
-            assert crash_ids == ["xxxx"]
+            assert crash_ids == [crash_id]
             return True
 
         Reprocessing.implementation().publish = mocked_publish
@@ -643,7 +645,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         assert response.status_code == 403
 
-        params = {"crash_ids": "xxxx"}
+        params = {"crash_ids": crash_id}
         response = self.client.get(url, params, HTTP_AUTH_TOKEN="somecrap")
         assert response.status_code == 403
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -22,6 +22,7 @@ from django.utils.encoding import iri_to_uri
 from django.utils.module_loading import import_string
 
 from socorro.lib import BadArgumentError
+from socorro.lib.ooid import is_crash_id_valid
 from socorro.lib.requestslib import session_with_retries
 from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData
 
@@ -1048,6 +1049,10 @@ class Reprocessing(SocorroMiddleware):
         crash_ids = data["crash_ids"]
         if not isinstance(crash_ids, (list, tuple)):
             crash_ids = [crash_ids]
+        # If one of them isn't a crash id, raise a 400.
+        for crash_id in crash_ids:
+            if not is_crash_id_valid(crash_id):
+                raise BadArgumentError("Crash id '%s' is not valid." % crash_id)
         return self.get_implementation().publish(
             queue="reprocessing", crash_ids=crash_ids
         )

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -16,6 +16,7 @@ from crashstats.crashstats import models
 from crashstats.crashstats.tests.conftest import Response
 from crashstats.crashstats.tests.testbase import DjangoTestCase
 from socorro.lib import BadArgumentError
+from socorro.lib.ooid import create_new_ooid
 from socorro.unittest.external.pubsub import get_config_manager, PubSubHelper
 
 
@@ -509,10 +510,15 @@ class TestMiddlewareModels(DjangoTestCase):
             api = models.Reprocessing()
 
             with pubsub_helper as helper:
-                api.post(crash_ids="some-crash-id")
+                crash_id = create_new_ooid()
+                api.post(crash_ids=crash_id)
 
                 crash_ids = helper.get_crash_ids("reprocessing")
-                assert crash_ids == ["some-crash-id"]
+                assert crash_ids == [crash_id]
+
+            # Now try an invalid crash id
+            with pytest.raises(BadArgumentError):
+                api.post(crash_ids="some-crash-id")
 
     def test_PriorityJob(self):
         # This test runs against the Pub/Sub emulator, so undo the mock to let


### PR DESCRIPTION
This fixes `/api/Reprocessing` to validate crash ids before submitting them. This reduces failures in the processor when it gets crash ids that aren't crash ids.

To test:

Use the /api/Reprocessing API and send in an invalid crash id. Easiest thing to do is test it with the API reference docs.

http://localhost:8000/api/#Reprocessing