### PR TITLE
bug 1628311: fix scripts/run_mdsw.sh

### DIFF
--- a/scripts/run_mdsw.sh
+++ b/scripts/run_mdsw.sh
@@ -20,7 +20,7 @@ function getenv {
 }
 
 DATADIR=./crashdata_mdsw_tmp
-STACKWALKER="$(getenv 'processor.breakpad.command_pathname')"
+STACKWALKER="$(getenv 'processor.command_pathname')"
 
 if [[ $# -eq 0 ]]; then
     if [ -t 0 ]; then

--- a/scripts/run_mdsw.sh
+++ b/scripts/run_mdsw.sh
@@ -33,7 +33,7 @@ if [[ $# -eq 0 ]]; then
     set -- ${@:-$(</dev/stdin)}
 fi
 
-mkdir "${DATADIR}" || echo "${DATADIR} already exists."
+mkdir "${DATADIR}" || true
 
 for CRASHID in "$@"
 do


### PR DESCRIPTION
It was looking at the wrong environment variable for the command pathname. That changed a while ago, but the change missed this script.