### PR TITLE
bug 1676593: fix adapter_driver_version sorting in signature report

### DIFF
--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
@@ -129,15 +129,34 @@ SignatureReport.ReportsTab.prototype.buildUrl = function (params) {
 SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, data) {
   var tab = this;
 
+  // jquery-tablesorter guesses the value type wrong and thus doesn't
+  // sort the data correctly for some columns. This hard-codes fixes
+  // for data we know it gets wrong. Bug 1676593.
+  //
+  // field name -> header override
+  var fieldOverride = {
+    adapter_driver_version: { sorter: 'text' },
+  };
+
   contentElement.empty().append($(data));
-  $('#reports-list').tablesorter({
-    headers: {
-      0: {
-        // disable the first column, `Crash ID`
-        sorter: false,
-      },
+  var headers = {
+    0: {
+      // disable sorting with the first column, `Crash ID`
+      sorter: false,
     },
+  };
+  var counter = 0;
+
+  $('#reports-list th').each(function (index, elem) {
+    var fieldName = elem.getAttribute('data-field-name');
+
+    if (fieldName in fieldOverride) {
+      headers[counter] = fieldOverride[fieldName];
+    }
+    counter += 1;
   });
+
+  $('#reports-list').tablesorter({ headers: headers });
   this.bindPaginationLinks(contentElement);
 
   // Make sure there are more than 1 page of results. If not,


### PR DESCRIPTION
jquery-tablesorter gets the value type wrong some how and thus sorts the values in the column wrong. If we "hard-code" it to be "text", then it sorts alphabetically which is correct.

There are a bunch of tables in Crash Stats, but I'm fixing this one specifically figuring we can generalize later if that's appropriate.