### PR TITLE
bug 1700770: update minidump-stackwalk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/socorro-minidump-stackwalk:2021.01.11@sha256:e6c855fe56db4464a8362369b92bbf0df5148d3234b68ec8e24ea459a6556bdb as breakpad
+FROM mozilla/socorro-minidump-stackwalk:2021.03.24@sha256:c665e82bb5695630973bee87f0a1529d3cdaa56e22900255ade75bdc92b312d3 as breakpad
 
 FROM python:3.9.2-slim@sha256:70b693f32768b122a6a5247b0c5d4394da69f5dc3baace93a34860bff00d8ecd
 


### PR DESCRIPTION
This picks up the following two fixes:

`01a5aa3`: Surface the `LastErrorValue` in json output (#17) (Gankra)
`5896847`: Remove the frame limit on the `crashing_thread` preview (Gankra)