### PR TITLE
bug 1678739: make remote_type public

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3136,7 +3136,7 @@ FIELDS = {
         "is_returned": True,
         "name": "remote_type",
         "namespace": "raw_crash",
-        "permissions_needed": ["crashstats.view_pii"],
+        "permissions_needed": [],
         "query_type": "enum",
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },


### PR DESCRIPTION
I can't tell why `remote_type` was originally protected data. The values in that field suggest it's fine to make public and it's a public field in the crash ping data set so I'm making it public in Crash Stats.
