### PR TITLE
bug 1596106: security fixes

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
@@ -23,7 +23,7 @@
     <div class="page-header">
       {% include "header_title.html" %}
 
-      <form id="simple_search" method="get" action="{{ url('crashstats:quick_search') }}">
+      <form id="simple_search" method="get" action="{{ url('crashstats:quick_search') }}" data-no-csrf>
         <label for="q" class="visually-hidden">Search</label>
         <input type="text" id="q" name="query" placeholder="Find Crash ID or Signature">
         <input type="submit" class="hidden">

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -68,6 +68,7 @@ ALLOWED_HOSTS = config("ALLOWED_HOSTS", "", cast=Csv())
 ROOT_URLCONF = "crashstats.urls"
 
 INSTALLED_APPS = (
+    "whitenoise.runserver_nostatic",
     "pipeline",
     "django.contrib.contenttypes",
     "django.contrib.auth",
@@ -669,3 +670,8 @@ VERSIONS_WINDOW_DAYS = config("VERSIONS_WINDOW_DAYS", 60, cast=int)
 # Minimum number of crash reports in the VERSIONS_WINDOW_DAYS to be
 # considered as a valid version.
 VERSIONS_COUNT_THRESHOLD = config("VERSIONS_COUNT_THRESHOLD", 50, cast=int)
+
+# Prevents whitenoise from adding "Access-Control-Allow-Origin: *" header for static
+# files. If we ever switch to hosting static assets on a CDN, we'll want to remove
+# this.
+WHITENOISE_ALLOW_ALL_ORIGINS = False

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -44,6 +44,7 @@
       <form method="get" action="{{ url('signature:signature_report') }}"
             data-fields-url="{{ url('supersearch:search_fields') }}?{{ make_query_string(exclude=['signature', 'date']) }}"
             data-signature="{{ signature }}"
+            data-no-csrf
       >
         <div class="form-controls">
           <button class="new-line">New line</button>

--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
@@ -44,6 +44,7 @@
             data-results-url="{{ url('supersearch:search_results') }}"
             data-custom-url="{{ url('supersearch:search_custom') }}"
             data-public-api-url="{{ url('api:model_wrapper', 'SuperSearch') }}"
+            data-no-csrf
       >
         <div class="form-controls">
           {% if request.user.has_perm('crashstats.run_custom_queries') %}


### PR DESCRIPTION
This fixes a couple of issues raised by ZAP.

Static assets are served by whitenoise which is adding this header:

```
Access-Control-Allow-Origin: *
```
    
Since we're not hosting static assets on a CDN, we don't need this so we should disable it.

This adds data-no-csrf attribute to three forms:
    
* quick search form in the navbar
* super search form on the super search page
* signature search form
    
These forms all use GET method and they're search forms, but ZAP doesn't know that, so we're adding the attribute so ZAP doesn't report them as failures.