### PR TITLE
bug 1701357: redo display of process_type in Details tab

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3003,9 +3003,8 @@ FIELDS = {
     "process_type": {
         "data_validation_type": "str",
         "description": (
-            "What type of process the crash happened in. When the main process crashes, this will "
-            "not be present. But when a plugin or content process crashes, this will be "
-            "'plugin' or 'content'."
+            'Type of the process that crashed. This will be "parent" if the crash '
+            "report had no ProcessType annotation."
         ),
         "form_field_choices": [
             "any",

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -309,29 +309,18 @@
                     </td>
                   </tr>
                 {% endif %}
-                {% if report.process_type %}
-                  <tr title="{{ fields_desc['processed_crash.process_type'] }}">
-                    <th scope="row">Process Type</th>
-                    <td>
-                      {{ report.process_type }}
-                      {% if request.user.has_perm('crashstats.view_pii') or your_crash %}
-                        ({{ raw.RemoteType and raw.RemoteType or 'web' }})
-                        - {{ protected_warning(your_crash) }}
-                      {% endif %}
-                      {% if report.PluginName %}
-                        <b class="name">{{ report.PluginName }}</b>
-                      {% endif %}
-                      {% if report.PluginVersion %}
-                        <span>Version:</span>
-                        <span class="version">{{ report.PluginVersion }}</span>
-                      {% endif %}
-                      {% if report.PluginFilename %}
-                        <span>Filename:</span>
-                        <span class="filename">{{ report.PluginFilename }}</span>
-                      {% endif %}
-                    </td>
-                  </tr>
-                {% endif %}
+                <tr title="{{ fields_desc['processed_crash.process_type'] }}">
+                  <th scope="row">Process Type</th>
+                  <td>
+                    {{ report.process_type or "browser" }}
+                    {% if report.process_type == "content" and request.user.has_perm("crashstats.view_pii") -%}
+                      ({{ raw.RemoteType or 'web' }}) - {{ protected_warning(your_crash) }}
+                    {%- endif %}
+                    {% if report.process_type == "plugin" -%}
+                      ({{ report.PluginName or "No name" }}, ver: {{ report.PluginVersion or "Unknown" }}, filename: {{ report.PluginFilename or "" }})
+                    {%- endif %}
+                  </td>
+                </tr>
                 {% if raw.FlashProcessDump %}
                   <tr title="{{ fields_desc['raw_crash.FlashProcessDump'] }}">
                     <th scope="row">Flash Process Dump</th>

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -558,6 +558,7 @@ class TestViews(BaseTestViews):
             assert "datatype" in params
             if params["datatype"] == "meta":
                 raw = copy.deepcopy(_SAMPLE_META)
+                raw["ProcessType"] = "content"
                 raw["RemoteType"] = "java-applet"
                 return raw
             raise NotImplementedError
@@ -568,7 +569,7 @@ class TestViews(BaseTestViews):
             assert "datatype" in params
             if params["datatype"] == "unredacted":
                 processed = copy.deepcopy(_SAMPLE_UNREDACTED)
-                processed["process_type"] = "contentish"
+                processed["process_type"] = "content"
                 return processed
 
             raise NotImplementedError(params)
@@ -588,9 +589,11 @@ class TestViews(BaseTestViews):
         )
         response = self.client.get(url)
         assert response.status_code == 200
-        assert "Process Type" in smart_text(response.content)
-        # Expect that it displays '{process_type}\s+({raw_crash.RemoteType})'
-        assert re.findall(r"contentish\s+\(java-applet\)", smart_text(response.content))
+
+        # Assert that it displays '{process_type}\s+({raw_crash.RemoteType})'
+        assert re.findall(
+            r"content[\s\n]+\(java-applet\)", smart_text(response.content), re.MULTILINE
+        )
 
     def test_report_index_with_additional_raw_dump_links(self):
         json_dump = {


### PR DESCRIPTION
There are several values for process_type that a crash report can have.

If it is "content", then we want to additionally show the RemoteType
value, but only if the user has protected data access.

If it is "plugin", then we want to additionally show data about the
plugin process.

This cleans the template code up so that's clearer both in the template
code and also in the rendered template.