### PR TITLE
Tweak Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,55 +21,17 @@ endif
 
 DC := $(shell which docker-compose)
 
-
+.DEFAULT_GOAL := help
 .PHONY: help
-help: default
-
-.PHONY: default
-default:
+help:
 	@echo "Usage: make RULE"
 	@echo ""
-	@echo "Socorro make rules:"
-	@echo ""
-	@echo "  build            - build docker containers"
-	@echo "  run              - run processor and webapp"
-	@echo "  runservices      - run service containers (postgres, sqs, etc)"
-	@echo "  stop             - stop all service containers"
-	@echo ""
-	@echo "  shell            - open a shell in the app container"
-	@echo "  clean            - remove all build, test, coverage and Python artifacts"
-	@echo "  lint             - lint code"
-	@echo "  lintfix          - reformat code"
-	@echo "  test             - run unit tests"
-	@echo "  testshell        - open a shell for running tests"
-	@echo "  docs             - generate Sphinx HTML documentation, including API docs"
-	@echo "  mdswshell        - debug/compile shell for minidump-stackwalk"
-	@echo ""
-	@echo "  setup            - set up Postgres, Pub/Sub, Elasticsearch, and local S3"
-	@echo "  updatedata       - add/update necessary database data"
-	@echo "  help             - see this text"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile \
+		| grep -v grep \
+	    | sed -n 's/^\(.*\): \(.*\)##\(.*\)/\1\3/p' \
+	    | column -t  -s '|'
 	@echo ""
 	@echo "See https://socorro.readthedocs.io/ for more documentation."
-
-.PHONY: clean
-clean:
-	-rm .docker-build*
-	-rm -rf build breakpad stackwalk google-breakpad breakpad.tar.gz depot_tools
-	-rm -rf .cache
-	-rm -rf mdsw_venv
-	cd minidump-stackwalk && make clean
-
-.PHONY: docs
-docs: my.env .docker-build-docs
-	${DC} run --rm --user ${SOCORRO_UID} docs ./docker/run_build_docs.sh
-
-.PHONY: lint
-lint: my.env
-	${DC} run --rm --no-deps app shell ./docker/run_lint.sh
-
-.PHONY: lintfix
-lintfix: my.env
-	${DC} run --rm --no-deps app shell ./docker/run_lint.sh --fix
 
 my.env:
 	@if [ ! -f my.env ]; \
@@ -82,7 +44,7 @@ my.env:
 	make build
 
 .PHONY: build
-build: my.env
+build: my.env  ## | Build docker images.
 	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${SOCORRO_UID} --build-arg groupid=${SOCORRO_GID} app
 	${DC} build oidcprovider
 	touch .docker-build
@@ -96,37 +58,59 @@ build-docs: my.env
 	touch .docker-build-docs
 
 .PHONY: setup
-setup: my.env .docker-build
+setup: my.env .docker-build  ## | Set up Postgres, Elasticsearch, local SQS, and local S3 services.
 	${DC} run --rm app shell /app/docker/run_setup.sh
 
 .PHONY: updatedata
-updatedata: my.env
+updatedata: my.env  ## | Add/update necessary database data.
 	${DC} run --rm app shell /app/docker/run_update_data.sh
 
+.PHONY: run
+run: my.env  ## | Run processor and webapp and all required services.
+	${DC} up processor webapp
+
+.PHONY: runservices
+runservices: my.env  ## | Run service containers (Postgres, SQS, etc)
+	${DC} up -d statsd postgresql memcached localstack elasticsearch
+
+.PHONY: stop
+stop: my.env  ## | Stop all service containers.
+	${DC} stop
+
 .PHONY: shell
-shell: my.env .docker-build
+shell: my.env .docker-build  ## | Open a shell in the app container.
 	${DC} run --rm app shell
 
-.PHONY: mdswshell
+.PHONY: clean
+clean:  ## | Remove all build, test, coverage, and Python artifacts.
+	-rm .docker-build*
+	-rm -rf build breakpad stackwalk google-breakpad breakpad.tar.gz depot_tools
+	-rm -rf .cache
+	-rm -rf mdsw_venv
+	cd minidump-stackwalk && make clean
+
+.PHONY: docs
+docs: my.env .docker-build-docs  ## | Generate Sphinx HTML documetation.
+	${DC} run --rm --user ${SOCORRO_UID} docs ./docker/run_build_docs.sh
+
+.PHONY: lint
+lint: my.env  ## | Lint code.
+	${DC} run --rm --no-deps app shell ./docker/run_lint.sh
+
+.PHONY: lintfix
+lintfix: my.env  ## | Reformat code.
+	${DC} run --rm --no-deps app shell ./docker/run_lint.sh --fix
+
+
+.PHONY: mdswshell  ## | Open a debug/compile shell for minidump-stackwalk.
 mdswshell: my.env .docker-build
 	./docker/run_mdswshell.sh
 
 .PHONY: test
-test: my.env .docker-build
+test: my.env .docker-build  ## | Run unit tests.
 	./docker/run_tests_in_docker.sh ${ARGS}
 
 .PHONY: testshell
-testshell: my.env .docker-build
+testshell: my.env .docker-build  ## | Open a shell in the test environment.
 	./docker/run_tests_in_docker.sh --shell
 
-.PHONY: run
-run: my.env
-	${DC} up processor webapp
-
-.PHONY: runservices
-runservices: my.env
-	${DC} up -d statsd postgresql memcached localstack elasticsearch
-
-.PHONY: stop
-stop: my.env
-	${DC} stop


### PR DESCRIPTION
This ditches the explicit help for help that's generated from the Makefile. This makes it a bit easier to maintain since you don't have to remember to update the docs far away from the things they're documenting.