### PR TITLE
bug 1610792: add mozilla::DOMEventTargetHelper::AddRef to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -145,6 +145,7 @@ mozilla::AndroidBridge::AutoLocalJNIFrame::~AutoLocalJNIFrame
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
+mozilla::DOMEventTargetHelper::AddRef
 mozilla::MozPromise<T>::ThenCommand<T>::Track
 mozilla::MozPromise<T>::ThenInternal
 SleepConditionVariableCS


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature a70cb2cd-0fe1-4087-976f-a820b0200123
Crash id: a70cb2cd-0fe1-4087-976f-a820b0200123
Original: mozilla::DOMEventTargetHelper::AddRef
New:      mozilla::DOMEventTargetHelper::AddRef | struct nsTimerImpl::Callback& const nsTimerImpl::Callback::operator=
Same?:    False
```