### PR TITLE
Update fennec versions

### DIFF
--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,3 +1,3 @@
 {
-    "featured_versions": ["68.6b", "68.6.0"]
+    "featured_versions": ["68.7.0"]
 }


### PR DESCRIPTION
Bump release to 68.7.0, and remove beta due to the migration to fenix