### PR TITLE
bug 1687907: add mozilla::detail::MutexImpl::mutexLock to sentinels

### DIFF
--- a/socorro/signature/siglists/signature_sentinels.txt
+++ b/socorro/signature/siglists/signature_sentinels.txt
@@ -19,5 +19,10 @@ std::panicking::begin_panic
 std::panicking::begin_panic<T>
 std::panicking::begin_panic_fmt
 
+# These mark the top-most interesting frame in a lock situation. Anything
+# before this is platform-specific stuff which prevents signatures from
+# grouping.
+mozilla::detail::MutexImpl::mutexLock
+
 # These mark the top-most interesting frame of a Linux assertion.
 __GI___assert_fail


### PR DESCRIPTION
Symbols prior to this symbol are machinery around locking, some of which
is platform-specific. To let signatures across platforms group better,
we're making this a sentinel thus dropping most of the platform-specific
bits.