### PR TITLE
bug 1674791: update to Python 3.9.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM mozilla/socorro-minidump-stackwalk:2020.09.17@sha256:9dfb090455c06c59f0ea574c0b41c9d6973be706c63ed31b099c0989a850235b as breakpad
 
-FROM python:3.8.6-slim@sha256:3a751ba465936180c83904df83436e835b9a919a6331062ae764deefbd3f3b47
+FROM python:3.9.1-slim@sha256:56d9bdc243bc53d4bb055305b58cc0be15b05cc09dcda9b9d5e224233889b61b
 
 # Set up user and group
 ARG groupid=10001

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim@sha256:3a751ba465936180c83904df83436e835b9a919a6331062ae764deefbd3f3b47
+FROM python:3.9.1-slim@sha256:56d9bdc243bc53d4bb055305b58cc0be15b05cc09dcda9b9d5e224233889b61b
 
 ARG groupid=10001
 ARG userid=10001

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,6 @@ mozilla-django-oidc==1.2.4
 oauth2client==4.1.3
 pip-tools==5.4.0
 psycopg2==2.8.6
-pyhs2==0.6.0
 pyinotify==0.9.6
 pyquery==1.4.1
 pytest-django==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -400,9 +400,6 @@ pygments==2.6.1 \
     --hash=sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44 \
     --hash=sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324 \
     # via -r requirements.in
-pyhs2==0.6.0 \
-    --hash=sha256:16aef41cc4e3d9a4a3e3a597481451aa8b26ba3e68bda2c820b1fef708206e21 \
-    # via -r requirements.in
 pyinotify==0.9.6 \
     --hash=sha256:9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4 \
     # via -r requirements.in
@@ -521,9 +518,6 @@ s3transfer==0.3.3 \
     --hash=sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13 \
     --hash=sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db \
     # via awscli, boto3
-sasl==0.2.1 \
-    --hash=sha256:04f22e17bbebe0cd42471757a48c2c07126773c38741b1dad8d9fe724c16289d \
-    # via pyhs2
 semver==2.13.0 \
     --hash=sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4 \
     --hash=sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f \
@@ -535,7 +529,7 @@ sentry-sdk==0.17.2 \
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via configman, configobj, cryptography, elasticsearch-dsl, isodate, josepy, jsonschema, mozilla-django-oidc, oauth2client, pip-tools, pyopenssl, python-dateutil, python-memcached, requests-mock, sasl, thrift
+    # via configman, configobj, cryptography, elasticsearch-dsl, isodate, josepy, jsonschema, mozilla-django-oidc, oauth2client, pip-tools, pyopenssl, python-dateutil, python-memcached, requests-mock
 sqlparse==0.4.1 \
     --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
     --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8 \
@@ -544,9 +538,6 @@ statsd==3.3.0 \
     --hash=sha256:c610fb80347fca0ef62666d241bce64184bd7cc1efe582f9690e045c25535eaa \
     --hash=sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f \
     # via -r requirements.in
-thrift==0.13.0 \
-    --hash=sha256:9af1c86bf73433afc6010ed376a6c6aca2b54099cc0d61895f640870a9ae7d89 \
-    # via pyhs2
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f \


### PR DESCRIPTION
In the previous attempt to upgrade from Python 3.8 to 3.9, I hit
problems with building lxml and sasl. Since then, the lxml problem went
away.

sasl is a dependency of pyhs2. That library is both unused (we don't use
Hive) and unmaintained (since 2016). I removed that which removed the
sasl and thrift dependencies.

That unblocked upgrading to Python 3.9.