### PR TITLE
bug 1682931: reduce JavaStackTrace confusion

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2258,8 +2258,8 @@ FIELDS = {
     "java_stack_trace": {
         "data_validation_type": "str",
         "description": (
-            "When Java code crashes due to an unhandled exception, this is the Java Stack Trace. "
-            "It is usually more useful than the system stack trace given for the crashing thread."
+            "The unstructured JavaStackTrace crash annotation without the exception "
+            "value which is protected data."
         ),
         "form_field_choices": [],
         "has_full_version": True,
@@ -2278,7 +2278,10 @@ FIELDS = {
     },
     "java_stack_trace_raw": {
         "data_validation_type": "str",
-        "description": "Raw JavaStackTrace value.",
+        "description": (
+            "The raw unstructured JavaStackTrace crash annotation value. This is "
+            "protected data."
+        ),
         "form_field_choices": [],
         "has_full_version": True,
         "in_database_name": "java_stack_trace_raw",

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -77,7 +77,7 @@
               <a href="#details" class="ui-tabs-anchor"><span>Details</span></a>
             </li>
             <li class="ui-state-default ui-corner-top">
-              <a href="#metadata" class="ui-tabs-anchor"><span>Metadata</span></a>
+              <a href="#annotations" class="ui-tabs-anchor"><span>Crash Annotations</span></a>
             </li>
             <li class="ui-state-default ui-corner-top">
               <a href="#bugzilla" class="ui-tabs-anchor"><span>Bugzilla</span></a>
@@ -108,7 +108,7 @@
             <table class="record data-table vertical hardwrapped">
               <tbody>
 
-                {# Crash report metadata #}
+                {# Crash Annotations #}
 
                 <tr title="{{ fields_desc['processed_crash.signature'] }}">
                   <th scope="row">Signature</th>
@@ -301,6 +301,7 @@
                       {{ report.process_type }}
                       {% if request.user.has_perm('crashstats.view_pii') or your_crash %}
                         ({{ raw.RemoteType and raw.RemoteType or 'web' }})
+                        - {{ protected_warning(your_crash) }}
                       {% endif %}
                       {% if report.PluginName %}
                         <b class="name">{{ report.PluginName }}</b>
@@ -365,6 +366,9 @@
                       <th scope="row">Java Stack Trace (Raw)</th>
                       <td>
                         <pre>{{ report.java_stack_trace_raw }}</pre>
+                        <div>
+                          {{ protected_warning(your_crash) }}
+                        </div>
                       </td>
                     </tr>
                   {% endif %}
@@ -396,24 +400,27 @@
                     <th scope="row">URL</th>
                     <td>
                       {% if raw.URL %}
-                        <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - {{ protected_warning(your_crash) }}
+                        <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a>
                       {% endif %}
+                      - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.email'] }}">
                     <th scope="row">Email Address</th>
                     <td>
                       {% if raw.Email %}
-                        <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - {{ protected_warning(your_crash) }}
+                        <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a>
                       {% endif %}
+                      - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.user_comments'] }}">
                     <th scope="row">User Comments</th>
                     <td>
                       {% if report.user_comments %}
-                        {{ report.user_comments | linebreaks }} - {{ protected_warning(your_crash) }}
+                        {{ report.user_comments | linebreaks }}
                       {% endif %}
+                      - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                 {% endif %}
@@ -474,30 +481,35 @@
                     <th scope="row">PHC Kind</th>
                     <td>
                       {{ report.phc_kind }}
+                        - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.phc_usable_size'] }}">
                     <th scope="row">PHC Usable Size</th>
                     <td>
                       {{ report.phc_usable_size }}
+                        - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.phc_base_address'] }}">
                     <th scope="row">PHC Base Address</th>
                     <td>
                       {{ report.phc_base_address }}
+                        - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.phc_alloc_stack'] }}">
                     <th scope="row">PHC Alloc Stack</th>
                     <td>
                       {{ report.phc_alloc_stack }}
+                        - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
                   <tr title="{{ fields_desc['processed_crash.phc_free_stack'] }}">
                     <th scope="row">PHC Free Stack</th>
                     <td>
                       {{ report.phc_free_stack }}
+                        - {{ protected_warning(your_crash) }}
                     </td>
                   </tr>
 		            {% endif %}
@@ -806,10 +818,21 @@
           </div>
           <!-- /details -->
 
-          <div id="metadata" class="ui-tabs-hide">
+          <div id="annotations" class="ui-tabs-hide">
+            <div>
+              These are the crash annotations from the submitted crash report. You
+              can see the annotations and descriptions at <a href="https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml">https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml</a>.
+            </div>
+            <div>
+              <h2>Public data</h2>
+            </div>
+            <div>
+              These are the crash annotations from the submitted crash report
+              that do not contain protected data.
+            </div>
             <table class="record data-table vertical hardwrapped">
               <tbody>
-                {% for key in raw_keys %}
+                {% for key in public_raw_keys %}
                   <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
                     <th scope="row">
                       {% if key %}
@@ -823,8 +846,42 @@
                 {% endfor %}
               </tbody>
             </table>
+            <div>
+              <h2>Protected data</h2>
+            </div>
+            <div>
+              These are the crash annotations from the submitted crash report
+              that contain protected data.
+            </div>
+            {% if request.user.has_perm('crashstats.view_pii') %}
+              <div>
+                {{ protected_warning(your_crash) }}
+              </div>
+              <table class="record data-table vertical hardwrapped">
+                <tbody>
+                  {% for key in protected_raw_keys %}
+                    <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
+                      <th scope="row">
+                        {% if key %}
+                          {{ key }}
+                        {% else %}
+                          <i>empty key</i>
+                        {% endif %}
+                      </th>
+                      <td><pre>{{ raw[key] }}</pre></td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            {% else %}
+              <div>
+                You do not have access to protected data for this crash report.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a> for more
+                information.
+              </div>
+            {% endif %}
           </div>
-          <!-- /#rawdetails -->
+          <!-- /#annotations -->
 
           <div id="bugzilla" class="ui-tabs-hide">
             <div class="bugreporter">

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -135,16 +135,20 @@ def report_index(request, crash_id, default_context=None):
         .order_by("-bug_id")
     )
 
-    context["raw_keys"] = []
+    context["public_raw_keys"] = [
+        x for x in context["raw"] if x in models.RawCrash.API_ALLOWLIST()
+    ]
     if request.user.has_perm("crashstats.view_pii"):
         # hold nothing back
-        context["raw_keys"] = context["raw"].keys()
-    else:
-        context["raw_keys"] = [
-            x for x in context["raw"] if x in models.RawCrash.API_ALLOWLIST()
+        context["protected_raw_keys"] = [
+            x for x in context["raw"] if x not in models.RawCrash.API_ALLOWLIST()
         ]
+    else:
+        context["protected_raw_keys"] = []
+
     # Sort keys case-insensitively
-    context["raw_keys"] = sorted(context["raw_keys"], key=lambda s: s.lower())
+    context["public_raw_keys"].sort(key=lambda s: s.lower())
+    context["protected_raw_keys"].sort(key=lambda s: s.lower())
 
     if request.user.has_perm("crashstats.view_rawdump"):
         context["raw_dump_urls"] = [


### PR DESCRIPTION
If you don't have protected data access, then on the Details tab, you
see the "JavaStackTrace (redacted)" key with the java_stack_trace value.
It doesn't show up at all on the Metadata tab.

If you do have protected data access, then on the Details tab, you see
JavaStackTrace (Raw) key with the java_stack_trace_raw value and on the
Metadata tab, you see JavaStackTrace with the java_stack_trace_raw
value.

If you have protected data access, this is confusing because you're
seeing both the raw value in the Details tab and the sanitized value in
the Metadata tab and they have the same value which makes it seem like
Crash Stats is not sanitizing the value correctly.

This fixes that by changing the "Metadata" tab to "Crash annotations",
splitting that data into "public" and "protected" sections, and adding
the "protected data" label to the protected data section.

Further, on the Details tab, I added the "protected data" label to
all the items that are protected data including the "Java Stack Trace
(raw)" field if it's showing.

I also improved the description for "Java Stack Trace (raw)" so it
notes that it's protected data.

I think this clarifies what value you're seeing and what you can do with
it. Further, I think this makes the "Metadata" tab a lot clearer along
with a link to the CrashAnnotations.yaml document that describes the
fields there.