### PR TITLE
bug 1626801: add RpcpRaiseException to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -253,6 +253,8 @@ __pthread_kill
 __pthread_mutex_lock
 _purecall
 raise
+RpcpRaiseException
+RpcRaiseException
 realloc
 recv
 .*ReentrantMonitor::Wait


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 9200a1e1-e1a2-4b17-89fb-19d560200402
Crash id: 9200a1e1-e1a2-4b17-89fb-19d560200402
Original: RpcpRaiseException
New:      RpcpRaiseException | RpcRaiseException | NdrpSendReceive
Same?:    False
```

Not wildly helpful here, but it might help some other signatures.