### PR TITLE
bug 1383113: switch mozilla processor rules to getitem notation

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -78,27 +78,26 @@ class SubmittedFromInfobarFixRule(Rule):
 
 class ProductRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.product = raw_crash.get("ProductName", "")
-        processed_crash.version = raw_crash.get("Version", "")
-        processed_crash.productid = raw_crash.get("ProductID", "")
-        processed_crash.release_channel = raw_crash.get("ReleaseChannel", "")
+        processed_crash["product"] = raw_crash.get("ProductName", "")
+        processed_crash["version"] = raw_crash.get("Version", "")
+        processed_crash["productid"] = raw_crash.get("ProductID", "")
+        processed_crash["release_channel"] = raw_crash.get("ReleaseChannel", "")
         # redundant, but I want to exactly match old processors.
-        processed_crash.ReleaseChannel = raw_crash.get("ReleaseChannel", "")
-        processed_crash.build = raw_crash.get("BuildID", "")
+        processed_crash["ReleaseChannel"] = raw_crash.get("ReleaseChannel", "")
+        processed_crash["build"] = raw_crash.get("BuildID", "")
 
 
 class UserDataRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.url = raw_crash.get("URL", None)
-        processed_crash.user_comments = raw_crash.get("Comments", None)
-        processed_crash.email = raw_crash.get("Email", None)
-        # processed_crash.user_id = raw_crash.get('UserID', '')
-        processed_crash.user_id = ""
+        processed_crash["url"] = raw_crash.get("URL", None)
+        processed_crash["user_comments"] = raw_crash.get("Comments", None)
+        processed_crash["email"] = raw_crash.get("Email", None)
+        processed_crash["user_id"] = ""
 
 
 class EnvironmentRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.app_notes = raw_crash.get("Notes", "")
+        processed_crash["app_notes"] = raw_crash.get("Notes", "")
 
 
 class PluginRule(Rule):  # Hangs are here
@@ -108,9 +107,9 @@ class PluginRule(Rule):  # Hangs are here
         except ValueError:
             plugin_hang_as_int = 0
         if plugin_hang_as_int:
-            processed_crash.hangid = "fake-" + raw_crash.uuid
+            processed_crash["hangid"] = "fake-" + raw_crash["uuid"]
         else:
-            processed_crash.hangid = raw_crash.get("HangID", None)
+            processed_crash["hangid"] = raw_crash.get("HangID", None)
 
         # the processed_crash.hang_type has the following meaning:
         #    hang_type == -1 is a plugin hang
@@ -122,25 +121,25 @@ class PluginRule(Rule):  # Hangs are here
         except ValueError:
             hang_as_int = 0
         if hang_as_int:
-            processed_crash.hang_type = 1
+            processed_crash["hang_type"] = 1
         elif plugin_hang_as_int:
-            processed_crash.hang_type = -1
+            processed_crash["hang_type"] = -1
         elif processed_crash.hangid:
-            processed_crash.hang_type = -1
+            processed_crash["hang_type"] = -1
         else:
-            processed_crash.hang_type = 0
+            processed_crash["hang_type"] = 0
 
-        processed_crash.process_type = raw_crash.get("ProcessType", None)
+        processed_crash["process_type"] = raw_crash.get("ProcessType", None)
 
-        if not processed_crash.process_type:
+        if not processed_crash["process_type"]:
             return
 
-        if processed_crash.process_type == "plugin":
+        if processed_crash["process_type"] == "plugin":
             # Bug#543776 We actually will are relaxing the non-null policy...
             # a null filename, name, and version is OK. We'll use empty strings
-            processed_crash.PluginFilename = raw_crash.get("PluginFilename", "")
-            processed_crash.PluginName = raw_crash.get("PluginName", "")
-            processed_crash.PluginVersion = raw_crash.get("PluginVersion", "")
+            processed_crash["PluginFilename"] = raw_crash.get("PluginFilename", "")
+            processed_crash["PluginName"] = raw_crash.get("PluginName", "")
+            processed_crash["PluginVersion"] = raw_crash.get("PluginVersion", "")
 
 
 class AddonsRule(Rule):
@@ -155,20 +154,20 @@ class AddonsRule(Rule):
         return addon if ":" in addon else addon + ":NO_VERSION"
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.addons_checked = None
+        processed_crash["addons_checked"] = None
 
         # it's okay to not have EMCheckCompatibility
         if "EMCheckCompatibility" in raw_crash:
-            addons_checked_txt = raw_crash.EMCheckCompatibility.lower()
-            processed_crash.addons_checked = False
+            addons_checked_txt = raw_crash["EMCheckCompatibility"].lower()
+            processed_crash["addons_checked"] = False
             if addons_checked_txt == "true":
-                processed_crash.addons_checked = True
+                processed_crash["addons_checked"] = True
 
         original_addon_str = raw_crash.get("Add-ons", "")
         if not original_addon_str:
-            processed_crash.addons = []
+            processed_crash["addons"] = []
         else:
-            processed_crash.addons = [
+            processed_crash["addons"] = [
                 unquote_plus(self._get_formatted_addon(x))
                 for x in original_addon_str.split(",")
             ]
@@ -192,19 +191,19 @@ class DatesAndTimesRule(Rule):
             return default
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processor_notes = processor_meta.processor_notes
+        processor_notes = processor_meta["processor_notes"]
 
-        processed_crash.submitted_timestamp = raw_crash.get(
-            "submitted_timestamp", date_from_ooid(raw_crash.uuid)
+        processed_crash["submitted_timestamp"] = raw_crash.get(
+            "submitted_timestamp", date_from_ooid(raw_crash["uuid"])
         )
-        if isinstance(processed_crash.submitted_timestamp, str):
-            processed_crash.submitted_timestamp = datetime_from_isodate_string(
-                processed_crash.submitted_timestamp
+        if isinstance(processed_crash["submitted_timestamp"], str):
+            processed_crash["submitted_timestamp"] = datetime_from_isodate_string(
+                processed_crash["submitted_timestamp"]
             )
-        processed_crash.date_processed = processed_crash.submitted_timestamp
+        processed_crash["date_processed"] = processed_crash["submitted_timestamp"]
         # defaultCrashTime: must have crashed before date processed
         submitted_timestamp_as_epoch = int(
-            time.mktime(processed_crash.submitted_timestamp.timetuple())
+            time.mktime(processed_crash["submitted_timestamp"].timetuple())
         )
         try:
             # the old name for crash time
@@ -223,10 +222,10 @@ class DatesAndTimesRule(Rule):
         except ValueError:
             crash_time = 0
             processor_notes.append(
-                'non-integer value of "CrashTime" (%s)' % raw_crash.CrashTime
+                'non-integer value of "CrashTime" (%s)' % raw_crash["CrashTime"]
             )
 
-        processed_crash.crash_time = crash_time
+        processed_crash["crash_time"] = crash_time
         if crash_time == submitted_timestamp_as_epoch:
             processor_notes.append("client_crash_date is unknown")
         # StartupTime: must have started up some time before crash
@@ -241,13 +240,13 @@ class DatesAndTimesRule(Rule):
         except ValueError:
             installTime = 0
             processor_notes.append('non-integer value of "InstallTime"')
-        processed_crash.client_crash_date = datetime.datetime.fromtimestamp(
+        processed_crash["client_crash_date"] = datetime.datetime.fromtimestamp(
             crash_time, UTC
         )
-        processed_crash.install_age = crash_time - installTime
-        processed_crash.uptime = max(0, crash_time - startupTime)
+        processed_crash["install_age"] = crash_time - installTime
+        processed_crash["uptime"] = max(0, crash_time - startupTime)
         try:
-            last_crash = int(raw_crash.SecondsSinceLastCrash)
+            last_crash = int(raw_crash["SecondsSinceLastCrash"])
         except (KeyError, TypeError, ValueError):
             last_crash = None
             processor_notes.append('non-integer value of "SecondsSinceLastCrash"')
@@ -256,7 +255,7 @@ class DatesAndTimesRule(Rule):
             processor_notes.append(
                 '"SecondsSinceLastCrash" larger than MAXINT - set to NULL'
             )
-        processed_crash.last_crash = last_crash
+        processed_crash["last_crash"] = last_crash
 
 
 class JavaProcessRule(Rule):
@@ -273,7 +272,7 @@ class JavaProcessRule(Rule):
             )
             java_stack_trace = java_exception.to_public_string()
         except javautil.MalformedJavaStackTrace:
-            processor_meta.processor_notes.append(
+            processor_meta["processor_notes"].append(
                 "JavaProcessRule: malformed java stack trace"
             )
             java_stack_trace = "malformed"
@@ -326,8 +325,7 @@ class OutOfMemoryBinaryRule(Rule):
         return "memory_report" in raw_dumps
 
     def _extract_memory_info(self, dump_pathname, processor_notes):
-        """Extract and return the JSON data from the .json.gz memory report.
-        file"""
+        """Extract and return the JSON data from the .json.gz memory report"""
 
         def error_out(error_message):
             processor_notes.append(error_message)
@@ -364,13 +362,14 @@ class OutOfMemoryBinaryRule(Rule):
         pathname = raw_dumps["memory_report"]
         with temp_file_context(pathname):
             memory_report = self._extract_memory_info(
-                dump_pathname=pathname, processor_notes=processor_meta.processor_notes
+                dump_pathname=pathname,
+                processor_notes=processor_meta["processor_notes"],
             )
 
             if isinstance(memory_report, dict) and memory_report.get("ERROR"):
-                processed_crash.memory_report_error = memory_report["ERROR"]
+                processed_crash["memory_report_error"] = memory_report["ERROR"]
             else:
-                processed_crash.memory_report = memory_report
+                processed_crash["memory_report"] = memory_report
 
 
 class ProductRewrite(Rule):
@@ -389,7 +388,7 @@ class ProductRewrite(Rule):
         # If we made any product name changes, persist them and keep the
         # original one so we can look at things later
         if product_name != original_product_name:
-            processor_meta.processor_notes.append(
+            processor_meta["processor_notes"].append(
                 "Rewriting ProductName from %r to %r"
                 % (original_product_name, product_name)
             )
@@ -412,7 +411,7 @@ class FenixVersionRewriteRule(Rule):
         return raw_crash.get("ProductName") == "Fenix" and is_nightly
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processor_meta.processor_notes.append(
+        processor_meta["processor_notes"].append(
             "Changed version from %r to 0.0a1" % raw_crash.get("Version")
         )
         raw_crash["Version"] = "0.0a1"
@@ -426,7 +425,7 @@ class ESRVersionRewrite(Rule):
         try:
             raw_crash["Version"] += "esr"
         except KeyError:
-            processor_meta.processor_notes.append(
+            processor_meta["processor_notes"].append(
                 '"Version" missing from esr release raw_crash'
             )
 
@@ -456,12 +455,14 @@ class PluginUserComment(Rule):
 class ExploitablityRule(Rule):
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         try:
-            processed_crash.exploitability = processed_crash["json_dump"]["sensitive"][
-                "exploitability"
-            ]
+            processed_crash["exploitability"] = processed_crash["json_dump"][
+                "sensitive"
+            ]["exploitability"]
         except KeyError:
-            processed_crash.exploitability = "unknown"
-            processor_meta.processor_notes.append("exploitability information missing")
+            processed_crash["exploitability"] = "unknown"
+            processor_meta["processor_notes"].append(
+                "exploitability information missing"
+            )
 
 
 class FlashVersionRule(Rule):
@@ -539,7 +540,7 @@ class FlashVersionRule(Rule):
         return None
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.flash_version = ""
+        processed_crash["flash_version"] = ""
         flash_version = None
 
         modules = processed_crash.get("json_dump", {}).get("modules", [])
@@ -550,9 +551,9 @@ class FlashVersionRule(Rule):
                     break
 
         if flash_version:
-            processed_crash.flash_version = flash_version
+            processed_crash["flash_version"] = flash_version
         else:
-            processed_crash.flash_version = "[blank]"
+            processed_crash["flash_version"] = "[blank]"
 
 
 class TopMostFilesRule(Rule):
@@ -572,16 +573,18 @@ class TopMostFilesRule(Rule):
     """
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.topmost_filenames = None
+        processed_crash["topmost_filenames"] = None
         try:
-            crashing_thread = processed_crash.json_dump["crash_info"]["crashing_thread"]
-            stack_frames = processed_crash.json_dump["threads"][crashing_thread][
+            crashing_thread = processed_crash["json_dump"]["crash_info"][
+                "crashing_thread"
+            ]
+            stack_frames = processed_crash["json_dump"]["threads"][crashing_thread][
                 "frames"
             ]
         except KeyError as x:
             # guess we don't have frames or crashing_thread or json_dump
             # we have to give up
-            processor_meta.processor_notes.append(
+            processor_meta["processor_notes"].append(
                 "no 'topmost_file' name because '%s' is missing" % x
             )
             return
@@ -589,7 +592,7 @@ class TopMostFilesRule(Rule):
         for a_frame in stack_frames:
             source_filename = a_frame.get("file", None)
             if source_filename:
-                processed_crash.topmost_filenames = source_filename
+                processed_crash["topmost_filenames"] = source_filename
                 return
 
 
@@ -767,7 +770,7 @@ class BetaVersionRule(Rule):
         # No real version, but this is an aurora or beta crash report, so we
         # tack on "b0" to make it match the channel
         processed_crash["version"] += "b0"
-        processor_meta.processor_notes.append(
+        processor_meta["processor_notes"].append(
             'release channel is %s but no version data was found - added "b0" '
             "suffix to version number" % release_channel
         )
@@ -884,7 +887,7 @@ class ThemePrettyNameRule(Rule):
         return False
 
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        addons = processed_crash.addons
+        addons = processed_crash["addons"]
 
         for index, addon in enumerate(addons):
             if ":" in addon:

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -111,7 +111,7 @@ class PluginRule(Rule):  # Hangs are here
         else:
             processed_crash["hangid"] = raw_crash.get("HangID", None)
 
-        # the processed_crash.hang_type has the following meaning:
+        # the processed_crash["hang_type"] has the following meaning:
         #    hang_type == -1 is a plugin hang
         #    hang_type ==  1 is a browser hang
         #    hang_type ==  0 is not a hang at all, but a normal crash
@@ -124,7 +124,7 @@ class PluginRule(Rule):  # Hangs are here
             processed_crash["hang_type"] = 1
         elif plugin_hang_as_int:
             processed_crash["hang_type"] = -1
-        elif processed_crash.hangid:
+        elif processed_crash["hangid"]:
             processed_crash["hang_type"] = -1
         else:
             processed_crash["hang_type"] = 0

--- a/socorro/signature/tests/__init__.py
+++ b/socorro/signature/tests/__init__.py
@@ -1,22 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# NOTE(willkg): This is a duplicate of Socorro's WHATEVER, but it allows
-# the signature generation code to stand alone.
-
-from functools import total_ordering
-
-
-@total_ordering
-class EqualAnything(object):
-    def __eq__(self, other):
-        return True
-
-    def __lt__(self, other):
-        return True
-
-
-#: Sentinel that is equal to anything; simplifies assertions in cases where
-#: part of the value changes from test to test
-WHATEVER = EqualAnything()

--- a/socorro/signature/tests/test_signature_generator.py
+++ b/socorro/signature/tests/test_signature_generator.py
@@ -5,7 +5,6 @@
 import importlib
 from unittest import mock
 
-from . import WHATEVER
 
 # NOTE(willkg): We do this so that we can extract signature generation into its
 # own namespace as an external library. This allows the tests to run if it's in
@@ -57,7 +56,7 @@ class TestSignatureGenerator:
         assert error_handler.call_args_list == [
             mock.call(
                 {"uuid": "ou812"},
-                exc_info=(Exception, exc_value, WHATEVER),
+                exc_info=(Exception, exc_value, mock.ANY),
                 extra={"rule": "BadRule"},
             )
         ]

--- a/socorro/unittest/__init__.py
+++ b/socorro/unittest/__init__.py
@@ -1,19 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-from functools import total_ordering
-
-
-@total_ordering
-class EqualAnything(object):
-    def __eq__(self, other):
-        return True
-
-    def __lt__(self, other):
-        return True
-
-
-#: Sentinel that is equal to anything; simplifies assertions in cases where
-#: part of the value changes from test to test
-WHATEVER = EqualAnything()

--- a/socorro/unittest/processor/__init__.py
+++ b/socorro/unittest/processor/__init__.py
@@ -30,6 +30,4 @@ def get_basic_config():
 
 
 def get_basic_processor_meta():
-    processor_meta = DotDict()
-    processor_meta.processor_notes = []
-    return processor_meta
+    return {"processor_notes": []}

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -16,10 +16,7 @@ from socorro.processor.rules.breakpad import (
     JitCrashCategorizeRule,
     MinidumpSha256Rule,
 )
-
-
-def get_basic_processor_meta():
-    return {"processor_notes": []}
+from socorro.unittest.processor import get_basic_processor_meta
 
 
 example_uuid = "00000000-0000-0000-0000-000002140504"

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -197,7 +197,7 @@ class MyBreakpadStackwalkerRule2015(BreakpadStackwalkerRule2015):
         yield "%s.json" % raw_crash["uuid"]
 
 
-class TestCrashingThreadRule(object):
+class TestCrashingThreadRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -224,7 +224,7 @@ class TestCrashingThreadRule(object):
         ]
 
 
-class TestMinidumpSha256HashRule(object):
+class TestMinidumpSha256HashRule:
     def test_hash_not_in_raw_crash(self):
         raw_crash = {}
         raw_dumps = {}
@@ -257,7 +257,7 @@ canonical_external_output = {"key": "value"}
 canonical_external_output_str = json.dumps(canonical_external_output)
 
 
-class TestBreakpadTransformRule2015(object):
+class TestBreakpadTransformRule2015:
     def build_rule(self):
         pprcb = ProcessorPipeline.required_config.breakpad
 
@@ -376,7 +376,7 @@ class TestBreakpadTransformRule2015(object):
         mocked_unlink.reset_mock()
 
 
-class TestJitCrashCategorizeRule(object):
+class TestJitCrashCategorizeRule:
     def build_rule(self):
         pprcj = ProcessorPipeline.required_config.jit
         return JitCrashCategorizeRule(

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -14,6 +14,7 @@ from socorro.processor.rules.general import (
     IdentifierRule,
     OSInfoRule,
 )
+from socorro.unittest.processor import get_basic_processor_meta
 
 
 canonical_standard_raw_crash = {
@@ -104,10 +105,6 @@ canonical_processed_crash = {
         }
     }
 }
-
-
-def get_basic_processor_meta():
-    return {"processor_notes": []}
 
 
 class TestDeNoneRule:

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -171,7 +171,7 @@ class TestDeNullRule:
         assert raw_crash == DotDict({"key1": "val1", "key2": b"val2", "key3": "val3"})
 
 
-class TestIdentifierRule(object):
+class TestIdentifierRule:
     def test_everything_we_hoped_for(self):
         uuid = "00000000-0000-0000-0000-000002140504"
         raw_crash = {"uuid": uuid}
@@ -199,7 +199,7 @@ class TestIdentifierRule(object):
         assert processed_crash == {}
 
 
-class TestCPUInfoRule(object):
+class TestCPUInfoRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -259,7 +259,7 @@ class TestCPUInfoRule(object):
         assert raw_crash == {}
 
 
-class TestOSInfoRule(object):
+class TestOSInfoRule:
     def test_everything_we_hoped_for(self):
         raw_crash = {}
         processed_crash = {

--- a/socorro/unittest/processor/rules/test_memory_report_extraction.py
+++ b/socorro/unittest/processor/rules/test_memory_report_extraction.py
@@ -17,7 +17,7 @@ def get_example_file_data(filename):
         return json.loads(f.read())
 
 
-class TestMemoryReportExtraction(object):
+class TestMemoryReportExtraction:
     def test_predicate_success(self):
         rule = MemoryReportExtraction()
 

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -9,7 +9,6 @@ import pytest
 
 from socorro.external.crashstorage_base import CrashIDNotFound, PolyStorageError
 from socorro.processor.processor_app import ProcessorApp
-from socorro.unittest import WHATEVER
 
 
 def sequencer(*args):
@@ -254,7 +253,7 @@ class TestProcessorApp(object):
 
         # Assert that the processor sent something to Sentry
         assert mock_hub.capture_exception.call_args_list == [
-            mock.call(error=(ValueError, expected_exception, WHATEVER))
+            mock.call(error=(ValueError, expected_exception, mock.ANY))
         ]
 
         # Assert that the logger logged the appropriate thing
@@ -296,11 +295,11 @@ class TestProcessorApp(object):
         # Assert logs for failing to process crash
         expected = [
             # Logs for failed Sentry reporting for first exception
-            ("Unable to report error with Sentry", WHATEVER),
+            ("Unable to report error with Sentry", mock.ANY),
             ("Sentry DSN is not configured and an exception happened", None),
             ("Exception occurred", first_exc_info),
             # Logs for failed Sentry reporting for second exception
-            ("Unable to report error with Sentry", WHATEVER),
+            ("Unable to report error with Sentry", mock.ANY),
             ("Sentry DSN is not configured and an exception happened", None),
             ("Exception occurred", second_exc_info),
             # Log for failing to process or save the crash


### PR DESCRIPTION
This updates the mozilla processor rules to getitem notation and removes `DotDict` usage.

To test:

1. run tests
2. process some crashes