### PR TITLE
bug 1701357: change default `process_type` to parent

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3007,7 +3007,15 @@ FIELDS = {
             "not be present. But when a plugin or content process crashes, this will be "
             "'plugin' or 'content'."
         ),
-        "form_field_choices": ["any", "browser", "plugin", "content", "gpu", "all"],
+        "form_field_choices": [
+            "any",
+            "parent",
+            "browser",
+            "plugin",
+            "content",
+            "gpu",
+            "all",
+        ],
         "has_full_version": False,
         "in_database_name": "process_type",
         "is_exposed": True,

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -49,6 +49,7 @@ from socorro.processor.rules.mozilla import (
     OSPrettyVersionRule,
     OutOfMemoryBinaryRule,
     PHCRule,
+    ProcessTypeRule,
     PluginContentURL,
     PluginRule,
     PluginUserComment,
@@ -181,6 +182,7 @@ class ProcessorPipeline(RequiredConfig):
             # rules to change the internals of the raw crash
             FenixVersionRewriteRule(),
             ESRVersionRewrite(),
+            ProcessTypeRule(),
             PluginContentURL(),
             PluginUserComment(),
             # rules to transform a raw crash into a processed crash

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -106,7 +106,16 @@ class EnvironmentRule(Rule):
         processed_crash["app_notes"] = raw_crash.get("Notes", "")
 
 
-class PluginRule(Rule):  # Hangs are here
+class ProcessTypeRule(Rule):
+    """Set process_type to ProcessType value or "parent"."""
+
+    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        processed_crash["process_type"] = raw_crash.get("ProcessType", "parent")
+
+
+class PluginRule(Rule):
+    """Handle plugin-related things and hang_type."""
+
     def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         try:
             plugin_hang_as_int = int(raw_crash.get("PluginHang", False))
@@ -118,9 +127,10 @@ class PluginRule(Rule):  # Hangs are here
             processed_crash["hangid"] = raw_crash.get("HangID", None)
 
         # the processed_crash["hang_type"] has the following meaning:
-        #    hang_type == -1 is a plugin hang
-        #    hang_type ==  1 is a browser hang
-        #    hang_type ==  0 is not a hang at all, but a normal crash
+        #
+        # * hang_type == -1 is a plugin hang
+        # * hang_type ==  1 is a browser hang
+        # * hang_type ==  0 is not a hang at all, but a normal crash
 
         try:
             hang_as_int = int(raw_crash.get("Hang", False))
@@ -135,14 +145,11 @@ class PluginRule(Rule):  # Hangs are here
         else:
             processed_crash["hang_type"] = 0
 
-        processed_crash["process_type"] = raw_crash.get("ProcessType", None)
+        process_type = raw_crash.get("ProcessType", None)
 
-        if not processed_crash["process_type"]:
-            return
-
-        if processed_crash["process_type"] == "plugin":
-            # Bug#543776 We actually will are relaxing the non-null policy...
-            # a null filename, name, and version is OK. We'll use empty strings
+        if process_type == "plugin":
+            # Bug#543776 We actually will are relaxing the non-null policy...  a null
+            # filename, name, and version is OK. We'll use empty strings
             processed_crash["PluginFilename"] = raw_crash.get("PluginFilename", "")
             processed_crash["PluginName"] = raw_crash.get("PluginName", "")
             processed_crash["PluginVersion"] = raw_crash.get("PluginVersion", "")

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -35,6 +35,7 @@ from socorro.processor.rules.mozilla import (
     PluginRule,
     PluginUserComment,
     ProductRule,
+    ProcessTypeRule,
     SignatureGeneratorRule,
     SubmittedFromInfobarFixRule,
     ThemePrettyNameRule,
@@ -333,6 +334,31 @@ class TestEnvironmentRule:
         assert processed_crash["app_notes"] == ""
 
 
+class TestProcessTypeRule:
+    def test_process_type(self):
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
+        raw_crash["ProcessType"] = "gpu"
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ProcessTypeRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+
+        assert processed_crash["process_type"] == "gpu"
+
+    def test_no_process_type_is_parent(self):
+        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
+        raw_dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule = ProcessTypeRule()
+        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+
+        assert processed_crash["process_type"] == "parent"
+
+
 class TestPluginRule:
     def test_plugin_hang(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
@@ -351,7 +377,6 @@ class TestPluginRule:
 
         assert processed_crash["hangid"] == "fake-00000000-0000-0000-0000-000002140504"
         assert processed_crash["hang_type"] == -1
-        assert processed_crash["process_type"] == "plugin"
         assert processed_crash["PluginFilename"] == "x.exe"
         assert processed_crash["PluginName"] == "X"
         assert processed_crash["PluginVersion"] == "0.0"
@@ -369,7 +394,6 @@ class TestPluginRule:
 
         assert processed_crash["hangid"] is None
         assert processed_crash["hang_type"] == 1
-        assert processed_crash["process_type"] == "browser"
         assert "PluginFilename" not in processed_crash
         assert "PluginName" not in processed_crash
         assert "PluginVersion" not in processed_crash

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -290,6 +290,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 # If tuple, the second option is human readable label.
 PROCESS_TYPES = (
     "any",
+    "parent",
     "browser",
     "plugin",
     "content",


### PR DESCRIPTION
Previously, we set the `process_type` value to `None` if there was no
ProcessType annotation. This is the case for "main" aka "browser" aka
"parent" process crashes. Then in Supersearch we handled "browser"
search as "does not have a ProcessType". That's awkward when you want to
look at an aggregate of the `process_type` field since "does not exist"
won't show up in the aggregate. Yuck.

This redoes all that nonsense. Now the default `process_type` is "parent"
because that's the word that's used in the gecko code so we maintain
terminology. All crash reports will have a `process_type` in the processed
crash going forward. This lets us remove the hard-coded "browser means
does not exist", it fixes the weirdness with aggregates, the Process
Type field shows up in all crash reports in the Details tab, and we're
one step closer to CONQUERING THE TRI-STATE AREA!

The next step, of course, is to remove the "browser" stuff, but I don't
want to do that for a few months, so I'll put that in a bug to do in
July or August or something.