### PR TITLE
bug 1619646: add handling for UnicodeEncodeError in truncating

### DIFF
--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -939,6 +939,11 @@ class Test_truncate_string_field_values:
             ({"key": "a" * 32_765}, {"key": "a" * 32_765}),
             ({"key": "a" * 32_766}, {"key": "a" * 32_766}),
             ({"key": "a" * 32_767}, {"key": "a" * 32_766}),
+            # Bad Unicode values shouldn't throw an exception
+            (
+                {"key": b"hi \xc3there".decode("utf-8", "surrogateescape")},
+                {"key": "BAD DATA"},
+            ),
         ],
     )
     def test_truncate_string_field_values(self, data, expected):


### PR DESCRIPTION
The Elasticsearch crash storage code tries to be really forgiving for bad data. One of the things it does is truncate absurdly long string values. Strings are unicode, but are stored in Elasticsearch as utf-8, so the truncation code encodes as utf-8 to get the length.

This handles the situation where the string value can't be encoded as utf-8. In that case, probably best to consider it bad dta and replace it with "BAD DATA"