### PR TITLE
bug 1667158: add reason and mozcrashreason to bug descriptions

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -1,5 +1,6 @@
 {# This is a Jinja2 template for bugs filed from the Socorro interface.
-   See crashstats.templatetags.jinja_helpers.generate_bug_create_url. #}
+   See crashstats.templatetags.jinja_helpers.generate_bug_create_url.
+   This renders to text--not html!! Whitespace is a complete nightmare. #}
 Crash report: {{ full_url(request, "crashstats:report_index", crash_id=uuid ) }}
 
 {% if java_stack_trace -%}
@@ -8,6 +9,10 @@ Java stack trace:
 {{ java_stack_trace }}
 ```
 {% elif crashing_thread_frames -%}
+{%- if reason %}Reason: {{ reason }}
+{% endif -%}
+{%- if moz_crash_reason %}MOZ_CRASH Reason: {{ moz_crash_reason }}
+{% endif %}
 Top {{ crashing_thread_frames|length }} frames of crashing thread:
 ```
 {% for frame in crashing_thread_frames -%}

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -613,6 +613,7 @@ class ProcessedCrash(SocorroMiddleware):
         "java_stack_trace",
         "json_dump",
         "last_crash",
+        "moz_crash_reason",
         "mdsw_status_string",
         "os_name",
         "os_version",

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -172,6 +172,8 @@ def generate_create_bug_url(
         {
             "request": request,
             "uuid": report["uuid"],
+            # NOTE(willkg): this is the redacted stack trace--not the raw one that can
+            # have PII in it
             "java_stack_trace": report.get("java_stack_trace", None),
             "crashing_thread_frames": crashing_thread_frames,
         },

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -146,6 +146,8 @@ def show_bug_link(bug_id):
 def generate_create_bug_url(
     request, template, raw_crash, report, parsed_dump, crashing_thread
 ):
+    parsed_dump = parsed_dump or {}
+
     # Some crashes has the `os_name` but it's null so we
     # fall back on an empty string on it instead. That way the various
     # `.startswith(...)` things we do don't raise an AttributeError.
@@ -175,6 +177,10 @@ def generate_create_bug_url(
             # NOTE(willkg): this is the redacted stack trace--not the raw one that can
             # have PII in it
             "java_stack_trace": report.get("java_stack_trace", None),
+            # NOTE(willkg): this is the redacted mozcrashreason--not the raw one that
+            # can have PII in it
+            "moz_crash_reason": report.get("moz_crash_reason", None),
+            "reason": report.get("reason", None),
             "crashing_thread_frames": crashing_thread_frames,
         },
     )


### PR DESCRIPTION
If the reason (extracted from the minidump) and `MozCrashReason` are available, add them to the bug description.

To test:

1. process a crash that has a `Reason`, but no `MozCrashReason` and verify that bugs created with that include a `Reason: ` line in the description (https://crash-stats.mozilla.org/report/index/bce9d31c-9785-4b66-8b6f-b382d0200929)
2. process a crash that has a `Reason` and a `MozCrashReason` and verify that bugs created with that include a `Reason: ` line and a `MOZ_CRASH Reason: ` line in the description (https://crash-stats.mozilla.org/report/index/1f36ff08-cc80-4733-b439-591eb0200929)
3. process a crash that has a `MozCrashReason` that has naughty bits in it, log in so you can see the raw version of the data, and make sure the `MOZ_CRASH Reason: ` line in the bug description is sanitized (https://crash-stats.mozilla.org/report/index/1b2772fb-0884-495b-a143-7670d0200929)