### PR TITLE
Add servo_arc::Arc<T>::drop_slow to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -260,6 +260,7 @@ seckey_
 SECKEY_
 __semwait_signal
 send
+servo_arc::Arc<T>::drop_slow
 setjmp
 sigblock
 sigprocmask


### PR DESCRIPTION
This is needed to disambiguate: https://crash-stats.mozilla.com/signature/?product=Firefox&signature=core%3A%3Aptr%3A%3Areal_drop_in_place%20%7C%20core%3A%3Aptr%3A%3Areal_drop_in_place%20%7C%20servo_arc%3A%3AArc%3CT%3E%3A%3Adrop_slow&date=%3E%3D2019-07-07T19%3A03%3A00.000Z&date=%3C2020-01-07T19%3A03%3A00.000Z&_columns=date&_columns=product&_columns=version&_columns=build_id&_columns=platform&_columns=reason&_columns=address&_columns=install_time&_columns=startup_crash&_sort=-platform&_sort=-version&_sort=-date&page=1