### PR TITLE
bug 1671276: process breadcrumbs and show on details page

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -34,6 +34,7 @@ from socorro.processor.rules.memory_report_extraction import MemoryReportExtract
 from socorro.processor.rules.mozilla import (
     AddonsRule,
     BetaVersionRule,
+    BreadcrumbsRule,
     ConvertModuleSignatureInfoRule,
     DatesAndTimesRule,
     EnvironmentRule,
@@ -204,6 +205,7 @@ class ProcessorPipeline(RequiredConfig):
             DatesAndTimesRule(),
             OutOfMemoryBinaryRule(),
             PHCRule(),
+            BreadcrumbsRule(),
             JavaProcessRule(),
             MozCrashReasonRule(),
             # post processing of the processed crash

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -679,6 +679,47 @@
               </tbody>
             </table>
 
+            {% if (request.user.has_perm('crashstats.view_pii') or your_crash) and report.breadcrumbs %}
+              <div id="breadcrumbs">
+                <h2>Breadcrumbs</h2>
+                <p>
+                  {{ protected_warning(your_crash) }} -
+                  {% if report.breadcrumbs|length > 10 %}
+                    Latest 10 breadcrumbs (out of {{ report.breadcrumbs|length }})
+                  {% else %}
+                    All {{ report.breadcrumbs|length }} breadcrumbs
+                  {% endif %}
+                </p>
+                <table class="data-table breadcrumbs-table">
+                  <thead>
+                    <tr>
+                      <th class="small-col" scope="col">Level</th>
+                      <th class="small-col" scope="col">Type</th>
+                      <th class="small-col" scope="col">Category</th>
+                      <th scope="col">Data</th>
+                      <th class="small-col" scope="col">Timestamp</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for item in report.breadcrumbs[-10:] %}
+                      <tr>
+                        <td>{{ item.level }}</td>
+                        <td>{{ item.type }}</td>
+                        <td>{{ item.category }}</td>
+                        <td>
+                          {% if item.message %}<b>message:</b> {{ item.message }}<br>{% endif %}
+                          {% for key, val in item.data.items()|sort %}
+                            <b>{{ key }}:</b> {{ val }}<br>
+                          {% endfor %}
+                        </td>
+                        <td>{{ item.timestamp }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            {% endif %}
+
             {% if parsed_dump.threads %}
               <div id="frames">
                 {% if crashing_thread is not none %}

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
@@ -63,54 +63,6 @@ table {
         }
     }
 
-    &.captioned-data-table {
-        margin: 1rem;
-        width: 98%;
-        caption {
-            position: relative;
-            background-color: @tan;
-            padding: 1em 1rem .5rem;
-            .rounded-corners(6px, 6px);
-            h3 {
-                display: block;
-                margin: 0 0 .3em;
-                font-weight: bold;
-                font-style: normal;
-                font-size: 1.4rem;
-            }
-            a {
-                &:link,
-                &:visited {
-                    color: @dark-grey;
-                }
-                &:focus {
-                    text-decoration: none;
-                }
-            }
-        }
-        th {
-            background-color: @grey;
-            color: @white;
-        }
-        th,
-        td {
-            padding: .5em;
-        }
-
-        &.initially-hidden {
-            caption {
-                background-image: none;
-                .rounded-corners(6px);
-            }
-            thead {
-                .accessibly-hidden();
-            }
-            tbody {
-                .accessibly-hidden();
-            }
-        }
-    }
-
     &.vertical {
         th {
             border: 1px solid @black;

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
@@ -10,6 +10,19 @@
     white-space: nowrap;
 }
 
+#breadcrumbs {
+    thead {
+        tr {
+            th.small-col {
+                width: 1%;
+            }
+        }
+    }
+    th, td {
+        vertical-align: top;
+    }
+}
+
 .humanized {
     padding-left: 3px;
     color: rgb(111, 111, 111);
@@ -30,7 +43,6 @@
     .rounded-corners(6px);
 }
 
-
 #report-index {
     clear: right;
 
@@ -39,6 +51,7 @@
         margin: 10px 0;
     }
 }
+
 #allthreads.hidden {
     display: none;
 }
@@ -53,6 +66,7 @@
     width: 39em;
     z-index: 1;
 }
+
 .record {
     line-height: 1.5em;
     th {
@@ -62,6 +76,7 @@
         white-space: pre-wrap;
     }
 }
+
 .sig-overview,
 .sig-search {
     background: transparent url("@{image-path}/icons/external.png") left top no-repeat;


### PR DESCRIPTION
The crash reporter in android-components which Fenix uses captures
breadcrumbs and puts it in the Breadcrumbs annotation.

This adds a processor rule to validate it and add it to the processed
crash and then display it in the Details of the report view.

This marks it as protected data, so if you don't have access to that,
you can't see it.

This doesn't make it searchable. I decided not to deal with that until I
know more about how people want to search it (or even if people do want
to search it).