### PR TITLE
bug 1262424: don't create/save django session for API endpoints

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -106,6 +106,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "crashstats.tokens.middleware.APIAuthenticationMiddleware",
     "session_csrf.CsrfMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -122,7 +123,6 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
     "waffle.middleware.WaffleMiddleware",
     "ratelimit.middleware.RatelimitMiddleware",
-    "crashstats.tokens.middleware.APIAuthenticationMiddleware",
     "crashstats.crashstats.middleware.Pretty400Errors",
 ]
 

--- a/webapp-django/crashstats/tokens/middleware.py
+++ b/webapp-django/crashstats/tokens/middleware.py
@@ -69,3 +69,7 @@ class APIAuthenticationMiddleware:
         # by logging the user in.
         request.user = user
         auth.login(request, user)
+
+        # For an API request, we don't want mere logging in to trigger saving of a
+        # session.
+        request.session.modified = False


### PR DESCRIPTION
This stops creating/saving django sessions for API endpoint requests. This also nixes the anoncsrf cookie since we don't need that with the API.

To test:

1. run the webapp
2. log in and create an API token
3. use curl to hit the SuperSearch endpoint a few times:
   ```
   curl -v -H "Auth-Token: TOKEN" http://localhost:8000/api/SuperSearch/
   ```
4. verify that no cookies are set in the response
5. verify that ```select count(*) from django_session``` doesn't change