### PR TITLE
bug 1699122: make cache key in __heartbeat__ unique

### DIFF
--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -4,6 +4,7 @@
 
 import datetime
 import json
+import uuid
 
 import elasticsearch
 
@@ -81,9 +82,9 @@ def dockerflow_heartbeat(request):
     assert Permission.objects.all().count() > 0
 
     # We should also be able to set and get a cache value
-    cache_key = "__healthcheck__"
+    cache_key = "__healthcheck__" + str(uuid.uuid4())
     cache.set(cache_key, 1, 10)
-    assert cache.get(cache_key)
+    assert cache.get(cache_key), f"cache_key {cache_key} not available"
     cache.delete(cache_key)
 
     # Do a really basic Elasticsearch query


### PR DESCRIPTION
This changes the cache_key that we use to test cache set/get with such
that it's unique. I think this will prevent race conditions from two
webapp things doing the cache set/get test at the same time from bumping
into one another creating a spurious error.