### PR TITLE
bug 1623064: rework save_processed and save_raw_and_processed

### DIFF
--- a/docs/crashstorage.rst
+++ b/docs/crashstorage.rst
@@ -31,7 +31,8 @@ to plug into any of the Socorro backend components.
 
 Base class:
 
-* `CrashStorageBase`: Defines ``save_raw_and_processed()``, ``get_raw()``, etc.
+* `CrashStorageBase`: Defines ``save_processed_crash()``, ``get_raw_crash()``,
+  etc.
 
 CrashStorage containers for aggregating multiple crash storage implementations:
 

--- a/docs/tests/system_checklist.rst
+++ b/docs/tests/system_checklist.rst
@@ -94,7 +94,7 @@ Checklist
 
       To check for errors grep for "ERRORS".
 
-    * Check Datadog "processor.save_raw_and_processed" for appropriate
+    * Check Datadog "processor.save_processed_crash" for appropriate
       environment.
 
       localdev: Check the logging in the console
@@ -104,13 +104,13 @@ Checklist
     Is the processor saving to ES? S3?
 
     * Check Datadog
-      "processor.es.ESCrashStorageRedactedJsonDump.save_raw_and_processed.avg"
+      "processor.es.ESCrashStorageRedactedJsonDump.save_processed_crash.avg"
 
       stage: https://app.datadoghq.com/dash/187676/socorro-stage-perf
       prod: https://app.datadoghq.com/dash/65215/socorro-prod
 
     * Check Datadog
-      "processor.s3.BotoS3CrashStorage.save_raw_and_processed" for
+      "processor.s3.BotoS3CrashStorage.save_processed_crash" for
       appropriate environment.
 
       stage: https://app.datadoghq.com/dash/187676/socorro-stage-perf

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""This is the base of the crashstorage system - a unified interfaces for
-saving, fetching and iterating over raw crashes, dumps and processed crashes.
-"""
+"""Base classes for crashstorage system."""
 
 import datetime
 import collections
@@ -160,30 +158,25 @@ class CrashStorageBase(RequiredConfig):
     )
 
     def __init__(self, config, namespace=""):
-        """base class constructor
+        """Initializer
 
-        parameters:
-            config - a configman dot dict holding configuration information
-            namespace - namespace for this crashstorage instance. Used for
-                        metrics prefixes and logging.
+        :param config: configman DotDict holding configuration information
+        :param namespace: namespace for this crashstorage instance; used
+            for metrics prefixes and logging
 
-        instance varibles:
-            self.config - a reference to the config mapping
-            self.logger - convience shortcut to the logger in the config
-            self.exceptions_eligible_for_retry - a collection of non-fatal
-                    exceptions that can be raised by a given storage
-                    implementation.  This may be fetched by a client of the
-                    crashstorge so that it can determine if it can try a failed
-                    storage operation again.
         """
         self.config = config
         self.namespace = namespace
+
+        # Collection of non-fatal exceptions that can be raised by a given storage
+        # implementation. This may be fetched by a client of the crashstorge so that it
+        # can determine if it can try a failed storage operation again.
         self.exceptions_eligible_for_retry = ()
         self.redactor = config.redactor_class(config)
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
     def close(self):
-        """some implementations may need explicit closing."""
+        """Close resources used by this crashstorage."""
         pass
 
     def is_mutator(self):
@@ -195,40 +188,15 @@ class CrashStorageBase(RequiredConfig):
         return False
 
     def save_raw_crash(self, raw_crash, dumps, crash_id):
-        """this method that saves  both the raw_crash and the dump, must be
-        overridden in any implementation.
+        """Save raw crash data.
 
-        Why is does this base implementation just silently do nothing rather
-        than raise a NotImplementedError?  Implementations of crashstorage
-        are not required to implement the entire api.  Some may save only
-        processed crashes but may be bundled (see the PolyCrashStorage class)
-        with other crashstorage implementations.  Rather than having a non-
-        implenting class raise an exeception that would derail the other
-        bundled operations, the non-implementing storageclass will just
-        quietly do nothing.
+        :param raw_crash: Mapping containing the raw crash meta data. It is often saved
+            as a json file, but here it is in the form of a dict.
+        :param dumps: A dict of dump name keys and binary blob values.
+        :param crash_id: the crash report id
 
-        parameters:
-            raw_crash - a mapping containing the raw crash meta data.  It is
-                        often saved as a json file, but here it is in the form
-                        of a dict.
-            dumps - a dict of dump name keys and binary blob values
-            crash_id - the crash key to use for this crash"""
+        """
         pass
-
-    def save_raw_crash_with_file_dumps(self, raw_crash, dumps, crash_id):
-        """this method that saves  both the raw_crash and the dump and must be
-        overridden in any implementation that wants a different behavior.  It
-        assumes that the dumps are in the form of paths to files and need to
-        be converted to memory_dumps
-
-        parameters:
-            raw_crash - a mapping containing the raw crash meta data.  It is
-                        often saved as a json file, but here it is in the form
-                        of a dict.
-            dumps - a dict of dump name keys and paths to file system locations
-                    for the dump data
-            crash_id - the crash key to use for this crash"""
-        self.save_raw_crash(raw_crash, dumps.as_memory_dumps_mapping(), crash_id)
 
     def save_processed_crash(self, raw_crash, processed_crash):
         """Save processed crash to crash storage
@@ -243,41 +211,52 @@ class CrashStorageBase(RequiredConfig):
         raise NotImplementedError("save_processed_crash not implemented")
 
     def get_raw_crash(self, crash_id):
-        """the default implementation of fetching a raw_crash
+        """Fetch raw crash
 
-        parameters:
-           crash_id - the id of a raw crash to fetch"""
+        :param crash_id: crash report id for data to fetch
+
+        :returns: DotDict of raw crash data
+
+        """
         raise NotImplementedError("get_raw_crash is not implemented")
 
     def get_raw_dump(self, crash_id, name=None):
-        """the default implementation of fetching a dump
+        """Fetch dump for a raw crash
 
-        parameters:
-           crash_id - the id of a dump to fetch
-           name - the name of the dump to fetch"""
+        :param crash_id: crash report id
+        :param name: name of dump to fetch
+
+        :returns: dump as bytes
+
+        """
         raise NotImplementedError("get_raw_dump is not implemented")
 
     def get_raw_dumps(self, crash_id):
-        """the default implementation of fetching all the dumps
+        """Fetch all dumps for a crash report
 
-        parameters:
-           crash_id - the id of a dump to fetch"""
+        :param crash_id: crash report id
+
+        :returns: MemoryDumpsMapping of dumps
+
+        """
         raise NotImplementedError("get_raw_dumps is not implemented")
 
     def get_raw_dumps_as_files(self, crash_id):
-        """the default implementation of fetching all the dumps as files on
-        a file system somewhere.  returns a list of pathnames.
+        """Fetch all dumps for a crash report and save as files.
 
-        parameters:
-           crash_id - the id of a dump to fetch"""
+        :param crash_id: crash report id
+
+        :returns: dict of dumpname -> file path
+
+        """
         raise NotImplementedError("get_raw_dumps is not implemented")
 
     def get_processed(self, crash_id):
-        """the default implementation of fetching a processed_crash.  This
-        method should not be overridden in subclasses unless the intent is to
-        alter the redaction process.
+        """Fetch processed crash.
 
-        :arg crash_id: the id of a processed_crash to fetch
+        :arg crash_id: crash report id
+
+        :returns: DotDict
 
         """
         processed_crash = self.get_unredacted_processed(crash_id)
@@ -285,31 +264,22 @@ class CrashStorageBase(RequiredConfig):
         return processed_crash
 
     def get_unredacted_processed(self, crash_id):
-        """the implementation of fetching a processed_crash with no redaction
+        """Fetch processed crash with no redaction
 
-        parameters:
-           crash_id - the id of a processed_crash to fetch"""
+        :param crash_id: crash report id
+
+        :returns: DotDict
+
+        """
         raise NotImplementedError("get_unredacted_processed is not implemented")
 
     def remove(self, crash_id):
-        """delete a crash from storage
+        """Delete crash report data from storage
 
-        parameters:
-           crash_id - the id of a crash to fetch"""
-        raise NotImplementedError("remove is not implemented")
+        :param crash_id: crash report id
 
-    def new_crashes(self):
-        """a generator handing out a sequence of crash_ids of crashes that are
-        considered to be new.  Each implementation can interpret the concept
-        of "new" in an implementation specific way.  To be useful, derived
-        class ought to override this method.
         """
-        return []
-
-    def ack_crash(self, crash_id):
-        """overridden by subclasses that must acknowledge a successful use of
-        an item pulled from the 'new_crashes' generator. """
-        return crash_id
+        raise NotImplementedError("remove is not implemented")
 
 
 class PolyStorageError(Exception, collections.MutableSequence):
@@ -405,18 +375,16 @@ class StorageNamespaceList(collections.Sequence):
 
 
 class PolyCrashStorage(CrashStorageBase):
-    """a crashstorage implementation that encapsulates a collection of other
-    crashstorage instances.  Any save operation applied to an instance of this
-    class will be applied to all the crashstorge in the collection.
+    """Crashstorage pipeline for multiple crashstorage destinations
 
-    This class is useful for 'save' operations only.  It does not implement
-    the 'get' operations.
+    This class is useful for "save" operations only--it does not implement the "get"
+    operations.
 
-    The contained crashstorage instances are specified in the configuration.
-    Each key in the `storage_namespaces`` config option will be used to create
-    a crashstorage instance that this saves to. The keys are namespaces in the
-    config, and any options defined under those namespaces will be isolated
-    within the config passed to the crashstorage instance. For example:
+    The contained crashstorage instances are specified in the configuration.  Each key
+    in the ``storage_namespaces`` config option will be used to create a crashstorage
+    instance that this saves to. The keys are namespaces in the config, and any options
+    defined under those namespaces will be isolated within the config passed to the
+    crashstorage instance. For example:
 
     .. code-block:: ini
         destination.crashstorage_namespaces=postgres,s3
@@ -427,10 +395,11 @@ class PolyCrashStorage(CrashStorageBase):
         destination.s3.crashstorage_class=module.path.S3Storage
         destination.s3.my.config=S3
 
-    With this config, there are two crashstorage instances this class will
-    create: one for Postgres, and one for S3. The PostgresStorage instance will
-    see the ``my.config`` option as being set to "Postgres", while the S3Storage
-    instance will see ``my.config`` set to "S3".
+    With this config, there are two crashstorage instances this class will create: one
+    for Postgres, and one for S3. The PostgresStorage instance will see the
+    ``my.config`` option as being set to "Postgres", while the S3Storage instance will
+    see ``my.config`` set to "S3".
+
     """
 
     required_config = Namespace()
@@ -443,20 +412,17 @@ class PolyCrashStorage(CrashStorageBase):
     )
 
     def __init__(self, config, namespace=""):
-        """instantiate all the subordinate crashstorage instances
+        """Instantiate all the subordinate crashstorage instances
 
-        parameters:
-            config - a configman dot dict holding configuration information
-            namespace - namespace for this crashstorage
-
-        instance variables:
-            self.storage_namespaces - the list of the namespaces in which the
-                                      subordinate instances are stored.
-            self.stores - instances of the subordinate crash stores
+        :param config: configman DotDict holding configuration information
+        :param namespace: namespace for this crashstorage instance; used
+            for metrics prefixes and logging
 
         """
         super().__init__(config, namespace)
+        # The list of the namespaces in which the subordinate instances are stored.
         self.storage_namespaces = config.storage_namespaces
+        # Instances of the subordinate crash stores.
         self.stores = DotDict()
         for storage_namespace in self.storage_namespaces:
             absolute_namespace = ".".join(
@@ -469,16 +435,13 @@ class PolyCrashStorage(CrashStorageBase):
             )
 
     def close(self):
-        """iterate through the subordinate crash stores and close them.
-        Even though the classes are closed in sequential order, all are
-        assured to close even if an earlier one raises an exception.  When all
-        are closed, any exceptions that were raised are reraised in a
-        PolyStorageError
+        """Close resources used by crashstorage instances.
 
-        raises:
-          PolyStorageError - an exception container holding a list of the
-                             exceptions raised by the subordinate storage
-                             systems"""
+        :raises PolyStorageError: An exception container holding a list of the
+            exceptions raised by the subordinate storage
+            systems.
+
+        """
         storage_exception = PolyStorageError()
         for a_store in self.stores.values():
             try:
@@ -490,13 +453,13 @@ class PolyCrashStorage(CrashStorageBase):
             raise storage_exception
 
     def save_raw_crash(self, raw_crash, dumps, crash_id):
-        """iterate through the subordinate crash stores saving the raw_crash
-        and the dump to each of them.
+        """Save raw crash to all crashstorage destinations.
 
-        parameters:
-            raw_crash - the meta data mapping
-            dumps - a mapping of dump name keys to dump binary values
-            crash_id - the id of the crash to use"""
+        :param raw_crash: the raw crash data
+        :param dumps: mapping of dump name keys -> dump binary
+        :param crash_id: the crash report id
+
+        """
         storage_exception = PolyStorageError()
         for a_store in self.stores.values():
             try:

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -171,17 +171,6 @@ class FSPermanentStorage(CrashStorageBase):
                 with open(os.sep.join([parent_dir, fn]), "wb") as f:
                     f.write(contents)
 
-    def save_processed(self, processed_crash):
-        crash_id = processed_crash["uuid"]
-        processed_crash = processed_crash.copy()
-        f = BytesIO()
-        with closing(gzip.GzipFile(mode="wb", fileobj=f)) as fz:
-            data = json.dumps(processed_crash, cls=JsonDTISOEncoder)
-            fz.write(data.encode("utf-8"))
-        self._save_files(
-            crash_id, {crash_id + self.config.jsonz_file_suffix: f.getvalue()}
-        )
-
     def save_raw_crash(self, raw_crash, dumps, crash_id):
         if dumps is None:
             dumps = MemoryDumpsMapping()
@@ -197,6 +186,17 @@ class FSPermanentStorage(CrashStorageBase):
             }
         )
         self._save_files(crash_id, files)
+
+    def save_processed_crash(self, raw_crash, processed_crash):
+        crash_id = processed_crash["uuid"]
+        processed_crash = processed_crash.copy()
+        f = BytesIO()
+        with closing(gzip.GzipFile(mode="wb", fileobj=f)) as fz:
+            data = json.dumps(processed_crash, cls=JsonDTISOEncoder)
+            fz.write(data.encode("utf-8"))
+        self._save_files(
+            crash_id, {crash_id + self.config.jsonz_file_suffix: f.getvalue()}
+        )
 
     def get_raw_crash(self, crash_id):
         parent_dir = self._get_radixed_parent_directory(crash_id)

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -55,9 +55,7 @@ class FSPermanentStorage(CrashStorageBase):
 
         root/20071025/name/0b/ba/92/9f/
 
-    This storage does not implement ``new_crashes``, but is able to store
-    processed crashes. Used alone, it is intended to store only processed
-    crashes.
+    Used alone, it is intended to store only processed crashes.
 
     """
 

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -25,8 +25,8 @@ class MockedTelemetryBotoS3CrashStorage(TelemetryBotoS3CrashStorage):
         print(r.url)
         self._all_fields = r.json()
 
-    def save_processed(self, crash):
-        self.combined = crash
+    def save_processed_crash(self, raw_crash, processed_crash):
+        self.combined = super().save_processed_crash(raw_crash, processed_crash)
 
 
 def run(no_crashes, *urls):
@@ -105,7 +105,7 @@ def run(no_crashes, *urls):
         print(r.url)
         processed_crash = r.json()
 
-        processor.save_raw_and_processed(raw_crash, (), processed_crash, uuid)
+        processor.save_processed_crash(raw_crash, processed_crash)
         log_all_keys(processor.combined)
 
         jsonschema.validate(processor.combined, schema)

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -100,45 +100,18 @@ class TestBotoS3CrashStorage:
         )
         assert flash_dump == b"fake flash dump"
 
-    def test_save_processed(self, boto_helper):
+    def test_save_processed_crash(self, boto_helper):
         boto_s3_store = self.get_s3_store()
         bucket = boto_s3_store.conn.bucket
         boto_helper.create_bucket(bucket)
 
-        boto_s3_store.save_processed(
-            {
-                "uuid": "0bba929f-8721-460c-dead-a43c20071027",
-                "completeddatetime": "2012-04-08 10:56:50.902884",
-                "signature": "now_this_is_a_signature",
-            }
-        )
-
-        # Verify the processed crash was put in the right place and has the
-        # right contents
-        processed_crash = boto_helper.download_fileobj(
-            bucket_name=bucket,
-            key="v1/processed_crash/0bba929f-8721-460c-dead-a43c20071027",
-        )
-        assert json.loads(processed_crash) == {
-            "uuid": "0bba929f-8721-460c-dead-a43c20071027",
-            "completeddatetime": "2012-04-08 10:56:50.902884",
-            "signature": "now_this_is_a_signature",
-        }
-
-    def test_save_raw_and_processed(self, boto_helper):
-        boto_s3_store = self.get_s3_store()
-        bucket = boto_s3_store.conn.bucket
-        boto_helper.create_bucket(bucket)
-
-        boto_s3_store.save_raw_and_processed(
+        boto_s3_store.save_processed_crash(
             {"submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"},
-            None,
             {
                 "uuid": "0bba929f-8721-460c-dead-a43c20071027",
                 "completeddatetime": "2012-04-08 10:56:50.902884",
                 "signature": "now_this_is_a_signature",
             },
-            "0bba929f-8721-460c-dead-a43c20071027",
         )
 
         # Verify processed crash is saved
@@ -373,22 +346,20 @@ class TestTelemetryBotoS3CrashStorage:
             config=get_config(TelemetryBotoS3CrashStorage)
         )
 
-    def test_save_raw_and_processed(self, boto_helper):
+    def test_save_processed_crash(self, boto_helper):
         boto_s3_store = self.get_s3_store()
         bucket = boto_s3_store.conn.bucket
         boto_helper.create_bucket(bucket)
 
-        # Run save_raw_and_processed
-        boto_s3_store.save_raw_and_processed(
+        # Run save_processed_crash
+        boto_s3_store.save_processed_crash(
             {"submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"},
-            None,
             {
                 "uuid": "0bba929f-8721-460c-dead-a43c20071027",
                 "completeddatetime": "2012-04-08 10:56:50.902884",
                 "signature": "now_this_is_a_signature",
                 "os_name": "Linux",
             },
-            "0bba929f-8721-460c-dead-a43c20071027",
         )
 
         # Get the crash data we just saved from the bucket and verify it's

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -166,11 +166,9 @@ class TestIntegrationESCrashStorage(ElasticsearchTestCase):
         """Test indexing a crash document."""
         es_storage = ESCrashStorage(config=self.config)
 
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=a_processed_crash["uuid"],
         )
 
         # Ensure that the document was indexed by attempting to retreive it.
@@ -190,11 +188,9 @@ class TestIntegrationESCrashStorage(ElasticsearchTestCase):
 
         es_storage = ESCrashStorage(config=self.config)
 
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash_with_bad_keys),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=a_processed_crash["uuid"],
         )
 
         # Ensure that the document was indexed by attempting to retreive it.
@@ -259,11 +255,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
         # it entirely we are ensuring that ES doesn't actually get touched.
         es_storage._submit_crash_to_elasticsearch = mock.Mock()
 
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=a_processed_crash["uuid"],
         )
 
         # Ensure that the indexing function is only called once.
@@ -280,11 +274,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
         # Submit a crash like normal, except that the back-end ES object is
         # mocked (see the decorator above).
         es_storage = ESCrashStorage(config=self.config)
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=crash_id,
         )
 
         # Ensure that the ES objects were instantiated by ConnectionContext.
@@ -337,11 +329,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
 
         # Submit a crash like normal, except that the back-end ES object is
         # mocked (see the decorator above).
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=crash_id,
         )
 
         # Ensure that the ES objects were instantiated by ConnectionContext.
@@ -397,11 +387,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
 
         # Submit a crash like normal, except that the back-end ES object is
         # mocked (see the decorator above).
-        es_storage.save_raw_and_processed(
+        es_storage.save_processed_crash(
             raw_crash=deepcopy(a_raw_crash),
-            dumps=None,
             processed_crash=deepcopy(a_processed_crash),
-            crash_id=crash_id,
         )
 
         # Ensure that the ES objects were instantiated by ConnectionContext.
@@ -457,11 +445,8 @@ class TestESCrashStorage(ElasticsearchTestCase):
 
         # Submit a crash like normal, except that the back-end ES object is
         # mocked (see the decorator above).
-        es_storage.save_raw_and_processed(
-            raw_crash=deepcopy(raw_crash),
-            dumps=None,
-            processed_crash=deepcopy(a_processed_crash),
-            crash_id=crash_id,
+        es_storage.save_processed_crash(
+            raw_crash=deepcopy(raw_crash), processed_crash=deepcopy(a_processed_crash),
         )
 
         # Ensure that the ES objects were instantiated by ConnectionContext.
@@ -505,7 +490,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
 
         # Submit a crash and ensure that it failed.
         with pytest.raises(Exception):
-            es_storage.save_raw_and_processed(
+            es_storage.save_processed_crash(
                 raw_crash=deepcopy(a_raw_crash),
                 dumps=None,
                 processed_crsah=deepcopy(a_processed_crash),
@@ -529,6 +514,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             "date_processed": "2012-04-08 10:56:41.558922",
             "bogus-field": "some bogus value",
             "foo": "bar",
+            "uuid": crash_id,
         }
 
         def mock_index(*args, **kwargs):
@@ -555,11 +541,8 @@ class TestESCrashStorage(ElasticsearchTestCase):
         es_class_mock().index.side_effect = mock_index
 
         # Submit a crash and ensure that it succeeds.
-        es_storage.save_raw_and_processed(
-            raw_crash=deepcopy(raw_crash),
-            dumps=None,
-            processed_crash=deepcopy(processed_crash),
-            crash_id=crash_id,
+        es_storage.save_processed_crash(
+            raw_crash=deepcopy(raw_crash), processed_crash=deepcopy(processed_crash),
         )
 
         expected_doc = {
@@ -568,6 +551,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             "processed_crash": {
                 "date_processed": string_to_datetime("2012-04-08 10:56:41.558922"),
                 "foo": "bar",
+                "uuid": crash_id,
             },
             "raw_crash": {},
         }
@@ -594,6 +578,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             "date_processed": "2012-04-08 10:56:41.558922",
             "bogus-field": 1234567890,
             "foo": "bar",
+            "uuid": crash_id,
         }
 
         def mock_index(*args, **kwargs):
@@ -615,11 +600,8 @@ class TestESCrashStorage(ElasticsearchTestCase):
         es_class_mock().index.side_effect = mock_index
 
         # Submit a crash and ensure that it succeeds.
-        es_storage.save_raw_and_processed(
-            raw_crash=deepcopy(raw_crash),
-            dumps=None,
-            processed_crash=deepcopy(processed_crash),
-            crash_id=crash_id,
+        es_storage.save_processed_crash(
+            raw_crash=deepcopy(raw_crash), processed_crash=deepcopy(processed_crash),
         )
 
         expected_doc = {
@@ -628,6 +610,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             "processed_crash": {
                 "date_processed": string_to_datetime("2012-04-08 10:56:41.558922"),
                 "foo": "bar",
+                "uuid": crash_id,
             },
             "raw_crash": {},
         }
@@ -653,6 +636,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
         processed_crash = {
             "date_processed": "2019-12-11 10:56:41.558922",
             "bogus-field": {"key": {"nested_key": "val"}},
+            "uuid": crash_id,
         }
 
         def mock_index(*args, **kwargs):
@@ -674,11 +658,8 @@ class TestESCrashStorage(ElasticsearchTestCase):
         es_class_mock().index.side_effect = mock_index
 
         # Submit crash and verify.
-        es_storage.save_raw_and_processed(
-            raw_crash=raw_crash,
-            dumps=None,
-            processed_crash=processed_crash,
-            crash_id=crash_id,
+        es_storage.save_processed_crash(
+            raw_crash=raw_crash, processed_crash=processed_crash,
         )
 
         expected_doc = {
@@ -686,6 +667,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             "removed_fields": "processed_crash.bogus-field",
             "processed_crash": {
                 "date_processed": string_to_datetime("2019-12-11 10:56:41.558922"),
+                "uuid": crash_id,
             },
             "raw_crash": {"uuid": crash_id},
         }
@@ -706,9 +688,11 @@ class TestESCrashStorage(ElasticsearchTestCase):
         """
         es_storage = ESCrashStorage(config=self.config)
 
-        crash_id = a_processed_crash["uuid"]
         raw_crash = {}
-        processed_crash = {"date_processed": "2012-04-08 10:56:41.558922"}
+        processed_crash = {
+            "uuid": "9d8e7127-9d98-4d92-8ab1-065982200317",
+            "date_processed": "2012-04-08 10:56:41.558922",
+        }
 
         # Test with an error from which a field name cannot be extracted.
         def mock_index_unparsable_error(*args, **kwargs):
@@ -724,11 +708,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
         es_class_mock().index.side_effect = mock_index_unparsable_error
 
         with pytest.raises(elasticsearch.exceptions.TransportError):
-            es_storage.save_raw_and_processed(
+            es_storage.save_processed_crash(
                 raw_crash=deepcopy(raw_crash),
-                dumps=None,
                 processed_crash=deepcopy(processed_crash),
-                crash_id=crash_id,
             )
 
         # Test with an error that we do not handle.
@@ -740,11 +722,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
         es_class_mock().index.side_effect = mock_index_unhandled_error
 
         with pytest.raises(elasticsearch.exceptions.TransportError):
-            es_storage.save_raw_and_processed(
+            es_storage.save_processed_crash(
                 raw_crash=deepcopy(raw_crash),
-                dumps=None,
                 processed_crash=deepcopy(processed_crash),
-                crash_id=crash_id,
             )
 
     def test_crash_size_capture(self):
@@ -754,11 +734,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
 
             es_storage._submit_crash_to_elasticsearch = mock.Mock()
 
-            es_storage.save_raw_and_processed(
+            es_storage.save_processed_crash(
                 raw_crash=deepcopy(a_raw_crash),
-                dumps=None,
                 processed_crash=deepcopy(a_processed_crash),
-                crash_id=a_processed_crash["uuid"],
             )
 
             # NOTE(willkg): The sizes of these json documents depend on what's

--- a/socorro/unittest/external/fs/test_fspermanentstorage.py
+++ b/socorro/unittest/external/fs/test_fspermanentstorage.py
@@ -52,15 +52,15 @@ class TestFSPermanentStorage(object):
         )
 
     def _make_processed_test_crash(self):
-        self.fsrts.save_processed(
-            {"uuid": self.CRASH_ID_2, "test": "TEST", "email": "should not exist"}
+        self.fsrts.save_processed_crash(
+            {}, {"uuid": self.CRASH_ID_2, "test": "TEST", "email": "should not exist"}
         )
 
     def test_save_raw_crash(self):
         self._make_test_crash()
         assert os.path.exists(self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1))
 
-    def test_save_processed(self):
+    def test_save_processed_crash(self):
         self._make_processed_test_crash()
         assert os.path.exists(
             os.path.join(

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -15,7 +15,6 @@ from socorro.external.crashstorage_base import (
     Redactor,
     BenchmarkingCrashStorage,
     MemoryDumpsMapping,
-    FileDumpsMapping,
     MetricsCounter,
     MetricsBenchmarkingWrapper,
 )
@@ -91,35 +90,7 @@ class TestCrashStorageBase(object):
             with pytest.raises(NotImplementedError):
                 crashstorage.remove("ooid")
 
-            assert crashstorage.new_crashes() == []
             crashstorage.close()
-
-        with config_manager.context() as config:
-
-            class MyCrashStorage(CrashStorageBase):
-                def save_raw_crash(self, raw_crash, dumps, crash_id):
-                    assert crash_id == "fake_id"
-                    assert raw_crash == "fake raw crash"
-                    assert sorted(dumps.keys()) == sorted(["one", "two", "three"])
-                    assert sorted(dumps.values()) == sorted(["eins", "zwei", "drei"])
-
-            values = ["eins", "zwei", "drei"]
-
-            def open_function(*args, **kwargs):
-                return values.pop(0)
-
-            crashstorage = MyCrashStorage(config)
-
-            with mock.patch("socorro.external.crashstorage_base.open") as open_mock:
-                open_mock.return_value = mock.MagicMock()
-                open_mock.return_value.__enter__.return_value.read.side_effect = (
-                    open_function
-                )
-                crashstorage.save_raw_crash_with_file_dumps(
-                    "fake raw crash",
-                    FileDumpsMapping({"one": "eins", "two": "zwei", "three": "drei"}),
-                    "fake_id",
-                )
 
     def test_polyerror(self):
         p = PolyStorageError("hell")


### PR DESCRIPTION
Previously, we had a save_processed and a `save_raw_and_processed`. `save_processed` is only called by `save_raw_and_processed` and `save_raw_and_processed` is misnamed--it doesn't save the raw crash since doing that would irrecoverably change our record of what we got from the collector.

This cleans up naming and reduces these two functions down to a single `save_processed_crash`. We pass in the `raw_crash` and `processed_crash` so crashstorage can combine them into a crash report, but no crashstorage should ever stomp on the original `raw_crash` data.

Since this changes `save_raw_and_processed` into `save_processed_crash` and that's part of metrics names, this will change those metrics and we need to update the dashboards.

To test:

1. run `make test` and `make lint`
2. run the processor and process some crashes