### PR TITLE
bug 1619606: add mozilla::CheckCheckedUnsafePtrs<T>::Check to prefix list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     volumes:
       - .:/app
 
-  # OpenID Connect provider
+  # https://hub.docker.com/r/mozilla/oidc-testprovider
   oidcprovider:
     build:
       context: .

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -145,6 +145,7 @@ mozalloc_handle_oom
 moz_free
 moz_malloc_size_of
 mozilla::AndroidBridge::AutoLocalJNIFrame::~AutoLocalJNIFrame
+mozilla::CheckCheckedUnsafePtrs<T>::Check
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
@@ -157,6 +158,7 @@ mozilla::TimeStamp::Now
 mozilla::detail::MutexImpl::
 mozilla::detail::nsStringRepr::First
 mozilla::detail::nsStringRepr::Last
+mozilla::detail::SupportCheckedUnsafePtrImpl<T>::~SupportCheckedUnsafePtrImpl
 mozilla::ipc::LogicError
 mozilla::ipc::MessageChannel::AssertWorkerThread
 mozilla::ipc::MessageChannel::Call


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature  https://crash-stats.mozilla.org/report/index/709d791b-1f4f-4b2e-8cff-235380200302
Crash id: 709d791b-1f4f-4b2e-8cff-235380200302
Original: mozilla::CheckCheckedUnsafePtrs<T>::Check
New:      mozilla::CheckCheckedUnsafePtrs<T>::Check | mozilla::detail::SupportCheckedUnsafePtrImpl<T>::~SupportCheckedUnsafePtrImpl | mozilla::dom::indexedDB::(anonymous namespace)::FactoryOp::~FactoryOp
Same?:    False
```