### PR TITLE
bug 1624403: switch SQS check to use waitfor script

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -37,8 +37,8 @@ PYTHON="$(which python)"
 echo ">>> wait for services to be ready"
 urlwait "${DATABASE_URL}" 10
 urlwait "${ELASTICSEARCH_URL}" 10
-urlwait "${S3_ENDPOINT_URL}" 10
-urlwait "${SQS_ENDPOINT_URL}" 10
+python ./scripts/waitfor.py --timeout=10 "${S3_ENDPOINT_URL}"
+python ./scripts/waitfor.py --timeout=10 --codes=200,400 "${SQS_ENDPOINT_URL}"
 
 echo ">>> build sqs things and db things"
 # Clear SQS for tests

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -25,9 +25,11 @@ SOCORRO_GID=${SOCORRO_GID:-"10001"}
 BASEIMAGENAME="python:3.7.6-slim-stretch"
 TESTIMAGE="local/socorro_app"
 
-# Start services in background (this is idempotent)
+# Start services in background (this is idempotent)--make sure to start
+# localstack first since it needs some extra time
 echo "Starting services needed by tests in the background..."
-${DC} up -d elasticsearch localstack postgresql statsd
+${DC} up -d localstack
+${DC} up -d elasticsearch postgresql statsd
 
 # If we're running a shell, then we start up a test container with . mounted
 # to /app.

--- a/scripts/waitfor.py
+++ b/scripts/waitfor.py
@@ -20,7 +20,11 @@ def main(args):
     )
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--timeout", type=int, default=10, help="Wait timeout")
-    parser.add_argument("--codes", default="200", help="Comma-separated list of valid HTTP response codes")
+    parser.add_argument(
+        "--codes",
+        default="200",
+        help="Comma-separated list of valid HTTP response codes",
+    )
     parser.add_argument("url", help="URL to test")
 
     parsed = parser.parse_args(args)
@@ -28,7 +32,10 @@ def main(args):
     ok_codes = [int(code.strip()) for code in parsed.codes.split(",")]
 
     if parsed.verbose:
-        print("Testing %s for %s with timeout %d..." % (parsed.url, repr(ok_codes), parsed.timeout))
+        print(
+            "Testing %s for %s with timeout %d..."
+            % (parsed.url, repr(ok_codes), parsed.timeout)
+        )
 
     socket.setdefaulttimeout(1)
 

--- a/scripts/waitfor.py
+++ b/scripts/waitfor.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Given a url, performs GET requests until it gets back an HTTP 200
+# or exceeds the wait timeout.
+
+import argparse
+import socket
+import urllib.error
+import urllib.request
+import sys
+import time
+
+
+def main(args):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Performs GET requests against given URL until HTTP 200 or exceeds "
+            "wait timeout."
+        )
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--timeout", type=int, default=10, help="Wait timeout")
+    parser.add_argument("--codes", default="200", help="Comma-separated list of valid HTTP response codes")
+    parser.add_argument("url", help="URL to test")
+
+    parsed = parser.parse_args(args)
+
+    ok_codes = [int(code.strip()) for code in parsed.codes.split(",")]
+
+    if parsed.verbose:
+        print("Testing %s for %s with timeout %d..." % (parsed.url, repr(ok_codes), parsed.timeout))
+
+    socket.setdefaulttimeout(1)
+
+    start_time = time.time()
+
+    last_fail = ""
+    while True:
+        try:
+            with urllib.request.urlopen(parsed.url) as resp:
+                if resp.code in ok_codes:
+                    sys.exit(0)
+                last_fail = "HTTP status code: %s" % resp.code
+        except urllib.error.URLError as error:
+            if error.code in ok_codes:
+                sys.exit(0)
+            last_fail = "URLError: %s" % error
+
+        if parsed.verbose:
+            print(last_fail)
+
+        time.sleep(1)
+
+        if time.time() - start_time > parsed.timeout:
+            print("Failed. %s" % last_fail)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This adds a waitfor script that does an HTTP connection and waits for a certain response code. This switches the SQS check to use that so we can avoid HTTP 502 bad gateway which passes urlwait, but hoses CI.