### PR TITLE
bug 1473068: add signature urls to OIDC_EXEMPT_URLS

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -11,6 +11,7 @@
 
 import logging
 import os
+import re
 import socket
 
 from decouple import config, Csv
@@ -610,12 +611,15 @@ OIDC_EXEMPT_URLS = [
     # Used by bugzilla.js
     "/buginfo/bug",
     # Used by signature report as an XHR
-    # TODO: Should include aggregations and graphs, but they include a parameter in the URL
     "signature:signature_summary",  # data-urls-summary
     "signature:signature_reports",  # data-urls-reports
     "signature:signature_bugzilla",  # data-urls-bugzilla
     "signature:signature_comments",  # data-urls-comments
     "signature:signature_correlations",  # data-urls-correlations
+    re.compile(r"^/signature/graphs/(?P<field>\w+)/$"),  # data-urls-graphs
+    re.compile(
+        r"^/signature/aggregation/(?P<aggregation>\w+)/$"
+    ),  # data-urls-aggregations
 ]
 LOGOUT_REDIRECT_URL = "/"
 

--- a/webapp-django/crashstats/signature/urls.py
+++ b/webapp-django/crashstats/signature/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls import url
 from crashstats.signature import views
 
 
+# NOTE(willkg): make sure to update settings.OIDC_EXEMPT_URLS with xhr urls
 app_name = "signature"
 urlpatterns = [
     url(r"^reports/$", views.signature_reports, name="signature_reports"),

--- a/webapp-django/crashstats/supersearch/urls.py
+++ b/webapp-django/crashstats/supersearch/urls.py
@@ -7,11 +7,12 @@ from django.conf.urls import url
 from crashstats.supersearch import views
 
 
+# NOTE(willkg): make sure to update settings.OIDC_EXEMPT_URLS with xhr urls
 app_name = "supersearch"
 urlpatterns = [
-    url(r"^search/$", views.search, name="search"),
-    url(r"^search/custom/$", views.search_custom, name="search_custom"),
-    url(r"^search/results/$", views.search_results, name="search_results"),
-    url(r"^search/query/$", views.search_query, name="search_query"),
-    url(r"^search/fields/$", views.search_fields, name="search_fields"),
+    url(r"^$", views.search, name="search"),
+    url(r"^custom/$", views.search_custom, name="search_custom"),
+    url(r"^results/$", views.search_results, name="search_results"),
+    url(r"^query/$", views.search_query, name="search_query"),
+    url(r"^fields/$", views.search_fields, name="search_fields"),
 ]

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -16,8 +16,8 @@ from crashstats.crashstats.monkeypatches import patch
 
 patch()
 
-handler500 = "crashstats.crashstats.views.handler500"
 handler404 = "crashstats.crashstats.views.handler404"
+handler500 = "crashstats.crashstats.views.handler500"
 
 
 urlpatterns = [
@@ -36,9 +36,9 @@ urlpatterns = [
         },
     ),
     url(r"", include("crashstats.crashstats.urls", namespace="crashstats")),
-    url(r"", include("crashstats.supersearch.urls", namespace="supersearch")),
     url(r"", include("crashstats.exploitability.urls", namespace="exploitability")),
     url(r"", include("crashstats.monitoring.urls", namespace="monitoring")),
+    url(r"^search/", include("crashstats.supersearch.urls", namespace="supersearch")),
     url(r"^signature/", include("crashstats.signature.urls", namespace="signature")),
     url(
         r"^topcrashers/",


### PR DESCRIPTION
This adds the two prefix url matches to `OIDC_EXEMPT_URLS` to cover
signature graphs and aggregations so they don't try to redirect to OIDC
login.