### PR TITLE
Bug 1653620: add 'WebExtensions' as a product to file bugs in the rep…

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -779,7 +779,7 @@
             <div class="bugreporter">
               <p>
                 <b>Bugzilla</b> - Report this bug in
-                {% for bug_product in [report.product, 'Core', 'External Software Affecting Firefox', 'Toolkit', 'GeckoView'] %}
+                {% for bug_product in [report.product, 'Core', 'External Software Affecting Firefox', 'Toolkit', 'GeckoView', 'WebExtensions'] %}
                   {% if bug_product in bug_product_map %}
                     {% set bug_product = BUG_PRODUCT_MAP[bug_product] %}
                   {% endif %}


### PR DESCRIPTION
…ort crash page

Hopefully changing that line in the jinja template is enough to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1653620.