### PR TITLE
bug 1608116: add DeNoneRule

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -25,6 +25,7 @@ from socorro.processor.rules.breakpad import (
 )
 from socorro.processor.rules.general import (
     CPUInfoRule,
+    DeNoneRule,
     DeNullRule,
     IdentifierRule,
     OSInfoRule,
@@ -167,8 +168,9 @@ class ProcessorPipeline(RequiredConfig):
 
         """
         return [
-            # fix the raw crash removing null characters
+            # fix the raw crash removing null characters and Nones
             DeNullRule(),
+            DeNoneRule(),
             # fix ModuleSignatureInfo if it needs fixing
             ConvertModuleSignatureInfoRule(),
             # rules to change the internals of the raw crash

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -9,6 +9,7 @@ import pytest
 
 from socorro.processor.rules.general import (
     CPUInfoRule,
+    DeNoneRule,
     DeNullRule,
     IdentifierRule,
     OSInfoRule,
@@ -110,7 +111,31 @@ canonical_processed_crash = DotDict(
 )
 
 
-class TestDeNullRule(object):
+class TestDeNoneRule:
+    @pytest.mark.parametrize(
+        "raw_crash, expected",
+        [
+            ({}, {}),
+            ({"foo": "bar"}, {"foo": "bar"}),
+            ({"foo": None}, {}),
+            ({"foo": "bar", "baz": None}, {"foo": "bar"}),
+        ],
+    )
+    def test_denone(self, raw_crash, expected):
+        rule = DeNoneRule()
+        rule.action(raw_crash, None, {}, {})
+        assert raw_crash == expected
+
+    def test_denone_with_dotdict(self):
+        raw_crash = DotDict({"foo": "bar", "baz": None})
+        expected = DotDict({"foo": "bar"})
+
+        rule = DeNoneRule()
+        rule.action(raw_crash, None, {}, {})
+        assert raw_crash == expected
+
+
+class TestDeNullRule:
     @pytest.mark.parametrize(
         "data, expected",
         [


### PR DESCRIPTION
This adds a `DeNoneRule` that will remove keys from the raw crash that have a `None` value. These come from crash annotations the crash reporter packs into a JSON-encoded value in the crash report. Previously, I think these would end up with empty strings.

The field we seem to be having the most problems with is `BuildID`.

This also adds some metrics code for the `DeNoneRule` and `DeNullRule` so we can see how often they're kicking off so as to identify bugs in the crash reporter.