### PR TITLE
bug 1629854: add core::result::unwrap_failed to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -44,7 +44,7 @@ core::ops::function::Fn::call<T>
 core::option::expect_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place
-core::result::unwrap_failed<T>
+core::result::unwrap_failed
 core::slice::slice_index_order_fail
 core::str::slice_error_fail
 CrashInJS


### PR DESCRIPTION
`core::result::unwrap_failed<T>` was in the prefix list already. This generalizes it to cover both cases.

```
app@socorro:/app$ socorro-cmd signature bp-589682e0-9e35-4095-b622-c194c0200409 bp-541a1dbc-e389-46ae-b311-ea22c0200414 bp-3d3b59a9-2bf1-4eb9-bcff-cbb540200414 bp-a8edddbc-edba-489f-8340-675c70200413
Crash id: 589682e0-9e35-4095-b622-c194c0200409
Original: core::result::unwrap_failed
New:      core::result::unwrap_failed | neqo_qpack::encoder::QPackEncoder::encode_header_block
Same?:    False
Crash id: 541a1dbc-e389-46ae-b311-ea22c0200414
Original: core::result::unwrap_failed
New:      core::result::unwrap_failed | style::rule_tree::StrongRuleNode::ensure_child
Same?:    False
Crash id: 3d3b59a9-2bf1-4eb9-bcff-cbb540200414
Original: core::result::unwrap_failed<T> | style::gecko::wrapper::get_animation_rule
New:      core::result::unwrap_failed<T> | style::gecko::wrapper::get_animation_rule
Same?:    True
Crash id: a8edddbc-edba-489f-8340-675c70200413
Original: core::result::unwrap_failed<T> | hashglobe::hash_set::HashSet<T>::insert<T>
New:      core::result::unwrap_failed<T> | hashglobe::hash_set::HashSet<T>::insert<T>
Same?:    True
```

This replaces PR #5344 