### PR TITLE
Bug 1612921 - Add some CString functions to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -67,6 +67,8 @@ __forwarding_prep_0___
 free_impl
 __fsetlocking
 CCGraphBuilder::NoteXPCOMChild
+Gecko_FinalizeCString
+Gecko_SetLengthCString
 getanswer
 GetTickCount64
 gfxPlatform::Init


### PR DESCRIPTION
This is a rebased version of PR #5206.

```
app@socorro:/app$ socorro-cmd signature  bp-9804c04c-a25e-4a54-85d0-e61150200202 bp-e08fb9b2-3af5-4265-b9bd-04fea0200131
Crash id: 9804c04c-a25e-4a54-85d0-e61150200202
Original: shutdownhang | Gecko_FinalizeCString
New:      shutdownhang | Gecko_FinalizeCString | PLDHashTable::~PLDHashTable | TelemetryOrigin::DeInitializeGlobalState
Same?:    False
Crash id: e08fb9b2-3af5-4265-b9bd-04fea0200131
Original: OOM | large | NS_ABORT_OOM | Gecko_SetLengthCString
New:      OOM | large | NS_ABORT_OOM | Gecko_SetLengthCString | mozilla::URLPreloader::URLEntry::ReadLocation
Same?:    False
app@socorro:/app$ 
```