### PR TITLE
bug 1607519: fix Caused By handling in java stack trace parser

### DIFF
--- a/socorro/lib/javautil.py
+++ b/socorro/lib/javautil.py
@@ -98,11 +98,7 @@ def parse_java_stack_trace(text):
                 stage = ADDITIONAL
 
         elif stage is ADDITIONAL:
-            # Verify this has a tab at the beginning of the line
-            if line[0] != "\t":
-                raise MalformedJavaStackTrace("additional line missing tab")
-
-            # Drop first tab from the line
-            new_exc.additional.append(line[1:])
+            # Append all the rest of the stack trace as is
+            new_exc.additional.append(line)
 
     return new_exc

--- a/socorro/unittest/lib/test_javautil.py
+++ b/socorro/unittest/lib/test_javautil.py
@@ -100,8 +100,8 @@ def test_parse_suppressed():
     assert java_exc.exception_message == "msg"
     assert java_exc.stack == ["at org.File.function(File.java:100)"]
     assert java_exc.additional == [
-        "Suppressed: Exception2: msg2",
-        "\tat org.File.function(File.java:101)",
+        "\tSuppressed: Exception2: msg2",
+        "\t\tat org.File.function(File.java:101)",
     ]
 
 
@@ -119,6 +119,24 @@ def test_parse_caused_by():
     assert java_exc.exception_message == "msg"
     assert java_exc.stack == ["at org.File.function(File.java:100)"]
     assert java_exc.additional == [
+        "\tCaused by: Exception2: msg2; no stack trace available"
+    ]
+
+
+EXC_WITH_UNINDENTED_CAUSED_BY = """\
+Exception: msg
+\tat org.File.function(File.java:100)
+Caused by: Exception2: msg2; no stack trace available
+"""
+
+
+def test_parse_unindented_caused_by():
+    """Parse an exception with an unindented "Caused by" section."""
+    java_exc = javautil.parse_java_stack_trace(EXC_WITH_UNINDENTED_CAUSED_BY)
+    assert java_exc.exception_class == "Exception"
+    assert java_exc.exception_message == "msg"
+    assert java_exc.stack == ["at org.File.function(File.java:100)"]
+    assert java_exc.additional == [
         "Caused by: Exception2: msg2; no stack trace available"
     ]
 
@@ -131,13 +149,6 @@ def test_parse_caused_by():
         "",
         # Line without a tab in STACK stage
         ("Exception: msg\n" "\tat org.File.function(File.java:100)\n" "badline"),
-        # Line without a tab in ADDITIONAL stage
-        (
-            "Exception: msg\n"
-            "\tat org.File.function(File.java:100)\n"
-            "\tSuppressed: Exception: msg\n"
-            "badline"
-        ),
     ],
 )
 def test_malformed(text):


### PR DESCRIPTION
Previously, we only saw "Caused By:" lines that were indented by one tab. Now we're seeing them unindented which is kicking up a `MalformedJavaStackTrace` exception.

This fixes the parsing to handle both situations.