### PR TITLE
bug 1630968: remove deprecated monitoring endpoints

### DIFF
--- a/webapp-django/crashstats/monitoring/jinja2/monitoring/index.html
+++ b/webapp-django/crashstats/monitoring/jinja2/monitoring/index.html
@@ -15,12 +15,5 @@
       <li><a href="{{ url('monitoring:dockerflow_heartbeat') }}">/__heartbeat__</a></li>
       <li><a href="{{ url('monitoring:dockerflow_lbheartbeat') }}">/__lbheartbeat__</a></li>
     </ul>
-    <p>
-      Deprecated monitoring urls:
-    </p>
-    <ul>
-      <li><a href="{{ url('monitoring:healthcheck') }}">Healthcheck</a></li>
-      <li><a href="{{ url('monitoring:healthcheck') }}?elb=true">Healthcheck (for ELB)</a></li>
-    </ul>
   </body>
 </html>

--- a/webapp-django/crashstats/monitoring/tests/test_views.py
+++ b/webapp-django/crashstats/monitoring/tests/test_views.py
@@ -87,7 +87,7 @@ class TestCrontabberStatusViews(BaseTestViews):
         assert data["status"] == "Stale"
 
 
-class TestHealthcheckViews(BaseTestViews):
+class TestDockerflowHeartbeatViews(BaseTestViews):
     def test_dockerflow_lbheartbeat(self):
         # Verify __lbheartbeat__ works
         url = reverse("monitoring:dockerflow_lbheartbeat")
@@ -98,15 +98,9 @@ class TestHealthcheckViews(BaseTestViews):
         # Verify it doesn't run ay db queries
         self.assertNumQueries(0, self.client.get, url)
 
-        # Verify deprecated endpoint works
-        url = reverse("monitoring:healthcheck")
-        response = self.client.get(url, {"elb": "true"})
-        assert response.status_code == 200
-        assert json.loads(response.content)["ok"] is True
-
     @mock.patch("requests.get")
     @mock.patch("crashstats.monitoring.views.elasticsearch")
-    def test_healthcheck(self, mocked_elasticsearch, rget):
+    def test_heartbeat(self, mocked_elasticsearch, rget):
         searches = []
 
         def mocked_supersearch_get(**params):
@@ -135,14 +129,6 @@ class TestHealthcheckViews(BaseTestViews):
         assert json.loads(response.content)["ok"] is True
         assert len(searches) == 1
 
-        # Verify the deprecated healthcheck endpoint
-        searches = []
-        url = reverse("monitoring:healthcheck")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert json.loads(response.content)["ok"] is True
-        assert len(searches) == 1
-
     def test_assert_supersearch_errors(self):
         searches = []
 
@@ -165,7 +151,7 @@ class TestHealthcheckViews(BaseTestViews):
         assert len(searches) == 1
 
 
-class TestDockerflow(object):
+class TestDockerflowVersionView:
     def test_version_no_file(self, client, settings, tmpdir):
         """Test with no version.json file"""
         # The tmpdir definitely doesn't have a version.json in it, so we use

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf.urls import url
-from django.views.generic import RedirectView
 
 from crashstats.monitoring import views
 
@@ -12,11 +11,6 @@ app_name = "monitoring"
 urlpatterns = [
     url(r"^monitoring/$", views.index, name="index"),
     url(r"^monitoring/cron/$", views.cron_status, name="cron_status"),
-    # FIXME(willkg): Deprecated as of 4/30/2019
-    url(
-        r"^monitoring/crontabber/$",
-        RedirectView.as_view(url="/monitoring/cron/", permanent=True),
-    ),
     # Dockerflow endpoints
     url(r"^__heartbeat__$", views.dockerflow_heartbeat, name="dockerflow_heartbeat"),
     url(
@@ -25,6 +19,4 @@ urlpatterns = [
         name="dockerflow_lbheartbeat",
     ),
     url(r"^__version__$", views.dockerflow_version, name="dockerflow_version"),
-    # FIXME(willkg): DEPRECATED
-    url(r"^monitoring/healthcheck/$", views.healthcheck, name="healthcheck"),
 ]

--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -109,14 +109,6 @@ def dockerflow_lbheartbeat(request):
     return {"ok": True}
 
 
-@utils.json_view
-def healthcheck(request):
-    """Deprecated healthcheck endpoint."""
-    if not request.GET.get("elb") in ("1", "true"):
-        return dockerflow_heartbeat(request)
-    return dockerflow_lbheartbeat(request)
-
-
 def assert_supersearch_no_errors():
     """Make sure an uncached SuperSearch query doesn't have any errors"""
     supersearch = SuperSearch()


### PR DESCRIPTION
We no longer use these endpoints for monitoring anymore, so we can remove them.