### PR TITLE
bug 1619638: remove java_stack_trace_full before indexing in Elasticsearch

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -456,7 +456,7 @@ class ESCrashStorageRedactedSave(ESCrashStorage):
         default="socorro.external.crashstorage_base.Redactor",
         from_string_converter=class_converter,
     )
-    required_config.add_option(
+    required_config.es_redactor.add_option(
         name="forbidden_keys",
         doc="a list of keys not allowed in a redacted processed crash",
         default=(
@@ -520,7 +520,7 @@ class ESCrashStorageRedactedJsonDump(ESCrashStorageRedactedSave):
         default="socorro.external.crashstorage_base.Redactor",
         from_string_converter=class_converter,
     )
-    required_config.add_option(
+    required_config.es_redactor.add_option(
         name="forbidden_keys",
         doc="a list of keys not allowed in a redacted processed crash",
         default=(

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -47,6 +47,10 @@ CONFIG_DEFAULTS = {
             "es_redactor": {
                 "forbidden_keys": ", ".join(
                     [
+                        # NOTE(willkg): "java_stack_trace_full" messes the Elasticsearch
+                        # crashstorage up and causes errors. We can remove it in
+                        # August 2020. Bug #1619638
+                        "java_stack_trace_full",
                         "memory_report",
                         "upload_file_minidump_browser.json_dump",
                         "upload_file_minidump_flash1.json_dump",


### PR DESCRIPTION
Elasticsearch crashstorage has problems with the `java_stack_trace_full` field. We removed it a while back, but crash reports processed before we removed it still have the field in the processed crash file.

This adds it to the `forbidden_keys` list for Elasticsearch. We can remove the forbidden key in August 2020.