### PR TITLE
bug 1607806: fix converting ModuleSignatureInfo values

### DIFF
--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -19,7 +19,7 @@ def dotdict_to_dict(sdotdict):
 
     def _dictify(thing):
         if isinstance(thing, collections.Mapping):
-            return dict([(key, _dictify(val)) for key, val in thing.items()])
+            return {key: _dictify(val) for key, val in thing.items()}
         elif isinstance(thing, str):
             # NOTE(willkg): Need to do this because strings are sequences but
             # we don't want to convert them into lists in the next clause

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -9,6 +9,7 @@ import re
 import time
 from urllib.parse import unquote_plus
 
+from configman.dotdict import DotDict
 import markus
 
 from socorro.lib import javautil
@@ -18,6 +19,7 @@ from socorro.lib.context_tools import temp_file_context
 from socorro.lib.datetimeutil import UTC, datetime_from_isodate_string
 from socorro.lib.ooid import date_from_ooid
 from socorro.lib.requestslib import session_with_retries
+from socorro.lib.util import dotdict_to_dict
 from socorro.processor.rules.base import Rule
 from socorro.signature.generator import SignatureGenerator
 from socorro.signature.utils import convert_to_crash_data
@@ -46,8 +48,11 @@ class ConvertModuleSignatureInfoRule(Rule):
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         info = raw_crash["ModuleSignatureInfo"]
-        info = json.dumps(info)
-        raw_crash["ModuleSignatureInfo"] = info
+        if isinstance(info, DotDict):
+            # Sometimes the value is a DotDict which json.dumps doesn't work with so
+            # convert it to a dict first
+            info = dotdict_to_dict(info)
+        raw_crash["ModuleSignatureInfo"] = json.dumps(info)
 
 
 class ProductRule(Rule):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -166,7 +166,7 @@ canonical_processed_crash = DotDict(
 
 class TestConvertModuleSignatureInfoRule:
     def test_no_value(self):
-        raw_crash = {}
+        raw_crash = DotDict()
         raw_dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -177,7 +177,7 @@ class TestConvertModuleSignatureInfoRule:
         assert processed_crash == {}
 
     def test_string_value(self):
-        raw_crash = {"ModuleSignatureInfo": "{}"}
+        raw_crash = DotDict({"ModuleSignatureInfo": "{}"})
         raw_dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -188,6 +188,17 @@ class TestConvertModuleSignatureInfoRule:
         assert processed_crash == {}
 
     def test_object_value(self):
+        raw_crash = DotDict({"ModuleSignatureInfo": {"foo": "bar"}})
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ConvertModuleSignatureInfoRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
+        assert processed_crash == {}
+
+    def test_object_value_with_dict(self):
         raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
         raw_dumps = {}
         processed_crash = {}


### PR DESCRIPTION
`raw_crash["ModuleSignatureInfo"]` is a `DotDict` which doesn't work with `json.dumps`. This fixes the code to convert it to a dict and then `json.dumps` it.