### PR TITLE
bug 1616718: fix code to use bugzilla api token if available

### DIFF
--- a/webapp-django/crashstats/crashstats/management/commands/bugassociations.py
+++ b/webapp-django/crashstats/crashstats/management/commands/bugassociations.py
@@ -142,7 +142,15 @@ class Command(BaseCommand):
 
         # Use a 30-second timeout because Bugzilla is slow sometimes
         session = session_with_retries(default_timeout=30.0)
-        r = session.get(settings.BZAPI_BASE_URL + "/bug", params=payload)
+        headers = {}
+        if settings.BZAPI_TOKEN:
+            headers["X-BUGZILLA-API-KEY"] = settings.BZAPI_TOKEN
+            self.stdout.write(
+                "using BZAPI_TOKEN (%s)" % (settings.BZAPI_TOKEN[:-8] + "xxxxxxxx")
+            )
+        r = session.get(
+            settings.BZAPI_BASE_URL + "/bug", headers=headers, params=payload
+        )
         if r.status_code < 200 or r.status_code >= 300:
             r.raise_for_status()
         results = r.json()

--- a/webapp-django/crashstats/crashstats/management/commands/bugassociations.py
+++ b/webapp-django/crashstats/crashstats/management/commands/bugassociations.py
@@ -14,6 +14,7 @@ signatures and bug ids.
 
 import datetime
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
@@ -25,13 +26,12 @@ from socorro.lib.requestslib import session_with_retries
 # Query all bugs that changed since a given date, and that either were created
 # or had their crash_signature field change. Only return the two fields that
 # interest us, the id and the crash_signature text.
-BUGZILLA_PARAMS = {
+BUG_QUERY_PARAMS = {
     "chfieldfrom": "%s",
     "chfieldto": "Now",
     "chfield": ["[Bug creation]", "cf_crash_signature"],
     "include_fields": ["id", "cf_crash_signature"],
 }
-BUGZILLA_BASE_URL = "https://bugzilla.mozilla.org/rest/bug"
 
 
 def find_signatures(content):
@@ -137,12 +137,12 @@ class Command(BaseCommand):
         self.stdout.write("Working on %s to now" % start_date)
         # Fetch all the bugs that have been created or had the crash_signature
         # field changed since start_date
-        payload = BUGZILLA_PARAMS.copy()
+        payload = BUG_QUERY_PARAMS.copy()
         payload["chfieldfrom"] = start_date
 
         # Use a 30-second timeout because Bugzilla is slow sometimes
         session = session_with_retries(default_timeout=30.0)
-        r = session.get(BUGZILLA_BASE_URL, params=payload)
+        r = session.get(settings.BZAPI_BASE_URL + "/bug", params=payload)
         if r.status_code < 200 or r.status_code >= 300:
             r.raise_for_status()
         results = r.json()

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1004,6 +1004,8 @@ class BugzillaBugInfo(SocorroCommon):
         if missing:
             params = {"bugs": ",".join(missing), "fields": ",".join(fields)}
             headers = {"Accept": "application/json", "Content-Type": "application/json"}
+            if settings.BZAPI_TOKEN:
+                headers["X-BUGZILLA-API-KEY"] = settings.BZAPI_TOKEN
             url = settings.BZAPI_BASE_URL + (
                 "/bug?id=%(bugs)s&include_fields=%(fields)s" % params
             )

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -331,8 +331,11 @@ CRASH_ID_PREFIX = "bp-"
 # If true, allow robots to spider the site
 ENGAGE_ROBOTS = False
 
-# Base URL for when we use the Bugzilla API
+# Base URL for Bugzilla API
 BZAPI_BASE_URL = config("BZAPI_BASE_URL", "https://bugzilla.mozilla.org/rest")
+
+# Bugzilla API token
+BZAPI_TOKEN = config("BZAPI_TOKEN", "")
 
 # Base URL for Buildhub
 BUILDHUB_BASE_URL = "https://buildhub.moz.tools/"


### PR DESCRIPTION
This adds a `BZAPI_TOKEN` setting. The `bugassociations` job and `BugzillaBugInfo` model will use it if it's available.

To test:

1. process some crashes
2. do `make shell` and `cd webapp-django` and `manage.py cronrun --job=bugassociations`

   It should work fine and not log that it's using a token.

3. Set up an account and API token on https://bugzilla-dev.allizom.org/ and set in `my.env`:

   ```
   BZAPI_BASE_URL=https://bugzilla-dev.allizom.org/rest
   BZAPI_TOKEN=yourtoken
   ```

4. run `manage.py cronreset bugassociations` and then `manage.py cronrun --job=bugassociations`

   It should run and log that it used a token.