### PR TITLE
bug 1681388: specify minidump sharing policy near links

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -843,12 +843,18 @@
             {% if request.user.has_perm('crashstats.view_rawdump') %}
               <p>
                 {{ protected_warning(your_crash) }}
+                {% if not your_crash %}
+                  Please don't share minidumps with third-parties.
+                  See <a href="{{ url('documentation:protected_data_access') }}">Protected data policy</a> for details.
+                {% endif %}
               </p>
-              {% for url in raw_dump_urls %}
-                <p><a href="{{ url }}">{{ url }}</a></p>
-              {% endfor %}
-              {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
-              <p><a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a></p>
+              <ul>
+                {% for name, url in raw_dump_urls %}
+                  <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
+                {% endfor %}
+                {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
+                <li>processed crash: <a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a>
+              </ul>
             {% elif request.user and request.user.is_active %}
               <p>
                 You do not have access to protected data.

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -148,8 +148,11 @@ def report_index(request, crash_id, default_context=None):
 
     if request.user.has_perm("crashstats.view_rawdump"):
         context["raw_dump_urls"] = [
-            reverse("crashstats:raw_data", args=(crash_id, "dmp")),
-            reverse("crashstats:raw_data", args=(crash_id, "json")),
+            ("dump", reverse("crashstats:raw_data", args=(crash_id, "dmp"))),
+            (
+                "minidump-stackwalk output",
+                reverse("crashstats:raw_data", args=(crash_id, "json")),
+            ),
         ]
         if context["raw"].get("additional_minidumps"):
             suffixes = [
@@ -160,7 +163,12 @@ def report_index(request, crash_id, default_context=None):
             for suffix in suffixes:
                 name = "upload_file_minidump_%s" % (suffix,)
                 context["raw_dump_urls"].append(
-                    reverse("crashstats:raw_data_named", args=(crash_id, name, "dmp"))
+                    (
+                        name,
+                        reverse(
+                            "crashstats:raw_data_named", args=(crash_id, name, "dmp")
+                        ),
+                    )
                 )
         if (
             context["raw"].get("ContainsMemoryReport")
@@ -168,9 +176,12 @@ def report_index(request, crash_id, default_context=None):
             and not context["report"].get("memory_report_error")
         ):
             context["raw_dump_urls"].append(
-                reverse(
-                    "crashstats:raw_data_named",
-                    args=(crash_id, "memory_report", "json.gz"),
+                (
+                    "memory_report",
+                    reverse(
+                        "crashstats:raw_data_named",
+                        args=(crash_id, "memory_report", "json.gz"),
+                    ),
                 )
             )
 


### PR DESCRIPTION
This fixes the raw info and minidump links so it's clearer what they
link to--it always confuses me and I work on the site.

This also modifies the note that minidumps are protected data by
additionally stating they should not be shared with third-parties.