### PR TITLE
bug 1497353: remove not_analyzed fields

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3707,7 +3707,7 @@ FIELDS = {
         "namespace": "processed_crash",
         "permissions_needed": [],
         "query_type": "enum",
-        "storage_mapping": {"index": "not_analyzed", "type": "string"},
+        "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
     "vendor": {
         "data_validation_type": "enum",

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1805,20 +1805,6 @@ FIELDS = {
         "query_type": "flag",
         "storage_mapping": {"None_value": 0, "type": "short"},
     },
-    "dump": {
-        "data_validation_type": "str",
-        "description": "",
-        "form_field_choices": [],
-        "has_full_version": False,
-        "in_database_name": "dump",
-        "is_exposed": False,
-        "is_returned": False,
-        "name": "dump",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "query_type": "string",
-        "storage_mapping": {"index": "not_analyzed", "type": "string"},
-    },
     "e10s_cohort": {
         "data_validation_type": "enum",
         "description": (


### PR DESCRIPTION
This removes the "dump" field which wasn't used and wasn't exposed.

This also switches the "uuid" field from `not_analyzed` to `keyword`. I did some searches and facets and it still works fine.