### PR TITLE
Remove "object" superclass

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -108,7 +108,7 @@ def add_doc_values(value):
             add_doc_values(field)
 
 
-class SuperSearchFieldsData(object):
+class SuperSearchFieldsData:
     """Data class for super search fields.
 
     This just holds the FIELDS and some accessors to get them.

--- a/socorro/lib/javautil.py
+++ b/socorro/lib/javautil.py
@@ -10,7 +10,7 @@ contents.
 from more_itertools import peekable
 
 
-class JavaException(object):
+class JavaException:
     def __init__(self, exception_class, exception_message, stack, additional):
         self.exception_class = exception_class
         self.exception_message = exception_message

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -59,7 +59,7 @@ MAXIMUM_DATE_RANGE = 365
 HISTOGRAM_QUERY_TYPES = ("date", "number")
 
 
-class SearchParam(object):
+class SearchParam:
     def __init__(self, name, value, operator=None, data_type=None, operator_not=False):
         self.name = name
         self.value = value
@@ -68,14 +68,14 @@ class SearchParam(object):
         self.operator_not = operator_not
 
 
-class SearchFilter(object):
+class SearchFilter:
     def __init__(self, name, default=None, data_type="enum"):
         self.name = name
         self.default = default
         self.data_type = data_type
 
 
-class SearchBase(object):
+class SearchBase:
     meta_filters = (
         SearchFilter("_aggs.product.version"),
         SearchFilter("_aggs.product.version.platform"),  # convenient for tests

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -19,7 +19,7 @@ if os.uname()[0] != "Linux":
         "have inotify in its kernel."
     )
 
-    class ProcessEvent(object):
+    class ProcessEvent:
         # Defining a class means we can't define the EventHandler class
         # without indenting the whole thing in an if-block.
         def __init__(self, *_, **__):

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -30,7 +30,7 @@ MAX_PAGE = 1000
 
 
 @total_ordering
-class Infinity(object):
+class Infinity:
     """Infinity is greater than anything else except other Infinities
 
     NOTE(willkg): There are multiple infinities and not all infinities are equal, so what we're

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -25,7 +25,7 @@ def join_ignore_empty(delimiter, list_of_strings):
     return delimiter.join(x for x in list_of_strings if x)
 
 
-class Rule(object):
+class Rule:
     """Base class for Signature generation rules"""
 
     def __init__(self):

--- a/socorro/signature/tests/test_signature_generator.py
+++ b/socorro/signature/tests/test_signature_generator.py
@@ -27,7 +27,7 @@ class TestSignatureGenerator:
         ]
 
     def test_failing_rule(self):
-        class BadRule(object):
+        class BadRule:
             pass
 
         generator_obj = generator.SignatureGenerator(pipeline=[BadRule()])
@@ -41,7 +41,7 @@ class TestSignatureGenerator:
     def test_error_handler(self):
         exc_value = Exception("Cough")
 
-        class BadRule(object):
+        class BadRule:
             def predicate(self, crash_data, result):
                 raise exc_value
 

--- a/socorro/unittest/app/test_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_fetch_transform_save_app.py
@@ -12,7 +12,7 @@ from socorro.lib.threaded_task_manager import ThreadedTaskManager
 from socorro.lib.task_manager import TaskManager
 
 
-class TestFetchTransformSaveApp(object):
+class TestFetchTransformSaveApp:
     def test_bogus_source_iter_and_worker(self):
         class TestFTSAppClass(FetchTransformSaveApp):
             def __init__(self, config):
@@ -65,7 +65,7 @@ class TestFetchTransformSaveApp(object):
                 for x in self.queue.new_crashes():
                     yield ((x,), {})
 
-        class FakeQueue(object):
+        class FakeQueue:
             def __init__(self, config, namespace=""):
                 pass
 
@@ -75,7 +75,7 @@ class TestFetchTransformSaveApp(object):
                 for crash_id in crash_ids:
                     yield crash_id
 
-        class FakeStorageSource(object):
+        class FakeStorageSource:
             def __init__(self, config, namespace=""):
                 self.store = DotDict(
                     {
@@ -108,7 +108,7 @@ class TestFetchTransformSaveApp(object):
             def close(self):
                 self.number_of_close_calls += 1
 
-        class FakeStorageDestination(object):
+        class FakeStorageDestination:
             def __init__(self, config, namespace=""):
                 self.store = DotDict()
                 self.dumps = DotDict()
@@ -156,7 +156,7 @@ class TestFetchTransformSaveApp(object):
     def test_queue_iterator(self):
         faked_finished_func = mock.Mock()
 
-        class FakeQueue(object):
+        class FakeQueue:
             def __init__(self):
                 self.first = True
 
@@ -176,7 +176,7 @@ class TestFetchTransformSaveApp(object):
                     for k in range(2):
                         yield None
 
-        class FakeStorageDestination(object):
+        class FakeStorageDestination:
             def __init__(self, config):
                 self.store = DotDict()
                 self.dumps = DotDict()
@@ -232,7 +232,7 @@ class TestFetchTransformSaveApp(object):
         assert faked_finished_func.call_count == (999 - no_finished_function_counter)
 
     def test_no_source(self):
-        class FakeStorageDestination(object):
+        class FakeStorageDestination:
             def __init__(self, config):
                 self.store = DotDict()
                 self.dumps = DotDict()
@@ -266,7 +266,7 @@ class TestFetchTransformSaveApp(object):
             fts_app.main()
 
     def test_no_destination(self):
-        class FakeStorageSource(object):
+        class FakeStorageSource:
             def __init__(self, config):
                 self.store = DotDict(
                     {

--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -11,7 +11,7 @@ import pytest
 from socorro.app.socorro_app import App
 
 
-class TestApp(object):
+class TestApp:
     def test_instantiation(self):
         config = DotDict()
         sa = App(config)

--- a/socorro/unittest/external/es/base.py
+++ b/socorro/unittest/external/es/base.py
@@ -63,7 +63,7 @@ class SuperSearchWithFields(SuperSearch):
         return super().get(**kwargs)
 
 
-class TestCaseWithConfig(object):
+class TestCaseWithConfig:
     """A simple TestCase class that can create configuration objects"""
 
     def setup_method(self, method):

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -135,7 +135,7 @@ class TestRawCrashRedactor(TestCaseWithConfig):
         assert crash == expected_crash
 
 
-class TestIsValidKey(object):
+class TestIsValidKey:
     @pytest.mark.parametrize(
         "key", ["a", "abc", "ABC", "AbcDef", "Abc_Def", "Abc-def" "Abc-123-def"]
     )
@@ -774,7 +774,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
             mm.assert_histogram_once("processor.es.index", tags=["outcome:failed"])
 
 
-class Test_get_fields_by_analyzer(object):
+class Test_get_fields_by_analyzer:
     @pytest.mark.parametrize(
         "fields",
         [

--- a/socorro/unittest/external/fs/test_fspermanentstorage.py
+++ b/socorro/unittest/external/fs/test_fspermanentstorage.py
@@ -16,7 +16,7 @@ from socorro.external.fs.crashstorage import FSPermanentStorage
 FS_ROOT = os.environ["resource.fs.fs_root"]
 
 
-class TestFSPermanentStorage(object):
+class TestFSPermanentStorage:
     CRASH_ID_1 = "0bba929f-8721-460c-dead-a43c20071025"
     CRASH_ID_2 = "0bba929f-8721-460c-dead-a43c20071026"
     CRASH_ID_3 = "0bba929f-8721-460c-dead-a43c20071027"

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -58,7 +58,7 @@ class MutatingProcessedCrashCrashStorage(CrashStorageBase):
         del processed_crash["foo"]
 
 
-class TestCrashStorageBase(object):
+class TestCrashStorageBase:
     def test_basic_crashstorage(self):
         required_config = Namespace()
 
@@ -300,7 +300,7 @@ class TestCrashStorageBase(object):
             assert processed_crash["bar"]["something"] == "else"
 
 
-class TestRedactor(object):
+class TestRedactor:
     def test_redact(self):
         d = DotDict()
         # these keys survive redaction
@@ -342,7 +342,7 @@ class TestRedactor(object):
         assert actual_surviving_keys == expected_surviving_keys
 
 
-class TestBench(object):
+class TestBench:
     def test_benchmarking_crashstore(self, caplogpp):
         caplogpp.set_level("DEBUG")
 
@@ -416,7 +416,7 @@ class TestBench(object):
             ]
 
 
-class TestDumpsMappings(object):
+class TestDumpsMappings:
     def test_simple(self):
         mdm = MemoryDumpsMapping(
             {"upload_file_minidump": b"binary_data", "moar_dump": b"more binary data"}
@@ -427,7 +427,7 @@ class TestDumpsMappings(object):
         assert fdm.as_memory_dumps_mapping() == mdm
 
 
-class TestMetricsCounter(object):
+class TestMetricsCounter:
     def test_count(self, metricsmock):
         config_manager = ConfigurationManager(
             [MetricsCounter.get_required_config()],
@@ -444,7 +444,7 @@ class TestMetricsCounter(object):
         mm.assert_incr_once("phil.run", value=1)
 
 
-class TestMetricsBenchmarkingWrapper(object):
+class TestMetricsBenchmarkingWrapper:
     def test_wrapper(self, metricsmock):
         fake_crash_store_class = mock.MagicMock()
         fake_crash_store_class.__name__ = "Phil"

--- a/socorro/unittest/lib/test_external_common.py
+++ b/socorro/unittest/lib/test_external_common.py
@@ -11,7 +11,7 @@ import pytest
 from socorro.lib import BadArgumentError, external_common
 
 
-class TestExternalCommon(object):
+class TestExternalCommon:
     """Test functions of the external_common module. """
 
     def test_check_type(self):
@@ -146,7 +146,7 @@ class TestExternalCommon(object):
         assert params == params_exp
 
     def test_parse_arguments_with_class_validators(self):
-        class NumberConverter(object):
+        class NumberConverter:
             def clean(self, value):
                 conv = {"one": 1, "two": 2, "three": 3}
                 try:

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -98,7 +98,7 @@ class SearchBaseWithFields(SearchBase):
         return super().get_parameters(**kwargs)
 
 
-class TestSearchBase(object):
+class TestSearchBase:
     def test_get_parameters(self):
         search = SearchBaseWithFields()
 
@@ -284,7 +284,7 @@ class TestSearchBase(object):
                 assert param.value == ["1.9b2"]
 
 
-class TestSearchCommon(object):
+class TestSearchCommon:
     """Test functions of the search_common module. """
 
     def test_convert_to_type(self):

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -9,7 +9,7 @@ from configman.dotdict import DotDict
 from socorro.lib.task_manager import TaskManager, default_task_func
 
 
-class TestTaskManager(object):
+class TestTaskManager:
     def test_constuctor1(self):
         config = DotDict()
         config.quit_on_empty_queue = False
@@ -33,7 +33,7 @@ class TestTaskManager(object):
         tm = TaskManager(config, job_source_iterator=an_iter)
         assert list(tm._get_iterator()) == [0, 1, 2, 3, 4]
 
-        class X(object):
+        class X:
             def __init__(self, config):
                 self.config = config
 

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -10,7 +10,7 @@ from configman.dotdict import DotDict
 from socorro.lib.threaded_task_manager import ThreadedTaskManager, default_task_func
 
 
-class TestThreadedTaskManager(object):
+class TestThreadedTaskManager:
     def test_constuctor1(self):
         config = DotDict()
         config.number_of_threads = 1

--- a/socorro/unittest/lib/test_util.py
+++ b/socorro/unittest/lib/test_util.py
@@ -10,7 +10,7 @@ import pytest
 from socorro.lib.util import dotdict_to_dict, retry, MaxAttemptsError
 
 
-class Testdotdict_to_dict(object):
+class Testdotdict_to_dict:
     def test_primitives(self):
         # Test all the primitives
         assert dotdict_to_dict(None) is None

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -19,7 +19,7 @@ def sequencer(*args):
     return foo
 
 
-class FakeCrashQueue(object):
+class FakeCrashQueue:
     def __init__(self, *args, **kwargs):
         pass
 
@@ -29,7 +29,7 @@ class FakeCrashQueue(object):
         )()
 
 
-class TestProcessorApp(object):
+class TestProcessorApp:
     def get_standard_config(self):
         config = DotDict()
 

--- a/socorro/unittest/processor/test_processor_pipeline.py
+++ b/socorro/unittest/processor/test_processor_pipeline.py
@@ -17,7 +17,7 @@ class BadRule(Rule):
         raise KeyError("pii")
 
 
-class TestProcessorPipeline(object):
+class TestProcessorPipeline:
     def get_config(self):
         cm = ConfigurationManager(
             definition_source=ProcessorPipeline.get_required_config(),

--- a/socorro/unittest/processor/test_symbol_cache_manager.py
+++ b/socorro/unittest/processor/test_symbol_cache_manager.py
@@ -14,7 +14,7 @@ from socorro.processor.symbol_cache_manager import (
 
 
 @pytest.mark.skipif(os.uname()[0] != "Linux", reason="only run if on Linux")
-class TestEventHandler(object):
+class TestEventHandler:
     def test_init(self):
         mocked_monitor = mock.Mock()
 

--- a/webapp-django/crashstats/api/cleaner.py
+++ b/webapp-django/crashstats/api/cleaner.py
@@ -6,7 +6,7 @@ import re
 import warnings
 
 
-class Cleaner(object):
+class Cleaner:
     """
     This class takes care of cleaning up a chunk of data that is some sort of
     mix of dicts and lists and stuff. The simplest case is::
@@ -88,7 +88,7 @@ class Cleaner(object):
             sequence[i] = data
 
 
-class SmartAllowlistMatcher(object):
+class SmartAllowlistMatcher:
     def __init__(self, allowlist):
         def format(item):
             return "^" + item.replace("*", r"[\w-]*") + "$"

--- a/webapp-django/crashstats/api/tests/test_cleaner.py
+++ b/webapp-django/crashstats/api/tests/test_cleaner.py
@@ -7,7 +7,7 @@ from unittest import mock
 from crashstats.api.cleaner import Cleaner, SmartAllowlistMatcher
 
 
-class TestCleaner(object):
+class TestCleaner:
     def test_simplest_case(self):
         allowlist = {"hits": ("foo", "bar")}
         data = {
@@ -103,7 +103,7 @@ class TestCleaner(object):
         assert data == expect
 
 
-class TestSmartAllowlistMatcher(object):
+class TestSmartAllowlistMatcher:
     def test_basic_in(self):
         allowlist = ["some", "thing*"]
         matcher = SmartAllowlistMatcher(allowlist)

--- a/webapp-django/crashstats/api/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/api/tests/test_jinja_helpers.py
@@ -5,7 +5,7 @@
 from crashstats.api.templatetags.jinja_helpers import pluralize
 
 
-class TestPluralize(object):
+class TestPluralize:
     def test_basics(self):
         assert pluralize(0) == "s"
         assert pluralize(1) == ""

--- a/webapp-django/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp-django/crashstats/authentication/tests/test_auditgroups.py
@@ -13,7 +13,7 @@ from crashstats.authentication.models import PolicyException
 from crashstats.tokens.models import Token
 
 
-class TestAuditGroupsCommand(object):
+class TestAuditGroupsCommand:
     """Test auditgroups command."""
 
     def test_no_users(self, db):

--- a/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
+++ b/webapp-django/crashstats/authentication/tests/test_makesuperuser.py
@@ -14,7 +14,7 @@ from django.core.management.base import CommandError
 from crashstats.authentication.management.commands import makesuperuser
 
 
-class TestMakeSuperuserCommand(object):
+class TestMakeSuperuserCommand:
     def test_make_existing_user(self, db):
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
         buffer = StringIO()

--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -5,7 +5,7 @@
 from django import forms
 
 
-class _BaseForm(object):
+class _BaseForm:
     def clean(self):
         cleaned_data = super().clean()
         for field in cleaned_data:

--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 from django.utils.encoding import smart_text
 
 
-class SetRemoteAddrFromRealIP(object):
+class SetRemoteAddrFromRealIP:
     """
     Middleware that sets REMOTE_ADDR based on HTTP_X_REAL_IP, if the
     latter is set. This is useful if you're sitting behind a reverse proxy that
@@ -34,7 +34,7 @@ class SetRemoteAddrFromRealIP(object):
             request.META["REMOTE_ADDR"] = real_ip
 
 
-class Pretty400Errors(object):
+class Pretty400Errors:
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -349,7 +349,7 @@ def measure_fetches(method):
     return inner
 
 
-class SocorroCommon(object):
+class SocorroCommon:
     # by default, we don't need username and password
     username = password = None
     # http_host

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -17,7 +17,7 @@ from crashstats.crashstats.tests.testbase import DjangoTestCase
 from socorro.external.es.super_search_fields import FIELDS
 
 
-class Response(object):
+class Response:
     def __init__(self, content=None, status_code=200):
         self.raw = content
         if not isinstance(content, str):

--- a/webapp-django/crashstats/crashstats/tests/test_decorators.py
+++ b/webapp-django/crashstats/crashstats/tests/test_decorators.py
@@ -8,7 +8,7 @@ from django.utils.encoding import smart_text
 from crashstats.crashstats import decorators
 
 
-class TestCheckDays(object):
+class TestCheckDays:
     def test_basics(self, rf):
         @decorators.check_days_parameter([1, 2], 2)
         def view(request, days=None, **kwargs):

--- a/webapp-django/crashstats/crashstats/tests/test_finders.py
+++ b/webapp-django/crashstats/crashstats/tests/test_finders.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 
 
-class TestLeftoverPipelineFinder(object):
+class TestLeftoverPipelineFinder:
     """Test our custom staticfiles finder class."""
 
     def test_missing_css_source_file(self, settings):

--- a/webapp-django/crashstats/crashstats/tests/test_forms.py
+++ b/webapp-django/crashstats/crashstats/tests/test_forms.py
@@ -5,7 +5,7 @@
 from crashstats.crashstats import forms
 
 
-class TestForms(object):
+class TestForms:
     def setup_method(self):
         self.active_versions = {
             "WaterWolf": [

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -26,7 +26,7 @@ from crashstats.crashstats.templatetags.jinja_helpers import (
 )
 
 
-class TestTimestampToDate(object):
+class TestTimestampToDate:
     def test_timestamp_to_date(self):
         timestamp = time.time()
         date = datetime.datetime.fromtimestamp(timestamp)
@@ -42,7 +42,7 @@ class TestTimestampToDate(object):
         assert output == ""
 
 
-class TestTimeTag(object):
+class TestTimeTag:
     def test_time_tag_with_datetime(self):
         date = datetime.datetime(2000, 1, 2, 3, 4, 5)
         output = time_tag(date)
@@ -85,7 +85,7 @@ class TestTimeTag(object):
         assert output == expected
 
 
-class TestBugzillaLink(object):
+class TestBugzillaLink:
     def test_show_bug_link_no_cache(self):
         output = show_bug_link(123)
         assert 'data-id="123"' in output
@@ -109,7 +109,7 @@ class TestBugzillaLink(object):
         assert 'data-summary="&lt;script&gt;xss()&lt;/script&gt;"' in output
 
 
-class TestBugzillaSubmitURL(object):
+class TestBugzillaSubmitURL:
     EMPTY_PARSED_DUMP = {}
     CRASHING_THREAD = 0
 
@@ -424,7 +424,7 @@ class TestBugzillaSubmitURL(object):
         assert quote_plus("frames of crashing thread:") not in url
 
 
-class TestReplaceBugzillaLinks(object):
+class TestReplaceBugzillaLinks:
     def test_simple(self):
         text = "a bug #1129515 b"
         res = replace_bugzilla_links(text)
@@ -439,7 +439,7 @@ class TestReplaceBugzillaLinks(object):
         assert "https://bugzilla.mozilla.org/show_bug.cgi?id=7845" in res
 
 
-class TesDigitGroupSeparator(object):
+class TesDigitGroupSeparator:
     def test_basics(self):
         assert digitgroupseparator(None) is None
         assert digitgroupseparator(1000) == "1,000"
@@ -447,7 +447,7 @@ class TesDigitGroupSeparator(object):
         assert digitgroupseparator(1000000) == "1,000,000"
 
 
-class TestHumanizers(object):
+class TestHumanizers:
     def test_show_duration(self):
         html = show_duration(59)
         assert isinstance(html, SafeText)
@@ -530,7 +530,7 @@ class TestHumanizers(object):
         assert html == "junk"
 
 
-class TestChangeURL(object):
+class TestChangeURL:
     def test_root_url_no_query_string(self):
         context = {}
         context["request"] = RequestFactory().get("/")
@@ -580,7 +580,7 @@ class TestChangeURL(object):
         assert result == "?foo=else"
 
 
-class TestURL(object):
+class TestURL:
     def test_basic(self):
         output = url("crashstats:login")
         assert output == reverse("crashstats:login")
@@ -609,7 +609,7 @@ class TestURL(object):
         assert output == reverse("crashstats:product_home", args=("Winterfoxnn",))
 
 
-class TestIsDangerousCPU(object):
+class TestIsDangerousCPU:
     def test_false(self):
         assert is_dangerous_cpu(None, None) is False
         assert is_dangerous_cpu(None, "family 20 model 1") is False

--- a/webapp-django/crashstats/crashstats/tests/test_middleware.py
+++ b/webapp-django/crashstats/crashstats/tests/test_middleware.py
@@ -5,7 +5,7 @@
 from crashstats.crashstats.middleware import SetRemoteAddrFromRealIP
 
 
-class TestSetRemoteAddrFromRealIP(object):
+class TestSetRemoteAddrFromRealIP:
     def test_no_headers(self, rf):
         """Should not break if there is no HTTP_X_REAL_IP"""
         middleware = SetRemoteAddrFromRealIP()

--- a/webapp-django/crashstats/crashstats/tests/test_updatesignatures.py
+++ b/webapp-django/crashstats/crashstats/tests/test_updatesignatures.py
@@ -10,7 +10,7 @@ from django.core.management import call_command
 from crashstats.crashstats.models import Signature
 
 
-class FakeModel(object):
+class FakeModel:
     def __init__(self):
         self._get_steps = []
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -135,7 +135,7 @@ SAMPLE_SIGNATURE_SUMMARY = {
 }
 
 
-class TestRobotsTxt(object):
+class TestRobotsTxt:
     def test_robots_txt(self, settings, client):
         settings.ENGAGE_ROBOTS = True
         url = "/robots.txt"
@@ -154,7 +154,7 @@ class TestRobotsTxt(object):
         assert "Disallow: /" in smart_text(response.content)
 
 
-class TestFavicon(object):
+class TestFavicon:
     def test_favicon(self, client):
         response = client.get("/favicon.ico")
         assert response.status_code == 200
@@ -166,7 +166,7 @@ class TestFavicon(object):
         assert response["Content-Type"] in expected
 
 
-class Test500(object):
+class Test500:
     def test_html(self):
         root_urlconf = __import__(
             settings.ROOT_URLCONF, globals(), locals(), ["urls"], 0
@@ -219,7 +219,7 @@ class Test500(object):
             assert result["query_string"] is None
 
 
-class Test404(object):
+class Test404:
     def test_handler404(self, client):
         response = client.get("/fillbert/mcpicklepants")
         assert response.status_code == 404
@@ -237,7 +237,7 @@ class Test404(object):
         assert result["query_string"] == "foo=bar"
 
 
-class TestContributeJson(object):
+class TestContributeJson:
     def test_view(self, client):
         response = client.get("/contribute.json")
         assert response.status_code == 200

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -65,7 +65,7 @@ def urlencode_obj(thing):
     return res.replace("+", "%20")
 
 
-class SignatureStats(object):
+class SignatureStats:
     def __init__(
         self,
         signature,

--- a/webapp-django/crashstats/manage/tests/test_utils.py
+++ b/webapp-django/crashstats/manage/tests/test_utils.py
@@ -10,7 +10,7 @@ from crashstats.manage import utils
 SAMPLE_CSV_FILE_PCI_IDS = os.path.join(os.path.dirname(__file__), "sample-pci.ids")
 
 
-class TestUtils(object):
+class TestUtils:
     def test_string_hex_to_hex_string(self):
         func = utils.string_hex_to_hex_string
         assert func("919A") == "0x919a"

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -45,7 +45,7 @@ def split_on_operator(value):
     return (None, value)
 
 
-class PrefixedField(object):
+class PrefixedField:
     """Special field that accepts an operator as prefix in the value.
 
     Removes the prefix from the initial value before the validation process

--- a/webapp-django/crashstats/supersearch/tests/test_form_fields.py
+++ b/webapp-django/crashstats/supersearch/tests/test_form_fields.py
@@ -14,7 +14,7 @@ from django.forms import ValidationError
 from crashstats.supersearch import form_fields
 
 
-class TestFormFields(object):
+class TestFormFields:
     def test_integer_field(self):
         field = form_fields.IntegerField()
         cleaned_value = field.clean([">13"])

--- a/webapp-django/crashstats/supersearch/tests/test_forms.py
+++ b/webapp-django/crashstats/supersearch/tests/test_forms.py
@@ -6,7 +6,7 @@ from crashstats.supersearch import forms
 from socorro.external.es.super_search_fields import FIELDS
 
 
-class TestForms(object):
+class TestForms:
     def setup_method(self):
         self.products = ["WaterWolf", "NightTrain", "SeaMonkey", "Tinkerbell"]
         self.product_versions = ["20.0", "21.0a1", "20.0", "9.5"]
@@ -15,7 +15,7 @@ class TestForms(object):
 
     def test_search_form(self):
         def get_new_form(data):
-            class User(object):
+            class User:
                 def has_perm(self, permission):
                     return {
                         "crashstats.view_pii": False,
@@ -61,7 +61,7 @@ class TestForms(object):
 
     def test_search_form_with_admin_mode(self):
         def get_new_form(data):
-            class User(object):
+            class User:
                 def has_perm(self, permission):
                     return {
                         "crashstats.view_pii": True,
@@ -109,7 +109,7 @@ class TestForms(object):
 
     def test_get_fields_list(self):
         def get_new_form(data):
-            class User(object):
+            class User:
                 def has_perm(self, permission):
                     permissions = {
                         "crashstats.view_pii": False,

--- a/webapp-django/crashstats/supersearch/tests/test_utils.py
+++ b/webapp-django/crashstats/supersearch/tests/test_utils.py
@@ -9,7 +9,7 @@ from django.utils.timezone import utc
 from crashstats.topcrashers.views import get_date_boundaries
 
 
-class TestDateBoundaries(object):
+class TestDateBoundaries:
     def test_get_date_boundaries(self):
         # Simple test.
         start, end = get_date_boundaries(

--- a/webapp-django/crashstats/tokens/middleware.py
+++ b/webapp-django/crashstats/tokens/middleware.py
@@ -24,7 +24,7 @@ def has_perm(all, codename, obj=None):
     return all.filter(codename=codename).count()
 
 
-class APIAuthenticationMiddleware(object):
+class APIAuthenticationMiddleware:
     def __init__(self, get_response=None):
         self.get_response = get_response
 


### PR DESCRIPTION
Python 2 required subclassing from `object` in order to use new-style class functionality. In Python 3, everything is a new-style class, so you don't need to specify `object` anymore.