### PR TITLE
bug 1607519: fix JavaStackTrace parsing

### DIFF
--- a/socorro/lib/javautil.py
+++ b/socorro/lib/javautil.py
@@ -74,7 +74,7 @@ def parse_java_stack_trace(text):
             # Append lines to the message until one of them starts with
             # a tab.
             next_line = lines.peek(None)
-            while next_line and not next_line.startswith("\tat "):
+            while next_line is not None and not next_line.startswith("\tat "):
                 msg = msg + "\n" + next(lines)
                 next_line = lines.peek(None)
 

--- a/socorro/unittest/lib/test_javautil.py
+++ b/socorro/unittest/lib/test_javautil.py
@@ -141,6 +141,26 @@ def test_parse_unindented_caused_by():
     ]
 
 
+EXC_MSG_WITH_PARENS = """\
+Exception: Error(
+
+General Error: "No subscriptions created yet.")
+\tat org.File.function(RustError.kt:4)
+"""
+
+
+def test_parenthesized_msg():
+    """Parse an exception with a exception message in parentheses."""
+    java_exc = javautil.parse_java_stack_trace(EXC_MSG_WITH_PARENS)
+    assert java_exc.exception_class == "Exception"
+    assert (
+        java_exc.exception_message
+        == 'Error(\n\nGeneral Error: "No subscriptions created yet.")'
+    )
+    assert java_exc.stack == ["at org.File.function(RustError.kt:4)"]
+    assert java_exc.additional == []
+
+
 @pytest.mark.parametrize(
     "text",
     [


### PR DESCRIPTION
There was a case where JavaStackTrace parsing would hit a multiline message where one of the lines was empty. In this case, the parser would get confused and state the JavaStackTrace was malformed.

This fixes that by restricting the check to just None allowing for empty lines.