### PR TITLE
bug 1649810: upgrade to python 3.8.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.8-slim-stretch@sha256:2dae8c3a67400c05270bc7f6c7bba46b0fc13a702d4a3ab9856f7e3840908154 as socorro_image_base
+FROM python:3.8.5-slim@sha256:a3ddbd9dcadbf9173bf9466c527aef36c01515dad4e3da5147940268232bd420 as socorro_image_base
 
 # Set up user and group
 ARG groupid=10001
@@ -20,7 +20,7 @@ WORKDIR /mdsw/
 # Install breakpad requirements and some helpful debugging things
 RUN apt-get update && apt-get install -y \
     gdb \
-    libcurl3 \
+    libcurl4 \
     libcurl3-gnutls \
     libcurl4-gnutls-dev \
     pkg-config \

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -466,7 +466,8 @@ class TestDatesAndTimesRule:
         )
         assert ret == "2012-05-08T23:26:33.454482+00:00"
         try:
-            42[:1]
+            val = 42
+            val[:1]
         except TypeError as err:
             type_error_value = str(err)
         expected = [

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -471,7 +471,7 @@ class SocorroMiddleware(SocorroCommon):
             kwargs[key] = kwargs.get(key) or value
 
         params = self.kwargs_to_params(kwargs)
-        for param in params:
+        for param in list(params):
             if aliases.get(param):
                 params[aliases.get(param)] = params[param]
                 del params[param]


### PR DESCRIPTION
This upgrades to 3.8.5. In doing that, we switched from stretch to buster as the base image. That required a tweak to the debian packages we install.

The switch from 3.7 to 3.8 also required us to fix a test which had a line that now kicks up a syntax error.

It also required us to fix a test that relied on an iterator over dict keys being stable even if you're deleting the underlying structure. I'm not sure what changed between Python 3.7 and 3.8 to cause the test to fail, but I didn't spend a lot of time looking since the fix is a good defensive thing to do anyhow.

To test:

1. build
2. run tests
3. test the processor by processing crashes with minidumps