### PR TITLE
bug 1609121: add __pthread_cond_wait to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -235,6 +235,7 @@ PR_
 .*ProcessNextEvent
 __psynch_cvwait
 _pthread_cond_wait
+__pthread_cond_wait
 pthread_cond_signal_thread_np
 pthread_mutex_lock
 __pthread_kill


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature https://crash-stats.mozilla.org/report/index/d5a4148d-d3b3-4103-bf64-26aef0200108
Crash id: d5a4148d-d3b3-4103-bf64-26aef0200108
Original: __pthread_cond_wait
New:      __pthread_cond_wait | mozilla::ipc::MessageChannel::WaitForSyncNotify | mozilla::ipc::MessageChannel::Call | mozilla::plugins::PPluginScriptableObjectChild::CallNPN_Evaluate
Same?:    False
app@socorro:/app$ socorro-cmd signature https://crash-stats.mozilla.org/report/index/bc2c76e7-b0ba-4ff7-8c12-73f0d0200107
Crash id: bc2c76e7-b0ba-4ff7-8c12-73f0d0200107
Original: __pthread_cond_wait
New:      __pthread_cond_wait | pa_cond_wait
Same?:    False
```