### PR TITLE
bug 1688203: improve crash report view summary in Matrix

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -9,6 +9,12 @@
 
 {% extends "crashstats_base.html" %}
 
+{% block summary_page_tags %}
+  <meta property="og:title" content="{{ report.uuid }} [@{{ report.signature }}]">
+  <meta property="og:url" content="{{ request.build_absolute_uri() }}">
+  <meta property="og:description" content="In {{ report.product }} {{ report.version }} ({{ report.release_channel }}) {{ report.build }}">
+{% endblock %}
+
 {% block site_css %}
   {{ super() }}
   {% stylesheet 'jquery_ui' %}

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats_base.html
@@ -5,6 +5,17 @@
     <meta charset="UTF-8" />
     <title>{% block page_title %}Crash Data for {{ product.name }}{% endblock %}</title>
 
+    {% block summary_tags %}
+      <meta property="og:type" content="website">
+      <meta property="og:site_name" content="Mozilla Crash Stats">
+
+      {% block summary_page_tags %}
+        <meta property="og:title" content="Mozilla Crash Stats">
+        <meta property="og:description" content="Mozilla Crash Stats site for viewing and searching crash reports.">
+        <meta name="description" content="Mozilla Crash Stats site for viewing and searching crash reports.">
+      {% endblock %}
+    {% endblock %}
+
     {% block site_css %}
       {% stylesheet 'crashstats_base' %}
       {% stylesheet 'fontawesome' %}


### PR DESCRIPTION
This is a first pass at adding summary information for the page so when
systems like Matrix/Slack show a summary of the url of a crash report
view page, it has something more helpful to show.