### PR TITLE
bug 1032227: fix sorting of hex addresses in signature report

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/tablesorter_utils.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/tablesorter_utils.js
@@ -1,0 +1,35 @@
+(function ($) {
+  $.tablesorter.addParser({
+    id: 'hexdigit',
+    is: function () {
+      return false;
+    },
+    format: function (str) {
+      var newstr;
+
+      if (str === null || str === '') {
+        return 0;
+      }
+
+      // if it starts with 0x, peel that off and if all digits, convert the
+      // rest from base 16 to base 10
+      if (str.substring(0, 2) === '0x') {
+        newstr = str.substring(2);
+        if (!newstr.match(/^[0-9A-Fa-f]+$/)) {
+          return 0;
+        }
+        newstr = parseInt(newstr, 16);
+        return newstr;
+      }
+
+      // if it's all digits, convert to int
+      if (!str.match(/^[0-9]+$/)) {
+        return 0;
+      }
+      newstr = parseInt(str);
+      return newstr;
+    },
+    // the parser converts to an int, so use numeric sort after that
+    type: 'numeric',
+  });
+})(jQuery);

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -194,7 +194,10 @@ PIPELINE_JS = {
         "output_filename": "js/select2.min.js",
     },
     "tablesorter": {
-        "source_filenames": ("tablesorter/dist/js/jquery.tablesorter.js",),
+        "source_filenames": (
+            "tablesorter/dist/js/jquery.tablesorter.js",
+            "crashstats/js/socorro/tablesorter_utils.js",
+        ),
         "output_filename": "js/jquery-tablesorter.min.js",
     },
     "socorro_utils": {

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
@@ -136,6 +136,7 @@ SignatureReport.ReportsTab.prototype.onAjaxSuccess = function (contentElement, d
   // field name -> header override
   var fieldOverride = {
     adapter_driver_version: { sorter: 'text' },
+    address: { sorter: 'hexdigit' },
   };
 
   contentElement.empty().append($(data));


### PR DESCRIPTION
Hex addresses were getting sorted alphanumerically. This fixes the address value so that it gets converted to a base 10 int and then sorted.