### PR TITLE
bug 1657465: support creating github issues

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -3,5 +3,27 @@
   "home_page_sort": 5,
 
   "_comment_featured_versions": "manually include 0.0a1, otherwise it sorts poorly",
-  "featured_versions": ["0.0a1", "auto"]
+  "featured_versions": ["0.0a1", "auto"],
+  "bug_links": [
+    [
+      "Fenix",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Fenix&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/Fennec.json
+++ b/product_details/Fennec.json
@@ -1,5 +1,27 @@
 {
   "name": "Fennec",
   "home_page_sort": 100,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "Firefox for Android",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox+for+Android&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,5 +1,27 @@
 {
   "name": "FennecAndroid",
   "home_page_sort": 2,
-  "featured_versions": ["68.11.0"]
+  "featured_versions": ["68.11.0"],
+  "bug_links": [
+    [
+      "Firefox for Android",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox+for+Android&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/Firefox.json
+++ b/product_details/Firefox.json
@@ -1,5 +1,27 @@
 {
   "name": "Firefox",
   "home_page_sort": 1,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/FirefoxReality.json
+++ b/product_details/FirefoxReality.json
@@ -1,5 +1,27 @@
 {
   "name": "FirefoxReality",
   "home_page_sort": 4,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "FirefoxReality",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=FirefoxReality&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/Focus.json
+++ b/product_details/Focus.json
@@ -1,5 +1,27 @@
 {
   "name": "Focus",
   "home_page_sort": 3,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "Focus",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Focus&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/GeckoView.json
+++ b/product_details/GeckoView.json
@@ -1,5 +1,27 @@
 {
   "name": "GeckoView",
   "home_page_sort": 10,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/GeckoViewExample.json
+++ b/product_details/GeckoViewExample.json
@@ -1,5 +1,27 @@
 {
   "name": "GeckoViewExample",
   "home_page_sort": 11,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "GeckoViewExample",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoViewExample&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/README.rst
+++ b/product_details/README.rst
@@ -16,7 +16,13 @@ Each product file in this directory is in JSON format. Here's an example:
    {
      "name": "Firefox",
      "home_page_sort": 1,
-     "featured_versions": ["auto"]
+     "featured_versions": ["auto"],
+     "bug_links": [
+       [
+         "Firefox",
+         "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+       ]
+     ]
    }
 
 Keys:
@@ -46,6 +52,27 @@ Keys:
 
     Use ``"auto"`` if you want Crash Stats to calculate the featured versions
     based on crash reports that have been submitted.
+
+``bug_links`` (list of [str, str])
+    List of "create a bug" links to show in the Bugzilla tab in the crash report.
+    The first string is the text for the link. The second string is the url
+    template. It's allowed to have the following keys in it:
+
+    * bug_type: set to "defect"
+    * op_sys: the operating system
+    * rep_platform: the architecture
+    * signature: the crash signature
+    * title: bug title
+    * description: the bug description in Markdown format
+
+    For example::
+
+       "bug_links": [
+         [
+           "Firefox",
+           "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+         ]
+       ]
 
 
 How to update product details files

--- a/product_details/ReferenceBrowser.json
+++ b/product_details/ReferenceBrowser.json
@@ -1,5 +1,27 @@
 {
   "name": "ReferenceBrowser",
   "home_page_sort": 11,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "ReferenceBrowser",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=ReferenceBrowser&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/SeaMonkey.json
+++ b/product_details/SeaMonkey.json
@@ -1,5 +1,27 @@
 {
   "name": "SeaMonkey",
   "home_page_sort": 90,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "SeaMonkey",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=SeaMonkey&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/product_details/Thunderbird.json
+++ b/product_details/Thunderbird.json
@@ -1,5 +1,27 @@
 {
   "name": "Thunderbird",
   "home_page_sort": 80,
-  "featured_versions": ["auto"]
+  "featured_versions": ["auto"],
+  "bug_links": [
+    [
+      "Thunderbird",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Thunderbird&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
 }

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -147,6 +147,7 @@ def main(argv=None):
         dest="signature",
         help="signature contains this string",
     )
+    parser.add_argument("--product", default="Firefox", help="Product to fetch for")
     parser.add_argument("--url", default="", help="Super Search url to base query on")
     parser.add_argument(
         "--num",
@@ -164,13 +165,14 @@ def main(argv=None):
 
     host = args.host.rstrip("/")
 
-    # Start with params from --url value or product=Firefox
+    # Start with params from --url value or empty dict
     if args.url:
         params = extract_params(args.url)
     else:
-        params = {"product": "Firefox"}
+        params = {}
 
     params["_columns"] = "uuid"
+    params["product"] = params.get("product", args.product)
 
     # Override with date if specified
     if "date" not in params or args.date:

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -1,4 +1,4 @@
-{# This is a Jinja2 template for Bugzilla bugs filed from the Socorro interface.
+{# This is a Jinja2 template for bugs filed from the Socorro interface.
    See crashstats.templatetags.jinja_helpers.bugzilla_submit_url. #}
 This bug is for crash report bp-{{ uuid }}.
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -778,12 +778,10 @@
           <div id="bugzilla" class="ui-tabs-hide">
             <div class="bugreporter">
               <p>
-                <b>Bugzilla</b> - Report this bug in
-                {% for bug_product in [report.product, 'Core', 'External Software Affecting Firefox', 'Toolkit', 'GeckoView'] %}
-                  {% if bug_product in bug_product_map %}
-                    {% set bug_product = BUG_PRODUCT_MAP[bug_product] %}
-                  {% endif %}
-                  <a href="{{ bugzilla_submit_url(raw, report, parsed_dump, crashing_thread, bug_product) }}" target="_blank">{{ bug_product }}</a>
+                <b>Create a bug:</b>
+                {% for text, template in bug_links %}
+                  <a href="{{ generate_create_bug_url(template, raw, report, parsed_dump, crashing_thread) }}" target="_blank">{{ text }}</a>
+                  {% if not loop.last %}|{% endif %}
                 {% endfor %}
               </p>
 

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -67,13 +67,22 @@ class ProductVersionsMixin:
         # Hard-code products for testing
         productlib._PRODUCTS = [
             productlib.Product(
-                name="WaterWolf", home_page_sort=1, featured_versions=["auto"]
+                name="WaterWolf",
+                home_page_sort=1,
+                featured_versions=["auto"],
+                bug_links=[["WaterWolf", "create-waterwolf-bug"]],
             ),
             productlib.Product(
-                name="NightTrain", home_page_sort=2, featured_versions=["auto"]
+                name="NightTrain",
+                home_page_sort=2,
+                featured_versions=["auto"],
+                bug_links=[["NightTrain", "create-nighttrain-bug"]],
             ),
             productlib.Product(
-                name="SeaMonkey", home_page_sort=3, featured_versions=["auto"]
+                name="SeaMonkey",
+                home_page_sort=3,
+                featured_versions=["auto"],
+                bug_links=[["SeaMonkey", "create-seamonkey-bug"]],
             ),
         ]
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -1084,7 +1084,7 @@ class TestViews(BaseTestViews):
             assert "datatype" in params
             if params["datatype"] == "unredacted":
                 crash = copy.deepcopy(_SAMPLE_UNREDACTED)
-                crash["product"] = "WinterSun"
+                crash["product"] = "WaterWolf"
                 return crash
 
             raise NotImplementedError
@@ -1097,19 +1097,17 @@ class TestViews(BaseTestViews):
             "crashstats:report_index", args=["11cb72f5-eb28-41e1-a8e4-849982120611"]
         )
 
-        bug_product_map = {"WinterSun": "Winter Is Coming"}
-        with self.settings(BUG_PRODUCT_MAP=bug_product_map):
-            response = self.client.get(url)
-            assert response.status_code == 200
-            doc = pyquery.PyQuery(response.content)
+        response = self.client.get(url)
+        assert response.status_code == 200
+        doc = pyquery.PyQuery(response.content)
 
-            link = doc('#bugzilla a[target="_blank"]').eq(0)
-            assert link.text() == "Winter Is Coming"
-            assert "product=Winter+Is+Coming" in link.attr("href")
+        link = doc('#bugzilla a[target="_blank"]').eq(0)
+        assert link.text() == "WaterWolf"
+        assert "create-waterwolf-bug" in link.attr("href")
 
-            # also, the "More Reports" link should have WinterSun in it
-            link = doc("a.sig-overview").eq(0)
-            assert "product=WinterSun" in link.attr("href")
+        # also, the "More Reports" link should have WinterSun in it
+        link = doc("a.sig-overview").eq(0)
+        assert "product=WaterWolf" in link.attr("href")
 
     def test_report_index_odd_product_and_version(self):
         # If the processed JSON references an unfamiliar product and version it
@@ -1128,7 +1126,7 @@ class TestViews(BaseTestViews):
             assert "datatype" in params
             if params["datatype"] == "unredacted":
                 crash = copy.deepcopy(_SAMPLE_UNREDACTED)
-                crash["product"] = "SummerWolf"
+                crash["product"] = "WaterWolf"
                 crash["version"] = "99.9"
                 return crash
 
@@ -1146,12 +1144,12 @@ class TestViews(BaseTestViews):
         # the title should have the "SummerWolf 99.9" in it
         doc = pyquery.PyQuery(response.content)
         title = doc("title").text()
-        assert "SummerWolf" in title
+        assert "WaterWolf" in title
         assert "99.9" in title
 
         # there shouldn't be any links to reports for the product mentioned in
         # the processed JSON
-        bad_url = reverse("crashstats:product_home", args=("SummerWolf",))
+        bad_url = reverse("crashstats:product_home", args=("WaterWolf",))
         assert bad_url not in smart_text(response.content)
 
     def test_report_index_no_dump(self):

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -16,6 +16,7 @@ from django.utils.http import urlquote
 
 from csp.decorators import csp_update
 
+from crashstats import productlib
 from crashstats.crashstats import forms, models, utils
 from crashstats.crashstats.decorators import pass_default_context
 from crashstats.supersearch.models import SuperSearchFields
@@ -123,7 +124,10 @@ def report_index(request, crash_id, default_context=None):
         context["crashing_thread"] = 0
 
     context["parsed_dump"] = parsed_dump
-    context["bug_product_map"] = settings.BUG_PRODUCT_MAP
+
+    context["bug_links"] = productlib.get_product_by_name(
+        context["report"]["product"]
+    ).bug_links
 
     context["bug_associations"] = list(
         models.BugAssociation.objects.filter(signature=context["report"]["signature"])
@@ -196,8 +200,6 @@ def report_index(request, crash_id, default_context=None):
     context["make_raw_crash_key"] = make_raw_crash_key
     context["fields_desc"] = descriptions
     context["empty_desc"] = "No description for this field. Search: unknown"
-
-    context["BUG_PRODUCT_MAP"] = settings.BUG_PRODUCT_MAP
 
     # report.addons used to be a list of lists.
     # In https://bugzilla.mozilla.org/show_bug.cgi?id=1250132

--- a/webapp-django/crashstats/productlib.py
+++ b/webapp-django/crashstats/productlib.py
@@ -52,25 +52,25 @@ def get_product_files():
     return product_files
 
 
+def load_product_from_file(fn):
+    with open(fn, "r") as fp:
+        json_data = json.load(fp)
+
+        # Take out any fields that start with _ so people can add "comments" to
+        # the file
+        json_data = {
+            key: json_data[key] for key in json_data if not key.startswith("_")
+        }
+
+        return Product(**json_data)
+
+
 def get_products():
     """Return Product list sorted by home_page_sort value"""
     global _PRODUCTS
     if not _PRODUCTS:
         product_files = get_product_files()
-
-        products = []
-        for fn in product_files:
-            with open(fn, "r") as fp:
-                json_data = json.load(fp)
-
-                # Take out any fields that start with _ so people can add "comments" to
-                # the file
-                json_data = {
-                    key: json_data[key] for key in json_data if not key.startswith("_")
-                }
-
-                products.append(Product(**json_data))
-
+        products = [load_product_from_file(fn) for fn in product_files]
         products.sort(key=lambda prod: (prod.home_page_sort, prod.name))
         _PRODUCTS = products
 
@@ -137,6 +137,21 @@ def validate_product_file(fn):
             json_data = {
                 key: json_data[key] for key in json_data if not key.startswith("_")
             }
+
+            # Type validation doesn't verify the shape of bug_links, so we need to do
+            # that manually
+            for item in json_data["bug_links"]:
+                if len(item) != 2:
+                    raise ProductValidationError(
+                        "product file %s has invalid bug_links: %s" % (fn, repr(item))
+                    )
+                if not isinstance(item[0], str) or not isinstance(item[1], str):
+                    raise ProductValidationError(
+                        "product file %s has invalid bug_links: %s" % (fn, repr(item))
+                    )
+
+                # NOTE(willkg): This doesn't verify templates are well formed. That's
+                # handled in a test in the code that uses the template.
 
             # Try to build a Product out of it
             Product(**json_data)

--- a/webapp-django/crashstats/productlib.py
+++ b/webapp-django/crashstats/productlib.py
@@ -30,6 +30,10 @@ class Product:
     # entries
     featured_versions: List[int]
 
+    # The list of [link name, link url] bug links for creating new bugs from the report
+    # view of a crash report
+    bug_links: List[List[str]]
+
 
 # In-memory cache of products files so we're not parsing them over-and-over
 _PRODUCTS = []

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -248,9 +248,6 @@ else:
         "crashstats": {"handlers": ["mozlog"], "level": LOGGING_LEVEL},
     }
 
-# Some products have a different name in bugzilla and Socorro.
-BUG_PRODUCT_MAP = {"FennecAndroid": "Firefox for Android"}
-
 # Link to source if possible
 VCS_MAPPINGS = {
     "cvs": {


### PR DESCRIPTION
This reworks the "create a bug" stuff so that each product can specify multiple (text, url template) combinations for where to file bugs. Because it's a url template, it can be a Bugzilla url or a GitHub url or whatever else.

In doing that, I tied the report view to products so I had to fix some tests that had the product hard-coded to something that wasn't in the test fixtures.

This also tweaks `fetch_crashids` so it can take a product--I was getting a little tired of specifying supersearch urls.