### PR TITLE
bug 1691393: drop defaults for http requests

### DIFF
--- a/socorro/lib/requestslib.py
+++ b/socorro/lib/requestslib.py
@@ -35,18 +35,27 @@ class HTTPAdapterWithTimeout(HTTPAdapter):
 
 def session_with_retries(
     total_retries=5,
-    backoff_factor=0.2,
+    backoff_factor=0.1,
     status_forcelist=(429, 500),
-    default_timeout=5.0,
+    default_timeout=3.0,
 ):
     """Returns session that retries on HTTP 429 and 500 with default timeout
 
     :arg int total_retries: total number of times to retry
 
-    :arg float backoff_factor: number of seconds to increment by between
-        attempts
+    :arg float backoff_factor: number of seconds to apply between attempts
 
-        For example, 0.1 will back off 0.1s, then 0.2s, then 0.3s, ...
+        The sleep amount is calculated like this::
+
+            sleep = backoff_factor * (2 ** (num_retries - 1))
+
+        For example, backoff_factor 0.1 will back off :
+
+        * 0.1
+        * 0.2
+        * 0.4
+        * 0.8
+        * 1.6 ...
 
     :arg tuple of HTTP codes status_forcelist: tuple of HTTP codes to
         retry on

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -41,7 +41,7 @@ class MaxAttemptsError(Exception):
 
 def wait_time_generator():
     """Return generator for wait times."""
-    yield from [2, 2, 2, 2, 2]
+    yield from [1] * 5
 
 
 def retry(

--- a/socorro/unittest/lib/test_util.py
+++ b/socorro/unittest/lib/test_util.py
@@ -98,7 +98,7 @@ class Test_retry:
 
         with pytest.raises(MaxAttemptsError):
             some_thing()
-        assert fake_sleep.sleeps == [2, 2, 2, 2, 2]
+        assert fake_sleep.sleeps == [1, 1, 1, 1, 1]
 
     def test_retryable_return(self):
         # Will keep retrying until max_attempts and then raise an error that includes
@@ -132,7 +132,7 @@ class Test_retry:
 
         some_thing = make_some_thing(fake_sleep)
         some_thing()
-        assert fake_sleep.sleeps == [2, 2]
+        assert fake_sleep.sleeps == [1, 1]
 
         # Will succeed and not retry because the return value is fine
         fake_sleep = make_fake_sleep()
@@ -154,7 +154,7 @@ class Test_retry:
         with pytest.raises(Exception):
             some_thing()
 
-        assert fake_sleep.sleeps == [2, 2, 2, 2, 2]
+        assert fake_sleep.sleeps == [1, 1, 1, 1, 1]
 
     def test_wait_time_generator(self):
         def waits():

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -948,9 +948,6 @@ class BugzillaBugInfo(SocorroCommon):
     # This is for how long we cache the metadata of each individual bug.
     BUG_CACHE_SECONDS = 60 * 60
 
-    # How patient we are with the Bugzilla REST API
-    BUGZILLA_REST_TIMEOUT = 5  # seconds
-
     @staticmethod
     def make_cache_key(bug_id):
         # This is the same cache key that we use in show_bug_link()
@@ -979,15 +976,13 @@ class BugzillaBugInfo(SocorroCommon):
                 "/bug?id=%(bugs)s&include_fields=%(fields)s" % params
             )
             session = session_with_retries(
-                # BZAPI isn't super reliable, so be extra patient
                 total_retries=5,
                 # 502 = Bad Gateway
+                # 503 = Service Unavailable
                 # 504 = Gateway Time-out
-                status_forcelist=(500, 502, 504),
+                status_forcelist=(500, 502, 503, 504),
             )
-            response = session.get(
-                url, headers=headers, timeout=self.BUGZILLA_REST_TIMEOUT
-            )
+            response = session.get(url, headers=headers)
             if response.status_code != 200:
                 raise BugzillaRestHTTPUnexpectedError(response.status_code)
 


### PR DESCRIPTION
This drops the `backoff_factor` to 0.1 and the default timeout to 3. This makes it less likely that trying to request a resource from a
non-responsive service (*cough*Bugzilla*cough*) doesn't end up exceeding Gunicorn's timeout value at which point Gunicorn kills the process.

I also dropped the waitlist generator from `[2, 2, 2, 2, 2]` to `[1, 1,1, 1, 1]` which might alleviate a similar issue in the crashstorage code where it's trying to push something to AWS S3 and has to retry a few times.