### PR TITLE
bug 1626048: fix SubmittedFromInfobar values

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -35,10 +35,10 @@ MAXINT = 9223372036854775807
 class ConvertModuleSignatureInfoRule(Rule):
     """Make ModuleSignatureInfo to a string.
 
-    For a while, crash reports submitted as a JSON blob had ModuleSignatureInfo appended
-    to the end of them as an object. This JSON-encodes that object so that it's always a
-    JSON-encoded string. That way, the rest of the processor doesn't have to handle both
-    cases. Bug #1607806.
+    For a while, crash reports with annotations submitted as a JSON blob had
+    ModuleSignatureInfo appended to the end of them as an object. This JSON-encodes that
+    object so that the value is always a JSON-encoded string. That way, the rest of the
+    processor doesn't have to handle both cases. Bug #1607806
 
     """
 
@@ -54,6 +54,26 @@ class ConvertModuleSignatureInfoRule(Rule):
             # convert it to a dict first
             info = dotdict_to_dict(info)
         raw_crash["ModuleSignatureInfo"] = json.dumps(info)
+
+
+class SubmittedFromInfobarFixRule(Rule):
+    """Fix SubmittedFromInfobar annotation values to "1"
+
+    SubmittedFromInfobar value was "true", but it should be "1". For crash reports
+    with annotations submitted as a JSON blob, the value is not true (JSON bool true).
+    This fixes both of those to "1" which is what the value should be. Bug #1626048
+
+    Crash reports with annotations submitted as a JSON blob.
+
+    """
+
+    def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return "SubmittedFromInfobar" in raw_crash and raw_crash[
+            "SubmittedFromInfobar"
+        ] in ("true", True)
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        raw_crash["SubmittedFromInfobar"] = "1"
 
 
 class ProductRule(Rule):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -35,6 +35,7 @@ from socorro.processor.rules.mozilla import (
     ProductRewrite,
     ProductRule,
     SignatureGeneratorRule,
+    SubmittedFromInfobarFixRule,
     ThemePrettyNameRule,
     TopMostFilesRule,
     UserDataRule,
@@ -211,7 +212,39 @@ class TestConvertModuleSignatureInfoRule:
         assert processed_crash == {}
 
 
-class TestProductRule(object):
+class TestSubmittedFromInfobarFixRule:
+    @pytest.mark.parametrize(
+        "value, expected", [(True, True), ("true", True), ("1", False)]
+    )
+    def test_predicate(self, value, expected):
+        raw_crash = {"SubmittedFromInfobar": value}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule = SubmittedFromInfobarFixRule()
+        ret = rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert ret == expected
+
+    def test_predicate_with_not_there(self):
+        raw_crash = {}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule = SubmittedFromInfobarFixRule()
+        ret = rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert ret is False
+
+    def test_action(self):
+        raw_crash = {"SubmittedFromInfobar": "true"}
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule = SubmittedFromInfobarFixRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        assert raw_crash == {"SubmittedFromInfobar": "1"}
+
+
+class TestProductRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}


### PR DESCRIPTION
The values are `"true"` and `true` and it should be `"1"`. The crash reporter was fixed to always send `"1"`, but we have to handle crash reports for all the broken versions.