### PR TITLE
bug 1617918: fix IPC Channel Error signature generation rule

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -829,21 +829,33 @@ class SignatureJitCategory(Rule):
 
 
 class SignatureIPCChannelError(Rule):
-    """Prepends signature with IPCError-browser or IPCError-content and error message."""
+    """Either stomp on or prepend signature for IPCError
+
+    If the IPCError is a ShutDownKill, then this prepends the signature with
+    "IPCError-browser | ShutDownKill".
+
+    Otherwise it stomps on the signature with "IPCError-browser/content" and the error
+    message.
+
+    """
 
     def predicate(self, crash_data, result):
         return bool(crash_data.get("ipc_channel_error"))
 
     def action(self, crash_data, result):
         if crash_data.get("additional_minidumps") == "browser":
-            new_sig = "IPCError-browser | {} | {}"
+            new_sig = "IPCError-browser | {}"
         else:
-            new_sig = "IPCError-content | {} | {}"
-        new_sig = new_sig.format(
-            crash_data["ipc_channel_error"][:100], result.signature
-        )
+            new_sig = "IPCError-content | {}"
+        new_sig = new_sig.format(crash_data["ipc_channel_error"][:100])
 
-        result.info(self.name, "IPC Channel Error prepended")
+        if crash_data["ipc_channel_error"] == "ShutDownKill":
+            # If it's a ShutDownKill, append the rest of the signature
+            result.info(self.name, "IPC Channel Error prepended")
+            new_sig = "{} | {}".format(new_sig, result.signature)
+        else:
+            result.info(self.name, "IPC Channel Error stomped on signature")
+
         result.set_signature(self.name, new_sig)
         return True
 


### PR DESCRIPTION
Previously, we adjusted the rule to always prepend `IPCError-content/browser | <error>`, but we only really wanted to do that for ShutDownKill crashes--not the other kinds of IPC channel errors.

This fixes it so that ShutDownKill crashes get that bit prepended and the signatures for other crashes don't.

```
app@socorro:/app$ socorro-cmd signature 9e4d772e-719e-4711-a688-122e80200204 bp-9c65dbfc-1862-4eb4-9e88-187b10200225 bp-7fd5c699-d230-462d-a8ac-aa96a0200225
Crash id: 9e4d772e-719e-4711-a688-122e80200204
Original: IPCError-browser | ShutDownKill | gfxHarfBuzzShaper::SetGlyphsFromRun
New:      IPCError-browser | ShutDownKill | gfxHarfBuzzShaper::SetGlyphsFromRun
Same?:    True
Notes:    (1)
          SignatureIPCChannelError: IPC Channel Error prepended
Crash id: 9c65dbfc-1862-4eb4-9e88-187b10200225
Original: IPCError-browser | CommonCreateWindow Unexpected aChromeFlags passed | __GI___poll
New:      IPCError-browser | CommonCreateWindow Unexpected aChromeFlags passed
Same?:    False
Notes:    (1)
          SignatureIPCChannelError: IPC Channel Error stomped on signature
Crash id: 7fd5c699-d230-462d-a8ac-aa96a0200225
Original: IPCError-browser | CommonCreateWindow Unexpected aChromeFlags passed | mozilla::ipc::MessagePump::Run
New:      IPCError-browser | CommonCreateWindow Unexpected aChromeFlags passed
Same?:    False
Notes:    (1)
          SignatureIPCChannelError: IPC Channel Error stomped on signature
```