### PR TITLE
bug 1608870: added mozilla::ipc::Shmem items to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -164,6 +164,8 @@ mozilla::ipc::RPCChannel::Call
 mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame
 mozilla::ipc::RPCChannel::EnteredCxxStack
 mozilla::ipc::RPCChannel::Send
+mozilla::ipc::Shmem::OpenExisting
+mozilla::ipc::IToplevelProtocol::ShmemCreated
 mozilla::layers::CompositorD3D11::Failed
 mozilla::layers::CompositorD3D11::HandleError
 mozilla::SpinEventLoopUntil<T>


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature https://crash-stats.mozilla.org/report/index/71d58118-c7f9-4323-aa58-9a0530191212 https://crash-stats.mozilla.org/report/index/ea51ec67-1cf3-4057-b6ad-a1c950200105
Crash id: 71d58118-c7f9-4323-aa58-9a0530191212
Original: mozilla::ipc::Shmem::OpenExisting
New:      mozilla::ipc::Shmem::OpenExisting | mozilla::ipc::IToplevelProtocol::ShmemCreated | mozilla::layers::PVideoBridgeParent::OnMessageReceived
Same?:    False
Crash id: ea51ec67-1cf3-4057-b6ad-a1c950200105
Original: mozilla::ipc::Shmem::OpenExisting
New:      mozilla::ipc::Shmem::OpenExisting | mozilla::ipc::IToplevelProtocol::ShmemCreated | mozilla::layers::PCompositorManagerParent::OnMessageReceived
Same?:    False
```