### PR TITLE
bug 1672847: normalize anonymous namespace variations

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -151,11 +151,16 @@ class CSignatureTool(SignatureTool):
             if function.endswith(ref):
                 function = function[: -len(ref)].strip()
 
+        # Convert `anonymous namespace' to (anonymous namespace)
+
         # Drop the prefix and return type if there is any if it's not operator
         # overloading--operator overloading syntax doesn't have the things
         # we're dropping here and can look curious, so don't try
         if "::operator" not in function:
             function = drop_prefix_and_return_type(function)
+
+        # Normalize `anonymous namespace' to (anonymous namespace). bug #1672847
+        function = function.replace("`anonymous namespace'", "(anonymous namespace)")
 
         # Collapse types
         function = collapse(

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -172,6 +172,9 @@ class TestCSignatureTool:
                 "23",  # noqa
                 "mozilla::jni::GlobalRef<T>::operator=",
             ),
+            # Normalize anonymous namespace
+            ("`anonymous namespace'::foo", "23", "(anonymous namespace)::foo"),
+            ("(anonymous namespace)::foo", "23", "(anonymous namespace)::foo"),
         ],
     )
     def test_normalize_cpp_function(self, function, line, expected):


### PR DESCRIPTION
This normalizes `anonymous namespace' (Windows) and (anonymous
namespace) (Mac/Linux) to (anonymous namespace).