### PR TITLE
bug 1672386: add nsTSubstring<T>::Append to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -219,6 +219,7 @@ nsThread::nsChainedEventQueue::GetEvent
 [-+]\[NSException raise(:format:(arguments:)?)?\]
 nsInterfaceHashtable<.*>::
 nsINode::Slots
+nsTSubstring<T>::Append
 nsJSThingHashtable<.*>::
 nsObjCExceptionLogAbort
 NS_QuickSort


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 4ec1c321-8d50-49c7-88fc-6876d0201021
Crash id: 4ec1c321-8d50-49c7-88fc-6876d0201021
Original: OOM | large | NS_ABORT_OOM | nsTSubstring<T>::Append
New:      OOM | large | NS_ABORT_OOM | nsTSubstring<T>::Append | mozilla::net::WebSocketChannelChild::RecvOnMessageAvailableInternal
Same?:    False
```