### PR TITLE
bug 1622932: fix featured versions

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -89,6 +89,10 @@ SECRET_KEY=secretkey
 STATSD_HOST=statsd
 OVERVIEW_VERSION_URLS=http://localhost:8000/__version__
 
+# For local dev environment, make the threshold 0 otherwise the webapp doesn't
+# show any versions or featured versions
+VERSIONS_COUNT_THRESHOLD=0
+
 # oidcprovider
 # ------------
 OIDC_RP_CLIENT_ID=1

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -352,7 +352,7 @@ def get_versions_for_product(product="Firefox", use_cache=True):
     """Returns list of recent version strings for specified product
 
     This looks at the crash reports submitted for this product over
-    VERSIONS_WINDOW_DAYS days and returns the versinos of those crash reports.
+    VERSIONS_WINDOW_DAYS days and returns the versions of those crash reports.
 
     If SuperSearch returns an error, this returns an empty list.
 
@@ -376,8 +376,8 @@ def get_versions_for_product(product="Firefox", use_cache=True):
     now = timezone.now()
 
     # Find versions for specified product in crash reports reported in the last
-    # 6 months and use a big _facets_size so that it picks up versions that
-    # have just been released that don't have many crash reports, yet
+    # VERSIONS_WINDOWS_DAYS days and use a big _facets_size so that it picks up versions
+    # that have just been released that don't have many crash reports, yet
     params = {
         "product": product,
         "_results_number": 0,
@@ -390,33 +390,29 @@ def get_versions_for_product(product="Firefox", use_cache=True):
     }
 
     # Since we're caching the results of the search plus additional work done,
-    # we don't need to cache the fetch
+    # we don't want to cache the fetch
     ret = api.get(**params, dont_cache=True)
     if "facets" not in ret or "version" not in ret["facets"]:
         return []
 
     # Get versions from facet, drop junk, and sort the final list
-    betas = set()
-    versions = []
+    versions = set()
     for item in ret["facets"]["version"]:
         version = item["term"]
         try:
             # This generates the sort key but also parses the version to
             # make sure it's a valid looking version
-            versions.append((generate_version_key(version), version))
+            versions.add((generate_version_key(version), version))
 
             # Add X.Yb to betas set
             if "b" in version:
                 beta_version = version[: version.find("b") + 1]
-                betas.add(beta_version)
+                versions.add((generate_version_key(beta_version), beta_version))
         except VersionParseError:
             pass
 
-    # Add the (sortkey, X.Yb) to the list
-    versions.extend([(generate_version_key(beta), beta) for beta in betas])
-
     # Sort by sortkey and then drop the sortkey
-    versions.sort(key=lambda v: v[0], reverse=True)
+    versions = sorted(versions, key=lambda v: v[0], reverse=True)
     versions = [v[1] for v in versions]
 
     if use_cache:
@@ -476,18 +472,19 @@ def get_version_context_for_product(product):
 
     versions = get_versions_for_product(product, use_cache=False)
 
-    # If this product has manually maintained featured versions, use that.
     featured_versions = get_manually_maintained_featured_versions(product)
     if featured_versions is not None:
+        # If this product has manually maintained featured versions, use that. Make
+        # sure featured versions are in the versions list and re-sort.
         for featured_version in featured_versions:
             if featured_version not in versions:
                 versions.insert(0, featured_version)
         versions.sort(key=lambda v: generate_version_key(v), reverse=True)
 
     else:
-        # Map of major version (int) -> list of (key (str), versions (str)) so
-        # we can get the most recent version of the last three majors which
-        # we'll assume are "featured versions"
+        # Map of major version (int) -> list of (key (str), versions (str)) so we can
+        # get the most recent version of the last three major versions which we'll
+        # assume are "featured versions".
         major_to_versions = OrderedDict()
         for version in versions:
             # In figuring for featured versions, we don't want to include the

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -659,4 +659,13 @@ CSP_REPORT_URI = ("/__cspreport__",)
 # This is the number of versions to display if a particular product
 # has no 'featured versions'. Then we use the active versions, but capped
 # up to this number.
-NUMBER_OF_FEATURED_VERSIONS = config("NUMBER_OF_FEATURED_VERSIONS", 4)
+NUMBER_OF_FEATURED_VERSIONS = config("NUMBER_OF_FEATURED_VERSIONS", 4, cast=int)
+
+# Number of days to look at for versions in crash reports. This is set
+# for two months. If we haven't gotten a crash report for some version in
+# two months, then seems like that version isn't active.
+VERSIONS_WINDOW_DAYS = config("VERSIONS_WINDOW_DAYS", 60, cast=int)
+
+# Minimum number of crash reports in the VERSIONS_WINDOW_DAYS to be
+# considered as a valid version.
+VERSIONS_COUNT_THRESHOLD = config("VERSIONS_COUNT_THRESHOLD", 50, cast=int)


### PR DESCRIPTION
The featured versions list is calculated for most products based on existing crash reports. This allows the list to be dynamic and change quickly which is helpful during releases. However, this means that calculating the list is vulnerable to junk data and bugs.
    
This adjusts the calculation slightly in that it adds a minimum count threshold. I picked 50 after looking at all the existing products on Socorro. Going lower increases the likelihood that junk data affects the featured versions. Going higher increases the likelihood we hit an issue with less-used products where versions take a really long time to show up.
    
We can tweak the number a little as circumstances come up, but I think if products have a problem with it, they should do what Fennec is doing and manually maintain a list of featured versions.
    
Note that the `VERSIONS_COUNT_THRESHOLD` is set to 0 for the local dev environment.