### PR TITLE
bug 1665126: add note about user-agent

### DIFF
--- a/docs/tests/system_checklist.rst
+++ b/docs/tests/system_checklist.rst
@@ -44,9 +44,9 @@ Checklist
     Before doing anything, verify the environment(s) that you're testing
     are running the version you expect.
 
-    * local dev: http://localhost:8000/api/Status
-    * -stage: https://crash-stats.allizom.org/api/Status
-    * -prod: https://crash-stats.mozilla.org/api/Status
+    * local dev: http://localhost:8000/__version__
+    * -stage: https://crash-stats.allizom.org/__version__
+    * -prod: https://crash-stats.mozilla.org/__version__
 
 
     Migrations
@@ -72,11 +72,11 @@ Checklist
 
     Is the collector handling incoming crashes?
 
-    * Check datadog Antenna dashboard for the appropriate environment.
+    * Check Grafana dashboard for the appropriate environment.
 
-      localdev: Check the logging in the console
-      stage: https://app.datadoghq.com/dash/272676/antenna--stage
-      prod: https://app.datadoghq.com/dash/274773/antenna--prod
+      * localdev: Check the logging in the console
+      * stage: https://earthangel-b40313e5.influxcloud.net/d/mTjlP_8Zz/socorro-stage-megamaster-remix?orgId=1
+      * prod: https://earthangel-b40313e5.influxcloud.net/d/LysVjx8Zk/socorro-prod-megamaster-remix?orgId=1
 
     * Log into Sentry and check for errors.
 
@@ -94,28 +94,21 @@ Checklist
 
       To check for errors grep for "ERRORS".
 
-    * Check Datadog "processor.save_processed_crash" for appropriate
+    * Check Grafana "processor.save_processed_crash" for appropriate
       environment.
 
-      localdev: Check the logging in the console
-      stage: https://app.datadoghq.com/dash/187676/socorro-stage-perf
-      prod: https://app.datadoghq.com/dash/65215/socorro-prod
+      * localdev: Check the logging in the console
+      * stage: https://earthangel-b40313e5.influxcloud.net/d/mTjlP_8Zz/socorro-stage-megamaster-remix?orgId=1
+      * prod: https://earthangel-b40313e5.influxcloud.net/d/LysVjx8Zk/socorro-prod-megamaster-remix?orgId=1
 
     Is the processor saving to ES? S3?
 
-    * Check Datadog
+    * Check Grafana
       "processor.es.ESCrashStorageRedactedJsonDump.save_processed_crash.avg"
 
-      stage: https://app.datadoghq.com/dash/187676/socorro-stage-perf
-      prod: https://app.datadoghq.com/dash/65215/socorro-prod
-
-    * Check Datadog
+    * Check Grafana
       "processor.s3.BotoS3CrashStorage.save_processed_crash" for
       appropriate environment.
-
-      stage: https://app.datadoghq.com/dash/187676/socorro-stage-perf
-      prod: https://app.datadoghq.com/dash/65215/socorro-prod
-
 
     Submit a crash or reprocess a crash. Wait a few minutes. Verify the crash was
     processed and made it to S3 and Elasticsearch.

--- a/webapp-django/crashstats/api/jinja2/api/documentation.html
+++ b/webapp-django/crashstats/api/jinja2/api/documentation.html
@@ -15,23 +15,20 @@
 {% block main_content %}
 <div class="panel">
   <div class="body">
-    <p class="tokens-callout">
-      You currently have
-      <a href="{{ url('tokens:home') }}">{{ count_tokens }} active API Token {{ count_tokens|pluralize }}</a>.
-    </p>
     <p>
       These API endpoints are publicly available. The parameters to some
       endpoints are non-trivial as some might require deeper understanding of
       the Soccoro backend.
     </p>
     <p>
-      <b>Note:</b> The API does depend on
-      <a href="{{ url('profile:profile') }}">your permissions</a> and if you
-      include an <a href="{{ url('tokens:home') }}">API Token</a> with your
-      requests.
-      <br>
-      Some endpoints' accessibility depend entirely on your permissions and
-      use of API Tokens.
+      Some API endpoints require an <a href="{{ url('tokens:home') }}">API Token</a>
+      and return different things depending on <a href="{{ url('profile:profile') }}">your access</a>.
+      You currently have
+      <a href="{{ url('tokens:home') }}">{{ count_tokens }} active API Token{{ count_tokens|pluralize }}</a>.
+    </p>
+    <p>
+      Please set a User-Agent when using APIs. This helps us know who to talk
+      with when planning API changes.
     </p>
   </div>
 </div>

--- a/webapp-django/crashstats/api/static/api/css/documentation.less
+++ b/webapp-django/crashstats/api/static/api/css/documentation.less
@@ -52,13 +52,6 @@ p.required-permission {
     float: right;
     margin: 0;
 }
-p.tokens-callout {
-    float: right;
-    font-size: 120%;
-}
-p.tokens-callout a {
-    font-weight: bold;
-}
 
 /* These are the little widgets for boolean choices */
 form.testdrive td ul li {

--- a/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
@@ -50,10 +50,15 @@
     </p>
 
     <h1 id="basic-usage">Basic Usage</h1>
-
     <div class="example">
       <pre><code data-url="{{ url("api:model_wrapper", model_name="SuperSearch") }}?{{ make_query_string(product=product_name, _results_number=10) }}"><span class="url-domain">{{ full_url(request, "api:model_wrapper", model_name="SuperSearch") }}</span><span class="query-string">?{{ make_query_string(product=product_name, _results_number=10) }}</span></code></pre>
     </div>
+
+    <h1 id="useragent">User-Agent</h1>
+    <p>
+      Please set a User-Agent when using the API. This helps us know who to
+      talk to when we're making changes.
+    </p>
 
     <h1 id="response">Response</h1>
     <p>
@@ -487,7 +492,7 @@
 
     <p>
       Sometimes you just need to count the distinct values of a field. That can
-      be done using the cardinality feature. For example, let"s count the number
+      be done using the cardinality feature. For example, let's count the number
       of distinct builds of {{ product.name }}:
     </p>
 
@@ -521,7 +526,7 @@
     </div>
 
     <p>
-      Or, let"s count the number of distinct <code>build_id</code> per day for
+      Now let's count the number of distinct <code>build_id</code> per day for
       {{ product.name }}:
     </p>
 
@@ -529,7 +534,7 @@
       <pre><code data-url="{{ url("api:model_wrapper", model_name="SuperSearch") }}?{{ make_query_string(**{"product": product_name, "_histogram.date": "_cardinality.build_id", "_histogram_interval.date": "1d"}) }}"><span class="url-domain">{{ full_url(request, "api:model_wrapper", model_name="SuperSearch") }}</span><span class="query-string">?{{ make_query_string(**{"product": product_name, "_histogram.date": "_cardinality.build_id", "_histogram_interval.date": "1d"}) }}</span></code></pre>
     </div>
 
-    <h1 id="what-s-next">What"s next?</h1>
+    <h1 id="what-s-next">What's next?</h1>
 
     <p>
       If you want to see more concrete examples of problems you can solve with

--- a/webapp-django/crashstats/documentation/static/documentation/js/documentation.js
+++ b/webapp-django/crashstats/documentation/static/documentation/js/documentation.js
@@ -28,7 +28,7 @@ $(function() {
   // Add a command to all examples.
   $('.example pre code')
     .prepend('"')
-    .prepend($('<span>', { text: 'curl ' }).addClass('http-verb'))
+    .prepend($('<span>', { text: 'curl --user-agent "example/1.0" ' }).addClass('http-verb'))
     .append('"');
 
   // JSON results viewers.

--- a/webapp-django/crashstats/documentation/views.py
+++ b/webapp-django/crashstats/documentation/views.py
@@ -39,16 +39,33 @@ def protected_data_access(request, default_context=None):
     return render(request, "documentation/protected_data_access.html", context)
 
 
+def get_valid_version(active_versions, product_name):
+    """Return version data.
+
+    If this is a local dev environment, then there's no version data.  However, the data
+    structures involved are complex and there are a myriad of variations.
+
+    This returns a valid version.
+
+    :arg active_versions: map of product_name -> list of version dicts
+    :arg product_name: a product name
+
+    :returns: version as a string
+
+    """
+    default_version = {"product": product_name, "version": "80.0"}
+    active_versions = active_versions.get("active_versions", {})
+    versions = active_versions.get(product_name, []) or [default_version]
+    return versions[0]["version"]
+
+
 @pass_default_context
 def supersearch_home(request, default_context=None):
     context = default_context or {}
 
     product_name = productlib.get_default_product().name
     context["product_name"] = product_name
-    default_version = {"product": product_name, "version": "80.0"}
-    active_versions = context.get("active_versions", {})
-    version = active_versions.get(product_name, [default_version])[0]["version"]
-    context["version"] = version
+    context["version"] = get_valid_version(context["active_versions"], product_name)
 
     return render(request, "documentation/supersearch/home.html", context)
 
@@ -59,10 +76,7 @@ def supersearch_examples(request, default_context=None):
 
     product_name = productlib.get_default_product().name
     context["product_name"] = product_name
-    default_version = {"product": product_name, "version": "80.0"}
-    active_versions = context.get("active_versions", {})
-    version = active_versions.get(product_name, [default_version])[0]["version"]
-    context["version"] = version
+    context["version"] = get_valid_version(context["active_versions"], product_name)
     context["today"] = datetime.datetime.utcnow().date()
     context["yesterday"] = context["today"] - datetime.timedelta(days=1)
     context["three_days_ago"] = context["today"] - datetime.timedelta(days=3)


### PR DESCRIPTION
We really want users to be specifying a User-Agent if they're using the APIs. It helps us help them. This fixes the docs to specify that.

Further, it fixes the supersearch documentation to work better when there's no version data.

While I was there, I also made some updates to the system checklist.