### PR TITLE
bug 1646675: add FindElementCommon to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -64,6 +64,7 @@ fastzero_I
 __fdelt_chk
 __fdelt_warn
 _files_getaddrinfo
+FindElementCommon
 .*free
 __fortify_fail
 __fortify_fail_abort


### PR DESCRIPTION
Signature generation examples:

```
app@socorro:/app$ socorro-cmd signature aafd3c93-7bfa-460c-a896-93f390200610 8a4b7d41-c233-4cc8-885a-569660200610
Crash id: aafd3c93-7bfa-460c-a896-93f390200610
Original: FindElementCommon
New:      FindElementCommon | ClientSideCacheContext::FindInSharedCache
Same?:    False
Crash id: 8a4b7d41-c233-4cc8-885a-569660200610
Original: FindElementCommon
New:      FindElementCommon | TryGetGlyphElement<T>
Same?:    False
```