### PR TITLE
bug 1669163: fix formatting for reason/moz_crash_reason in bug links

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -9,10 +9,12 @@ Java stack trace:
 {{ java_stack_trace }}
 ```
 {% elif crashing_thread_frames -%}
-{%- if reason %}Reason: {{ reason }}
-{% endif -%}
-{%- if moz_crash_reason %}MOZ_CRASH Reason: {{ moz_crash_reason }}
-{% endif %}
+{%- if moz_crash_reason -%}
+MOZ_CRASH Reason: ```{{ moz_crash_reason }}```
+{%- elif reason -%}
+Reason: ```{{ reason }}```
+{%- endif %}
+
 Top {{ crashing_thread_frames|length }} frames of crashing thread:
 ```
 {% for frame in crashing_thread_frames -%}

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -524,7 +524,7 @@ class Test_generate_create_bug_url:
         url = generate_create_bug_url(
             req, self.TEMPLATE, raw_crash, report, parsed_dump, 0
         )
-        assert quote_plus("Reason: SIGSEGV /0x00000080") in url
+        assert quote_plus("Reason: ```SIGSEGV /0x00000080```") in url
 
     def test_comment_moz_crash_reason(self):
         """Verify Reason makes it into the comment."""
@@ -547,7 +547,7 @@ class Test_generate_create_bug_url:
         url = generate_create_bug_url(
             req, self.TEMPLATE, raw_crash, report, parsed_dump, 0
         )
-        assert quote_plus("MOZ_CRASH Reason: good_data") in url
+        assert quote_plus("MOZ_CRASH Reason: ```good_data```") in url
         assert quote_plus("bad_data") not in url
 
     def test_fission_enabled(self):


### PR DESCRIPTION
`MozCrashReason` only gets generated in cases where the `reason` is `SIGSEGV` or `EXCEPTION_BREAKPOINT` so the reason isn't helpful. This changes the template to show `MozCrashReason` or `Reason` or nothing.

Bugzilla comments use Markdown for formatting, so we need to put the `MozCrashReason`/`Reason` in backticks so the values aren't kicking off Markdown formatting inadvertently.

To test:

1. process a crash report with a `Reason`, but no `MozCrashReason` and check bug link--should show `Reason` in backticks
2. process a crash report with a `Reason` and a `MozCrashReason` and check bug link--should show `MozCrashReason` in backticks