### PR TITLE
bug 1625154: fix updatemissing to work across date bounds

### DIFF
--- a/webapp-django/crashstats/crashstats/management/commands/verifyprocessed.py
+++ b/webapp-django/crashstats/crashstats/management/commands/verifyprocessed.py
@@ -63,13 +63,15 @@ def check_elasticsearch(supersearch, crash_ids):
     """
     crash_ids = [crash_ids] if isinstance(crash_ids, str) else crash_ids
     crash_date = date_from_ooid(crash_ids[0])
-    start_date = crash_date.strftime("%Y-%m-%d")
-    end_date = (crash_date + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+
+    # The datestamp in the crashid doesn't match the processed date sometimes especially
+    # when the crash came in at the end of the day.
+    start_date = (crash_date - datetime.timedelta(days=5)).strftime("%Y-%m-%d")
+    end_date = (crash_date + datetime.timedelta(days=5)).strftime("%Y-%m-%d")
 
     params = {
         "uuid": crash_ids,
         "date": [">=%s" % start_date, "<=%s" % end_date],
-        "_results_number": len(crash_ids),
         "_columns": ["uuid"],
         "_facets": [],
         "_facets_size": 0,


### PR DESCRIPTION
updatemissing can't find processed crash data in Elasticsearch where the crash came in on one day and was processed the next day. This happens around midnight.

This increases the date range to look at and also nixes the `_results_number` which I don't think we need to pass in.

To test:

1. process some crashes
2. use `socorro-cmd es list` to get the list of indexes, then use `socorro-cmd es list_crashids <INDEX>` to figure out which index to delete, then `socorro-cmd es delete <INDEX>` to delete the index with crashes in it
3. run `cd webapp-django` then `./manage.py verifyprocessed` which creates a missing processed crash item
4. run `./manage.py updatemissing` and it'll say it didn't update any missing crashes
5. reprocess the crashes
6. run `./manage.py updatemissing` and it'll say it found them