### PR TITLE
bug 1659795: add fission indicators to signature/topcrashers reports

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
@@ -7,6 +7,7 @@
 
     {% block site_css %}
       {% stylesheet 'crashstats_base' %}
+      {% stylesheet 'fontawesome' %}
     {% endblock %}
   </head>
 

--- a/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
+++ b/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
@@ -1,17 +1,25 @@
+{% macro fission_icon() %}
+  <i class="status-icon fas fa-atom" title="Fission Crash"></i>
+{%- endmacro %}
+
+{% macro potential_fission_icon() %}
+  <i class="status-icon fas fa-atom" title="Potential Fission Crash"></i>
+{%- endmacro %}
+
 {% macro startup_crash_icon() %}
   <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
        alt="red flag"
-       title="Startup Crash, all crashes happened during startup"
+       title="Startup Crash"
        class="startup"
        height="16"
        width="16"
   />
 {%- endmacro %}
 
-{% macro potential_startup_crash_icon(num_startup_crashes, num_crashes) %}
+{% macro potential_startup_crash_icon() %}
   <img src="{{ static('img/3rdparty/silk/flag_yellow.png') }}"
        alt="yellow flag"
-       title="Potential Startup Crash, {{ num_startup_crashes }} out of {{ num_crashes }} crashes happened during startup"
+       title="Potential Startup Crash"
        class="startup"
        height="16"
        width="16"

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -19,6 +19,7 @@
 @import "components/panel.less";
 @import "components/select.less";
 @import "components/simplebox.less";
+@import "components/statusicon.less";
 @import "components/sumo_link.less";
 @import "components/table_sorter.less";
 @import "components/tip.less";

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/statusicon.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/statusicon.less
@@ -1,0 +1,5 @@
+.status-icon {
+  font-size: 1.3em;
+  margin-right: 5px;
+  width: 16px;
+}

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -158,6 +158,22 @@ class SignatureStats:
         )
 
     @cached_property
+    def num_fission_crashes(self):
+        return sum(
+            row["count"] for row in self.signature["facets"]["dom_fission_enabled"]
+        )
+
+    @cached_property
+    def is_fission_crash(self):
+        return self.num_fission_crashes == self.num_crashes
+
+    @cached_property
+    def is_potential_fission_crash(self):
+        return (
+            self.num_fission_crashes > 0 and self.num_fission_crashes < self.num_crashes
+        )
+
+    @cached_property
     def is_startup_window_crash(self):
         is_startup_window_crash = False
         for row in self.signature["facets"]["histogram_uptime"]:

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -31,7 +31,7 @@ NPM_FILE_PATTERNS = {
         "select2x2.png",
     ],
     "metrics-graphics": ["dist/*"],
-    "font-awesome": ["css/*", "fonts/*"],
+    "@fortawesome/fontawesome-free": ["css/all.min.css", "webfonts/*"],
     "tablesorter": ["dist/css/theme.default.min.css", "dist/js/jquery.tablesorter.js"],
     "d3": ["dist/*"],
     "jssha": ["src/*.js"],
@@ -49,6 +49,10 @@ NPM_FILE_PATTERNS = {
 #
 
 PIPELINE_CSS = {
+    "fontawesome": {
+        "source_filenames": ("@fortawesome/fontawesome-free/css/all.min.css",),
+        "output_filename": "css/fontawesome.min.css",
+    },
     "search": {
         "source_filenames": ("supersearch/css/search.less",),
         "output_filename": "css/search.min.css",

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -1,4 +1,6 @@
 {% from "macros/signature_startup_icons.html" import startup_crash_icon,
+                                                     fission_icon,
+                                                     potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
                                                      hang_crash_icon, plugin_crash_icon,
@@ -6,16 +8,27 @@
 
 {% if signature_stats %}
   <div class="panel tab-inner-panel crash-type-indicators-panel {% if signature_stats.is_startup_related_crash %} startup-crash-warning {% endif %}">
+    {% if signature_stats.is_fission_crash %}
+      <div class="crash-type-indicator-container">
+        {{ fission_icon() }}
+        Fission Crash, all crashes have Fission enabled
+      </div>
+    {% elif signature_stats.is_potential_fission_crash %}
+      <div class="crash-type-indicator-container">
+        {{ potential_fission_icon() }}
+        Potential Fission Crash, {{signature_stats.num_fission_crashes}}
+        out of {{signature_stats.num_crashes}} crashes have Fission enabled
+      </div>
+    {% endif %}
+
     {% if signature_stats.is_startup_crash %}
       <div class="crash-type-indicator-container">
         {{ startup_crash_icon() }}
         Startup Crash, all crashes happened during startup
       </div>
-    {% endif %}
-
-    {% if signature_stats.is_potential_startup_crash %}
+    {% elif signature_stats.is_potential_startup_crash %}
       <div class="crash-type-indicator-container">
-        {{ potential_startup_crash_icon(num_startup_crashes=signature_stats.num_startup_crashes, num_crashes=signature_stats.num_crashes) }}
+        {{ potential_startup_crash_icon() }}
         Potential Startup Crash, {{ signature_stats.num_startup_crashes }}
         out of {{ signature_stats.num_crashes }} crashes happened during startup
       </div>

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -393,6 +393,7 @@ def signature_summary(request, params):
         "hang_type",
         "process_type",
         "startup_crash",
+        "dom_fission_enabled",
         "_histogram.uptime",
     ]
     params["_results_number"] = 0

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -1,4 +1,6 @@
 {% from "macros/signature_startup_icons.html" import startup_crash_icon,
+                                                     fission_icon,
+                                                     potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
                                                      hang_crash_icon, plugin_crash_icon,
@@ -163,12 +165,16 @@
                       <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ topcrashers_stats_item.signature_term }}" />
                     </div>
                     <div class="signature-icons">
-                      {% if topcrashers_stats_item.is_startup_crash %}
-                        {{ startup_crash_icon() }}
+                      {% if topcrashers_stats_item.is_fission_crash %}
+                        {{ fission_icon() }}
+                      {% elif topcrashers_stats_item.is_potential_fission_crash %}
+                        {{ potential_fission_icon() }}
                       {% endif %}
 
-                      {% if topcrashers_stats_item.is_potential_startup_crash %}
-                        {{ potential_startup_crash_icon(num_startup_crashes=topcrashers_stats_item.num_startup_crashes, num_crashes=topcrashers_stats_item.num_crashes) }}
+                      {% if topcrashers_stats_item.is_startup_crash %}
+                        {{ startup_crash_icon() }}
+                      {% elif topcrashers_stats_item.is_potential_startup_crash %}
+                        {{ potential_startup_crash_icon() }}
                       {% endif %}
 
                       {% if topcrashers_stats_item.is_startup_window_crash %}

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -81,6 +81,7 @@ class TestTopCrasherViews(BaseTestViews):
                                     "hang_type": [{"term": 1, "count": 50}],
                                     "process_type": [{"term": "plugin", "count": 50}],
                                     "startup_crash": [{"term": "T", "count": 100}],
+                                    "dom_fission_enabled": [{"term": 1, "count": 50}],
                                     "histogram_uptime": [{"term": 0, "count": 60}],
                                     "cardinality_install_time": {"value": 13},
                                 },
@@ -96,6 +97,7 @@ class TestTopCrasherViews(BaseTestViews):
                                     "hang_type": [{"term": 1, "count": 50}],
                                     "process_type": [{"term": "browser", "count": 50}],
                                     "startup_crash": [{"term": "T", "count": 50}],
+                                    "dom_fission_enabled": [{"term": 1, "count": 80}],
                                     "histogram_uptime": [{"term": 0, "count": 40}],
                                     "cardinality_install_time": {"value": 11},
                                 },
@@ -151,14 +153,16 @@ class TestTopCrasherViews(BaseTestViews):
         selected_count = doc('.tc-result-count a[class="selected"]')
         assert selected_count.text() == "100"
 
+        print(smart_text(response.content))
+
         # Check the startup crash icon is there.
         assert (
-            "Potential Startup Crash, 50 out of 80 crashes happened during startup"
+            "Potential Startup Crash, more than half of the crashes happened "
             in smart_text(response.content)
         )
-        assert "Startup Crash, all crashes happened during startup" in smart_text(
-            response.content
-        )
+
+        # Check the fission icon.
+        assert "Fission Crash" in smart_text(response.content)
 
     def test_product_sans_featured_version(self):
         def mocked_supersearch_get(**params):

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -35,6 +35,7 @@ def get_topcrashers_stats(**kwargs):
     params["_aggs.signature"] = [
         "platform",
         "is_garbage_collecting",
+        "dom_fission_enabled",
         "hang_type",
         "process_type",
         "startup_crash",

--- a/webapp-django/package-lock.json
+++ b/webapp-django/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
+      "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
+    },
     "@sentry/cli": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.40.0.tgz",
@@ -1037,11 +1042,6 @@
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/webapp-django/package.json
+++ b/webapp-django/package.json
@@ -24,7 +24,7 @@
     "ace-builds": "1.3.3",
     "d3": "5.1.0",
     "filesize": "3.6.1",
-    "font-awesome": "4.7.0",
+    "@fortawesome/fontawesome-free": "5.14.0",
     "jquery": "3.5.0",
     "jquery-jsonview": "1.2.3",
     "jquery-ui": "1.12.1",


### PR DESCRIPTION
This adds indicators to the signature report summary and topcrashers
report to indicate if all of the crash reports have DOMFissionEnabled as
well as an indicator if some of the crash reports have
DOMFissionEnabled.

This also removes the remnants of font-awesome stuff we had before which
wasn't in use and replaces it with an updated font-awesome. font-awesome
is used for the fission icon.