### PR TITLE
bug 1605429: fix stackwalker to work with ModuleSignatureInfo as object

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -603,14 +603,20 @@ static ModuleCertMap GetModuleCertMap(const Json::Value& raw_root)
   ModuleCertMap result;
 
   const Json::Value& infoString = raw_root["ModuleSignatureInfo"];
-  if (!infoString || !infoString.isString()) {
+  if (!infoString) {
     return result;
   }
 
   Json::Value info;
-  Json::Reader reader;
-  if (!reader.parse(infoString.asString(), info, false)) {
-    return result;
+  if (infoString.isString()) {
+    // If ModuleSignatureInfo is a string, then parse it
+    Json::Reader reader;
+    if (!reader.parse(infoString.asString(), info, false)) {
+      return result;
+    }
+  } else {
+    // If ModuleSignatureInfo is not a string, then assume it's a Json::Value
+    info = infoString;
   }
 
   Json::Value::Members certs = info.getMemberNames();


### PR DESCRIPTION
Recently, the crash reporter was changed so it sends a JSON blob with the annotations in it. When that happened, the type of the `ModuleSignatureInfo` value changed from a JSON-encoded string to an
object. stackwalker expected a JSON-encoded string, so if it was an object, it'd ignore it. Thus it didn't capture the signed-by information for modules.

This fixes that by supporting both JSON-encoded string and `Json::Value` values of `ModuleSignatureInfo`.