### PR TITLE
bug 1581927: fix cronrun to run jobs despite OngoingJobError

### DIFF
--- a/webapp-django/crashstats/cron/management/commands/cronrun.py
+++ b/webapp-django/crashstats/cron/management/commands/cronrun.py
@@ -80,7 +80,12 @@ class Command(BaseCommand):
     def cmd_run_all(self):
         logger.info("Running all jobs...")
         for job_spec in JOBS:
-            self._run_one(job_spec, cmd_args=job_spec.get("cmd_args", []))
+            try:
+                self._run_one(job_spec, cmd_args=job_spec.get("cmd_args", []))
+            except OngoingJobError:
+                # If the job is already running somehow, then move on
+                logger.error("OngoingJobError: %s", job_spec.get("cmd", "no command"))
+                pass
         return 0
 
     def cmd_run_one(self, description, force=False, cmd_args=None):

--- a/webapp-django/crashstats/cron/tests/test_cronrun.py
+++ b/webapp-django/crashstats/cron/tests/test_cronrun.py
@@ -82,3 +82,12 @@ class TestCronrun:
             call_command("cronrun")
 
         assert Job.objects.all().count() == len(JOBS)
+
+    def test_run_all_with_ongoingjoberror(self, db):
+        """Verify jobs can kick up OngoingJobError."""
+        mock_path = "crashstats.cron.management.commands.cronrun.call_command"
+        with mock.patch(mock_path) as mock_call_command:
+            mock_call_command.side_effect = OngoingJobError("test")
+            call_command("cronrun")
+
+        assert Job.objects.all().count() == len(JOBS)


### PR DESCRIPTION
Previously, if `cronrun` hit an `OngoingJobError`, it would stop running any jobs. This fixes it to continue through the list of jobs that are ready to run even if one of them throws an `OngoingJobError`.