### PR TITLE
bug 1696363: add env_logger bits to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -26,6 +26,8 @@ dalvik-jit-code-cache
 dalvik-LinearAlloc
 dalvik-mark-stack
 data@app@org\.mozilla\.f.*-\d\.apk@classes\.dex@0x
+<env_logger::Logger as log::Log>::log::{{closure}}
+<env_logger::Logger as log::Log>::log
 exp2
 .*FNODOBFM
 framework\.odex@0x
@@ -61,6 +63,7 @@ libMali\.so@0x
 libutils\.so@0x
 libz\.so@0x
 linux-gate\.so@0x
+log::__private_api_log
 mach_msg
 _mach_msg
 mach_msg_trap


### PR DESCRIPTION
This adds three items to the irrelevant list so they get skipped over
during signature generation. We want the thing that kicked off logging
to show up in the signature rather than the logging and resulting panic.

```
app@socorro:/app$ socorro-cmd signature c4a046b7-6f12-4bce-bbea-18fec0210304
Crash id: c4a046b7-6f12-4bce-bbea-18fec0210304
Original: <env_logger::Logger as log::Log>::log::{{closure}}
New:      osclientcerts_static::manager::Manager::maybe_find_new_objects
Same?:    False
```