### PR TITLE
bug #1688249: remove lambda number from signature

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -109,6 +109,7 @@ class CSignatureTool(SignatureTool):
         self.fixup_space = re.compile(r" (?=[\*&,])")
         self.fixup_comma = re.compile(r",(?! )")
         self.fixup_hash = re.compile(r"::h[0-9a-fA-F]+$")
+        self.fixup_lambda_numbers = re.compile(r"::\$_\d+::")
 
     def normalize_rust_function(self, function, line):
         """Normalizes a single Rust frame with a function."""
@@ -161,6 +162,9 @@ class CSignatureTool(SignatureTool):
 
         # Normalize `anonymous namespace' to (anonymous namespace). bug #1672847
         function = function.replace("`anonymous namespace'", "(anonymous namespace)")
+
+        # Remove lambda number from frames. bug #1688249
+        function = self.fixup_lambda_numbers.sub("::$::", function)
 
         # Collapse types
         #

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -175,6 +175,12 @@ class TestCSignatureTool:
             # Normalize anonymous namespace
             ("`anonymous namespace'::foo", "23", "(anonymous namespace)::foo"),
             ("(anonymous namespace)::foo", "23", "(anonymous namespace)::foo"),
+            # Normalize lambda numbers
+            (
+                "ShutdownWorkThreads::$_52::__invoke",
+                "23",
+                "ShutdownWorkThreads::$::__invoke",
+            ),
         ],
     )
     def test_normalize_cpp_function(self, function, line, expected):


### PR DESCRIPTION
This changes things like `$_52` to `$` in signatures so that they group
better.

```
app@socorro:/app$ socorro-cmd signature ffa98c79-33e2-4983-9f13-2f96e0210126
Crash id: ffa98c79-33e2-4983-9f13-2f96e0210126
Original: mozilla::dom::indexedDB::(anonymous namespace)::QuotaClient::ShutdownWorkThreads::$_52::__invoke
New:      mozilla::dom::indexedDB::(anonymous namespace)::QuotaClient::ShutdownWorkThreads::$::__invoke
Same?:    False
```