### PR TITLE
bug 1688880: fix fetch_crashids to work for all products

### DIFF
--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -147,7 +147,11 @@ def main(argv=None):
         dest="signature",
         help="signature contains this string",
     )
-    parser.add_argument("--product", default="Firefox", help="Product to fetch for")
+    parser.add_argument(
+        "--product",
+        default="Firefox",
+        help='Product to fetch for or "all" for all; defaults to "Firefox"',
+    )
     parser.add_argument("--url", default="", help="Super Search url to base query on")
     parser.add_argument(
         "--num",
@@ -173,6 +177,10 @@ def main(argv=None):
 
     params["_columns"] = "uuid"
     params["product"] = params.get("product", args.product)
+    if params["product"] == "all":
+        # If the user specified "all", then we don't want to pass a product filter
+        # in
+        del params["product"]
 
     # Override with date if specified
     if "date" not in params or args.date:


### PR DESCRIPTION
This fixes `fetch_crashids` so it's possible to specify getting crashids
for all products rather than a specific product. Previously, it
defaulted to Firefox, so there wasn't a way to specify "all products".

To test:

```
$ make shell
app@socorro:/app$ socorro-cmd fetch_crashids --num=5
# shows 5 crashids all for Firefox
app@socorro:/app$ socorro-cmd fetch_crashids --num=5 --product=all
# shows 5 crashids which may not all be Firefox
```