### PR TITLE
bug 1654028: fix platform count in topcrashers report

### DIFF
--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -198,11 +198,11 @@
                     <td>{{ topcrashers_stats_item.num_crashes_per_platform.mac_count }}</td>
                     <td>{{ topcrashers_stats_item.num_crashes_per_platform.lin_count }}</td>
                   {% elif os_name == 'Windows' %}
-                    <td>{{ topcrashers_stats_item.win_count }}</td>
+                    <td>{{ topcrashers_stats_item.num_crashes_per_platform.win_count }}</td>
                   {% elif os_name == 'Linux' %}
-                    <td>{{ topcrashers_stats_item.lin_count }}</td>
+                    <td>{{ topcrashers_stats_item.num_crashes_per_platform.lin_count }}</td>
                   {% elif os_name == 'Mac OS X' %}
-                    <td>{{ topcrashers_stats_item.mac_count }}</td>
+                    <td>{{ topcrashers_stats_item.num_crashes_per_platform.mac_count }}</td>
                   {% endif %}
                   <td>{{ topcrashers_stats_item.num_installs }}</td>
                   <td>{{ topcrashers_stats_item.num_crashes_in_garbage_collection }}</td>


### PR DESCRIPTION
This fixes the platform count column when looking at a specific platform in the topcrashers report. Looking at the code history, I suspect this has been broken for years. :cry: 

To test:

1. process 100 crashes
2. look at topcrashers report for all platforms, then for a specific platform--the counts for that platform should not be an empty field