### PR TITLE
bug 1626618: change BetaVersionRule to only work on supported products

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -707,9 +707,14 @@ class BetaVersionRule(Rule):
         return real_version
 
     def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        # Beta and aurora versions send the wrong version in the crash report,
-        # so we need to fix them
-        return processed_crash.get("release_channel", "").lower() in ("beta", "aurora")
+        # Beta and aurora versions send the wrong version in the crash report for
+        # certain products
+        product = processed_crash.get("product", "")
+        release_channel = processed_crash.get("release_channel", "")
+        return product.lower() in self.SUPPORTED_PRODUCTS and release_channel.lower() in (
+            "beta",
+            "aurora",
+        )
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         product = processed_crash.get("product", "").strip().lower()

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1283,11 +1283,38 @@ class TestModulesInStackRule(object):
         assert rule.format_module(item) == expected
 
 
-class TestBetaVersionRule(object):
+class TestBetaVersionRule:
     API_URL = "http://example.com/api/VersionString"
 
     def build_rule(self):
         return BetaVersionRule(version_string_api=self.API_URL)
+
+    @pytest.mark.parametrize(
+        "product, channel, expected",
+        [
+            ("Firefox", "beta", True),
+            ("Fennec", "beta", True),
+            ("FennecAndroid", "beta", True),
+            # Unsupported products and channels yield false
+            ("Firefox", "nightly", False),
+            ("Fenix", "beta", False),
+        ],
+    )
+    def test_predicate(self, product, channel, expected):
+        raw_crash = {}
+        raw_dumps = {}
+        processed_crash = {
+            "product": product,
+            "release_channel": channel,
+            "version": "3.0",
+            "build": "20001001101010",
+        }
+        processor_meta = get_basic_processor_meta()
+        rule = self.build_rule()
+        assert (
+            rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+            == expected
+        )
 
     def test_beta_channel_known_version(self):
         # Beta channel with known version gets converted correctly


### PR DESCRIPTION
We've got lots of products that aren't like Firefox and Fennec and adding the "b0" at the end is disasterous. I don't even know how to spell that word it's so bad.

This changes the rule to only operate on Firefox, Fennec, and FennecAndroid.