### PR TITLE
bug 1633501: remove vestigal user_id bits in processor

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -110,7 +110,7 @@ class Redactor(RequiredConfig):
         name="forbidden_keys",
         doc="a list of keys not allowed in a redacted processed crash",
         default=(
-            "url, email, user_id, exploitability,"
+            "url, email, exploitability,"
             "json_dump.sensitive,"
             "upload_file_minidump_flash1.json_dump.sensitive,"
             "upload_file_minidump_flash2.json_dump.sensitive,"

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -92,7 +92,6 @@ class UserDataRule(Rule):
         processed_crash["url"] = raw_crash.get("URL", None)
         processed_crash["user_comments"] = raw_crash.get("Comments", None)
         processed_crash["email"] = raw_crash.get("Email", None)
-        processed_crash["user_id"] = ""
 
 
 class EnvironmentRule(Rule):

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -312,7 +312,6 @@ class TestBotoS3CrashStorage:
                 # These keys do not survive redaction
                 "url": "http://example.com",
                 "email": "lars@example.com",
-                "user_id": "3333",
                 "exploitability": "yep",
                 "json_dump": {"sensitive": 22},
             }

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -82,7 +82,6 @@ a_processed_crash = {
     "uptime": 170,
     "url": "http://embarasing.example.com",
     "user_comments": None,
-    "user_id": None,
     "uuid": "936ce666-ff3b-4c7a-9674-367fe2120408",
     "version": "13.0a1",
     "upload_file_minidump_flash1": {
@@ -742,8 +741,9 @@ class TestESCrashStorage(ElasticsearchTestCase):
             # NOTE(willkg): The sizes of these json documents depend on what's
             # in them. If we changed a_processed_crash and a_raw_crash, then
             # these numbers will change.
+            mm.print_records()
             mm.assert_histogram("processor.es.raw_crash_size", value=27)
-            mm.assert_histogram("processor.es.processed_crash_size", value=1738)
+            mm.assert_histogram("processor.es.processed_crash_size", value=1721)
 
     def test_index_data_capture(self):
         """Verify we capture index data in ES crashstorage"""

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -311,7 +311,6 @@ class TestRedactor(object):
         # these keys do not survive redaction
         d["url"] = "http://very.embarassing.com"
         d["email"] = ("lars@fake.com",)
-        d["user_id"] = "3333"
         d["exploitability"] = "yep"
         d["json_dump.sensitive"] = 22
         d["upload_file_minidump_flash1.json_dump.sensitive"] = 33

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -287,7 +287,6 @@ class TestUserDataRule:
         assert processed_crash["url"] == "http://www.mozilla.com"
         assert processed_crash["user_comments"] == "why did my browser crash?  #fail"
         assert processed_crash["email"] == "noreply@mozilla.com"
-        assert processed_crash["user_id"] == ""
 
     def test_stuff_missing(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)


### PR DESCRIPTION
Seems like there was a UserId in raw crashes a while ago and someone wrote code in the processor to stomp on those values. We don't need this anymore, so we can remove it.