### PR TITLE
bug 1609247: move __security_check_cookie to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -88,6 +88,7 @@ _sigtramp
 __sigtramp
 schedule_class_load
 _security_check_cookie
+__security_check_cookie
 SkyLight
 SleepConditionVariableCS
 SleepConditionVariableSRW

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -257,7 +257,6 @@ __rust_start_panic
 SEC_.*Item
 seckey_
 SECKEY_
-__security_check_cookie
 __semwait_signal
 send
 setjmp


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 57e55e97-8d71-4ca9-b143-0708b0200116
Crash id: 57e55e97-8d71-4ca9-b143-0708b0200116
Original: __security_check_cookie | sandbox::PolicyRule::AddStringMatch
New:      sandbox::PolicyRule::AddStringMatch
Same?:    False
```