### PR TITLE
Update Fennec versions for 68.6 release

### DIFF
--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,3 +1,3 @@
 {
-    "featured_versions": ["68.5a1", "68.6b", "68.5.0"]
+    "featured_versions": ["68.6b", "68.6.0"]
 }


### PR DESCRIPTION
Drop nightly version as users were migrated to Fenix.  Beta is kept at 68.6b for now as 68.7b hasn't shipped (and might never ship).