### PR TITLE
Add core::option::expect_none_failed to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -42,6 +42,7 @@ CleanupPerAppKey
 ConditionVariableFallback::wait\(.*\)
 core::ops::function::Fn::call<T>
 core::option::expect_failed
+core::option::expect_none_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place
 core::result::unwrap_failed


### PR DESCRIPTION
This is needed for crashes like: https://crash-stats.mozilla.org/report/index/af37f4f7-0c5d-4818-bc26-a86f10200506