### PR TITLE
bug 1657465: redo Fenix "create a bug" links

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -7,23 +7,19 @@
   "bug_links": [
     [
       "Fenix",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Fenix&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "Core",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "External Software Affecting Firefox",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "Toolkit",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+      "https://github.com/mozilla-mobile/fenix/issues/new?title=%(title)s&body=%(description)s"
     ],
     [
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Android-Components",
+      "https://github.com/mozilla-mobile/android-components/issues/new?title=%(title)s&body=%(description)s"
+    ],
+    [
+      "Application-Services",
+      "https://github.com/mozilla/application-services/issues/new?title=%(title)s&body=%(description)s"
     ]
   ]
 }


### PR DESCRIPTION
This redoes the "create a bug" links for Fenix per Roger's suggestions.

Couple of unexciting things:

1. There's no link back to the crash report. With bugzilla, it replaces "bp-xxxxxxxxx" with a link to the crash report on Crash Stats. GitHub doesn't do this (obviously). So we'd need to explicitly create the link. This PR doesn't do that.
2. For Fenix crashes, it'd probably help if device information were included. I'm not sure what information is specifically helpful, though.

I figure we can improve after we get some more feedback.