### PR TITLE
bug 1633473: add pthread_mutex_trylock to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -249,6 +249,7 @@ _pthread_cond_wait
 __pthread_cond_wait
 pthread_cond_signal_thread_np
 pthread_mutex_lock
+pthread_mutex_trylock
 __pthread_kill
 __pthread_mutex_lock
 _purecall


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature e6e85e81-a2e0-4356-ab68-6b1790200425
Crash id: e6e85e81-a2e0-4356-ab68-6b1790200425
Original: pthread_mutex_trylock
New:      pthread_mutex_trylock | mozilla::detail::MutexImpl::lock | mozilla::wr::RenderThread::RegisterExternalImage
Same?:    False
```