### PR TITLE
bug 1676900: add std::io::stdio::_eprint to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -114,6 +114,7 @@ SleepConditionVariableCS
 SleepConditionVariableSRW
 std::_Atomic_fetch_add_4
 std::alloc::rust_oom
+std::io::stdio::_eprint
 std::panicking::
 std::__terminate
 std::terminate


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 9305172a-e7a8-49e0-9894-2c38b0201112 bb91e742-f3ec-4018-8608-a00b70201113
Crash id: 9305172a-e7a8-49e0-9894-2c38b0201112
Original: std::io::stdio::_eprint
New:      <env_logger::Logger as log::Log>::log
Same?:    False
Crash id: bb91e742-f3ec-4018-8608-a00b70201113
Original: std::io::stdio::_eprint
New:      env_logger::{{impl}}::log
Same?:    False
```