### PR TITLE
Fix renovate separateMultipleMajor config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "schedule": "on the first day of the month",
-  "separateMajorReleases": false,
+  "separateMultipleMajor": false,
   "groupName": "all",
   "docker": {
     "enabled":  false

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "schedule": "on the first day of the month",
-  "separateMultipleMajor": false,
+  "separateMajorMinor": false,
   "groupName": "all",
   "docker": {
     "enabled":  false


### PR DESCRIPTION
Fixes a typo in Renovate config that is preventing it from running on this repo. Issues are disabled in this repo so you are not receiving our typical warning issue.  