### PR TITLE
bug 1664509: only show Buildhub link if product has buildhub data

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -4,6 +4,7 @@
 
   "_comment_featured_versions": "manually include 0.0a1, otherwise it sorts poorly",
   "featured_versions": ["0.0a1", "auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "Fenix",

--- a/product_details/Fennec.json
+++ b/product_details/Fennec.json
@@ -2,6 +2,7 @@
   "name": "Fennec",
   "home_page_sort": 100,
   "featured_versions": ["auto"],
+  "in_buildhub": true,
   "bug_links": [
     [
       "Firefox for Android",

--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -2,6 +2,7 @@
   "name": "FennecAndroid",
   "home_page_sort": 2,
   "featured_versions": ["68.11.0"],
+  "in_buildhub": true,
   "bug_links": [
     [
       "Firefox for Android",

--- a/product_details/Firefox.json
+++ b/product_details/Firefox.json
@@ -2,6 +2,7 @@
   "name": "Firefox",
   "home_page_sort": 1,
   "featured_versions": ["auto"],
+  "in_buildhub": true,
   "bug_links": [
     [
       "Firefox",

--- a/product_details/FirefoxReality.json
+++ b/product_details/FirefoxReality.json
@@ -2,6 +2,7 @@
   "name": "FirefoxReality",
   "home_page_sort": 4,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "FirefoxReality",

--- a/product_details/Focus.json
+++ b/product_details/Focus.json
@@ -2,6 +2,7 @@
   "name": "Focus",
   "home_page_sort": 3,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "Focus",

--- a/product_details/GeckoView.json
+++ b/product_details/GeckoView.json
@@ -2,6 +2,7 @@
   "name": "GeckoView",
   "home_page_sort": 10,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "GeckoView",

--- a/product_details/GeckoViewExample.json
+++ b/product_details/GeckoViewExample.json
@@ -2,6 +2,7 @@
   "name": "GeckoViewExample",
   "home_page_sort": 11,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "GeckoViewExample",

--- a/product_details/ReferenceBrowser.json
+++ b/product_details/ReferenceBrowser.json
@@ -2,6 +2,7 @@
   "name": "ReferenceBrowser",
   "home_page_sort": 11,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "ReferenceBrowser",

--- a/product_details/SeaMonkey.json
+++ b/product_details/SeaMonkey.json
@@ -2,6 +2,7 @@
   "name": "SeaMonkey",
   "home_page_sort": 90,
   "featured_versions": ["auto"],
+  "in_buildhub": false,
   "bug_links": [
     [
       "SeaMonkey",

--- a/product_details/Thunderbird.json
+++ b/product_details/Thunderbird.json
@@ -2,6 +2,7 @@
   "name": "Thunderbird",
   "home_page_sort": 80,
   "featured_versions": ["auto"],
+  "in_buildhub": true,
   "bug_links": [
     [
       "Thunderbird",

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -183,7 +183,9 @@
                   <td>
                     {{ report.build }}
                     <span class="humanized">({{ report.build | buildid_to_date }})</span>
-                    <a href="{{ settings.BUILDHUB_BASE_URL }}?{{ make_query_string(**{'q': report.build, 'channel[0]': report.release_channel}) }}" class="sig-overview" title="Buildhub data">Buildhub data</a>
+                    {% if product_details.in_buildhub %}
+                      <a href="{{ settings.BUILDHUB_BASE_URL }}?{{ make_query_string(**{'q': report.build, 'channel[0]': report.release_channel}) }}" class="sig-overview" title="Buildhub data">Buildhub data</a>
+                    {% endif %}
                   </td>
                 </tr>
 
@@ -779,7 +781,7 @@
             <div class="bugreporter">
               <p>
                 <b>Create a bug:</b>
-                {% for text, template in bug_links %}
+                {% for text, template in product_details.bug_links %}
                   <a href="{{ generate_create_bug_url(request, template, raw, report, parsed_dump, crashing_thread) }}" target="_blank">{{ text }}</a>
                   {% if not loop.last %}|{% endif %}
                 {% endfor %}

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -70,18 +70,21 @@ class ProductVersionsMixin:
                 name="WaterWolf",
                 home_page_sort=1,
                 featured_versions=["auto"],
+                in_buildhub=True,
                 bug_links=[["WaterWolf", "create-waterwolf-bug"]],
             ),
             productlib.Product(
                 name="NightTrain",
                 home_page_sort=2,
                 featured_versions=["auto"],
+                in_buildhub=False,
                 bug_links=[["NightTrain", "create-nighttrain-bug"]],
             ),
             productlib.Product(
                 name="SeaMonkey",
                 home_page_sort=3,
                 featured_versions=["auto"],
+                in_buildhub=False,
                 bug_links=[["SeaMonkey", "create-seamonkey-bug"]],
             ),
         ]

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -99,6 +99,10 @@ def report_index(request, crash_id, default_context=None):
             cache.set(cache_key, True, 60)
         return render(request, "crashstats/report_index_pending.html", context)
 
+    context["product_details"] = productlib.get_product_by_name(
+        context["report"]["product"]
+    )
+
     if "json_dump" in context["report"]:
         json_dump = context["report"]["json_dump"]
         if "sensitive" in json_dump and not request.user.has_perm(
@@ -124,10 +128,6 @@ def report_index(request, crash_id, default_context=None):
         context["crashing_thread"] = 0
 
     context["parsed_dump"] = parsed_dump
-
-    context["bug_links"] = productlib.get_product_by_name(
-        context["report"]["product"]
-    ).bug_links
 
     context["bug_associations"] = list(
         models.BugAssociation.objects.filter(signature=context["report"]["signature"])

--- a/webapp-django/crashstats/productlib.py
+++ b/webapp-django/crashstats/productlib.py
@@ -30,6 +30,9 @@ class Product:
     # entries
     featured_versions: List[int]
 
+    # Whether or not this product has data in Buildhub
+    in_buildhub: bool
+
     # The list of [link name, link url] bug links for creating new bugs from the report
     # view of a crash report
     bug_links: List[List[str]]


### PR DESCRIPTION
Most products don't have data on Buildhub. For products that don't, Crash Stats shouldn't show a Buildhub link because it doesn't make any sense.