### PR TITLE
bug 1416014: redo favicon.ico and contribute.json

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -239,11 +239,15 @@ class TestContributeJson:
     def test_view(self, client):
         response = client.get("/contribute.json")
         assert response.status_code == 200
-        # Should be valid JSON, but it's a streaming content because
-        # it comes from django.views.static.serve
-        data = "".join([smart_text(part) for part in response.streaming_content])
-        assert json.loads(data)
+        assert json.loads(response.content)
         assert response["Content-Type"] == "application/json"
+
+
+class TestFaviconIco:
+    def test_view(self, client):
+        response = client.get("/favicon.ico")
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/vnd.microsoft.icon"
 
 
 class TestViews(BaseTestViews):

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -18,6 +18,8 @@ perm_legacy_redirect = settings.PERMANENT_LEGACY_REDIRECTS
 
 app_name = "crashstats"
 urlpatterns = [
+    url(r"^contribute\.json$", views.contribute_json, name="contribute_json"),
+    url(r"^favicon\.ico$", views.favicon_ico, name="favicon_ico"),
     url(r"^robots\.txt$", views.robots_txt, name="robots_txt"),
     url(
         r"^report/index/(?P<crash_id>[\w-]+)$", views.report_index, name="report_index"

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from functools import cache as memoized
 import json
+from pathlib import Path
 
 from django import http
 from django.conf import settings
@@ -47,6 +49,30 @@ def robots_txt(request):
         "User-agent: *\n" "%s: /" % ("Allow" if settings.ENGAGE_ROBOTS else "Disallow"),
         content_type="text/plain",
     )
+
+
+@memoized
+def _load_contribute_json():
+    index_path = Path(settings.SOCORRO_ROOT) / "contribute.json"
+    return json.loads(index_path.read_bytes())
+
+
+def contribute_json(request):
+    """Serve contribute.json file"""
+    data = _load_contribute_json()
+    return http.JsonResponse(data, json_dumps_params={"indent": 2})
+
+
+@memoized
+def _load_favicon():
+    index_path = Path(settings.ROOT) / "crashstats/crashstats/static/img/favicon.ico"
+    return index_path.read_bytes()
+
+
+def favicon_ico(request):
+    """Serve the favicon.ico file"""
+    data = _load_favicon()
+    return HttpResponse(data, content_type="image/vnd.microsoft.icon")
 
 
 def build_id_to_date(build_id):

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -2,13 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.generic.base import RedirectView
-from django.views.static import serve
 
 from crashstats.manage import admin_site
 from crashstats.crashstats.monkeypatches import patch
@@ -21,20 +18,6 @@ handler500 = "crashstats.crashstats.views.handler500"
 
 
 urlpatterns = [
-    url(
-        r"^(?P<path>contribute\.json)$",
-        serve,
-        {"document_root": os.path.join(settings.ROOT, "..")},
-    ),
-    url(
-        r"^(?P<path>favicon\.ico)$",
-        serve,
-        {
-            "document_root": os.path.join(
-                settings.ROOT, "crashstats", "crashstats", "static", "img"
-            )
-        },
-    ),
     url(r"", include("crashstats.crashstats.urls", namespace="crashstats")),
     url(r"", include("crashstats.exploitability.urls", namespace="exploitability")),
     url(r"", include("crashstats.monitoring.urls", namespace="monitoring")),


### PR DESCRIPTION
These files were served with staticfiles before. The Django docs say
that's not "hardened for production", so I reworked them to be memoized
views.