### PR TITLE
bug 1624403: reduce localstack containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ run: my.env
 
 .PHONY: runservices
 runservices: my.env
-	${DC} up -d statsd postgresql memcached localstack-s3 localstack-sqs elasticsearch
+	${DC} up -d statsd postgresql memcached localstack elasticsearch
 
 .PHONY: stop
 stop: my.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,7 @@ services:
       - my.env
     depends_on:
       - statsd
-      - localstack-s3
-      - localstack-sqs
+      - localstack
       - elasticsearch
     command: ["processor"]
     volumes:
@@ -55,8 +54,7 @@ services:
       - my.env
     depends_on:
       - statsd
-      - localstack-s3
-      - localstack-sqs
+      - localstack
       - postgresql
       - elasticsearch
       - memcached
@@ -104,8 +102,7 @@ services:
       - docker/config/never_on_a_server.env
       - my.env
     depends_on:
-      - localstack-s3
-      - localstack-sqs
+      - localstack
       - statsd
     expose:
       - 8000
@@ -153,27 +150,16 @@ services:
       - POSTGRES_DB=breakpad
 
   # https://hub.docker.com/r/localstack/localstack/
-  # localstack running a fake AWS S3
-  localstack-s3:
-    image: localstack/localstack:0.10.5
+  # localstack running a fake AWS S3 and SQS
+  localstack:
+    image: localstack/localstack:0.10.8
     environment:
-      - SERVICES=s3:4572
-      - DEFAULT_REGION=us-west-2
-      - HOSTNAME=localstack-s3
-      - HOSTNAME_EXTERNAL=localstack-s3
+      - SERVICES=s3:4572,sqs:4576
+      - DEFAULT_REGION=us-east-1
+      - HOSTNAME=localstack
+      - HOSTNAME_EXTERNAL=localstack
     ports:
       - "4572:4572"
-
-  # https://hub.docker.com/r/localstack/localstack/
-  # localstack running a fake sqs
-  localstack-sqs:
-    image: localstack/localstack:0.10.5
-    environment:
-      - SERVICES=sqs:4576
-      - DEFAULT_REGION=us-east-1
-      - HOSTNAME=localstack-sqs
-      - HOSTNAME_EXTERNAL=localstack-sqs
-    ports:
       - "4576:4576"
 
   # https://hub.docker.com/_/memcached/

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -42,14 +42,14 @@ resource.elasticsearch.elasticsearch_urls=http://elasticsearch:9200
 # boto (s3/sqs)
 # -------------
 
-resource.boto.s3_endpoint_url=http://localstack-s3:4572/
+resource.boto.s3_endpoint_url=http://localstack:4572/
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
 resource.boto.bucket_name=dev_bucket
 resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.region=us-west-2
 
-resource.boto.sqs_endpoint_url=http://localstack-sqs:4576/
+resource.boto.sqs_endpoint_url=http://localstack:4576/
 resource.boto.standard_queue=local_dev_standard
 resource.boto.priority_queue=local_dev_priority
 resource.boto.reprocessing_queue=local_dev_reprocessing
@@ -105,14 +105,14 @@ OIDC_OP_USER_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/userinfo
 # -------
 LOCAL_DEV_ENV=True
 CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
-CRASHSTORAGE_ENDPOINT_URL=http://localstack-s3:4572/
+CRASHSTORAGE_ENDPOINT_URL=http://localstack:4572/
 CRASHSTORAGE_REGION=us-west-2
 CRASHSTORAGE_ACCESS_KEY=foo
 CRASHSTORAGE_SECRET_ACCESS_KEY=foo
 CRASHSTORAGE_BUCKET_NAME=dev_bucket
 
 CRASHPUBLISH_CLASS=antenna.ext.sqs.crashpublish.SQSCrashPublish
-CRASHPUBLISH_ENDPOINT_URL=http://localstack-sqs:4576
+CRASHPUBLISH_ENDPOINT_URL=http://localstack:4576
 CRASHPUBLISH_REGION=us-east-1
 CRASHPUBLISH_ACCESS_KEY=foo
 CRASHPUBLISH_SECRET_ACCESS_KEY=foo

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -10,8 +10,7 @@
 # services have been launched. It depends on:
 #
 # * elasticsearch
-# * localstack-s3
-# * localstack-sqs
+# * localstack
 # * postgresql
 
 # Failures should cause setup to fail

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -27,7 +27,7 @@ TESTIMAGE="local/socorro_app"
 
 # Start services in background (this is idempotent)
 echo "Starting services needed by tests in the background..."
-${DC} up -d elasticsearch localstack-s3 localstack-sqs postgresql statsd
+${DC} up -d elasticsearch localstack postgresql statsd
 
 # If we're running a shell, then we start up a test container with . mounted
 # to /app.
@@ -42,8 +42,7 @@ if [ "$1" == "--shell" ]; then
            --network socorro_default \
            --link socorro_elasticsearch_1 \
            --link socorro_postgresql_1 \
-           --link socorro_localstack-sqs_1 \
-           --link socorro_localstack-s3_1 \
+           --link socorro_localstack_1 \
            --link socorro_statsd_1 \
            --env-file ./docker/config/local_dev.env \
            --env-file ./docker/config/never_on_a_server.env \
@@ -97,8 +96,7 @@ docker run \
        --network socorro_default \
        --link socorro_elasticsearch_1 \
        --link socorro_postgresql_1 \
-       --link socorro_localstack-sqs_1 \
-       --link socorro_localstack-s3_1 \
+       --link socorro_localstack_1 \
        --link socorro_statsd_1 \
        --env-file ./docker/config/local_dev.env \
        --env-file ./docker/config/never_on_a_server.env \

--- a/docs/localdevenvironment.rst
+++ b/docs/localdevenvironment.rst
@@ -499,10 +499,10 @@ Let's process crashes for Firefox from yesterday. We'd do this:
   # "crashdata" directory on the host
   app@socorro:/app$ cat crashids.txt | socorro-cmd fetch_crash_data ./crashdata
 
-  # Create a dev_bucket in localstack-s3
+  # Create a dev_bucket in localstack s3
   app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev_bucket/
 
-  # Copy that data from the host into the localstack-s3 container
+  # Copy that data from the host into the localstack s3 container
   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./crashdata s3://dev_bucket/
 
   # Add all the crash ids to the queue


### PR DESCRIPTION
We can run one localstack container that handles both services, so this fixes things accordingly.

Further this updates localstack to 0.10.8.

The issue is intermittent and I can't reproduce it locally. Hopefully one of these two things reduces CI failures because the SQS container isn't really up, yet.