### PR TITLE
Bug 1690034: add _rust_alloc_error_handler to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -94,6 +94,7 @@ panic_abort::
 PR_WaitCondVar
 RaiseException
 RealMsgWaitFor
+_rust_alloc_error_handler
 __rust_alloc_error_handler
 rust_oom
 rtc::FatalMessage


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-e17483cd-347e-46fb-ab61-fdc320210131
Crash id: e17483cd-347e-46fb-ab61-fdc320210131
Original: OOM | large | mozalloc_abort | alloc::alloc::__alloc_error_handler::__rg_oom
New:      OOM | large | mozalloc_abort | std::fs::read::inner
Same?:    False
```