### PR TITLE
bug 1649774: add mozilla::detail::nsTStringRepr<T>::Equals to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -156,6 +156,7 @@ mozilla::CheckCheckedUnsafePtrs<T>::Check
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
+mozilla::detail::nsTStringRepr<T>::Equals
 mozilla::DOMEventTargetHelper::AddRef
 mozilla::MozPromise<T>::ThenCommand<T>::Track
 mozilla::MozPromise<T>::ThenInternal


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 7757e29c-012e-46df-a487-15c560200629
Crash id: 7757e29c-012e-46df-a487-15c560200629
Original: mozilla::detail::nsTStringRepr<T>::Equals
New:      mozilla::detail::nsTStringRepr<T>::Equals | mozilla::dom::ContentChild::RecvNotifyAlertsObserver
Same?:    False
```