### PR TITLE
bug 1626801: add CxxThrowException and friends to sig lists

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -20,6 +20,7 @@ CrashStatsLogForwarder::CrashAction
 __cxa_rethrow
 __cxa_throw
 _CxxThrowException
+CxxThrowException
 dalvik-heap
 dalvik-jit-code-cache
 dalvik-LinearAlloc

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -9,6 +9,8 @@
 .*CrashAtUnhandlableOOM
 Abort
 .*abort
+__abi_WinRTraiseCOMException
+__abi_WinRTraiseException
 __aeabi_memcpy4
 __aeabi_memcpy
 __aeabi_memmove


### PR DESCRIPTION
This adds `CxxThrowException` to the irrelevant list. `_CxxThrowException` is already there and the frame isn't helpful for signatures.

This adds `__abi_WinRTraiseCOMException` and `__abi_WinRTraiseException` to the prefix list so signature generation continues beyond them.

```
app@socorro:/app$ socorro-cmd signature bp-d0371db3-c844-43ea-94c3-19c9e0200329 bp-2282557f-868a-4a95-8db1-ab4580181218 bp-4c1410c4-c35e-4a04-b767-de09a0200401
Crash id: d0371db3-c844-43ea-94c3-19c9e0200329
Original: CxxThrowException
New:      __abi_WinRTraiseCOMException | __abi_WinRTraiseException | Windows::UI::Xaml::Application::LoadComponent
Same?:    False
WARNING: 2282557f-868a-4a95-8db1-ab4580181218: does not exist.
Crash id: 4c1410c4-c35e-4a04-b767-de09a0200401
Original: CxxThrowException
New:      goingime.x64.dll | CThreadMgrEventSink::OnSetFocus
Same?:    False
```