### PR TITLE
bug 1657465: fix crash report link in create-a-bug links

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -29,6 +29,5 @@ DATABASE_URL=postgres://postgres:aPassword@postgresql:5432/socorro_test
 DEBUG=False
 
 BZAPI_BASE_URL=http://bugzilla.example.com/rest
-PRODUCT_DETAILS_BASE_URL=http://github.example.com
 CACHE_IMPLEMENTATION_FETCHES=True
 SECRET_KEY=fakekey

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -1,6 +1,6 @@
 {# This is a Jinja2 template for bugs filed from the Socorro interface.
-   See crashstats.templatetags.jinja_helpers.bugzilla_submit_url. #}
-This bug is for crash report bp-{{ uuid }}.
+   See crashstats.templatetags.jinja_helpers.generate_bug_create_url. #}
+Crash report: {{ full_url(request, "crashstats:report_index", crash_id=uuid ) }}
 
 {% if java_stack_trace -%}
 Java stack trace:

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -780,7 +780,7 @@
               <p>
                 <b>Create a bug:</b>
                 {% for text, template in bug_links %}
-                  <a href="{{ generate_create_bug_url(template, raw, report, parsed_dump, crashing_thread) }}" target="_blank">{{ text }}</a>
+                  <a href="{{ generate_create_bug_url(request, template, raw, report, parsed_dump, crashing_thread) }}" target="_blank">{{ text }}</a>
                   {% if not loop.last %}|{% endif %}
                 {% endfor %}
               </p>

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -143,7 +143,9 @@ def show_bug_link(bug_id):
 
 
 @library.global_function
-def generate_create_bug_url(template, raw_crash, report, parsed_dump, crashing_thread):
+def generate_create_bug_url(
+    request, template, raw_crash, report, parsed_dump, crashing_thread
+):
     # Some crashes has the `os_name` but it's null so we
     # fall back on an empty string on it instead. That way the various
     # `.startswith(...)` things we do don't raise an AttributeError.
@@ -168,6 +170,7 @@ def generate_create_bug_url(template, raw_crash, report, parsed_dump, crashing_t
     comment = render_to_string(
         "crashstats/bug_comment.txt",
         {
+            "request": request,
             "uuid": report["uuid"],
             "java_stack_trace": report.get("java_stack_trace", None),
             "crashing_thread_frames": crashing_thread_frames,

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -190,11 +190,6 @@ LOGGING_LEVEL = config("LOGGING_LEVEL", "INFO")
 
 host_id = socket.gethostname()
 
-# GitHub repo url base
-PRODUCT_DETAILS_BASE_URL = (
-    "https://raw.githubusercontent.com/mozilla-services/socorro/main/product_details"
-)
-
 
 class AddHostID(logging.Filter):
     def filter(self, record):


### PR DESCRIPTION
To test:

1. process a fenix crash report so you have something to work with
2. look at the report view for that crash report and at the Bugzilla tab (that should get renamed) and click on the create a bug links
3. verify that there is now a crash report url and not the bp-xxxxxx text in the issue description