### PR TITLE
bug 1694894: add glib assertion bits to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -31,6 +31,10 @@ exp2
 framework\.odex@0x
 __fixunsdfsi
 __GI___assert_fail
+g_assertion_message
+g_assertion_message.cold
+g_assertion_message_error
+g_assertion_message_expr
 gdk_x_error
 _gdk_x11_display_error_event
 GetLCIDFromLangListNodeWithLICCheck


### PR DESCRIPTION
```
$ socorro-cmd signature 773fb3cf-cd3b-4721-928e-371490210224 9ffa8dfa-efd0-40ae-a5a4-d82a10210224 af565290-30b1-4543-a67c-857d50210223 20610573-2fff-4dfb-97bc-253330210222
Crash id: 773fb3cf-cd3b-4721-928e-371490210224
Original: mozalloc_abort | abort | g_assertion_message
New:      mozalloc_abort | abort | set_button_image_get_info_cb
Same?:    False
Crash id: 9ffa8dfa-efd0-40ae-a5a4-d82a10210224
Original: mozalloc_abort | abort | g_assertion_message
New:      mozalloc_abort | abort | ensure_surface_for_gicon
Same?:    False
Crash id: af565290-30b1-4543-a67c-857d50210223
Original: mozalloc_abort | abort | g_assertion_message.cold
New:      mozalloc_abort | abort | ensure_surface_for_gicon
Same?:    False
Crash id: 20610573-2fff-4dfb-97bc-253330210222
Original: mozalloc_abort | abort | g_assertion_message.cold
New:      mozalloc_abort | abort | set_button_image_get_info_cb
Same?:    False
```