### PR TITLE
bug 1605806: fix language around requesting pii access

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -67,10 +67,11 @@ For more complex crash sets, pass a search URL to generate the list::
     app@socorro:app$ cat crashids | socorro-cmd reprocess
 
 
-Processing requests for PII access
-==================================
+Processing requests for memory dumps and private user data access
+=================================================================
 
-People file bugs in Bugzilla asking to be granted access to PII using
+People file bugs in Bugzilla asking to be granted access to memory dumps
+and private user data using
 `these instructions <https://crash-stats.mozilla.org/documentation/memory_dump_access/>`_.
 
 Process for handling those:
@@ -99,8 +100,9 @@ Then wait for those needinfos to be filled. Once that's done:
 
 Then reply in the bug something like this::
 
-    You have access to PII on Crash Stats. You might have to log out and log
-    back in again. Let us know if you have any problems!
+    You have access to memory dumps and private user data on Crash Stats. You
+    might have to log out and log back in again. Let us know if you have any
+    problems!
 
     Thank you!
 

--- a/webapp-django/crashstats/documentation/jinja2/documentation/docs_base.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/docs_base.html
@@ -31,7 +31,7 @@
         <nav>
           <ul class="options">
             {{ navlink(url('documentation:home'), 'Home') }}
-            {{ navlink(url('documentation:memory_dump_access'), 'Memory Dump Access') }}
+            {{ navlink(url('documentation:memory_dump_access'), 'Memory Dump and Private User Data Access') }}
             {{ navlink(url('documentation:products'), 'Products') }}
             {{ navlink(url('api:documentation'), 'API Reference') }}
             {{ navlink(url('documentation:supersearch_home'), 'Super Search') }}

--- a/webapp-django/crashstats/documentation/jinja2/documentation/memory_dump_access.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/memory_dump_access.html
@@ -1,15 +1,19 @@
 {% extends "documentation/docs_base.html" %}
 
-{% block doc_title %}Memory Dump Access{% endblock %}
+{% block doc_title %}Memory Dump and Private User Data Access{% endblock %}
 
 {% block doc_content %}
   <div class="body">
-    <h1 id="policy">Access to memory dumps</h1>
+    <h1 id="policy">Access to memory dumps and private user data</h1>
     <p>
       Crash reports include memory dumps which contain sensitive information
       and is not publicly available on Crash Stats. Memory dumps are important
-      for diagnosing and debugging issues. As such, users can request access
-      to memory dumps in order to debug issues.
+      for diagnosing and debugging issues. Further, crash reports may also
+      contain private user data such as the user's email address and comments
+      if they provided any. As such, users can request access to memory dumps
+      and private user data information in order to debug issues.
+    </p>
+    <p>
     </p>
     <p>
       Anyone with access to memory dumps and private data agrees to the following:
@@ -28,9 +32,9 @@
 
 The most recent copy of this agreement is at: https://crash-stats.mozilla.org/documentation/memory_dump_access/</pre>
 
-    <h1 id="requestaccess">How to request memory dump access</h1>
+    <h1 id="requestaccess">How to request access to memory dumps and private user data</h1>
     <p>
-      To request access to memory dumps, please:
+      To request access to memory dumps and private user data, please:
     </p>
     <ol>
       <li>Log into <a href="https://crash-stats.mozilla.org/">Crash Stats</a>


### PR DESCRIPTION
Previously, the documentation only talked about memory dumps, but the process for requesting access covers both memory dumps and private user data.

This fixes the language so that's clearer.