### PR TITLE
bug 1668381: add _XReply to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -125,5 +125,6 @@ ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
 WaitForSingleObjectExImplementation
 WaitForMultipleObjectsExImplementation
 _XError
+_XReply
 _ZdlPv
 zero


### PR DESCRIPTION
_XReply is an x11 function that waits for a reply packet and triggers an
error if it gets back an XError which is what we see in crash reports,
so it's not very interesting.