### PR TITLE
bug 1663670: handle zlib errors when decompressing memory report

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -8,6 +8,7 @@ import json
 import re
 import time
 from urllib.parse import unquote_plus
+from zlib import error as ZlibError
 
 from configman.dotdict import DotDict
 from glom import glom
@@ -346,7 +347,7 @@ class OutOfMemoryBinaryRule(Rule):
                 return error_out(error_message)
 
             memory_info = json.loads(memory_info_as_string)
-        except (EOFError, IOError) as x:
+        except (EOFError, IOError, ZlibError) as x:
             error_message = "error in gzip for %s: %r" % (dump_pathname, x)
             return error_out(error_message)
         except ValueError as x:


### PR DESCRIPTION
To test:

1. process 48c08f87-06c1-4e30-8793-24bf70200908 without this fix and it'll spit out a traceback in the logs, but nothing in the processor notes
2. process 48c08f87-06c1-4e30-8793-24bf70200908 with this fix and it won't spit out anything in the logs, but it will add a processor note