### PR TITLE
bug 1624403: fix bucket and queue names

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -45,14 +45,14 @@ resource.elasticsearch.elasticsearch_urls=http://elasticsearch:9200
 resource.boto.s3_endpoint_url=http://localstack:4572/
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
-resource.boto.bucket_name=dev_bucket
+resource.boto.bucket_name=dev-bucket
 resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.region=us-west-2
 
 resource.boto.sqs_endpoint_url=http://localstack:4576/
-resource.boto.standard_queue=local_dev_standard
-resource.boto.priority_queue=local_dev_priority
-resource.boto.reprocessing_queue=local_dev_reprocessing
+resource.boto.standard_queue=local-dev-standard
+resource.boto.priority_queue=local-dev-priority
+resource.boto.reprocessing_queue=local-dev-reprocessing
 
 # processor
 # ---------
@@ -75,8 +75,8 @@ processor.breakpad.symbols_urls=https://s3-us-west-2.amazonaws.com/org.mozilla.c
 processor.command_pathname=/stackwalk/stackwalker
 
 # Set the telemetry bucket name explicitly
-destination.telemetry.bucket_name=telemetry_bucket
-telemetry.bucket_name=telemetry_bucket
+destination.telemetry.bucket_name=telemetry-bucket
+telemetry.bucket_name=telemetry-bucket
 
 # webapp
 # ------
@@ -109,11 +109,11 @@ CRASHSTORAGE_ENDPOINT_URL=http://localstack:4572/
 CRASHSTORAGE_REGION=us-west-2
 CRASHSTORAGE_ACCESS_KEY=foo
 CRASHSTORAGE_SECRET_ACCESS_KEY=foo
-CRASHSTORAGE_BUCKET_NAME=dev_bucket
+CRASHSTORAGE_BUCKET_NAME=dev-bucket
 
 CRASHPUBLISH_CLASS=antenna.ext.sqs.crashpublish.SQSCrashPublish
 CRASHPUBLISH_ENDPOINT_URL=http://localstack:4576
 CRASHPUBLISH_REGION=us-east-1
 CRASHPUBLISH_ACCESS_KEY=foo
 CRASHPUBLISH_SECRET_ACCESS_KEY=foo
-CRASHPUBLISH_QUEUE_NAME=local_dev_standard
+CRASHPUBLISH_QUEUE_NAME=local-dev-standard

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -14,9 +14,9 @@ resource.boto.bucket_name=crashstats-test
 destination.telemetry.bucket_name=telemetry-test
 telemetry.bucket_name=telemetry-test
 
-resource.boto.standard_queue=test_standard
-resource.boto.priority_queue=test_priority
-resource.boto.reprocessing_queue=test_reprocessing
+resource.boto.standard_queue=test-standard
+resource.boto.priority_queue=test-priority
+resource.boto.reprocessing_queue=test-reprocessing
 
 # Elasticsearch configuration
 resource.elasticsearch.elasticsearch_index=testsocorro%Y%W

--- a/docs/localdevenvironment.rst
+++ b/docs/localdevenvironment.rst
@@ -424,25 +424,25 @@ scripts/socorro_aws_s3.sh
 This script is a convenience wrapper around the aws cli s3 subcommand that uses
 Socorro environment variables to set the credentials and endpoint.
 
-For example, this creates an S3 bucket named ``dev_bucket``:
+For example, this creates an S3 bucket named ``dev-bucket``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev-bucket/
 
 
-This copies the contents of ``./testdata`` into the ``dev_bucket``:
+This copies the contents of ``./testdata`` into the ``dev-bucket``:
 
 .. code-block:: shell
 
-   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./testdata s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./testdata s3://dev-bucket/
 
 
 This lists the contents of the bucket:
 
 .. code-block:: shell
 
-   app@socorro:/app$ scripts/socorro_aws_s3.sh ls s3://dev_bucket/
+   app@socorro:/app$ scripts/socorro_aws_s3.sh ls s3://dev-bucket/
 
 
 Since this is just a wrapper, you can get help:
@@ -465,7 +465,7 @@ For example:
 
 .. code-block:: shell
 
-   app@socorro:/app$ socorro-cmd sqs publish local_dev_standard \
+   app@socorro:/app$ socorro-cmd sqs publish local-dev-standard \
        ed35821d-3af5-4fe9-bfa3-dc4dc0181128
 
 
@@ -499,14 +499,14 @@ Let's process crashes for Firefox from yesterday. We'd do this:
   # "crashdata" directory on the host
   app@socorro:/app$ cat crashids.txt | socorro-cmd fetch_crash_data ./crashdata
 
-  # Create a dev_bucket in localstack s3
-  app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+  # Create a dev-bucket in localstack s3
+  app@socorro:/app$ scripts/socorro_aws_s3.sh mb s3://dev-bucket/
 
   # Copy that data from the host into the localstack s3 container
-  app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./crashdata s3://dev_bucket/
+  app@socorro:/app$ scripts/socorro_aws_s3.sh sync ./crashdata s3://dev-bucket/
 
   # Add all the crash ids to the queue
-  app@socorro:/app$ cat crashids.txt | socorro-cmd sqs publish local_dev_standard
+  app@socorro:/app$ cat crashids.txt | socorro-cmd sqs publish local-dev-standard
 
   # Then exit the container
   app@socorro:/app$ exit
@@ -531,7 +531,7 @@ To run Antenna in the Socorro local dev environment, do::
 
 
 It will listen on ``http://localhost:8888/`` for incoming crashes from a
-breakpad crash reporter. It will save crash data to the ``dev_bucket`` in the
+breakpad crash reporter. It will save crash data to the ``dev-bucket`` in the
 local S3 which is where the processor looks for it. It will publish the crash
 ids to the AWS SQS standard queue.
 

--- a/scripts/process_crashes.sh
+++ b/scripts/process_crashes.sh
@@ -46,12 +46,12 @@ mkdir "${DATADIR}" || echo "${DATADIR} already exists."
 ./socorro-cmd fetch_crash_data "${DATADIR}" $@
 
 # Make the bucket and sync contents
-./scripts/socorro_aws_s3.sh mb s3://dev_bucket/
-./scripts/socorro_aws_s3.sh cp --recursive "${DATADIR}" s3://dev_bucket/
-./scripts/socorro_aws_s3.sh ls --recursive s3://dev_bucket/
+./scripts/socorro_aws_s3.sh mb s3://dev-bucket/
+./scripts/socorro_aws_s3.sh cp --recursive "${DATADIR}" s3://dev-bucket/
+./scripts/socorro_aws_s3.sh ls --recursive s3://dev-bucket/
 
 # Add crash ids to queue
-./socorro-cmd sqs publish local_dev_standard $@
+./socorro-cmd sqs publish local-dev-standard $@
 
 # Print urls to make it easier to look at them
 for crashid in "$@"

--- a/scripts/socorro_aws_s3.sh
+++ b/scripts/socorro_aws_s3.sh
@@ -12,19 +12,19 @@ set -e
 #
 # make bucket
 #
-#     scripts/socorro_aws_s3.sh mb s3://dev_bucket/
+#     scripts/socorro_aws_s3.sh mb s3://dev-bucket/
 #
 # list bucket
 #
-#     scripts/socorro_aws_s3.sh ls s3://dev_bucket/
+#     scripts/socorro_aws_s3.sh ls s3://dev-bucket/
 #
 # copy files into s3 container
 #
-#     scripts/socorro_aws_s3.sh cp --recursive ./my_s3_root/ s3://dev_bucket/
+#     scripts/socorro_aws_s3.sh cp --recursive ./my_s3_root/ s3://dev-bucket/
 #
 # sync local directory and s3 container
 #
-#     scripts/socorro_aws_s3.sh sync ./my_s3_root/ s3://dev_bucket/
+#     scripts/socorro_aws_s3.sh sync ./my_s3_root/ s3://dev-bucket/
 
 # First convert configman environment vars which have bad identifiers to ones
 # that don't


### PR DESCRIPTION
AWS S3 bucket names can't have underscores in them. This fixes the names in the local dev environment to comply with that.

AWS SQS queue names *can* have underscores, but I figured it's easier on my brain if names all have the same conventinos so I changed those, too.

This only affects the local dev environment.