### PR TITLE
bug 1692983: remove mozilla::detail::MutexImpl::unlock from sentinels

### DIFF
--- a/socorro/signature/siglists/signature_sentinels.txt
+++ b/socorro/signature/siglists/signature_sentinels.txt
@@ -26,7 +26,6 @@ mozilla::detail::MutexImpl::lock
 mozilla::detail::MutexImpl::mutexLock
 mozilla::detail::MutexImpl::mutexTryLock
 mozilla::detail::MutexImpl::tryLock
-mozilla::detail::MutexImpl::unlock
 
 # These mark the top-most interesting frame of a Linux assertion.
 __GI___assert_fail


### PR DESCRIPTION
This removes `mozilla::detail::MutexImpl::unlock` from the sentinels list. There's a problem with stack unwinding so having this in the sentinels list causes crash reports with different causes to unhelpfully end up with the same signature.

```
app@socorro:/app$ socorro-cmd signature ab8322f0-31ff-4723-8d9f-ca4f80210216 28027409-e582-4bee-ad01-c51bc0210216 9cbd629b-b449-4758-a77c-6c03e0210216
Crash id: ab8322f0-31ff-4723-8d9f-ca4f80210216
Original: mozilla::detail::MutexImpl::unlock | free | moz_arena_malloc
New:      js::GCMarker::processMarkStackTop
Same?:    False
Crash id: 28027409-e582-4bee-ad01-c51bc0210216
Original: mozilla::detail::MutexImpl::unlock | free | moz_arena_malloc
New:      js::GCMarker::eagerlyMarkChildren
Same?:    False
Crash id: 9cbd629b-b449-4758-a77c-6c03e0210216
Original: mozilla::detail::MutexImpl::unlock | free | moz_arena_malloc
New:      js::GCMarker::processMarkStackTop
Same?:    False
```