### PR TITLE
bug 1626801: move CxxThrowException to prefix list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -20,7 +20,6 @@ CrashStatsLogForwarder::CrashAction
 __cxa_rethrow
 __cxa_throw
 _CxxThrowException
-CxxThrowException
 dalvik-heap
 dalvik-jit-code-cache
 dalvik-LinearAlloc

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -50,6 +50,7 @@ core::str::slice_error_fail
 CrashInJS
 CreateFileMappingA
 __cxxabiv1::failed_throw
+CxxThrowException
 __delayLoadHelper2
 dlmalloc
 dlmalloc_trim


### PR DESCRIPTION
Having `CxxThrowException` in the prefix and show up in the signature fixes some bucketing.