### PR TITLE
bug 1669163: fix reason in bug report creation

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -6,13 +6,13 @@ Crash report: {{ full_url(request, "crashstats:report_index", crash_id=uuid ) }}
 {% if java_stack_trace -%}
 Java stack trace:
 ```
-{{ java_stack_trace }}
+{{ java_stack_trace|safe }}
 ```
 {% elif crashing_thread_frames -%}
 {%- if moz_crash_reason -%}
-MOZ_CRASH Reason: ```{{ moz_crash_reason }}```
+MOZ_CRASH Reason: ```{{ moz_crash_reason|safe }}```
 {%- elif reason -%}
-Reason: ```{{ reason }}```
+Reason: ```{{ reason|safe }}```
 {%- endif %}
 
 Top {{ crashing_thread_frames|length }} frames of crashing thread:


### PR DESCRIPTION
The reason was being escaped by the bug creation template, but it
shouldn't be. This marks the relevant fields as safe.