### PR TITLE
bug 1624911: change Fenix nightly versions from "Nightly..." to "0.0a1"

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -39,6 +39,7 @@ from socorro.processor.rules.mozilla import (
     EnvironmentRule,
     ESRVersionRewrite,
     ExploitablityRule,
+    FenixVersionRewriteRule,
     FlashVersionRule,
     JavaProcessRule,
     ModulesInStackRule,
@@ -175,6 +176,7 @@ class ProcessorPipeline(RequiredConfig):
             ConvertModuleSignatureInfoRule(),
             # rules to change the internals of the raw crash
             ProductRewrite(),
+            FenixVersionRewriteRule(),
             ESRVersionRewrite(),
             PluginContentURL(),
             PluginUserComment(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -377,6 +377,28 @@ class ProductRewrite(Rule):
             raw_crash["OriginalProductName"] = original_product_name
 
 
+class FenixVersionRewriteRule(Rule):
+    """Fix 'Nightly YYMMDD HH:MM' version values to '0.0a1'
+
+    This allows nightlies for Fenix to group in Crash Stats. We can probably ditch this
+    at some point when we're not getting crash reports that have this version structure.
+
+    Bug #1624911
+
+    """
+
+    def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return raw_crash.get("ProductName") == "Fenix" and (
+            raw_crash.get("Version") or ""
+        ).startswith("Nightly ")
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        processor_meta.processor_notes.append(
+            "Changed version from %r to 0.0a1" % raw_crash.get("Version")
+        )
+        raw_crash["Version"] = "0.0a1"
+
+
 class ESRVersionRewrite(Rule):
     def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
         return raw_crash.get("ReleaseChannel", "") == "esr"

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -388,9 +388,8 @@ class FenixVersionRewriteRule(Rule):
     """
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        return raw_crash.get("ProductName") == "Fenix" and (
-            raw_crash.get("Version") or ""
-        ).startswith("Nightly ")
+        is_nightly = (raw_crash.get("Version") or "").startswith("Nightly ")
+        return raw_crash.get("ProductName") == "Fenix" and is_nightly
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         processor_meta.processor_notes.append(


### PR DESCRIPTION
This allows grouping of Fenix nightly crash reports until they change the version number to something Socorro understands better.
