### PR TITLE
bug 1497353: make telemetry_environment not searchable

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3364,7 +3364,9 @@ FIELDS = {
         "storage_mapping": {"type": "long"},
     },
     "telemetry_environment": {
-        "data_validation_type": "str",
+        # NOTE(willkg): This field used to be searchable, but when anyone did search it,
+        # it would DOS the site. So we stopped that in bug #1497353.
+        "data_validation_type": "enum",
         "description": (
             "A field containing the entire Telemetry Environment, as sent with crash pings to "
             "Telemetry."
@@ -3372,13 +3374,13 @@ FIELDS = {
         "form_field_choices": [],
         "has_full_version": False,
         "in_database_name": "TelemetryEnvironment",
-        "is_exposed": True,
+        "is_exposed": False,
         "is_returned": True,
         "name": "telemetry_environment",
         "namespace": "raw_crash",
         "permissions_needed": [],
         "query_type": "string",
-        "storage_mapping": {"index": "not_analyzed", "type": "string"},
+        "storage_mapping": None,
     },
     "theme": {
         "data_validation_type": "enum",


### PR DESCRIPTION
This changes `telemetry_environment` to be like `json_dump` and not searchable.

I verified that you can specify it as a column and get it back in the response, so everything continues to work except that it's no longer searchable.