### PR TITLE
Improve signature generation docs

### DIFF
--- a/socorro/signature/cmd_doc.py
+++ b/socorro/signature/cmd_doc.py
@@ -59,7 +59,10 @@ def dedent_docstring(text):
 
 
 def get_doc(cls):
-    return "Rule: %s\n\n%s" % (cls.__class__.__name__, dedent_docstring(cls.__doc__))
+    return "**Rule: %s**\n\n%s" % (
+        cls.__class__.__name__,
+        dedent_docstring(cls.__doc__),
+    )
 
 
 def main(argv=None):

--- a/socorro/signature/pipeline.rst
+++ b/socorro/signature/pipeline.rst
@@ -8,7 +8,7 @@ Signature generation rules pipeline
 
 This is the signature generation pipeline defined at ``socorro.signature.generator.DEFAULT_PIPELINE``:
 
-1. Rule: SignatureGenerationRule
+1. **Rule: SignatureGenerationRule**
    
    Generates a signature based on stack frames.
    
@@ -36,39 +36,45 @@ This is the signature generation pipeline defined at ``socorro.signature.generat
    This rule also generates the proto_signature which is the complete list
    of normalized frames.
 
-2. Rule: StackwalkerErrorSignatureRule
+2. **Rule: StackwalkerErrorSignatureRule**
    
    Appends minidump-stackwalker error to signature.
 
-3. Rule: OOMSignature
+3. **Rule: OOMSignature**
    
    Prepends ``OOM | <size>`` to signatures for OOM crashes.
    
    See bug #1007530.
 
-4. Rule: AbortSignature
+4. **Rule: AbortSignature**
    
    Prepends abort message to signature.
    
    See bug #803779.
 
-5. Rule: SignatureShutdownTimeout
+5. **Rule: SignatureShutdownTimeout**
    
    Replaces signature with async_shutdown_timeout message.
 
-6. Rule: SignatureRunWatchDog
+6. **Rule: SignatureRunWatchDog**
    
    Prepends "shutdownhang" to signature for shutdown hang crashes.
 
-7. Rule: SignatureIPCChannelError
+7. **Rule: SignatureIPCChannelError**
    
-   Prepends signature with IPCError-browser or IPCError-content and error message.
+   Either stomp on or prepend signature for IPCError
+   
+   If the IPCError is a ShutDownKill, then this prepends the signature with
+   "IPCError-browser | ShutDownKill".
+   
+   Otherwise it stomps on the signature with "IPCError-browser/content" and the error
+   message.
 
-8. Rule: SignatureIPCMessageName
+8. **Rule: SignatureIPCMessageName**
    
    Appends ipc_message_name to signature.
 
-9. Rule: SignatureParentIDNotEqualsChildID
+9. **Rule: SignatureParentIDNotEqualsChildID**
    
    Stomp on the signature if moz_crash_reason is ``parentBuildID != childBuildID``.
    
@@ -76,11 +82,11 @@ This is the signature generation pipeline defined at ``socorro.signature.generat
    different. This causes a lot of strangeness particularly in symbolification, so the signatures
    end up as junk. Instead, we want to bucket all these together so we replace the signature.
 
-10. Rule: SignatureJitCategory
+10. **Rule: SignatureJitCategory**
     
     Replaces signature with JIT classification.
 
-11. Rule: SigFixWhitespace
+11. **Rule: SigFixWhitespace**
     
     Fix whitespace in signatures.
     
@@ -90,7 +96,7 @@ This is the signature generation pipeline defined at ``socorro.signature.generat
     * converts all non-space whitespace characters to space
     * reduce consecutive spaces to a single space
 
-12. Rule: SigTruncate
+12. **Rule: SigTruncate**
     
     Truncates signatures down to SIGNATURE_MAX_LENGTH characters.
 

--- a/socorro/signature/siglists/README.rst
+++ b/socorro/signature/siglists/README.rst
@@ -11,7 +11,7 @@ use the `Python syntax
 Signature Generation Algorithm
 ------------------------------
 
-When generating a C signature, 5 steps are involved.
+When generating a C/Rust signature, 5 steps are involved.
 
 1. We walk the crashing thread's stack, looking for things that would match the
    `Signature Sentinels <#signature-sentinels>`_. The first matching element, if
@@ -60,18 +60,6 @@ If it finds no match, it passes the whole list of frames to the next step.
 A typical line might be ``_purecall``.
 
 
-Irrelevant Signatures
-~~~~~~~~~~~~~~~~~~~~~
-
-File: ``irrelevant_signature_re.txt``
-
-Irrelevant Signatures are regular expressions of signatures that will be ignored
-while going through the stack. Anything that matches this list will not be added
-to the overall signature.
-
-A typical rule might be ``(Nt|Zw)?WaitForSingleObject(Ex)?``.
-
-
 Prefix Signatures
 ~~~~~~~~~~~~~~~~~
 
@@ -83,8 +71,29 @@ non-matching signature it finds.
 
 A typical rule might be ``JSAutoCompartment::JSAutoCompartment.*``.
 
-Note: These are regular expressions. Dollar signs and other regexp characters
-need to be escaped with a ``\``.
+.. Note::
+
+   These are regular expressions. Dollar signs and other regexp characters need
+   to be escaped with a ``\``.
+
+
+Irrelevant Signatures
+~~~~~~~~~~~~~~~~~~~~~
+
+File: ``irrelevant_signature_re.txt``
+
+Irrelevant Signatures are regular expressions of signatures that will be
+ignored while going through the stack. Anything that matches this list will not
+be added to the overall signature.
+
+Add symbols to this list that:
+
+1. have platform variants that prevent crash signatures from being the same
+   across platforms
+2. are involved in panic, error, or crash handling code that happens *after*
+   the actual crash
+
+A typical rule might be ``(Nt|Zw)?WaitForSingleObject(Ex)?``.
 
 
 Signatures With Line Numbers
@@ -94,67 +103,3 @@ File: ``signatures_with_line_numbers_re.txt``
 
 Signatures with line number are regular expressions of signatures that will be
 combined with their associated source code line numbers.
-
-
-How to edit these lists
------------------------
-
-The first thing we will ask you to do is to file a bug. We keep track of every
-change in Socorro via bugs, so it's important that each commit has one
-associated to it.
-
-File a bug in the `Socorro::Signature component
-<https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Signature>`__,
-describe the changes you want to make, and assign it to you.
-
-Then proceed to making those changes and creating a pull request.
-
-
-Using the command line
-~~~~~~~~~~~~~~~~~~~~~~
-
-If you are a git power user, you probably don't need us to explain how to do
-this! :)
-
-If you are not, you're probably better off using GitHub's interface. Read on!
-
-
-Using GitHub's interface
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-First, you need to be logged in to GitHub. Open the file you want to edit, and
-then click the little pen in the top right corner of the page, the one that says
-*Fork this project and edit the file*, or *Edit the file in your fork of this
-project* if you already have a fork of it.
-
-That will take you to an editor, where you can write any changes you want. Once
-you are done editting the file, enter a commit description. We have some
-conventions, and a bot that will automatically close bugs, so please make your
-commit message following this pattern: *Fixes bug XYZ - Desciption of the
-change*. Once you are ready, click *Propose file change*.
-
-That will create a branch in your fork of the Socorro project, and take you to
-the commit you just created. You can verify that the changes you made are
-correct, and then click *Create pull request*, and then *Create pull request*
-again. Once the pull request is opened, `Circle CI
-<https://circleci.com/gh/mozilla-services/socorro>`_ will automatically start
-running our test suite, which includes sanity checks for those signature lists.
-You can see the status of those tests in the pull request, and click the
-*Details* link to see logs in case of a failure.
-
-That's it! You have proposed a change, we have been notified about it. Someone
-from the Socorro team will review your changes and merge them if they are
-appropriate. Thank you for contributing to Socorro!
-
-
-Watching only the siglists folder
----------------------------------
-
-If you are interested in watching what's changing in the ``siglists`` directory
-in the repository, but don't care much about what happens in the rest of the
-Socorro repo, you can easily set a filter in your email client to do that.
-Here's an example filter you can use today:
-
-::
-
-  to:(socorro@noreply.github.com) ("A socorro/signature/siglists/" OR "M socorro/signature/siglists/" OR "D socorro/signature/siglists")


### PR DESCRIPTION
* cleanup and improve overview
* remove duplicate content
* add philosophy on signature generation which helps guide future
  changes
* add example cases where adding a symbol to the irrelevant list is the
  right thing to do
* fix the pipeline docs generator command to make the rule name bold
  for easier reading