### PR TITLE
bug 1054508: add warning to raw crash data and minidumps section

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -72,7 +72,7 @@
               <a href="#modules" class="ui-tabs-anchor"><span>Modules</span></a>
             </li>
             <li class="ui-state-default ui-corner-top">
-              <a href="#rawdump" class="ui-tabs-anchor"><span>Raw Dump</span></a>
+              <a href="#rawdump" class="ui-tabs-anchor"><span>Raw Data and Minidumps</span></a>
             </li>
             <li class="ui-state-default ui-corner-top">
               <a href="#extensions" class="ui-tabs-anchor"><span>Extensions</span></a>
@@ -825,21 +825,18 @@
           <div id="rawdump" class="ui-tabs-hide">
             <div class="code">{{ raw_stackwalker_output }}</div>
 
-            <h3>Download the Raw Dump</h3>
+            <h3>Download Raw Crash Data and Minidumps</h3>
             {% if request.user.has_perm('crashstats.view_rawdump') %}
+              <p>
+                {{ sensitive_warning(your_crash) }}
+              </p>
               {% for url in raw_dump_urls %}
                 <p><a href="{{ url }}">{{ url }}</a></p>
               {% endfor %}
-            {% else %}
-              <p>You need to be signed in to download raw dumps.</p>
-            {% endif %}
-
-            <h3>View the Unredacted Crash</h3>
-            {% if request.user.has_perm('crashstats.view_rawdump') %}
               {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
               <p><a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a></p>
             {% else %}
-              <p>You need to be signed in to view unredacted crashes.</p>
+            <p>You need to be signed in to download raw crash data and minidump files.</p>
             {% endif %}
           </div>
           <!-- /rawdump -->

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -425,8 +425,10 @@ class TestViews(BaseTestViews):
         assert _SAMPLE_UNREDACTED["user_comments"] not in content
         assert _SAMPLE_META["Email"] not in content
         assert _SAMPLE_META["URL"] not in content
-        assert "You need to be signed in to download raw dumps." in content
-        assert "You need to be signed in to view unredacted crashes." in content
+        assert (
+            "You need to be signed in to download raw crash data and minidump files."
+            in content
+        )
         # Should not be able to see sensitive key from stackwalker JSON
         assert "&#34;sensitive&#34;" not in content
         assert "&#34;exploitability&#34;" not in content


### PR DESCRIPTION
This cleans up some of the language (in my opinion) and also adds the "this data is sensitive" warning to the section that has links to downloading raw crash data and minidumps.