### PR TITLE
bug 1693265: fix select buttons in signature report

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
@@ -46,11 +46,9 @@
         padding: 1em;
         min-height: 4em;
 
-        ul {
-            li {
-                list-style: disc;
-                list-style-position: inside;
-            }
+        li {
+            list-style: disc;
+            list-style-position: inside;
         }
     }
     .table {


### PR DESCRIPTION
This reduces the specificity of the CSS rule matching li items and
adding the list-style. This fixes the column buttons in the signature
report Reports tab and also the tabs in the search results so they don't
show discs anymore.