### PR TITLE
bug 1641316: fix bugzilla bug creation for java errors

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bugzilla_comment.txt
@@ -2,16 +2,16 @@
    See crashstats.templatetags.jinja_helpers.bugzilla_submit_url. #}
 This bug is for crash report bp-{{ uuid }}.
 
-```
 {% if java_stack_trace -%}
 Java stack trace:
-
+```
 {{ java_stack_trace }}
+```
 {% elif crashing_thread_frames -%}
 Top {{ crashing_thread_frames|length }} frames of crashing thread:
-
+```
 {% for frame in crashing_thread_frames -%}
 {{ frame.frame|safe}} {{ frame.module|safe }} {{ frame.signature|safe }} {{ frame.source|safe }}
-{% endfor %}
+{% endfor -%}
 ```
 {% endif %}


### PR DESCRIPTION
If the crash report represents a java error, then there's a `JavaStackTrace` annotation and Crash Stats puts that in the crash report. However, the backticks were in the wrong place in respects to if/for blocks and so it was missing the end set.

While fixing that, I tweaked the description a bit.