### PR TITLE
bug 1603663: add cleanse_cronlog

### DIFF
--- a/webapp-django/crashstats/cron/__init__.py
+++ b/webapp-django/crashstats/cron/__init__.py
@@ -22,6 +22,12 @@ JOBS = [
         "time": "05:00",
     },
     {
+        # Expire old cronlog entries every week
+        "cmd": "cleanse_cronlog",
+        "frequency": "7d",
+        "time": "05:00",
+    },
+    {
         # Update BugAssociations every hour
         "cmd": "bugassociations",
         "frequency": "1h",

--- a/webapp-django/crashstats/cron/management/commands/cleanse_cronlog.py
+++ b/webapp-django/crashstats/cron/management/commands/cleanse_cronlog.py
@@ -1,0 +1,43 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from crashstats.cron.models import Log
+
+
+# Number of days to keep records--anything older than this will get
+# deleted.
+RECORD_AGE_CUTOFF = 180
+
+
+class Command(BaseCommand):
+    """Periodic maintenance task for deleting old cron log records."""
+
+    help = "Cleanse old cron_log records"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", action="store_true", help="Whether or not to do a dry run."
+        )
+
+    def handle(self, *args, **options):
+        is_dry_run = options["dry_run"]
+        today = timezone.now()
+        today.replace(hour=0, minute=0, second=0, microsecond=0)
+        cutoff = today - datetime.timedelta(days=RECORD_AGE_CUTOFF)
+
+        total_count = Log.objects.all().count()
+        records = Log.objects.filter(log_time__lte=cutoff)
+        if is_dry_run:
+            self.stdout.write("cleanse_cronlog: THIS IS A DRY RUN.")
+            count = records.count()
+        else:
+            count = records.delete()[0]
+
+        self.stdout.write(
+            f"cleanse_cronlog: count before cleansing: cron_log={total_count}"
+        )
+        self.stdout.write(
+            f"cleanse_cronlog: cutoff={cutoff.date()}: deleted cron_log={count}"
+        )

--- a/webapp-django/crashstats/cron/tests/test_cleansecronlog.py
+++ b/webapp-django/crashstats/cron/tests/test_cleansecronlog.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.utils import timezone
+
+from crashstats.cron.models import Log
+
+
+def test_cleanse_cronlog(db):
+    today = timezone.now()
+    cutoff = today - datetime.timedelta(days=180)
+
+    # Create some Log records from before cutoff
+    with mock.patch("django.utils.timezone.now") as mock_now:
+        mock_now.return_value = cutoff - datetime.timedelta(days=1)
+        Log.objects.create(app_name="log1", duration=10)
+        Log.objects.create(app_name="log2", duration=10)
+
+    # Create one Log after cutoff
+    with mock.patch("django.utils.timezone.now") as mock_now:
+        mock_now.return_value = cutoff + datetime.timedelta(days=1)
+        Log.objects.create(app_name="log3", duration=10)
+
+    out = StringIO()
+    call_command("cleanse_cronlog", dry_run=True, stdout=out)
+    assert "DRY RUN" in out.getvalue()
+    assert Log.objects.all().count() == 3
+
+    out = StringIO()
+    call_command("cleanse_cronlog", dry_run=False, stdout=out)
+    assert "DRY RUN" not in out.getvalue()
+    assert list(Log.objects.all().values_list("app_name", flat=True)) == ["log3"]


### PR DESCRIPTION
This adds a `cleanse_cronlog` command and schedules it to run once a week.
It'll delete cron log entries older than 6 months.