### PR TITLE
bug 1611131: fix protected-info css

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
@@ -174,9 +174,8 @@ body {
 }
 
 .protected-info {
-    margin: 1em 1em 1em;
-    display: flex;
     align-items: center;
+    margin: 1em 1em 1em;
 }
 
 .threecol {


### PR DESCRIPTION
This removes an errant `display: flex`.