### PR TITLE
bug 1700172: re-add FennecAndroid product support

### DIFF
--- a/docs/products.rst
+++ b/docs/products.rst
@@ -103,3 +103,20 @@ isn't calculating them right because of bad data or extenuating circumstances.
 
 For more details, see the `product details README
 <https://github.com/mozilla-services/socorro/tree/main/product_details>`_.
+
+
+How to remove support for a product
+===================================
+
+There are two ways to do this:
+
+1. Remove the ``product_details`` file AND delete all the crash report data
+   in AWS S3 and Elasticsearch for that product, OR
+2. Change the ``product_details`` file description to reflect that support has
+   ended, wait for the data to expire, and then delete the ``product_details``
+   file
+
+If you remove the ``product_details`` file without deleting the data, then
+people will get HTTP 500 errors when trying to visit crash reports that are
+still in the system for the unsupported product. Links will continue to be in
+signature reports and elsewhere.

--- a/product_details/FennecAndroid.json
+++ b/product_details/FennecAndroid.json
@@ -1,0 +1,29 @@
+{
+  "name": "FennecAndroid",
+  "description": "Firefox for Android browser (no longer supported as of 2021-03-18)",
+  "home_page_sort": 100,
+  "featured_versions": ["68.11.0"],
+  "in_buildhub": true,
+  "bug_links": [
+    [
+      "Firefox for Android",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Firefox+for+Android&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "External Software Affecting Firefox",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Toolkit",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "GeckoView",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ]
+  ]
+}


### PR DESCRIPTION
This adds the minimum support for FennecAndroid so that viewing Fennec
crash reports doesn't kick up an HTTP 500.

We can remove this file in 6 months when the Fennec data has expired.

This also adds a note to the product documentation about this.