### PR TITLE
bug 1619962: crash report deletion script

### DIFF
--- a/scripts/delete_crash_data.py
+++ b/scripts/delete_crash_data.py
@@ -108,7 +108,7 @@ def s3_delete(crashid):
     key = "v2/raw_crash/%(entropy)s/%(date)s/%(crashid)s" % {
         "entropy": crashid[0:3],
         "date": "20" + crashid[-6:],
-        "crashid": crashid
+        "crashid": crashid,
     }
     obj = s3_fetch_object(s3_client, bucket, key)
     if obj:
@@ -132,7 +132,7 @@ def s3_delete(crashid):
                 dump_name = "dump"
             key = "v1/%(dump_name)s/%(crashid)s" % {
                 "dump_name": dump_name,
-                "crashid": crashid
+                "crashid": crashid,
             }
 
             # If the dump is not there, that's fine; but if deleting the dump kicks up
@@ -180,9 +180,7 @@ def es_fetch_document(es_conn, crashid):
             if hits:
                 return results["hits"]["hits"][0]
         except Exception:
-            logger.exception(
-                "ERROR: es: when fetching %s %s" % (doc_type, crashid)
-            )
+            logger.exception("ERROR: es: when fetching %s %s" % (doc_type, crashid))
 
     print("es: not found: %s %s" % (doc_type, crashid))
 

--- a/scripts/delete_crash_data.py
+++ b/scripts/delete_crash_data.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Given a set of crash reports ids via a file, removes all crash report data from
+all crash storage:
+
+* S3
+
+  * raw crash
+  * dump_names
+  * minidump files
+  * processed crash
+
+* Elasticsearch
+
+  * crash report document
+
+Usage:
+
+    python scripts/delete_crash_data.py CRASHIDSFILE
+
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from configman import ConfigurationManager
+from configman.environment import environment
+from elasticsearch_dsl import Search
+
+from socorro.external.boto.connection_context import S3Connection
+from socorro.external.es.connection_context import ConnectionContext
+
+
+logging.basicConfig()
+
+logger = logging.getLogger(__name__)
+
+
+def crashid_generator(fn):
+    """Lazily yield crash ids."""
+    with open(fn, "r") as fp:
+        for line in fp:
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+            yield line
+
+
+def get_s3_context():
+    """Return an S3ConnectionContext."""
+    cm = ConfigurationManager(
+        S3Connection.get_required_config(), values_source_list=[environment]
+    )
+    config = cm.get_config()
+    return S3Connection(config)
+
+
+def s3_delete_object(client, bucket, key):
+    """Deletes a specific object from S3.
+
+    Requires s3:DeleteObject.
+
+    :return: True if the delete was fine or already not there; False if there was an
+        error
+
+    """
+    try:
+        client.delete_object(Bucket=bucket, Key=key)
+        print("s3: deleted %s" % key)
+        return True
+    except Exception:
+        logger.exception("ERROR: s3: when deleting %s" % key)
+        return False
+
+
+def s3_fetch_object(client, bucket, key):
+    """Fetch an object from S3 with appropriate handling for issues.
+
+    Requires s3:GetObject.
+
+    :returns: Body or None
+
+    """
+    try:
+        resp = client.get_object(Bucket=bucket, Key=key)
+        return resp["Body"].read()
+    except client.exceptions.NoSuchKey:
+        print("s3: not found: %s" % key)
+    except Exception:
+        logger.exception("ERROR: s3: when fetching %s" % key)
+
+
+def s3_delete(crashid):
+    """Delete crash report data from S3."""
+    s3_context = get_s3_context()
+    bucket = s3_context.config.bucket_name
+    s3_client = s3_context.client
+
+    # Delete the raw crash
+    key = "v2/raw_crash/%(entropy)s/%(date)s/%(crashid)s" % {
+        "entropy": crashid[0:3],
+        "date": "20" + crashid[-6:],
+        "crashid": crashid
+    }
+    obj = s3_fetch_object(s3_client, bucket, key)
+    if obj:
+        s3_delete_object(s3_client, bucket, key)
+
+    # Fetch dump_names which tells us which dumps exist
+    key = "v1/dump_names/%(crashid)s" % {"crashid": crashid}
+    dump_names = s3_fetch_object(s3_client, bucket, key)
+    if dump_names:
+        try:
+            dump_names = json.loads(dump_names)
+        except Exception:
+            logger.exception("ERROR: %s: s3: when parsing dump_names json" % crashid)
+            dump_names = []
+
+        # For each dump, delete it if it exists
+        dump_errors = 0
+        for dump_name in dump_names:
+            # Handle dump_name -> key goofiness
+            if dump_name in (None, "", "upload_file_minidump"):
+                dump_name = "dump"
+            key = "v1/%(dump_name)s/%(crashid)s" % {
+                "dump_name": dump_name,
+                "crashid": crashid
+            }
+
+            # If the dump is not there, that's fine; but if deleting the dump kicks up
+            # an error, we want to make sure we don't delete dump_names.
+            obj = s3_fetch_object(s3_client, bucket, key)
+            if obj:
+                if not s3_delete_object(s3_client, bucket, key):
+                    dump_errors += 1
+
+        # If there were no errors, then we try to delete dump_names
+        if dump_errors == 0:
+            key = "v1/dump_names/%(crashid)s" % {"crashid": crashid}
+            s3_delete_object(s3_client, bucket, key)
+
+    # Delete processed crash
+    key = "v1/processed_crash/%(crashid)s" % {"crashid": crashid}
+    obj = s3_fetch_object(s3_client, bucket, key)
+    if obj:
+        s3_delete_object(s3_client, bucket, key)
+
+
+def get_es_conn():
+    """Return an Elasticsearch ConnectionContext."""
+    cm = ConfigurationManager(
+        ConnectionContext.get_required_config(), values_source_list=[environment]
+    )
+    config = cm.get_config()
+    return ConnectionContext(config)
+
+
+def es_fetch_document(es_conn, crashid):
+    """Fetch a crash report document from Elasticsearch.
+
+    :returns: Elasticsearch document as a dict or None
+
+    """
+    doc_type = es_conn.get_doctype()
+
+    with es_conn() as conn:
+        try:
+            search = Search(using=conn, doc_type=doc_type)
+            search = search.filter("term", **{"processed_crash.uuid": crashid})
+            results = search.execute().to_dict()
+            hits = results["hits"]["hits"]
+            if hits:
+                return results["hits"]["hits"][0]
+        except Exception:
+            logger.exception(
+                "ERROR: es: when fetching %s %s" % (doc_type, crashid)
+            )
+
+    print("es: not found: %s %s" % (doc_type, crashid))
+
+
+def es_delete_document(es_conn, index, doc_type, doc_id):
+    """Delete document in Elasticsearch."""
+    with es_conn() as conn:
+        try:
+            conn.delete(index=index, doc_type=doc_type, id=doc_id)
+            print("es: deleted %s %s %s" % (index, doc_type, doc_id))
+        except Exception:
+            logger.exception(
+                "ERROR: es: when deleting %s %s %s" % (index, doc_type, doc_id)
+            )
+
+
+def es_delete(crashid):
+    """Delete crash report data from Elasticsearch."""
+    es_conn = get_es_conn()
+
+    resp = es_fetch_document(es_conn, crashid)
+    if resp:
+        es_delete_document(es_conn, resp["_index"], resp["_type"], resp["_id"])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Delete crash report data from crash storage."
+    )
+    parser.add_argument(
+        "crashidsfile", nargs=1, help="Path to the file with crashids in it."
+    )
+
+    args = parser.parse_args()
+    crashidsfile = args.crashidsfile[0]
+    if not os.path.exists(crashidsfile):
+        print("File %s does not exist." % crashidsfile)
+        return 1
+
+    crashids = crashid_generator(crashidsfile)
+
+    for crashid in crashids:
+        print("Working on %s" % crashid)
+        s3_delete(crashid)
+        es_delete(crashid)
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/permadelete_crash_data.py
+++ b/scripts/permadelete_crash_data.py
@@ -19,9 +19,15 @@ all crash storage:
 
   * crash report document
 
+Notes:
+
+1. This **deletes** crash data permanently. Once deleted, this data can't be undeleted.
+2. This doesn't delete any data from cache. Caches will expire data eventually.
+
+
 Usage:
 
-    python scripts/delete_crash_data.py CRASHIDSFILE
+    python scripts/permadelete_crash_data.py CRASHIDSFILE
 
 """
 
@@ -178,7 +184,7 @@ def es_fetch_document(es_conn, crashid):
             results = search.execute().to_dict()
             hits = results["hits"]["hits"]
             if hits:
-                return results["hits"]["hits"][0]
+                return hits[0]
         except Exception:
             logger.exception("ERROR: es: when fetching %s %s" % (doc_type, crashid))
 
@@ -208,7 +214,7 @@ def es_delete(crashid):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Delete crash report data from crash storage."
+        description="Permanently deletes crash report data from crash storage."
     )
     parser.add_argument(
         "crashidsfile", nargs=1, help="Path to the file with crashids in it."

--- a/scripts/remove_field.py
+++ b/scripts/remove_field.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Given a set of crash reports via a file and a list of fields to remove, removes the
+Given a set of crash report ids via a file and a list of fields to remove, removes the
 fields from the raw crash file in S3 and the document in Elasticsearch.
 
 Usage:


### PR DESCRIPTION
This implements a script that can be run in a server environment to remove crash report data from crashstorage destinations.

Usage: `python scripts/permadelete_crash_data.py <CRASHIDSFILE>`

This has no tests, yet. I tested it manually. Need to add tests for the bug.