### PR TITLE
bug 1611131: improve language around protected data and access

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1,8 +1,9 @@
-{% macro sensitive_warning(your_crash) -%}
+{% macro protected_warning(your_crash) -%}
+  <img src="{{ static('img/3rdparty/silk/exclamation.png') }}" alt="protected" title="Protected Data" />
   {% if your_crash %}
-    You can only see this because it is your crash!
+    Protected data: You can see it because it is your crash.
   {% else %}
-    This is super sensitive data! Be careful how you use it!
+    Protected data: Be careful how you use it.
   {% endif %}
 {%- endmacro %}
 
@@ -39,6 +40,19 @@
   >
     <div class="page-heading">
       <h2>{{ report.product }} {{ report.version }} Crash Report [@ {{ report.signature }} ]</h2>
+    </div>
+
+    <div class="protected-info">
+      {% if your_crash %}
+        You are seeing public and protected data for your crash.
+      {% elif request.user.has_perm('crashstats.view_pii') %}
+        <img src="{{ static('img/3rdparty/silk/exclamation.png') }}" alt="protected" title="Protected Data" />
+        You are seeing public and protected data.
+      {% else %}
+        You are seeing public data only.
+        See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a> for more
+        information.
+      {% endif %}
     </div>
 
     <div class="panel">
@@ -304,7 +318,7 @@
                   {% if report.moz_crash_reason_raw %}
                     <tr title="{{ fields_desc['processed_crash.moz_crash_reason_raw'] }}">
                       <th scope="row">MOZ_CRASH Reason (Raw)</th>
-                      <td>{{ report.moz_crash_reason_raw }} - {{ sensitive_warning(your_crash) }}</td>
+                      <td>{{ report.moz_crash_reason_raw }} - {{ protected_warning(your_crash) }}</td>
                     </tr>
                   {% elif raw.MozCrashReason %}
                     {# FIXME(willkg): This can get removed in April 2019 #}
@@ -359,7 +373,7 @@
                     <th scope="row">Exploitability</th>
                     <td>
                       {% if report.exploitability %}
-                        {{ report.exploitability }} - {{ sensitive_warning(your_crash) }}
+                        {{ report.exploitability }} - {{ protected_warning(your_crash) }}
                       {% endif %}
                     </td>
                   </tr>
@@ -372,7 +386,7 @@
                     <th scope="row">URL</th>
                     <td>
                       {% if raw.URL %}
-                        <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - {{ sensitive_warning(your_crash) }}
+                        <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - {{ protected_warning(your_crash) }}
                       {% endif %}
                     </td>
                   </tr>
@@ -380,7 +394,7 @@
                     <th scope="row">Email Address</th>
                     <td>
                       {% if raw.Email %}
-                        <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - {{ sensitive_warning(your_crash) }}
+                        <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - {{ protected_warning(your_crash) }}
                       {% endif %}
                     </td>
                   </tr>
@@ -388,7 +402,7 @@
                     <th scope="row">User Comments</th>
                     <td>
                       {% if report.user_comments %}
-                        {{ report.user_comments | linebreaks }} - {{ sensitive_warning(your_crash) }}
+                        {{ report.user_comments | linebreaks }} - {{ protected_warning(your_crash) }}
                       {% endif %}
                     </td>
                   </tr>
@@ -828,15 +842,27 @@
             <h3>Download Raw Crash Data and Minidumps</h3>
             {% if request.user.has_perm('crashstats.view_rawdump') %}
               <p>
-                {{ sensitive_warning(your_crash) }}
+                {{ protected_warning(your_crash) }}
               </p>
               {% for url in raw_dump_urls %}
                 <p><a href="{{ url }}">{{ url }}</a></p>
               {% endfor %}
               {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
               <p><a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a></p>
+            {% elif request.user and request.user.is_active %}
+              <p>
+                You do not have access to protected data.
+                You need to be signed in and have access to protected data to see this.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+                for more information.
+              </p>
             {% else %}
-            <p>You need to be signed in to download raw crash data and minidump files.</p>
+              <p>
+                You are not signed in.
+                You need to be signed in and have access to protected data to see this.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+                for more information.
+              </p>
             {% endif %}
           </div>
           <!-- /rawdump -->

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
@@ -15,7 +15,7 @@ html {
             display: none;
         }
         .page-heading {
-            margin: 4em 2em 2em;
+            margin: 1em 1em 1em;
             display: flex;
             align-items: center;
 
@@ -25,7 +25,7 @@ html {
             }
         }
         .panel {
-            margin: 20px;
+            margin: 1em;
         }
     }
 }
@@ -171,6 +171,12 @@ body {
     p.old-new-report-link {
         float: right;
     }
+}
+
+.protected-info {
+    margin: 1em 1em 1em;
+    display: flex;
+    align-items: center;
 }
 
 .threecol {

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -426,7 +426,7 @@ class TestViews(BaseTestViews):
         assert _SAMPLE_META["Email"] not in content
         assert _SAMPLE_META["URL"] not in content
         assert (
-            "You need to be signed in to download raw crash data and minidump files."
+            "You need to be signed in and have access to protected data to see this."
             in content
         )
         # Should not be able to see sensitive key from stackwalker JSON

--- a/webapp-django/crashstats/documentation/jinja2/documentation/docs_base.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/docs_base.html
@@ -37,7 +37,7 @@
         <nav>
           <ul class="options">
             {{ navlink(url('documentation:home'), 'Home') }}
-            {{ navlink(url('documentation:memory_dump_access'), 'Memory Dump and Private User Data Access') }}
+            {{ navlink(url('documentation:protected_data_access'), 'Protected Data Access') }}
             {{ navlink(url('api:documentation'), 'API Reference') }}
             {{ navlink(url('documentation:supersearch_home'), 'Super Search') }}
             {{ navlink(url('documentation:supersearch_examples'), 'Super Search Examples') }}

--- a/webapp-django/crashstats/documentation/jinja2/documentation/protected_data_access.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/protected_data_access.html
@@ -1,22 +1,25 @@
 {% extends "documentation/docs_base.html" %}
 
-{% block doc_title %}Memory Dump and Private User Data Access{% endblock %}
+{% block doc_title %}Protected Data Access{% endblock %}
 
 {% block doc_content %}
   <div class="body">
-    <h1 id="policy">Access to memory dumps and private user data</h1>
+    <h1 id="definition">Protected data on Crash Stats</h1>
     <p>
       Crash reports include memory dumps which contain sensitive information
       and is not publicly available on Crash Stats. Memory dumps are important
       for diagnosing and debugging issues. Further, crash reports may also
       contain private user data such as the user's email address and comments
-      if they provided any. As such, users can request access to memory dumps
-      and private user data information in order to debug issues.
+      if they provided any.
     </p>
     <p>
+      In order to view protected data, you must be signed in and have been
+      granted access to that data.
     </p>
+
+    <h1 id="policy">Access to protected data</h1>
     <p>
-      Anyone with access to memory dumps and private data agrees to the following:
+      Anyone with access to protected data agrees to the following:
     </p>
     <pre>* Crash dumps contain memory contents, and may contain private user data
 * Only access dumps as necessary
@@ -30,23 +33,23 @@
 * Access is conditional on employment and will be revoked upon departure from Mozilla
 * Access will be removed after a year of inactivity
 
-The most recent copy of this agreement is at: https://crash-stats.mozilla.org/documentation/memory_dump_access/</pre>
+The most recent copy of this agreement is at: https://crash-stats.mozilla.org/documentation/protected_data_access/</pre>
 
-    <h1 id="requestaccess">How to request access to memory dumps and private user data</h1>
+    <h1 id="requestaccess">How to request protected data access</h1>
     <p>
-      To request access to memory dumps and private user data, please:
+      To request access to protected data, please:
     </p>
     <ol>
       <li>Log into <a href="https://crash-stats.mozilla.org/">Crash Stats</a>
           using your LDAP account.
       </li>
       <li>Fill out a
-          <a href="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro&component=General&short_desc=grant%20YOURNAME%20access%20to%20raw%20dumps">bug report</a>.
+          <a href="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro&component=General&short_desc=grant%20YOURNAME%20access%20to%20protected%20data">bug report</a>.
       </li>
     </ol>
     <p>
-      A Crash Stats admin will field the request as soon as they are able.
-      If you need access immediately, please note that in the bug.
+      A Crash Stats admin will field the request as soon as they are able. If
+      you need access immediately, please note that in the bug.
     </p>
   </div>
 {% endblock %}

--- a/webapp-django/crashstats/documentation/tests/test_views.py
+++ b/webapp-django/crashstats/documentation/tests/test_views.py
@@ -28,3 +28,14 @@ class TestViews(BaseTestViews):
         assert "_results_number" in smart_text(response.content)
         assert "_aggs.*" in smart_text(response.content)
         assert "signature" in smart_text(response.content)
+
+    def test_memory_dump_access_redirect(self):
+        """Verify memory_dump_access url redirects
+
+        This is the old url to the data access policy. In order to keep those links
+        working, we need it to redirect to the new url.
+
+        """
+        response = self.client.get("/documentation/memory_dump_access/")
+        assert response.status_code == 302
+        assert response.url == reverse("documentation:protected_data_access")

--- a/webapp-django/crashstats/documentation/urls.py
+++ b/webapp-django/crashstats/documentation/urls.py
@@ -17,7 +17,17 @@ urlpatterns = [
         name="supersearch_examples",
     ),
     url(r"^supersearch/api/$", views.supersearch_api, name="supersearch_api"),
-    url(r"^memory_dump_access/$", views.memory_dump_access, name="memory_dump_access"),
+    url(
+        r"^protected_data_access/$",
+        views.protected_data_access,
+        name="protected_data_access",
+    ),
+    # NOTE(willkg): Need to keep this redirect because it's linked to in a lot of
+    # places like agreements in Bugzilla.
+    url(
+        r"^memory_dump_access/$",
+        lambda request: redirect("documentation:protected_data_access"),
+    ),
     url(
         r"^products/$",
         lambda request: redirect(

--- a/webapp-django/crashstats/documentation/views.py
+++ b/webapp-django/crashstats/documentation/views.py
@@ -33,10 +33,9 @@ def home(request, default_context=None):
 
 
 @pass_default_context
-def memory_dump_access(request, default_context=None):
+def protected_data_access(request, default_context=None):
     context = default_context or {}
-
-    return render(request, "documentation/memory_dump_access.html", context)
+    return render(request, "documentation/protected_data_access.html", context)
 
 
 @pass_default_context

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -32,10 +32,23 @@
   >
     <div class="page-heading">
       <h2>Signature report for <em>{{ signature }}</em></h2>
-      <p>
-        <a href="#" class="display-toggle-filters toggle-filters show" data-text-opposite="Hide Filters">Show Filters</a>
+      <div>
         Showing results from {{ query.start_date | time_tag }} to {{ query.end_date | time_tag }}.
-      </p>
+      </div>
+      <div>
+        <a href="#" class="display-toggle-filters toggle-filters show" data-text-opposite="Hide Filters">Show Filters</a>
+      </div>
+    </div>
+
+    <div class="protected-info">
+      {% if request.user.has_perm('crashstats.view_pii') %}
+        <img src="{{ static('img/3rdparty/silk/exclamation.png') }}" alt="protected" title="Protected Data" />
+        You are seeing public and protected data.
+      {% else %}
+        You are seeing public data only.
+        See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a> for more
+        information.
+      {% endif %}
     </div>
 
     <section id="search-form">

--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -2,8 +2,6 @@
 
 .page-heading {
     p {
-        font-style: italic;
-
         time {
             font-weight: bold;
         }

--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
@@ -19,7 +19,6 @@
   >
     <div class="page-heading">
       <h2>Super Search</h2>
-
       <nav>
         {% if request.user.has_perm('crashstats.run_custom_queries') %}
           <ul class="options">
@@ -34,6 +33,17 @@
           >A guide to searching crash reports</a>
         </div>
       </nav>
+    </div>
+
+    <div class="protected-info">
+      {% if request.user.has_perm('crashstats.view_pii') %}
+        <img src="{{ static('img/3rdparty/silk/exclamation.png') }}" alt="protected" title="Protected Data" />
+        You are seeing public and protected data.
+      {% else %}
+        You are seeing public data only.
+        See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a> for more
+        information.
+      {% endif %}
     </div>
 
     <section id="search-form">


### PR DESCRIPTION
Over the years, Crash Stats has evolved how it talks about data that can only be seen by people who have been vetted and granted access to it.

This goes through and changes all the language to talk about "protected data" and "protected data access". This updates the url where the protected data access policy exists and provides a redirect for the original policy url. This reduces wasted space on the report view and adds a statement at the top explaining what can be seen and why with links to documentation on requesting protected data access. This adds exclamation marks to some sensitive fields--we should add more as we find them.

The goals of this work are three-fold:

1. use consistent language
2. make it clearer what is and isn't protected
3. make it clearer what users can see depending on whether they're logged in or not and whether they've been granted access to protected data