### PR TITLE
bug 1693579: fix os_pretty_version for macOS >= 11

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -937,7 +937,12 @@ class OSPrettyVersionRule(Rule):
             return
 
         elif os_name == "Mac OS X":
-            if major_version >= 10 and minor_version >= 0:
+            # https://en.wikipedia.org/wiki/MacOS#Release_history
+            if major_version >= 11:
+                # NOTE(willkg): this assumes Apple versions macOS with just the major
+                # version going forward.
+                pretty_name = "macOS %s" % major_version
+            elif major_version >= 10 and minor_version >= 0:
                 pretty_name = "OS X %s.%s" % (major_version, minor_version)
             else:
                 pretty_name = "OS X Unknown"

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1586,6 +1586,8 @@ class TestOsPrettyName:
             ("Mac OS X", "10.18.324", "OS X 10.18"),
             # An invalid version of Mac OS X
             ("Mac OS X", "9.1", "OS X Unknown"),
+            # Mac OS >= 11
+            ("Mac OS X", "11.2.1 20D74", "macOS 11"),
             # Generic Linux
             ("Linux", "0.0.12.13", "Linux"),
         ],


### PR DESCRIPTION
For macOS >= 11, the "pretty version" consists of just the major version
part of the os_ver from system_info from the minidump.

For example, this system_info value:

```
  "system_info": {
        "cpu_arch": "arm64",
        "cpu_count": 8,
        "cpu_info": "",
        "os": "Mac OS X",
        "os_ver": "11.2.1 20D74"
    },
```

now yields os_pretty_version value "macOS 11".