### PR TITLE
bug 1625515: redo version parsing and sorting

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -189,3 +189,6 @@ elasticsearch==1.9.0 \
 elasticsearch-dsl==0.0.11 \
     --hash=sha256:663fb62ad39200c7d903e973aa0aa693578613264d83796455cbf4cd172bd878 \
     --hash=sha256:59a76c4142478a1952bba6f9a9ca4fc7b029afb619e8ffcf0d135ce37ea692da
+semver==2.10.0 \
+    --hash=sha256:4ae5f926f2c4c1aa0612f95d4d502c838f41526f0b71e20cc706c28aa9763c47 \
+    --hash=sha256:a0fd30b371474a6ffcbb106074187bdacb4e17fbdd80abc9dffebccc420993a2

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -23,7 +23,7 @@ from django.utils.functional import cached_property
 
 from crashstats.crashstats import models
 import crashstats.supersearch.models as supersearch_models
-from socorro.lib.versionutil import generate_version_key, VersionParseError
+from socorro.lib.versionutil import generate_semver, VersionParseError
 
 
 logger = logging.getLogger(__name__)
@@ -408,12 +408,12 @@ def get_versions_for_product(product="Firefox", use_cache=True):
         try:
             # This generates the sort key but also parses the version to make sure it's
             # a valid looking version
-            versions.add((generate_version_key(version), version))
+            versions.add((generate_semver(version), version))
 
             # Add X.Yb to betas set
             if "b" in version:
                 beta_version = version[: version.find("b") + 1]
-                versions.add((generate_version_key(beta_version), beta_version))
+                versions.add((generate_semver(beta_version), beta_version))
         except VersionParseError:
             pass
 
@@ -485,7 +485,7 @@ def get_version_context_for_product(product):
         for featured_version in featured_versions:
             if featured_version not in versions:
                 versions.insert(0, featured_version)
-        versions.sort(key=lambda v: generate_version_key(v), reverse=True)
+        versions.sort(key=lambda v: generate_semver(v), reverse=True)
 
     else:
         # Map of major version (int) -> list of (key (str), versions (str)) so we can
@@ -510,7 +510,7 @@ def get_version_context_for_product(product):
         # for each major version. Since versions were sorted when we went through
         # them, the most recent one is in index 0.
         featured_versions = [values[0] for values in major_to_versions.values()]
-        featured_versions.sort(key=lambda v: generate_version_key(v), reverse=True)
+        featured_versions.sort(key=lambda v: generate_semver(v), reverse=True)
         featured_versions = featured_versions[:3]
 
     # Generate the version data the context needs


### PR DESCRIPTION
This converts versions into semver `VersionInfo` instances and uses those for sorting. Generally, this works, but there are some hacks:
    
1. Firefox/Fennec versions aren't valid semver, so I changed the parser we had before to parse those versions and generate semver `VersionInfo` instances.

   * 75.0a1 -> 75.0.0-alpha.1
   * 75.0b2 -> 75.0.0-beta.2

2. ESR releases need to sort *after* normal regular releases. The only way to do that with semver that I could figure is to mark everything with prerelease bits so that they sort correctly.
    
   * 68.0.2esr -> 68.0.2-xsr
    
   Note that "xsr" parses alphabetically after alpha, beta, and release.
    
3. Firefox/Fennec have release candidates of betas so we have to add "rc" to everything.
    
   * 75.0b2 -> 75.0.0-beta.2.rc.999
   * 75.0.1 -> 75.0.1-release.rc.999
   * 68.0.2esr -> 68.0.2-xsr.rc.999
    
4. The "b" ending thing needs to sort before all the betas--it's a catch-all for all betas.

I tested this by pulling all the versions for 10,000 crash reports for Firefox and Fenix and then making sure that `generate_semver` works and that the resulting lists of versions sorted correctly.

After this lands, I'll need to do some more verification on stage.