### PR TITLE
bug 1662720: add *$VARIANT$* symbols to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -104,6 +104,9 @@ std::__terminate
 std::terminate
 system@framework@.*\.jar@classes\.dex@0x
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
+# These frames have platform variants and bucket poorly so we nix them
+# from the signature
+.*\$VARIANT\$
 WaitForSingleObjectExImplementation
 WaitForMultipleObjectsExImplementation
 RealMsgWaitFor

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -142,8 +142,6 @@ __memmove_avx_unaligned_erms
 __memmove_avx_unaligned
 __memmove_ssse3_back
 __memmove_ssse3
-_platform_memmove\$VARIANT\$
-__platform_memmove\$VARIANT\$
 memset
 MessageLoop::PostTask_Helper
 MessageLoop::PostTask


### PR DESCRIPTION
Symbols that have `$VARIANT$` in them are platform-specific variants with
the platform in the symbol name which prevents signatures from
coalescing across platforms.

This adds `$VARIANT$` to the irrelevant list such that *all* symbols that
have this bit in them will be skipped over during signature generation.

```
app@socorro:/app$ socorro-cmd signature 2ce1acf5-9caa-47cc-9380-5e7870200910 08a036a0-f6a2-4052-bb8d-b13090200910
Crash id: 2ce1acf5-9caa-47cc-9380-5e7870200910
Original: _platform_memmove$VARIANT$Merom | nsTArray_Impl<T>::ReplaceElementsAtInternal<T> | mozilla::TrackBuffersManager::InsertFrames
New:      nsTArray_Impl<T>::ReplaceElementsAtInternal<T> | mozilla::TrackBuffersManager::InsertFrames
Same?:    False
Crash id: 08a036a0-f6a2-4052-bb8d-b13090200910
Original: _platform_memmove$VARIANT$Nehalem | nsTArray_Impl<T>::ReplaceElementsAtInternal<T> | mozilla::TrackBuffersManager::InsertFrames
New:      nsTArray_Impl<T>::ReplaceElementsAtInternal<T> | mozilla::TrackBuffersManager::InsertFrames
Same?:    False
```