### PR TITLE
bug 1643339: re-fix cutoff policy code

### DIFF
--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1452,9 +1452,7 @@ class TestIntegrationSuperSearch(ElasticsearchTestCase):
         res = api.get(**params)
         assert res["total"] == 0
         assert len(res["hits"]) == 0
-        # NOTE(willkg): There are at least two missing indexes--we don't really care
-        # about how many there are as long as it detected there are missing indexes
-        assert len(res["errors"]) >= 2
+        assert len(res["errors"]) == 3  # 3 weeks are missing
 
     def test_get_too_large_date_range(self):
         # this is a whole year apart


### PR DESCRIPTION
When someone does a supersearch and specifies a date range, we don't
want to try to search indices that are outside the retention policy. In
September, I wrote some code that I thought correctly removed indices
that weren't valid, but I didn't think about how our index templates
include a week number, but not a year.

This fixes that code so it's not longer doing bad comparisons with index
names and instead figures out the set of valid indices and intersects
that with the set getting searched.

This is the correct fix for the test failure I saw last week.