### PR TITLE
bug 1616253: fix aggregation for ipc_shutdown_state

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2192,7 +2192,7 @@ FIELDS = {
         "namespace": "raw_crash",
         "permissions_needed": [],
         "query_type": "enum",
-        "storage_mapping": {"type": "string"},
+        "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
     "ipc_system_error": {
         "data_validation_type": "int",


### PR DESCRIPTION
Previously, the values were getting tokenized when indexed and that
caused problems when looking at `ipc_shutdown_state` facet. This fixes
that by switching it to the keyword analyzer which doesn't tokenize.

To test, process crash reports with `ipc_shutdown_state` values. Then use supersearch and do a facet on that. The facet options should be something like:

* `SendFinishShutdown (sent)`

and not something like:

* `sendfinishshutdown`
* `sent`