### PR TITLE
Fix flakey ES test with more state-checking

### DIFF
--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -95,11 +95,13 @@ class TestIntegrationSuperSearchFields(ElasticsearchTestCase):
         # Refresh and then delete existing indices so we can rebuild the mappings
         # in order to diff them
         self.es_context.refresh()
+        self.es_context.health_check()
         for index_name in self.es_context.get_indices():
             self.es_context.delete_index(index_name)
 
         # Refresh ES to wait for indices to delete
         self.es_context.refresh()
+        self.es_context.health_check()
 
         now = datetimeutil.utc_now()
         template = api.context.get_index_template()
@@ -116,6 +118,7 @@ class TestIntegrationSuperSearchFields(ElasticsearchTestCase):
 
         # Refresh ES to wait for indices to be created
         self.es_context.refresh()
+        self.es_context.health_check()
 
         api = SuperSearchFieldsModel(config=config)
         missing_fields = api.get_missing_fields()


### PR DESCRIPTION
This one test is failing sometimes. I'm pretty sure it's a
race-condition between the state of ES indices and what the test is
doing to setup the indices it needs for the test.

This adds some `health_check` calls which should enforce the cluster is
good for the test to continue.