### PR TITLE
bug 1702984: add std::vector<T>::_Emplace_reallocate<T> to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -311,6 +311,7 @@ std::_Func_impl_no_alloc<T>::_Do_call
 std::_Hash<T>::
 std::list<.*>::
 std::collections::hash::map::
+std::vector<T>::_Emplace_reallocate<T>
 stdext::hash_map<T>::
 strcat
 strncmp


### PR DESCRIPTION
Recreating @jrmuizel pr #5732. This should help separate the signatures on bug 1695379.

Examples:
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature-contains=Emplace | socorro-cmd signature
Crash id: acc562ff-6ab4-46cb-aafd-1545c0210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: 06ada910-8946-4ce9-9b9b-cdca80210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: 5530c3bd-1714-4279-a5d4-85fb50210404
Original: std::vector<T>::_Emplace_reallocate<T>
New:      std::vector<T>::_Emplace_reallocate<T> | mozilla::gfx::PathBuilderCapture::BezierTo
Same?:    False

Crash id: 40a37976-87f6-41ce-9696-290080210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: 089ba326-b84e-4cb0-b72c-d74b60210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: 845c1e1c-5a2c-4290-b8ac-8ec1a0210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: 6f0c446d-a7ee-434c-97b9-4ea340210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | mozilla::gfx::PathCairo::AppendPathToBuilder
Same?:    False

Crash id: 0ff9ea46-e0fe-4a06-8528-6afe60210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: be1eb497-7d76-4ca5-b81b-73c7e0210404
Original: std::vector<T>::_Emplace_reallocate<T>
New:      std::vector<T>::_Emplace_reallocate<T> | ots::OpenTypeGLYF::ParseSimpleGlyph
Same?:    False

Crash id: cc51464f-e0ac-45ae-9f56-46e5a0210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: d0c3ea17-44f7-44fb-a402-403a50210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: cf26fd03-0c0f-48b6-9cad-42a260210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False

Crash id: fe53f1aa-cc6c-4250-aad1-a27e20210404
Original: OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T>
New:      OOM | large | mozalloc_abort | moz_xmalloc | std::vector<T>::_Emplace_reallocate<T> | gl::Program::loadBinary
Same?:    False
```

