### PR TITLE
bug 1644234: add libart.so to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -116,6 +116,7 @@ __libc_android_abort
 __libc_message
 libc\.so(\.\d+)?@0x
 libc-\d+\.\d+(\.\d+)?\.so@0x
+libart\.so@0x
 libobjc.A.dylib@0x1568.
 (libxul\.so|xul\.dll|XUL)@0x
 LL_


### PR DESCRIPTION
Here's a signature generation run for two signatures:

```
app@socorro:/app$ socorro-cmd signature 955b6def-f591-480f-9a5a-500340200610
Crash id: 955b6def-f591-480f-9a5a-500340200610
Original: libc.so@0x1cca6 | libc.so@0x5b415 | libc.so@0x5348d | libart.so@0x233305
New:      libc.so@0x1cca6 | libc.so@0x5b415 | libc.so@0x5348d | libart.so@0x233305 | dalvik-allocation stack (deleted)@0x51da13
Same?:    False
app@socorro:/app$ socorro-cmd signature c8359231-1e7b-4f51-ab74-b199e0200610
Crash id: c8359231-1e7b-4f51-ab74-b199e0200610
Original: libc.so@0x6b410 | libc.so@0x1dbd0 | libart.so@0x4377e0
New:      libc.so@0x6b410 | libc.so@0x1dbd0 | libart.so@0x4377e0 | libart.so@0x437ef0 | libart.so@0x522a3c | libart.so@0x24b9d0 | libart.so@0x2d61d8 | libart.so@0x315814 | libart.so@0x4e2378 | mozilla::jni::NativeStub<T>::Wrap<T>
Same?:    False
```