### PR TITLE
bug 1693265: fix signature report summary headers

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
@@ -9,7 +9,7 @@
         .shadow-none();
     }
 
-    div.title {
+    header.title, div.title {
         background: @tan repeat-x left top;
         display: flex;
         font-size: 12px;


### PR DESCRIPTION
This fixes the aggregation headers in the signature report summary tab.
It used "header", so I had to fix the title class tweak I did a few
commits ago.