### PR TITLE
bug 1607806: make ModuleSignatureInfo always a JSON-encoded string

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -33,6 +33,7 @@ from socorro.processor.rules.memory_report_extraction import MemoryReportExtract
 from socorro.processor.rules.mozilla import (
     AddonsRule,
     BetaVersionRule,
+    ConvertModuleSignatureInfoRule,
     DatesAndTimesRule,
     EnvironmentRule,
     ESRVersionRewrite,
@@ -168,6 +169,8 @@ class ProcessorPipeline(RequiredConfig):
         return [
             # fix the raw crash removing null characters
             DeNullRule(),
+            # fix ModuleSignatureInfo if it needs fixing
+            ConvertModuleSignatureInfoRule(),
             # rules to change the internals of the raw crash
             ProductRewrite(),
             ESRVersionRewrite(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -29,6 +29,27 @@ from socorro.signature.utils import convert_to_crash_data
 MAXINT = 9223372036854775807
 
 
+class ConvertModuleSignatureInfoRule(Rule):
+    """Make ModuleSignatureInfo to a string.
+
+    For a while, crash reports submitted as a JSON blob had ModuleSignatureInfo appended
+    to the end of them as an object. This JSON-encodes that object so that it's always a
+    JSON-encoded string. That way, the rest of the processor doesn't have to handle both
+    cases. Bug #1607806.
+
+    """
+
+    def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return "ModuleSignatureInfo" in raw_crash and not isinstance(
+            raw_crash["ModuleSignatureInfo"], str
+        )
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        info = raw_crash["ModuleSignatureInfo"]
+        info = json.dumps(info)
+        raw_crash["ModuleSignatureInfo"] = info
+
+
 class ProductRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         processed_crash.product = raw_crash.get("ProductName", "")

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -16,6 +16,7 @@ from socorro.lib.util import dotdict_to_dict
 from socorro.processor.rules.mozilla import (
     AddonsRule,
     BetaVersionRule,
+    ConvertModuleSignatureInfoRule,
     DatesAndTimesRule,
     ESRVersionRewrite,
     EnvironmentRule,
@@ -161,6 +162,41 @@ canonical_processed_crash = DotDict(
         }
     }
 )
+
+
+class TestConvertModuleSignatureInfoRule:
+    def test_no_value(self):
+        raw_crash = {}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ConvertModuleSignatureInfoRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert raw_crash == {}
+        assert processed_crash == {}
+
+    def test_string_value(self):
+        raw_crash = {"ModuleSignatureInfo": "{}"}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ConvertModuleSignatureInfoRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert raw_crash == {"ModuleSignatureInfo": "{}"}
+        assert processed_crash == {}
+
+    def test_object_value(self):
+        raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ConvertModuleSignatureInfoRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
+        assert processed_crash == {}
 
 
 class TestProductRule(object):


### PR DESCRIPTION
This fixes `raw_crash["ModuleSignatureInfo"]` to always have a JSON-encoded string value so the rest of the processor doesn't have to handle both cases.