### PR TITLE
bug 1608873: switch from hg annotate to hg file link

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_enhance_frame():
     vcs_mappings = {
         "hg": {
             "hg.m.org": (
-                "http://hg.m.org/%(repo)s/annotate/%(revision)s/%(file)s#l%(line)s"
+                "http://hg.m.org/%(repo)s/file/%(revision)s/%(file)s#l%(line)s"
             )
         }
     }
@@ -41,7 +41,7 @@ def test_enhance_frame():
         "function": "Func(A* a, B b)",
         "short_signature": "Func",
         "line": 576,
-        "source_link": "http://hg.m.org/repo/name/annotate/rev/dname/fname#l576",
+        "source_link": "http://hg.m.org/repo/name/file/rev/dname/fname#l576",
         "file": "dname/fname",
         "frame": 0,
         "signature": "Func(A* a, B b)",
@@ -188,7 +188,7 @@ def test_enhance_json_dump():
     vcs_mappings = {
         "hg": {
             "hg.m.org": (
-                "http://hg.m.org/%(repo)s/annotate/%(revision)s/%(file)s#l%(line)s"
+                "http://hg.m.org/%(repo)s/file/%(revision)s/%(file)s#l%(line)s"
             )
         }
     }
@@ -245,7 +245,7 @@ def test_enhance_json_dump():
                         "short_signature": "Func",
                         "line": 576,
                         "source_link": (
-                            "http://hg.m.org/repo/name/annotate/rev/dname/fname#l576"
+                            "http://hg.m.org/repo/name/file/rev/dname/fname#l576"
                         ),
                         "file": "dname/fname",
                         "signature": "Func",
@@ -258,7 +258,7 @@ def test_enhance_json_dump():
                         "signature": "Func2",
                         "short_signature": "Func2",
                         "source_link": (
-                            "http://hg.m.org/repo/name/annotate/rev/dname/fname#l576"
+                            "http://hg.m.org/repo/name/file/rev/dname/fname#l576"
                         ),
                         "file": "dname/fname",
                         "line": 576,
@@ -274,7 +274,7 @@ def test_enhance_json_dump():
                         "short_signature": "Func",
                         "line": 576,
                         "source_link": (
-                            "http://hg.m.org/repo/name/annotate/rev/dname/fname#l576"
+                            "http://hg.m.org/repo/name/file/rev/dname/fname#l576"
                         ),
                         "file": "dname/fname",
                         "signature": "Func",
@@ -287,7 +287,7 @@ def test_enhance_json_dump():
                         "signature": "Func2",
                         "short_signature": "Func2",
                         "source_link": (
-                            "http://hg.m.org/repo/name/annotate/rev/dname/fname#l576"
+                            "http://hg.m.org/repo/name/file/rev/dname/fname#l576"
                         ),
                         "file": "dname/fname",
                         "line": 576,

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -255,30 +255,25 @@ BUG_PRODUCT_MAP = {"FennecAndroid": "Firefox for Android"}
 VCS_MAPPINGS = {
     "cvs": {
         "cvs.mozilla.org": (
-            "http://bonsai.mozilla.org/cvsblame.cgi?"
-            "file=%(file)s&rev=%(revision)s&"
-            "mark=%(line)s#%(line)s"
+            "http://bonsai.mozilla.org/cvsblame.cgi?file=%(file)s&rev=%(revision)s&mark=%(line)s#%(line)s"  # noqa
         )
     },
     "hg": {
         "hg.mozilla.org": (
-            "https://hg.mozilla.org/%(repo)s"
-            "/annotate/%(revision)s/%(file)s#l%(line)s"
+            "https://hg.mozilla.org/%(repo)s/file/%(revision)s/%(file)s#l%(line)s"
         )
     },
     "git": {
         "git.mozilla.org": (
-            "http://git.mozilla.org/?p=%(repo)s;a=blob;"
-            "f=%(file)s;h=%(revision)s#l%(line)s"
+            "http://git.mozilla.org/?p=%(repo)s;a=blob;f=%(file)s;h=%(revision)s#l%(line)s"  # noqa
         ),
         "github.com": (
-            "https://github.com/%(repo)s/blob/%(revision)s/" "%(file)s#L%(line)s"
+            "https://github.com/%(repo)s/blob/%(revision)s/%(file)s#L%(line)s"
         ),
     },
     "s3": {
         "gecko-generated-sources": (
-            "/sources/highlight/?url=https://gecko-generated-so"
-            "urces.s3.amazonaws.com/%(file)s&line=%(line)s#L-%(line)s"
+            "/sources/highlight/?url=https://gecko-generated-sources.s3.amazonaws.com/%(file)s&line=%(line)s#L-%(line)s"  # noqa
         )
     },
 }


### PR DESCRIPTION
The file link comes up much faster than the annotate link does. If users want annotations, they can easily switch to the annotate link after the file link comes up.