### PR TITLE
bug 1681388: clean up protected data language and links

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -3,7 +3,7 @@
   {% if your_crash %}
     Protected data: You can see it because it is your crash.
   {% else %}
-    Protected data: Be careful how you use it.
+    Protected data: <a href="{{ url('documentation:protected_data_access') }}">Protected data policy.</a>
   {% endif %}
 {%- endmacro %}
 

--- a/webapp-django/crashstats/documentation/jinja2/documentation/protected_data_access.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/protected_data_access.html
@@ -21,14 +21,14 @@
     <p>
       Anyone with access to protected data agrees to the following:
     </p>
-    <pre>* Crash dumps contain memory contents, and may contain private user data
+    <pre>* Crash dumps contain memory contents and may contain private user data
 * Only access protected data and dumps as necessary
-* Keep data securely on Mozilla hardware
-* When finished with a dump, delete it (within 30 days)
-* Do not share personal data from the dump publicly (on bugzilla, irc, etc)
-* Do not share personal data with non-employees, including partner organizations; any
+* Keep protected data securely on Mozilla hardware
+* When finished with a memory dump, delete it (within 30 days)
+* Do not share protected data from the dump publicly (on bugzilla, irc, etc)
+* Do not share protected data with non-employees, including partner organizations; any
   requests to review exceptions to this policy can be brought up with Trust and Security
-* It is fine to share stack traces, analysis, and other non-personal data
+* It is fine to share stack traces, analysis, and other non-protected data
 * Access is conditional on employment and will be revoked upon departure from Mozilla
 * Access will be removed after a year of inactivity
 


### PR DESCRIPTION
This cleans up the language about protected data near things like minidump links. The goal is to make it much clearer what is expected of the user in regards to protected data.

This also switches out the old terms "personal data" for the new term "protected data" in the data policy.