### PR TITLE
bug 1640942: improve rust OOM signatures

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -31,6 +31,7 @@ framework\.odex@0x
 __fixunsdfsi
 GetLCIDFromLangListNodeWithLICCheck
 gfxPlatform::GetPlatform
+gkrust_shared::oom_hook::hook
 google_breakpad::CrashGenerationClient::RequestDumpForException
 google_breakpad::ExceptionHandler::SignalHandler
 google_breakpad::ExceptionHandler::WriteMinidumpWithException
@@ -53,6 +54,7 @@ _mach_msg_trap
 mnt@asec@org\.mozilla\.f.*-\d@pkg\.apk@classes\.dex@0x
 MOZ_Assert
 MOZ_Crash
+mozalloc_handle_oom
 mozglue_static::panic_hook
 mozcrt19.dll@0x
 mozilla::CondVar::Wait
@@ -81,6 +83,7 @@ org\.mozilla\.f.*-\d\.apk@0x
 panic_abort::
 PR_WaitCondVar
 RaiseException
+rust_oom
 rtc::FatalMessage
 RtlpAdjustHeapLookasideDepth
 RtlSleepConditionVariableCS
@@ -95,6 +98,7 @@ SkyLight
 SleepConditionVariableCS
 SleepConditionVariableSRW
 std::_Atomic_fetch_add_4
+std::alloc::rust_oom
 std::panicking::
 std::__terminate
 std::terminate

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -83,6 +83,7 @@ __GI_strlen
 gkrust_shared::oom_hook::hook
 gsignal
 HandleInvalidParameter
+hashbrown::raw::RawTable<T>::new_uninitialized<T>
 HeapFree
 huge_dalloc
 huge_palloc


### PR DESCRIPTION
This adds `hashbrown::raw::RawTable<T>::new_uninitialized<T>` to the prefix list so signature generation can continue.

This adds `mozalloc_handle_oom`, `gkrust_shared::oom_hook::hook`, `std::alloc::rust_oom`, and `rust_oom` to the irrelevant list because they're all indicators of the OOM and otherwise not helpful.

```
app@socorro:/app$ socorro-cmd signature e4802059-f714-46b0-84c6-e76460200523 34da10d4-80ac-4142-862f-76b0a0200520
Crash id: e4802059-f714-46b0-84c6-e76460200523
Original: OOM | large | mozalloc_abort | mozalloc_handle_oom | gkrust_shared::oom_hook::hook | std::alloc::rust_oom | hashbrown::raw::RawTable<T>::new_uninitialized<T>
New:      OOM | large | mozalloc_abort | hashbrown::raw::RawTable<T>::new_uninitialized<T> | webrender_bindings::moz2d_renderer::{{impl}}::create_blob_rasterizer
Same?:    False
Crash id: 34da10d4-80ac-4142-862f-76b0a0200520
Original: OOM | large | mozalloc_abort | <name omitted> | gkrust_shared::oom_hook::hook | rust_oom
New:      OOM | large | mozalloc_abort | <name omitted> | <dogear::tree::Tree as core::convert::TryFrom<dogear::tree::Builder>>::try_from
Same?:    False
```