### PR TITLE
bug 1383113: switch from getattr to getitem notation in breakpad rules

### DIFF
--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -265,6 +265,13 @@ class BreakpadStackwalkerRule2015(Rule):
 
 
 class JitCrashCategorizeRule(Rule):
+    """Categorizes JIT crashes.
+
+    NOTE(willkg): This needs to run after BreakpadStackwalkerRule2015 and
+    SignatureGenerationRule.
+
+    """
+
     def __init__(self, dump_field, command_pathname, command_line, kill_timeout):
         super().__init__()
         self.dump_field = dump_field

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -7,7 +7,6 @@ import copy
 import json
 from unittest import mock
 
-from configman.dotdict import DotDict
 from markus.testing import MetricsMock
 
 from socorro.processor.processor_pipeline import ProcessorPipeline
@@ -16,90 +15,90 @@ from socorro.processor.rules.breakpad import (
     CrashingThreadRule,
     JitCrashCategorizeRule,
     MinidumpSha256Rule,
-    dot_save,
 )
-from socorro.unittest.processor import get_basic_processor_meta
+
+
+def get_basic_processor_meta():
+    return {"processor_notes": []}
 
 
 example_uuid = "00000000-0000-0000-0000-000002140504"
-canonical_standard_raw_crash = DotDict(
-    {
-        "uuid": example_uuid,
-        "InstallTime": "1335439892",
-        "AdapterVendorID": "0x1002",
-        "TotalVirtualMemory": "4294836224",
-        "Comments": "why did my browser crash?  #fail",
-        "Theme": "classic/1.0",
-        "Version": "12.0",
-        "Email": "noreply@mozilla.com",
-        "Vendor": "Mozilla",
-        "EMCheckCompatibility": "true",
-        "Throttleable": "1",
-        "id": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
-        "buildid": "20120420145725",
-        "AvailablePageFile": "10641510400",
-        "version": "12.0",
-        "AdapterDeviceID": "0x7280",
-        "ReleaseChannel": "release",
-        "submitted_timestamp": "2012-05-08T23:26:33.454482+00:00",
-        "URL": "http://www.mozilla.com",
-        "timestamp": 1336519593.454627,
-        "Notes": (
-            "AdapterVendorID: 0x1002, AdapterDeviceID: 0x7280, "
-            "AdapterSubsysID: 01821043, "
-            "AdapterDriverVersion: 8.593.100.0\nD3D10 Layers? D3D10 "
-            "Layers- D3D9 Layers? D3D9 Layers- "
-        ),
-        "CrashTime": "1336519554",
-        "Winsock_LSP": (
-            "MSAFD Tcpip [TCP/IPv6] : 2 : 1 :  \n "
-            "MSAFD Tcpip [UDP/IPv6] : 2 : 2 : "
-            "%SystemRoot%\\system32\\mswsock.dll \n "
-            "MSAFD Tcpip [RAW/IPv6] : 2 : 3 :  \n "
-            "MSAFD Tcpip [TCP/IP] : 2 : 1 : "
-            "%SystemRoot%\\system32\\mswsock.dll \n "
-            "MSAFD Tcpip [UDP/IP] : 2 : 2 :  \n "
-            "MSAFD Tcpip [RAW/IP] : 2 : 3 : "
-            "%SystemRoot%\\system32\\mswsock.dll \n "
-            "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-            "\u0443\u0441\u043b\u0443\u0433 RSVP TCPv6 : 2 : 1 :  \n "
-            "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-            "\u0443\u0441\u043b\u0443\u0433 RSVP TCP : 2 : 1 : "
-            "%SystemRoot%\\system32\\mswsock.dll \n "
-            "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-            "\u0443\u0441\u043b\u0443\u0433 RSVP UDPv6 : 2 : 2 :  \n "
-            "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-            "\u0443\u0441\u043b\u0443\u0433 RSVP UDP : 2 : 2 : "
-            "%SystemRoot%\\system32\\mswsock.dll"
-        ),
-        "FramePoisonBase": "00000000f0de0000",
-        "AvailablePhysicalMemory": "2227773440",
-        "FramePoisonSize": "65536",
-        "StartupTime": "1336499438",
-        "Add-ons": (
-            "adblockpopups@jessehakanen.net:0.3,"
-            "dmpluginff%40westbyte.com:1%2C4.8,"
-            "firebug@software.joehewitt.com:1.9.1,"
-            "killjasmin@pierros14.com:2.4,"
-            "support@surfanonymous-free.com:1.0,"
-            "uploader@adblockfilters.mozdev.org:2.1,"
-            "{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}:20111107,"
-            "{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}:2.0.3,"
-            "anttoolbar@ant.com:2.4.6.4,"
-            "{972ce4c6-7e08-4474-a285-3208198ce6fd}:12.0,"
-            "elemhidehelper@adblockplus.org:1.2.1"
-        ),
-        "BuildID": "20120420145725",
-        "SecondsSinceLastCrash": "86985",
-        "ProductName": "Firefox",
-        "legacy_processing": 0,
-        "AvailableVirtualMemory": "3812708352",
-        "SystemMemoryUsePercentage": "48",
-        "ProductID": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
-        "Distributor": "Mozilla",
-        "Distributor_version": "12.0",
-    }
-)
+canonical_standard_raw_crash = {
+    "uuid": example_uuid,
+    "InstallTime": "1335439892",
+    "AdapterVendorID": "0x1002",
+    "TotalVirtualMemory": "4294836224",
+    "Comments": "why did my browser crash?  #fail",
+    "Theme": "classic/1.0",
+    "Version": "12.0",
+    "Email": "noreply@mozilla.com",
+    "Vendor": "Mozilla",
+    "EMCheckCompatibility": "true",
+    "Throttleable": "1",
+    "id": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+    "buildid": "20120420145725",
+    "AvailablePageFile": "10641510400",
+    "version": "12.0",
+    "AdapterDeviceID": "0x7280",
+    "ReleaseChannel": "release",
+    "submitted_timestamp": "2012-05-08T23:26:33.454482+00:00",
+    "URL": "http://www.mozilla.com",
+    "timestamp": 1336519593.454627,
+    "Notes": (
+        "AdapterVendorID: 0x1002, AdapterDeviceID: 0x7280, "
+        "AdapterSubsysID: 01821043, "
+        "AdapterDriverVersion: 8.593.100.0\nD3D10 Layers? D3D10 "
+        "Layers- D3D9 Layers? D3D9 Layers- "
+    ),
+    "CrashTime": "1336519554",
+    "Winsock_LSP": (
+        "MSAFD Tcpip [TCP/IPv6] : 2 : 1 :  \n "
+        "MSAFD Tcpip [UDP/IPv6] : 2 : 2 : "
+        "%SystemRoot%\\system32\\mswsock.dll \n "
+        "MSAFD Tcpip [RAW/IPv6] : 2 : 3 :  \n "
+        "MSAFD Tcpip [TCP/IP] : 2 : 1 : "
+        "%SystemRoot%\\system32\\mswsock.dll \n "
+        "MSAFD Tcpip [UDP/IP] : 2 : 2 :  \n "
+        "MSAFD Tcpip [RAW/IP] : 2 : 3 : "
+        "%SystemRoot%\\system32\\mswsock.dll \n "
+        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
+        "\u0443\u0441\u043b\u0443\u0433 RSVP TCPv6 : 2 : 1 :  \n "
+        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
+        "\u0443\u0441\u043b\u0443\u0433 RSVP TCP : 2 : 1 : "
+        "%SystemRoot%\\system32\\mswsock.dll \n "
+        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
+        "\u0443\u0441\u043b\u0443\u0433 RSVP UDPv6 : 2 : 2 :  \n "
+        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
+        "\u0443\u0441\u043b\u0443\u0433 RSVP UDP : 2 : 2 : "
+        "%SystemRoot%\\system32\\mswsock.dll"
+    ),
+    "FramePoisonBase": "00000000f0de0000",
+    "AvailablePhysicalMemory": "2227773440",
+    "FramePoisonSize": "65536",
+    "StartupTime": "1336499438",
+    "Add-ons": (
+        "adblockpopups@jessehakanen.net:0.3,"
+        "dmpluginff%40westbyte.com:1%2C4.8,"
+        "firebug@software.joehewitt.com:1.9.1,"
+        "killjasmin@pierros14.com:2.4,"
+        "support@surfanonymous-free.com:1.0,"
+        "uploader@adblockfilters.mozdev.org:2.1,"
+        "{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}:20111107,"
+        "{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}:2.0.3,"
+        "anttoolbar@ant.com:2.4.6.4,"
+        "{972ce4c6-7e08-4474-a285-3208198ce6fd}:12.0,"
+        "elemhidehelper@adblockplus.org:1.2.1"
+    ),
+    "BuildID": "20120420145725",
+    "SecondsSinceLastCrash": "86985",
+    "ProductName": "Firefox",
+    "legacy_processing": 0,
+    "AvailableVirtualMemory": "3812708352",
+    "SystemMemoryUsePercentage": "48",
+    "ProductID": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+    "Distributor": "Mozilla",
+    "Distributor_version": "12.0",
+}
 
 
 canonical_stackwalker_output = {
@@ -198,43 +197,41 @@ canonical_stackwalker_output_str = json.dumps(canonical_stackwalker_output)
 class MyBreakpadStackwalkerRule2015(BreakpadStackwalkerRule2015):
     @contextmanager
     def _temp_raw_crash_json_file(self, raw_crash, crash_id):
-        yield "%s.json" % raw_crash.uuid
+        yield "%s.json" % raw_crash["uuid"]
 
 
 class TestCrashingThreadRule(object):
     def test_everything_we_hoped_for(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
-        processed_crash = DotDict()
-        processed_crash.json_dump = copy.copy(canonical_stackwalker_output)
+        processed_crash = {"json_dump": copy.copy(canonical_stackwalker_output)}
         processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        assert processed_crash.crashedThread == 0
+        assert processed_crash["crashedThread"] == 0
 
     def test_stuff_missing(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
-        processed_crash = DotDict()
-        processed_crash.json_dump = {}
+        processed_crash = {"json_dump": {}}
         processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadRule()
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        assert processed_crash.crashedThread is None
-        assert processor_meta.processor_notes == [
+        assert processed_crash["crashedThread"] is None
+        assert processor_meta["processor_notes"] == [
             "MDSW did not identify the crashing thread"
         ]
 
 
 class TestMinidumpSha256HashRule(object):
     def test_hash_not_in_raw_crash(self):
-        raw_crash = DotDict()
+        raw_crash = {}
         raw_dumps = {}
-        processed_crash = DotDict()
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = MinidumpSha256Rule()
@@ -244,9 +241,9 @@ class TestMinidumpSha256HashRule(object):
         )
 
     def test_hash_in_raw_crash(self):
-        raw_crash = DotDict({"MinidumpSha256Hash": "hash"})
+        raw_crash = {"MinidumpSha256Hash": "hash"}
         raw_dumps = {}
-        processed_crash = DotDict()
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = MinidumpSha256Rule()
@@ -261,24 +258,6 @@ class TestMinidumpSha256HashRule(object):
 
 canonical_external_output = {"key": "value"}
 canonical_external_output_str = json.dumps(canonical_external_output)
-
-
-def test_dot_save():
-    d = {}
-    dot_save(d, "x", 1)
-    assert d["x"] == 1
-
-    dot_save(d, "z.y", 10)
-    assert d["z"]["y"] == 10
-
-    d["a"] = {}
-    d["a"]["b"] = {}
-    dot_save(d, "a.b.c", 100)
-    assert d["a"]["b"]["c"] == 100
-
-    dd = DotDict()
-    dot_save(dd, "a.b.c.d.e.f", 1000)
-    assert dd.a.b.c.d.e.f == 1000
 
 
 class TestBreakpadTransformRule2015(object):
@@ -302,7 +281,7 @@ class TestBreakpadTransformRule2015(object):
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -314,10 +293,10 @@ class TestBreakpadTransformRule2015(object):
         with MetricsMock() as mm:
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-            assert processed_crash.json_dump == canonical_stackwalker_output
-            assert processed_crash.mdsw_return_code == 0
-            assert processed_crash.mdsw_status_string == "OK"
-            assert processed_crash.success is True
+            assert processed_crash["json_dump"] == canonical_stackwalker_output
+            assert processed_crash["mdsw_return_code"] == 0
+            assert processed_crash["mdsw_status_string"] == "OK"
+            assert processed_crash["success"] is True
 
             mm.assert_incr(
                 "processor.breakpadstackwalkerrule.run",
@@ -330,7 +309,7 @@ class TestBreakpadTransformRule2015(object):
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -340,11 +319,11 @@ class TestBreakpadTransformRule2015(object):
         with MetricsMock() as mm:
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-            assert processed_crash.json_dump == {}
-            assert processed_crash.mdsw_return_code == 124
-            assert processed_crash.mdsw_status_string == "unknown error"
-            assert processed_crash.success is False
-            assert processor_meta.processor_notes == ["MDSW timeout (SIGKILL)"]
+            assert processed_crash["json_dump"] == {}
+            assert processed_crash["mdsw_return_code"] == 124
+            assert processed_crash["mdsw_status_string"] == "unknown error"
+            assert processed_crash["success"] is False
+            assert processor_meta["processor_notes"] == ["MDSW timeout (SIGKILL)"]
 
             mm.assert_incr(
                 "processor.breakpadstackwalkerrule.run",
@@ -357,7 +336,7 @@ class TestBreakpadTransformRule2015(object):
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -367,15 +346,17 @@ class TestBreakpadTransformRule2015(object):
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        assert processed_crash.json_dump == {}
-        assert processed_crash.mdsw_return_code == -1
-        assert processed_crash.mdsw_status_string == "unknown error"
-        assert not processed_crash.success
+        assert processed_crash["json_dump"] == {}
+        assert processed_crash["mdsw_return_code"] == -1
+        assert processed_crash["mdsw_status_string"] == "unknown error"
+        assert not processed_crash["success"]
         assert (
             rule.command_pathname + " output failed in json: Expecting property name"
-            in processor_meta.processor_notes[0]
+            in processor_meta["processor_notes"][0]
         )
-        assert processor_meta.processor_notes[1] == "MDSW failed with -1: unknown error"
+        assert (
+            processor_meta["processor_notes"][1] == "MDSW failed with -1: unknown error"
+        )
 
     @mock.patch("socorro.processor.rules.breakpad.os.unlink")
     def test_temp_file_context(self, mocked_unlink):
@@ -414,15 +395,17 @@ class TestJitCrashCategorizeRule(object):
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "Windows 386"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows 386",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -431,9 +414,9 @@ class TestJitCrashCategorizeRule(object):
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        assert processor_meta.processor_notes == []
-        assert processed_crash.classifications.jit.category == "EXTRA-SPECIAL"
-        assert processed_crash.classifications.jit.category_return_code == 0
+        assert processor_meta["processor_notes"] == []
+        assert processed_crash["classifications"]["jit"]["category"] == "EXTRA-SPECIAL"
+        assert processed_crash["classifications"]["jit"]["category_return_code"] == 0
 
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_success_all_types_of_signatures(self, mocked_subprocess_module):
@@ -441,14 +424,16 @@ class TestJitCrashCategorizeRule(object):
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        base_processed_crash = DotDict()
-        base_processed_crash.product = "Firefox"
-        base_processed_crash.os_name = "Windows 386"
-        base_processed_crash.cpu_arch = "x86"
-        base_processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        base_processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows 386",
+            "cpu_arch": "x86",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -464,28 +449,34 @@ class TestJitCrashCategorizeRule(object):
             "Small | js::irregexp::ExecuteCode<T>",
         ]
         for signature in signatures:
-            processed_crash = DotDict(base_processed_crash)
-            processed_crash.signature = signature
+            processed_crash = copy.copy(base_processed_crash)
+            processed_crash["signature"] = signature
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-            assert processor_meta.processor_notes == []
-            assert processed_crash.classifications.jit.category == "EXTRA-SPECIAL"
-            assert processed_crash.classifications.jit.category_return_code == 0
+            assert processor_meta["processor_notes"] == []
+            assert (
+                processed_crash["classifications"]["jit"]["category"] == "EXTRA-SPECIAL"
+            )
+            assert (
+                processed_crash["classifications"]["jit"]["category_return_code"] == 0
+            )
 
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_subprocess_fail(self, mocked_subprocess_module):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "Windows 386"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows 386",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -494,24 +485,26 @@ class TestJitCrashCategorizeRule(object):
 
         rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
-        assert processor_meta.processor_notes == []
-        assert processed_crash.classifications.jit.category is None
-        assert processed_crash.classifications.jit.category_return_code == -1
+        assert processor_meta["processor_notes"] == []
+        assert processed_crash["classifications"]["jit"]["category"] is None
+        assert processed_crash["classifications"]["jit"]["category_return_code"] == -1
 
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_wrong_os(self, mocked_subprocess_module):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "MS-DOS"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "MS-DOS",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -528,15 +521,17 @@ class TestJitCrashCategorizeRule(object):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefrenzy"
-        processed_crash.os_name = "Windows NT"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefrenzy",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -553,15 +548,17 @@ class TestJitCrashCategorizeRule(object):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "Windows NT"
-        processed_crash.cpu_arch = "VAX 750"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "VAX 750",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -578,15 +575,17 @@ class TestJitCrashCategorizeRule(object):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "Windows NT"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "this-is-not-a-JIT-signature"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"not_module": "not-a-module"}),
-            DotDict({"module": "a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "this-is-not-a-JIT-signature",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"not_module": "not-a-module"}, {"module": "a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -603,15 +602,17 @@ class TestJitCrashCategorizeRule(object):
         rule = self.build_rule()
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
-        processed_crash = DotDict()
-        processed_crash.product = "Firefox"
-        processed_crash.os_name = "Windows NT"
-        processed_crash.cpu_arch = "x86"
-        processed_crash.signature = "EnterBaseline"
-        processed_crash["json_dump.crashing_thread.frames"] = [
-            DotDict({"module": "a-module"}),
-            DotDict({"not_module": "not-a-module"}),
-        ]
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    "frames": [{"module": "a-module"}, {"not_module": "not-a-module"}]
+                }
+            },
+        }
         processor_meta = get_basic_processor_meta()
 
         mocked_subprocess_handle = mocked_subprocess_module.Popen.return_value
@@ -625,64 +626,56 @@ class TestJitCrashCategorizeRule(object):
 
     def test_predicate_no_json_dump(self):
         rule = self.build_rule()
-        processed_crash = DotDict(
-            {
-                "product": "Firefox",
-                "os_name": "Windows NT",
-                "cpu_arch": "x86",
-                "signature": "EnterBaseline",
-            }
-        )
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+        }
 
         assert rule.predicate({}, {}, processed_crash, {}) is True
 
     def test_predicate_no_crashing_thread(self):
         rule = self.build_rule()
-        processed_crash = DotDict(
-            {
-                "product": "Firefox",
-                "os_name": "Windows NT",
-                "cpu_arch": "x86",
-                "signature": "EnterBaseline",
-                # No "crashing_thread" key
-                "json_dump": {},
-            }
-        )
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            # No "crashing_thread" key
+            "json_dump": {},
+        }
 
         assert rule.predicate({}, {}, processed_crash, {}) is True
 
     def test_predicate_no_frames(self):
         rule = self.build_rule()
-        processed_crash = DotDict(
-            {
-                "product": "Firefox",
-                "os_name": "Windows NT",
-                "cpu_arch": "x86",
-                "signature": "EnterBaseline",
-                "json_dump": {
-                    # No "frames" key
-                    "crashing_thread": {}
-                },
-            }
-        )
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                # No "frames" key
+                "crashing_thread": {}
+            },
+        }
 
         assert rule.predicate({}, {}, processed_crash, {}) is True
 
     def test_predicate_empty_frames(self):
         rule = self.build_rule()
-        processed_crash = DotDict(
-            {
-                "product": "Firefox",
-                "os_name": "Windows NT",
-                "cpu_arch": "x86",
-                "signature": "EnterBaseline",
-                "json_dump": {
-                    "crashing_thread": {
-                        # There is a "frames" key, but nothing in the list
-                        "frames": []
-                    }
-                },
-            }
-        )
+        processed_crash = {
+            "product": "Firefox",
+            "os_name": "Windows NT",
+            "cpu_arch": "x86",
+            "signature": "EnterBaseline",
+            "json_dump": {
+                "crashing_thread": {
+                    # There is a "frames" key, but nothing in the list
+                    "frames": []
+                }
+            },
+        }
 
         assert rule.predicate({}, {}, processed_crash, {}) is True

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -202,9 +202,9 @@ class MyBreakpadStackwalkerRule2015(BreakpadStackwalkerRule2015):
 
 class TestCrashingThreadRule(object):
     def test_everything_we_hoped_for(self):
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
-        processed_crash = {"json_dump": copy.copy(canonical_stackwalker_output)}
+        processed_crash = {"json_dump": copy.deepcopy(canonical_stackwalker_output)}
         processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadRule()
@@ -213,7 +213,7 @@ class TestCrashingThreadRule(object):
         assert processed_crash["crashedThread"] == 0
 
     def test_stuff_missing(self):
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
         processed_crash = {"json_dump": {}}
         processor_meta = get_basic_processor_meta()
@@ -279,7 +279,7 @@ class TestBreakpadTransformRule2015(object):
     def test_everything_we_hoped_for(self, mocked_subprocess_module):
         rule = self.build_rule()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -307,7 +307,7 @@ class TestBreakpadTransformRule2015(object):
     def test_stackwalker_fails(self, mocked_subprocess_module):
         rule = self.build_rule()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -334,7 +334,7 @@ class TestBreakpadTransformRule2015(object):
     def test_stackwalker_fails_2(self, mocked_subprocess_module):
         rule = self.build_rule()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
@@ -393,7 +393,7 @@ class TestJitCrashCategorizeRule(object):
     def test_everything_we_hoped_for(self, mocked_subprocess_module):
         rule = self.build_rule()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",
@@ -422,7 +422,7 @@ class TestJitCrashCategorizeRule(object):
     def test_success_all_types_of_signatures(self, mocked_subprocess_module):
         rule = self.build_rule()
 
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         base_processed_crash = {
             "product": "Firefox",
@@ -449,7 +449,7 @@ class TestJitCrashCategorizeRule(object):
             "Small | js::irregexp::ExecuteCode<T>",
         ]
         for signature in signatures:
-            processed_crash = copy.copy(base_processed_crash)
+            processed_crash = copy.deepcopy(base_processed_crash)
             processed_crash["signature"] = signature
             rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
 
@@ -464,7 +464,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_subprocess_fail(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",
@@ -492,7 +492,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_wrong_os(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",
@@ -519,7 +519,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_wrong_product(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefrenzy",
@@ -546,7 +546,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_wrong_cpu(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",
@@ -573,7 +573,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_wrong_signature(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",
@@ -600,7 +600,7 @@ class TestJitCrashCategorizeRule(object):
     @mock.patch("socorro.processor.rules.breakpad.subprocess")
     def test_module_on_stack_top(self, mocked_subprocess_module):
         rule = self.build_rule()
-        raw_crash = copy.copy(canonical_standard_raw_crash)
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {rule.dump_field: "a_fake_dump.dump"}
         processed_crash = {
             "product": "Firefox",


### PR DESCRIPTION
This switches from getattr notation to getitem notation in the breakpad processor rules. We're transitioning off of DotDict and dict doesn't support getattr notation.

I did this in a few passes:

* switch from getattr to getitem in the `breakpad.py` file and get tests to pass
* remove `DotDict` usage in the `test_breakpad.py` file and get tests to pass
* read through both files for anything I missed

To test:

1. run tests and linting
2. process some crashes