### PR TITLE
bug 1616837: add RustMozCrash to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -53,6 +53,7 @@ _mach_msg_trap
 mnt@asec@org\.mozilla\.f.*-\d@pkg\.apk@classes\.dex@0x
 MOZ_Assert
 MOZ_Crash
+mozglue_static::panic_hook
 mozcrt19.dll@0x
 mozilla::CondVar::Wait
 mozilla::detail::ConditionVariableImpl
@@ -84,6 +85,7 @@ rtc::FatalMessage
 RtlpAdjustHeapLookasideDepth
 RtlSleepConditionVariableCS
 RtlSleepConditionVariableSRW
+RustMozCrash
 _sigtramp
 __sigtramp
 schedule_class_load

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -38,6 +38,7 @@ _chkstk
 __chk_fail
 CleanupPerAppKey
 ConditionVariableFallback::wait\(.*\)
+core::ops::function::Fn::call<T>
 core::option::expect_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place


### PR DESCRIPTION
This adds `RustMozCrash` and `mozglue_static::panic_hook` to the irrelevant list. If they show up in stacks, they'll get skipped over in signature generation.

This also adds `core::ops::function::Fn::call<T>` to the prefix list so it's included in the signature, but generation continues past it.

These changes let us differentiate between causes for crash reports that are all currently getting a signature of `RustMozCrash`.