### PR TITLE
bug 1597730: remove quit check

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -142,25 +142,16 @@ class FetchTransformSaveApp(App):
             except Exception as x:
                 self.logger.error("removing raw: %s", str(x), exc_info=True)
 
-    def quit_check(self):
-        self.task_manager.quit_check()
-
     def _setup_source_and_destination(self):
         """Instantiate queue, source, and destination classes."""
         self.queue = self.config.queue.crashqueue_class(
-            self.config.queue,
-            namespace=self.app_instance_name,
-            quit_check_callback=self.quit_check,
+            self.config.queue, namespace=self.app_instance_name,
         )
         self.source = self.config.source.crashstorage_class(
-            self.config.source,
-            namespace=self.app_name,
-            quit_check_callback=self.quit_check,
+            self.config.source, namespace=self.app_name,
         )
         self.destination = self.config.destination.crashstorage_class(
-            self.config.destination,
-            namespace=self.app_name,
-            quit_check_callback=self.quit_check,
+            self.config.destination, namespace=self.app_name,
         )
 
     def _setup_task_manager(self):

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -149,10 +149,8 @@ class BotoS3CrashStorage(CrashStorageBase):
         from_string_converter=class_converter,
     )
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
-        super().__init__(
-            config, namespace=namespace, quit_check_callback=quit_check_callback
-        )
+    def __init__(self, config, namespace=""):
+        super().__init__(config, namespace=namespace)
         self.conn = config.resource_class(config)
 
     def save_raw_crash(self, raw_crash, dumps, crash_id):

--- a/socorro/external/crashqueue_base.py
+++ b/socorro/external/crashqueue_base.py
@@ -14,13 +14,9 @@ class CrashQueueBase(RequiredConfig):
 
     required_config = Namespace()
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
+    def __init__(self, config, namespace=""):
         self.config = config
         self.namespace = namespace
-        if quit_check_callback:
-            self.quit_check = quit_check_callback
-        else:
-            self.quit_check = lambda: False
 
     def close(self):
         pass

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -240,10 +240,8 @@ class ESCrashStorage(CrashStorageBase):
     field_name_number_error_re = re.compile(r"\[failed to parse \[([\w\-.]+)]]")
     field_name_unknown_property_error_re = field_name_number_error_re
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
-        super().__init__(
-            config, namespace=namespace, quit_check_callback=quit_check_callback
-        )
+    def __init__(self, config, namespace=""):
+        super().__init__(config, namespace=namespace)
 
         self.es_context = self.config.elasticsearch.elasticsearch_class(
             config=self.config.elasticsearch

--- a/socorro/external/pubsub/crashqueue.py
+++ b/socorro/external/pubsub/crashqueue.py
@@ -80,8 +80,8 @@ class PubSubCrashQueue(CrashQueueBase):
         reference_value_from="resource.pubsub",
     )
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
-        super().__init__(config, namespace, quit_check_callback)
+    def __init__(self, config, namespace=""):
+        super().__init__(config, namespace)
 
         if os.environ.get("PUBSUB_EMULATOR_HOST", ""):
             self.subscriber = pubsub_v1.SubscriberClient()

--- a/socorro/external/sqs/crashqueue.py
+++ b/socorro/external/sqs/crashqueue.py
@@ -141,8 +141,8 @@ class SQSCrashQueue(CrashQueueBase):
         reference_value_from="resource.boto",
     )
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
-        super().__init__(config, namespace, quit_check_callback)
+    def __init__(self, config, namespace=""):
+        super().__init__(config, namespace)
 
         self.client = self.build_client()
         self.standard_queue_url = self.get_queue_url(self.config.standard_queue)

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -149,10 +149,8 @@ class ThreadedTaskManager(TaskManager):
         while True:
             if self.task_queue.empty():
                 break
-            self.quit_check()
             if wait_log_interval and not seconds % wait_log_interval:
                 self.logger.info("%s: %dsec so far", wait_reason, seconds)
-                self.quit_check()
             seconds += 1
             time.sleep(1.0)
 
@@ -218,7 +216,6 @@ class ThreadedTaskManager(TaskManager):
                     )
                     self._responsive_sleep(self.config.idle_delay)
                     continue
-                self.quit_check()
                 # self.logger.debug("queuing job %s", job_params)
                 self.task_queue.put((self.task_func, job_params))
         except Exception:

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -235,7 +235,7 @@ class ProcessorApp(FetchTransformSaveApp):
         super()._setup_source_and_destination()
         if self.config.companion_process.companion_class:
             self.companion_process = self.config.companion_process.companion_class(
-                self.config.companion_process, self.quit_check
+                self.config.companion_process
             )
         else:
             self.companion_process = None
@@ -246,9 +246,7 @@ class ProcessorApp(FetchTransformSaveApp):
         # while the threaded_task_manager processes crashes.
         self.waiting_func = None
 
-        self.processor = self.config.processor.processor_class(
-            self.config.processor, quit_check_callback=self.quit_check
-        )
+        self.processor = self.config.processor.processor_class(self.config.processor)
 
     def close(self):
         """Clean up the processor on shutdown."""

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -258,9 +258,6 @@ class BreakpadStackwalkerRule2015(Rule):
             raw_crash, raw_crash.uuid
         ) as raw_crash_pathname:
             for dump_name in raw_dumps.keys():
-                if processor_meta.quit_check:
-                    processor_meta.quit_check()
-
                 # this rule is only interested in dumps targeted for the
                 # minidump stackwalker external program.  As of the writing
                 # of this code, there is one other dump type.  The only way

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -140,7 +140,7 @@ class SymbolLRUCacheManager(RequiredConfig):
         from_string_converter=int,
     )
 
-    def __init__(self, config, quit_check_callback=None):
+    def __init__(self, config):
         """constructor for a registration object that runs an LRU cache
        cleaner"""
         self.config = config

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -58,7 +58,7 @@ class Rule(object):
         return True
 
 
-class SignatureTool(object):
+class SignatureTool:
     """Stack walking signature generator base class
 
     This defines the interface for classes that take a stack and generate a
@@ -67,9 +67,6 @@ class SignatureTool(object):
     Subclasses should implement the ``_do_generate`` method.
 
     """
-
-    def __init__(self, quit_check_callback=None):
-        self.quit_check_callback = quit_check_callback
 
     def generate(self, source_list, hang_type=0, crashed_thread=None, delimiter=" | "):
         signature, notes, debug_notes = self._do_generate(
@@ -93,8 +90,8 @@ class CSignatureTool(SignatureTool):
 
     hang_prefixes = {-1: "hang", 1: "chromehang"}
 
-    def __init__(self, quit_check_callback=None):
-        super(CSignatureTool, self).__init__(quit_check_callback)
+    def __init__(self):
+        super(CSignatureTool, self).__init__()
 
         self.irrelevant_signature_re = re.compile(
             "|".join(siglists_utils.IRRELEVANT_SIGNATURE_RE)

--- a/socorro/unittest/app/test_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_fetch_transform_save_app.py
@@ -66,7 +66,7 @@ class TestFetchTransformSaveApp(object):
                     yield ((x,), {})
 
         class FakeQueue(object):
-            def __init__(self, config, namespace="", quit_check_callback=None):
+            def __init__(self, config, namespace=""):
                 pass
 
             def new_crashes(self):
@@ -76,7 +76,7 @@ class TestFetchTransformSaveApp(object):
                     yield crash_id
 
         class FakeStorageSource(object):
-            def __init__(self, config, namespace="", quit_check_callback=None):
+            def __init__(self, config, namespace=""):
                 self.store = DotDict(
                     {
                         "1234": DotDict(
@@ -109,7 +109,7 @@ class TestFetchTransformSaveApp(object):
                 self.number_of_close_calls += 1
 
         class FakeStorageDestination(object):
-            def __init__(self, config, namespace="", quit_check_callback=None):
+            def __init__(self, config, namespace=""):
                 self.store = DotDict()
                 self.dumps = DotDict()
                 self.number_of_close_calls = 0
@@ -177,7 +177,7 @@ class TestFetchTransformSaveApp(object):
                         yield None
 
         class FakeStorageDestination(object):
-            def __init__(self, config, quit_check_callback):
+            def __init__(self, config):
                 self.store = DotDict()
                 self.dumps = DotDict()
 
@@ -233,7 +233,7 @@ class TestFetchTransformSaveApp(object):
 
     def test_no_source(self):
         class FakeStorageDestination(object):
-            def __init__(self, config, quit_check_callback):
+            def __init__(self, config):
                 self.store = DotDict()
                 self.dumps = DotDict()
 
@@ -267,7 +267,7 @@ class TestFetchTransformSaveApp(object):
 
     def test_no_destination(self):
         class FakeStorageSource(object):
-            def __init__(self, config, quit_check_callback):
+            def __init__(self, config):
                 self.store = DotDict(
                     {
                         "1234": DotDict(

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -26,8 +26,8 @@ class A(CrashStorageBase):
     required_config.add_option("x", default=1)
     required_config.add_option("y", default=2)
 
-    def __init__(self, config, namespace="", quit_check_callback=None):
-        super().__init__(config, namespace, quit_check_callback)
+    def __init__(self, config, namespace=""):
+        super().__init__(config, namespace)
         self.raw_crash_count = 0
 
     def save_raw_crash(self, raw_crash, dump):
@@ -58,10 +58,6 @@ class MutatingProcessedCrashCrashStorage(CrashStorageBase):
         del processed_crash["foo"]
 
 
-def fake_quit_check():
-    return False
-
-
 class TestCrashStorageBase(object):
     def test_basic_crashstorage(self):
         required_config = Namespace()
@@ -80,7 +76,7 @@ class TestCrashStorageBase(object):
         )
 
         with config_manager.context() as config:
-            crashstorage = CrashStorageBase(config, quit_check_callback=fake_quit_check)
+            crashstorage = CrashStorageBase(config)
             crashstorage.save_raw_crash({}, "payload", "ooid")
             crashstorage.save_processed({})
             with pytest.raises(NotImplementedError):
@@ -112,7 +108,7 @@ class TestCrashStorageBase(object):
             def open_function(*args, **kwargs):
                 return values.pop(0)
 
-            crashstorage = MyCrashStorage(config, quit_check_callback=fake_quit_check)
+            crashstorage = MyCrashStorage(config)
 
             with mock.patch("socorro.external.crashstorage_base.open") as open_mock:
                 open_mock.return_value = mock.MagicMock()
@@ -409,14 +405,10 @@ class TestBench(object):
         )
 
         with config_manager.context() as config:
-            crashstorage = BenchmarkingCrashStorage(
-                config, namespace="", quit_check_callback=fake_quit_check
-            )
+            crashstorage = BenchmarkingCrashStorage(config, namespace="")
             crashstorage.start_timer = lambda: 0
             crashstorage.end_timer = lambda: 1
-            fake_crash_store.assert_called_with(
-                config, namespace="", quit_check_callback=fake_quit_check
-            )
+            fake_crash_store.assert_called_with(config, namespace="")
 
             crashstorage.save_raw_crash({}, "payload", "ooid")
             crashstorage.wrapped_crashstore.save_raw_crash.assert_called_with(

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -52,7 +52,7 @@ class TestTaskManager(object):
             def _responsive_sleep(self, seconds, wait_log_interval=0, wait_reason=""):
                 try:
                     if self.count >= 2:
-                        self.quit = True
+                        raise KeyboardInterrupt
                     self.count += 1
                 except AttributeError:
                     self.count = 0

--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -13,7 +13,7 @@ csig_config.prefix_signature_re = ""
 csig_config.signatures_with_line_numbers_re = ""
 csig_config.signature_sentinels = []
 csig_config.collapse_arguments = True
-c_signature_tool = CSignatureTool(csig_config)
+c_signature_tool = CSignatureTool()
 
 
 def create_basic_fake_processor():
@@ -32,5 +32,4 @@ def get_basic_config():
 def get_basic_processor_meta():
     processor_meta = DotDict()
     processor_meta.processor_notes = []
-    processor_meta.quit_check = lambda: False
     return processor_meta


### PR DESCRIPTION
We used to do deploys by stopping the processor service, updating the code, and then starting it again. That was a long time ago. Now we create a bunch of new processor nodes and then kill off the old processor nodes. Because of that, we no longer need the quit check code that allows the processor to shut down nicely.

To test the local dev environment:

1. run the processor
2. process a crash
3. hit ctrl-c and shut down the processor