### PR TITLE
bug 1681347: fix Linux assertion crash signatures

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -29,6 +29,7 @@ exp2
 .*FNODOBFM
 framework\.odex@0x
 __fixunsdfsi
+__GI___assert_fail
 gdk_x_error
 _gdk_x11_display_error_event
 GetLCIDFromLangListNodeWithLICCheck

--- a/socorro/signature/siglists/signature_sentinels.txt
+++ b/socorro/signature/siglists/signature_sentinels.txt
@@ -18,3 +18,6 @@ core::panicking::panic_fmt
 std::panicking::begin_panic
 std::panicking::begin_panic<T>
 std::panicking::begin_panic_fmt
+
+# These mark the top-most interesting frame of a Linux assertion.
+__GI___assert_fail


### PR DESCRIPTION
For Linux assertions, the interesting stuff comes fater
`__GI___assert_fail`, so this adds that as a sentinel and then adds it to
the irrelevant list so it doesn't also show up in the signatures.

```
socorro-cmd signature bp-eda13b8d-e4ad-48a5-ad3a-d2bf80201208 bp-c8110dcc-0c70-44be-b387-0bdd20201208 bp-4aa0a5e6-21ee-4d24-951c-855240201208 bp-3e212630-f206-460d-a570-1da3b0201208
Crash id: eda13b8d-e4ad-48a5-ad3a-d2bf80201208
Original: __GI_raise
New:      libwayland-client.so.0@0x639c
Same?:    False
Crash id: c8110dcc-0c70-44be-b387-0bdd20201208
Original: __GI_raise
New:      libwayland-client.so.0@0x639c
Same?:    False
Crash id: 4aa0a5e6-21ee-4d24-951c-855240201208
Original: raise | abort | __assert_fail_base.cold | __GI___assert_fail
New:      poll_for_event
Same?:    False
Crash id: 3e212630-f206-460d-a570-1da3b0201208
Original: raise | abort | __assert_fail_base.cold | __GI___assert_fail
New:      wl_proxy_unref | destroy_queued_closure
Same?:    False
```