### PR TITLE
bug 1651336: add mozilla::detail::nsTStringRepr<T>:: to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -156,7 +156,7 @@ mozilla::CheckCheckedUnsafePtrs<T>::Check
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
-mozilla::detail::nsTStringRepr<T>::Equals
+mozilla::detail::nsTStringRepr<T>::
 mozilla::DOMEventTargetHelper::AddRef
 mozilla::MozPromise<T>::ThenCommand<T>::Track
 mozilla::MozPromise<T>::ThenInternal


### PR DESCRIPTION
This swaps out `::Equals` for `::` which will cover all the member functions.

```
app@socorro:/app$ socorro-cmd signature 7757e29c-012e-46df-a487-15c560200629
Crash id: 7757e29c-012e-46df-a487-15c560200629
Original: mozilla::detail::nsTStringRepr<T>::Equals
New:      mozilla::detail::nsTStringRepr<T>::Equals | mozilla::dom::ContentChild::RecvNotifyAlertsObserver
Same?:    False
app@socorro:/app$ socorro-cmd signature 6210c03a-a844-4d99-8bd6-d04370200709
Crash id: 6210c03a-a844-4d99-8bd6-d04370200709
Original: mozilla::detail::nsTStringRepr<T>::First
New:      mozilla::detail::nsTStringRepr<T>::First | mozilla::HTMLEditor::InsertTextWithQuotationsInternal
Same?:    False
```