### PR TITLE
bug 1702984: Add std::vector<T>::_Emplace_reallocate<T> to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -311,6 +311,7 @@ std::_Func_impl_no_alloc<T>::_Do_call
 std::_Hash<T>::
 std::list<.*>::
 std::collections::hash::map::
+std::vector<T>::_Emplace_reallocate<T>
 stdext::hash_map<T>::
 strcat
 strncmp


### PR DESCRIPTION
This should help separate the signatures on bug 1695379