### PR TITLE
bug 1696910: fix data links and redo "raw data and minidumps tab"

### DIFF
--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -51,9 +51,13 @@ class SimplifiedCrashData(BotoS3CrashStorage):
             raise MissingArgumentError("datatype")
 
         datatype_method_mapping = {
+            # Minidumps
             "raw": "get_raw_dump",
+            # Raw Crash
             "meta": "get_raw_crash",
+            # Redacted processed crash
             "processed": "get_processed",
+            # Unredacted processed crash
             "unredacted": "get_unredacted_processed",
         }
         if params.datatype not in datatype_method_mapping:

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -307,9 +307,9 @@ def model_wrapper(request, model_name):
         return {"errors": dict(form.errors)}, 400
 
     if binary_response:
-        assert model.API_BINARY_FILENAME, "No API_BINARY_FILENAME set on model"
+        filename = model.get_binary_filename(form.cleaned_data)
+        assert filename is not None, "No API_BINARY_FILENAME set on model"
         response = http.HttpResponse(result, content_type="application/octet-stream")
-        filename = model.API_BINARY_FILENAME % form.cleaned_data
         response["Content-Disposition"] = 'attachment; filename="%s"' % filename
         return response
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1002,9 +1002,36 @@
           <!-- /modules -->
 
           <div id="rawdump" class="ui-tabs-hide">
-            <div class="code">{{ raw_stackwalker_output }}</div>
+            <h3>Download raw and processed crash data</h3>
+            {% if request.user.has_perm('crashstats.view_pii') %}
+              <p>
+                {{ protected_warning(your_crash) }}
+                {% if not your_crash %}
+                  Raw and processed crash reports contain protected data.
+                {% endif %}
+              </p>
+              <ul class="list-inside list-disc">
+                {% for name, url in raw_data_urls %}
+                  <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
+                {% endfor %}
+              </ul>
+            {% elif request.user and request.user.is_active %}
+              <p>
+                You do not have access to protected data.
+                You need to be logged in and have access to protected data to see links to crash report data.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+                for more information.
+              </p>
+            {% else %}
+              <p>
+                You are not logged in.
+                You need to be logged in and have access to protected data to see links to crash report data.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+                for more information.
+              </p>
+            {% endif %}
 
-            <h3>Download Raw Crash Data and Minidumps</h3>
+            <h3>Download dumps and memory report</h3>
             {% if request.user.has_perm('crashstats.view_rawdump') %}
               <p>
                 {{ protected_warning(your_crash) }}
@@ -1013,28 +1040,52 @@
                   See <a href="{{ url('documentation:protected_data_access') }}">Protected data policy</a> for details.
                 {% endif %}
               </p>
-              <ul>
-                {% for name, url in raw_dump_urls %}
-                  <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
-                {% endfor %}
-                {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
-                <li>processed crash: <a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a>
-              </ul>
+              {% if raw_dump_urls %}
+                <ul class="list-inside list-disc">
+                  {% for name, url in raw_dump_urls %}
+                    <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p>
+                  There are no dumps or memory report to download.
+                </p>
+              {% endif %}
             {% elif request.user and request.user.is_active %}
               <p>
                 You do not have access to protected data.
-                You need to be logged in and have access to protected data to see this.
+                You need to be logged in and have access to protected data to see links to crash report data.
                 See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
                 for more information.
               </p>
             {% else %}
               <p>
                 You are not logged in.
-                You need to be logged in and have access to protected data to see this.
+                You need to be logged in and have access to protected data to see links to crash report data.
                 See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
                 for more information.
               </p>
             {% endif %}
+
+            <h3>minidump-stackwalk output</h3>
+            <div>
+              {% if request.user.has_perm('crashstats.view_rawdump') %}
+                {{ protected_warning(your_crash) }}
+                {% if not your_crash %}
+                  minidump-stackwalk output contains sensitive and exploitability information.
+                {% endif %}
+              {% else %}
+                You do not have access to protected data so the minidump-stackwalk output is redacted.
+                See <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+                for more information.
+              {% endif %}
+            </div>
+            {% if raw_stackwalker_output %}
+              <div id="minidump-stackwalk-json" data-minidumpstackwalk="{{ raw_stackwalker_output }}"></div>
+            {% else %}
+              <p>No dump available.</p>
+            {% endif %}
+
           </div>
           <!-- /rawdump -->
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/signup.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/signup.html
@@ -10,34 +10,32 @@
 
     <div class="panel">
       <div class="body">
-        <div class="prose">
-          <div class="title"><h2>Accounts on Crash Stats<h2></div>
-          <p>
-            Sign up if you require one of the following:
-          </p>
-          <ul>
-            <li>
-              <b>Protected data access.</b> See
-              <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
-              for details
-            </li>
-            <li>
-              <b>API tokens.</b>
-            </li>
-          </ul>
-          <p>
-            If you don't need one of those things, then signing up doesn't help you.
-          </p>
+        <div class="title"><h2>Accounts on Crash Stats<h2></div>
+        <p>
+          Sign up if you require one of the following:
+        </p>
+        <ul class="list-inside list-disc">
+          <li>
+            <b>Protected data access.</b> See
+            <a href="{{ url('documentation:protected_data_access') }}">protected data access documentation</a>
+            for details
+          </li>
+          <li>
+            <b>API tokens.</b>
+          </li>
+        </ul>
+        <p>
+          If you don't need one of those things, then signing up doesn't help you.
+        </p>
 
-          <div class="title"><h2>Creating an account</h2></div>
-          <p>
-            Crash Stats accounts are created the first time you log in. You can log in using
-            the "Log in" link in the upper right hand corner.
-          </p>
-          <p>
-            If you are a Mozilla Corporation employee, please log in using your LDAP account.
-          </p>
-        </div>
+        <div class="title"><h2>Creating an account</h2></div>
+        <p>
+          Crash Stats accounts are created the first time you log in. You can log in using
+          the "Log in" link in the upper right hand corner.
+        </p>
+        <p>
+          If you are a Mozilla Corporation employee, please log in using your LDAP account.
+        </p>
       </div>
     </div>
   </div>

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -418,11 +418,13 @@ class SocorroMiddleware(SocorroCommon):
 
     # By default, no binary response
     API_BINARY_RESPONSE = {}
-    # and thus no needed binary filename
-    API_BINARY_FILENAME = None
 
     # By default no special permissions are needed for binary response
     API_BINARY_PERMISSIONS = ()
+
+    @classmethod
+    def get_binary_filename(cls, params):
+        return None
 
     def get(self, expect_json=True, **kwargs):
         return self._get(expect_json=expect_json, **kwargs)
@@ -783,9 +785,20 @@ class RawCrash(SocorroMiddleware):
     # If this is matched in the query string parameters, then
     # we will return the response in binary format in the API
     API_BINARY_RESPONSE = {"format": "raw"}
-    API_BINARY_FILENAME = "%(crash_id)s.dmp"
     # permissions needed to download it as a binary response
     API_BINARY_PERMISSIONS = ("crashstats.view_rawdump",)
+
+    @classmethod
+    def get_binary_filename(cls, params):
+        name = params["name"]
+        crash_id = params["crash_id"]
+
+        if name == "memory_report":
+            return "memory_report.json.gz"
+        elif name:
+            return f"{crash_id}-{name}.dmp"
+        else:
+            return f"{crash_id}.dmp"
 
     def get(self, **kwargs):
         format_ = kwargs.get("format", "meta")

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/reset.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/reset.less
@@ -64,7 +64,7 @@ var {
     font-style: normal;
     font-weight: normal;
 }
-li {
+ul, ol {
     list-style: none;
 }
 caption,

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/typography.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/typography.less
@@ -45,3 +45,12 @@ em {
 strong, b {
     font-weight: bold;
 }
+
+// tailwind-like classes
+.list-disc {
+    list-style-type: disc;
+}
+
+.list-inside {
+    list-style-position: inside;
+}

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/panel.less
@@ -45,12 +45,6 @@
         background: @white;
         padding: 1em;
         min-height: 4em;
-
-        .prose {
-            li {
-                list-style: disc inside;
-            }
-        }
     }
     .table {
         font-size: 10px;

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -25,6 +25,29 @@ $(document).ready(function () {
     };
   })();
 
+  /* Idempotent function to display the json dump with jQuery JSONView */
+  var displayMinidumpStackwalkJson = (function () {
+    var once = false;
+    return function inner() {
+      if (once) {
+        // idempotent function
+        return;
+      }
+      once = true;
+      var container = $('#minidump-stackwalk-json');
+      if (container.length) {
+        var jsonData = container.data('minidumpstackwalk');
+        try {
+          $('#minidump-stackwalk-json').JSONView(jsonData);
+        } catch (ex) {
+          console.warn('The data in the #minidump-stackwalk-json dataset is not valid JSON');
+          container.append($('<p>Error when parsing JSON. Showing raw value:</p>'));
+          container.append(document.createTextNode(jsonData));
+        }
+      }
+    };
+  })();
+
   // If the page is loaded with a location.hash like '#tab-...'
   // then find out which index that is so when we set up $.tabs()
   // we can set the right active one.
@@ -36,6 +59,8 @@ $(document).ready(function () {
     if (tab.length) {
       if (tabId === 'telemetryenvironment') {
         displayTelemetryEnvironment();
+      } else if (tabId === 'rawdump') {
+        displayMinidumpStackwalkJson();
       }
       $('.ui-tabs li a').each(function (i, tab) {
         if (tab.href.search('#' + tabId) > -1) {
@@ -50,6 +75,8 @@ $(document).ready(function () {
       var tabId = ui.newPanel.attr('id');
       if (tabId === 'telemetryenvironment') {
         displayTelemetryEnvironment();
+      } else if (tabId === 'rawdump') {
+        displayMinidumpStackwalkJson();
       }
       document.location.hash = 'tab-' + tabId;
     },

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -146,14 +146,19 @@ class BaseTestViews(ProductVersionsMixin, SuperSearchFieldsMock, DjangoTestCase)
         group = self._create_group_with_permission(codename)
         user.groups.add(group)
 
-    def _create_group_with_permission(self, codename, group_name="Group"):
+    def _create_group_with_permission(self, permissions, group_name="Group"):
+        if not isinstance(permissions, list):
+            permissions = [permissions]
+        permissions
         appname = "crashstats"
-        ct, __ = ContentType.objects.get_or_create(model="", app_label=appname)
-        permission, __ = Permission.objects.get_or_create(
-            codename=codename, name=PERMISSIONS[codename], content_type=ct
-        )
-        group, __ = Group.objects.get_or_create(name=group_name)
-        group.permissions.add(permission)
+        ct, _ = ContentType.objects.get_or_create(model="", app_label=appname)
+        group, _ = Group.objects.get_or_create(name=group_name)
+
+        for permission in permissions:
+            obj, _ = Permission.objects.get_or_create(
+                codename=permission, name=PERMISSIONS[permission], content_type=ct
+            )
+            group.permissions.add(obj)
         return group
 
     @staticmethod


### PR DESCRIPTION
This redoes the "Raw data and minidumps" tab so that the links are at
the top and a syntax-highlighted and more usable version of the
minidump-stackwalk output is below it.

This fixes the data links so they're generated in the view code using
API endpoints rather than an odd crashstats view. This fixes the
RawCrash model to have a class method for figuring out the binary
filename rather than a static template.

This redoes how we do list-style CSS by adding a couple of
tailwind-inspired classes and putting them in the typography base file.