### PR TITLE
bug 1692504: add note to Profile and report view re: email

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -63,6 +63,15 @@
 
     <div class="panel">
       <div class="body">
+        {% if your_crash %}
+          <div class="note">
+            <p>
+              As of February 11th, 2021, we no longer store Email address data in
+              crash reports. Crash reports sent on or after that date will not
+              show up as your crash.
+            </p>
+          </div>
+        {% endif %}
 
         {# Header #}
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -22,6 +22,7 @@
 @import "components/statusicon.less";
 @import "components/sumo_link.less";
 @import "components/table_sorter.less";
+@import "components/note.less";
 @import "components/tip.less";
 @import "components/tree.less";
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/typography.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/typography.less
@@ -42,9 +42,6 @@ p {
 em {
     font-style: italic;
 }
-
 strong, b {
     font-weight: bold;
 }
-
-

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/note.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/note.less
@@ -1,0 +1,26 @@
+.note {
+    &.float-right {
+        float: right;
+        min-width: 300px;
+        width: 30%;
+    }
+
+    background-color: @off-white;
+    border: 1px solid @primary;
+    border-radius: 4px;
+    margin: 0 0 10px 10px;
+
+    p {
+        padding: 10px 10px;
+        margin: 0;
+    }
+
+    &::before {
+        content: url('../../img/3rdparty/silk/information.png') ' Note';
+        display: block;
+        background-color: @primary;
+        color: @white;
+        font-weight: bold;
+        padding: 4px 10px;
+    }
+}

--- a/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
@@ -353,7 +353,7 @@
 
     <h1 id="aggregations">Aggregations</h1>
 
-    <div class="side-note">
+    <div class="note float-right">
       <p>
         "Facets" and "aggregations" are the same thing. Those names come from
         Elasticsearch, which renamed the feature to "aggregations" in its

--- a/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
+++ b/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
@@ -122,30 +122,6 @@
         }
     }
 
-    .side-note {
-        background-color: @off-white;
-        border: 1px solid @primary;
-        border-radius: 4px;
-        float: right;
-        margin: 0 0 10px 10px;
-        min-width: 300px;
-        width: 30%;
-
-        p {
-            padding: 10px 10px;
-            margin: 0;
-        }
-
-        &::before {
-            content: url('../../img/3rdparty/silk/information.png') ' Note';
-            display: block;
-            background-color: @primary;
-            color: @white;
-            font-weight: bold;
-            padding: 4px 10px;
-        }
-    }
-
     .example {
         border: 1px solid @light-grey;
         border-radius: 4px;

--- a/webapp-django/crashstats/profile/jinja2/profile/profile.html
+++ b/webapp-django/crashstats/profile/jinja2/profile/profile.html
@@ -29,6 +29,13 @@
         <h2>Your Crash Reports</h2>
       </div>
       <div class="body">
+        <div class="note">
+          <p>
+            As of February 11th, 2021, we no longer store Email address data in
+            crash reports. Crash reports sent on or after that date will not
+            have Email data and will not show up on this page.
+          </p>
+        </div>
         {% if crashes_list %}
           <p>
             Here is a list of the crash reports we have received from you,


### PR DESCRIPTION
This adds a note that shows up in the Profile page and the report view if `your_crash` is true stating that we're no longer collecting Email data and the subsequent consequences.

In order to make the note standout, I repurposed the side-note from the documentation.