### PR TITLE
bug 1624790: add "syscall" to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -314,6 +314,7 @@ _platform_strlen
 strncpy
 strzcmp16
 strstr
+syscall
 __swrite
 TlsGetValue
 TouchBadMemory


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature https://crash-stats.mozilla.com/report/index/6c300571-a7fa-4812-ae43-5d4850200319 https://crash-stats.mozilla.com/report/index/0b2e2416-9785-475a-b362-714260200319
Crash id: 6c300571-a7fa-4812-ae43-5d4850200319
Original: syscall
New:      syscall | std::vector<T>::operator=
Same?:    False
Crash id: 0b2e2416-9785-475a-b362-714260200319
Original: syscall
New:      syscall | g_thread_pool_new
Same?:    False
```