### PR TITLE
bug 1693265: fix signup page layout

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/signup.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/signup.html
@@ -5,37 +5,39 @@
 {% block content %}
   <div id="mainbody">
     <div class="page-heading">
-      <h2>Sign up</h2>
+      <h2>Signing up for an account on Crash Stats</h2>
     </div>
 
     <div class="panel">
       <div class="body">
-        <h3>Accounts on Crash Stats</h3>
-        <p>
-          Sign up if you require one of the following:
-        </p>
-        <ul>
-          <li>
-            <b>Protected data access.</b> See
-            <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
-            for details
-          </li>
-          <li>
-            <b>API tokens.</b>
-          </li>
-        </ul>
-        <p>
-          If you don't need one of those things, then signing up doesn't help you.
-        </p>
+        <div class="prose">
+          <div class="title"><h2>Accounts on Crash Stats<h2></div>
+          <p>
+            Sign up if you require one of the following:
+          </p>
+          <ul>
+            <li>
+              <b>Protected data access.</b> See
+              <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+              for details
+            </li>
+            <li>
+              <b>API tokens.</b>
+            </li>
+          </ul>
+          <p>
+            If you don't need one of those things, then signing up doesn't help you.
+          </p>
 
-        <h3>Creating an account</h3>
-        <p>
-          Crash Stats accounts are created the first time you log in. You can log in using
-          the "Log in" link in the upper right hand corner.
-        </p>
-        <p>
-          If you are a Mozilla Corporation employee, please log in using your LDAP account.
-        </p>
+          <div class="title"><h2>Creating an account</h2></div>
+          <p>
+            Crash Stats accounts are created the first time you log in. You can log in using
+            the "Log in" link in the upper right hand corner.
+          </p>
+          <p>
+            If you are a Mozilla Corporation employee, please log in using your LDAP account.
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
@@ -46,9 +46,10 @@
         padding: 1em;
         min-height: 4em;
 
-        li {
-            list-style: disc;
-            list-style-position: inside;
+        .prose {
+            li {
+                list-style: disc inside;
+            }
         }
     }
     .table {


### PR DESCRIPTION
This redoes the headers on the signup page so they match more of the
site. Further, this tweaks the li CSS so it doesn't affect the rest of
the site.

To test:

1. run the webapp
2. go to `http://localhost:8000/signup/` and verify it looks ok
3. log in and go to the API Tokens page, create a token with multiple permissions, and verify the permissions show correctly