### PR TITLE
bug 1667741: add Windows heap failure error handling to irrelevant list

### DIFF
--- a/docker/socorro_entrypoint.sh
+++ b/docker/socorro_entrypoint.sh
@@ -10,6 +10,11 @@ set -e
 
 if [ -z "$*" ]; then
     echo "usage: socorro_entrypoint.sh SERVICE"
+    echo ""
+    echo "Services:"
+    grep -E '^[a-zA-Z0-9_-]+).*?## .*$$' docker/socorro_entrypoint.sh \
+        | grep -v grep \
+        | sed -n 's/^\(.*\)) \(.*\)##\(.*\)/* \1:\3/p'
     exit 1
 fi
 
@@ -17,16 +22,16 @@ SERVICE=$1
 shift
 
 case ${SERVICE} in
-processor)
+processor)  ## Run processor service
     /app/docker/run_processor.sh "$@"
     ;;
-crontabber)
+crontabber)  ## Run crontabber service
     /app/docker/run_crontabber.sh "$@"
     ;;
-webapp)
+webapp)  ## Run webapp service
     /app/docker/run_webapp.sh "$@"
     ;;
-shell)
+shell)  ## Open a shell or run something else
     if [ -z "$*" ]; then
         bash
     else

--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -85,9 +85,15 @@ PR_WaitCondVar
 RaiseException
 rust_oom
 rtc::FatalMessage
-RtlpAdjustHeapLookasideDepth
+RtlReportCriticalFailure
+RtlReportFatalFailure
 RtlSleepConditionVariableCS
 RtlSleepConditionVariableSRW
+RtlpAdjustHeapLookasideDepth
+RtlpAnalyzeHeapFailure
+RtlpHeapHandleError
+RtlpHpHeapHandleError
+RtlpLogHeapFailure
 RustMozCrash
 _sigtramp
 __sigtramp


### PR DESCRIPTION
From Gabriele: Crash signatures that include heap failures on Windows
tend to be very, very long as the first few frames are taken by Windows
own error-handling machinery. It might be better to ignore those frames
entirely in signature generation to make the interesting part of the
stack stand out.

```
app@socorro:/app$ socorro-cmd signature b1ccbc43-9695-4ecb-ba98-d95830200929 e1c9683d-0bc2-4911-b727-7726c0200929
Crash id: b1ccbc43-9695-4ecb-ba98-d95830200929
Original: RtlReportFatalFailure | RtlReportCriticalFailure | RtlpHeapHandleError | RtlpHpHeapHandleError | RtlpLogHeapFailure | RtlFreeHeap | Dns_HeapFree
New:      RtlFreeHeap | Dns_HeapFree
Same?:    False
Crash id: e1c9683d-0bc2-4911-b727-7726c0200929
Original: RtlReportFatalFailure | RtlReportCriticalFailure | RtlpHeapHandleError | RtlpHpHeapHandleError | RtlpLogHeapFailure | RtlpAllocateHeap | RtlpAllocateHeapInternal | hpzui4wm.dll | rpcrt4.dll | LocalBaseRegOpenKey
New:      RtlpAllocateHeap | RtlpAllocateHeapInternal | hpzui4wm.dll | rpcrt4.dll | LocalBaseRegOpenKey
Same?:    False
```