### PR TITLE
bug 1552976: fix correlations tab

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -77,12 +77,10 @@
             <li class="ui-state-default ui-corner-top">
               <a href="#extensions" class="ui-tabs-anchor"><span>Extensions</span></a>
             </li>
-            {% if raw.TelemetryEnvironment %}
-              <li class="ui-state-default ui-corner-top">
-                <a href="#telemetryenvironment" class="ui-tabs-anchor"><span>Telemetry Environment</span></a>
-              </li>
-            {% endif %}
-            <li class="ui-state-default ui-corner-top correlations hidden">
+            <li class="ui-state-default ui-corner-top">
+              <a href="#telemetryenvironment" class="ui-tabs-anchor"><span>Telemetry Environment</span></a>
+            </li>
+            <li class="ui-state-default ui-corner-top">
               <a href="#correlation" class="ui-tabs-anchor"><span>Correlations</span></a>
             </li>
             {% if request.user.has_perm('crashstats.reprocess_crashes') %}
@@ -867,15 +865,17 @@
           </div>
           <!-- /extensions -->
 
-          {% if raw.TelemetryEnvironment %}
-            <div id="telemetryenvironment" class="ui-tabs-hide">
+          <div id="telemetryenvironment" class="ui-tabs-hide">
+            {% if raw.TelemetryEnvironment %}
               {# Remember, raw.TelemetryEnvironment is a string.
-                 jQuery will automatically convert it a map upon accessing it.
+                 jQuery will automatically convert it to a map upon accessing it.
                  Safe to include because jinja will escape anything in it. #}
               <div id="telemetryenvironment-json" data-telemetryenvironment="{{ raw.TelemetryEnvironment }}"></div>
-            </div>
-            <!-- /telemetryenvironment -->
-          {% endif %}
+            {% else %}
+              <p>No telemetry environment data available.</p>
+            {% endif %}
+          </div>
+          <!-- /telemetryenvironment -->
 
           <div id="correlation" class="ui-tabs-hide">
             <h3></h3>

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -117,14 +117,15 @@ $(document).ready(function() {
   var product = container.data('product');
 
   window.correlations.getCorrelations(signature, channel, product).then(function(results) {
+    $('#correlation h3').text('Correlations for ' + product + ' ' + channel[0].toUpperCase() + channel.substr(1));
+
     if (!Array.isArray(results)) {
+      $('#correlation pre').text('No correlation data available.');
       return;
     }
 
     var content = results.join('\n');
 
-    $('li.correlations').show();
-    $('#correlation h3').text('Correlations for ' + product + ' ' + channel[0].toUpperCase() + channel.substr(1));
     $('#correlation pre')
       .empty()
       .text(content);


### PR DESCRIPTION
When the report view page is loaded, the correlations tab is hidden. JavaScript in the page goes to fetch correlation data and if it gets some, then it unhides the tab so as to show correlations data. The
problem here is that unhiding the tab causes the tabs to the right to jump.

This changes the code so that the tab is always shown and when there's no correlations data, it states there's no correlations data. This fixes the UI jumping which keeps biting me. It also reduces confusion around why the tab isn't showing up in some cases.

While doing this, I also unhid the Telemetry Environment tab. That will now show all the time and when there's no TelemetryEnvironment data, it'll state there's no data.