### PR TITLE
Adjust core::result::unwrap_failed entry in the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -44,7 +44,7 @@ core::ops::function::Fn::call<T>
 core::option::expect_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place
-core::result::unwrap_failed<T>
+core::result::unwrap_failed
 core::slice::slice_index_order_fail
 core::str::slice_error_fail
 CrashInJS


### PR DESCRIPTION
Looks like it sometimes occurs without the extra `<T>`, e.g.
https://bugzilla.mozilla.org/show_bug.cgi?id=1628886