### PR TITLE
bug 1701357: fix topcrasher report process type filter

### DIFF
--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -220,24 +220,47 @@ class TestSearchBase:
         with pytest.raises(BadArgumentError):
             search.get_parameters(date=">1999-01-01")
 
-    def test_process_type_parameter_correction(self):
+    def test_process_type_parameter_correction_parent(self):
+        search = SearchBaseWithFields()
+
+        args = {"process_type": "parent"}
+        params = search.get_parameters(**args)
+        assert "process_type" in params
+        assert len(params["process_type"]) == 2
+        assert params["process_type"][0].value == ["parent"]
+        assert params["process_type"][1].value == [""]
+        assert params["process_type"][1].operator == "__null__"
+        assert params["process_type"][1].operator_not is False
+
+        args = {"process_type": "=parent"}
+        params = search.get_parameters(**args)
+        assert "process_type" in params
+        assert len(params["process_type"]) == 2
+        assert params["process_type"][0].value == "parent"
+        assert params["process_type"][1].value == [""]
+        assert params["process_type"][1].operator == "__null__"
+        assert params["process_type"][1].operator_not is False
+
+    def test_process_type_parameter_correction_browser(self):
         search = SearchBaseWithFields()
 
         args = {"process_type": "browser"}
         params = search.get_parameters(**args)
         assert "process_type" in params
-        assert len(params["process_type"]) == 1
-        assert params["process_type"][0].value == [""]
-        assert params["process_type"][0].operator == "__null__"
-        assert params["process_type"][0].operator_not is False
+        assert len(params["process_type"]) == 2
+        assert params["process_type"][0].value == ["parent"]
+        assert params["process_type"][1].value == [""]
+        assert params["process_type"][1].operator == "__null__"
+        assert params["process_type"][1].operator_not is False
 
         args = {"process_type": "=browser"}
         params = search.get_parameters(**args)
         assert "process_type" in params
-        assert len(params["process_type"]) == 1
-        assert params["process_type"][0].value == [""]
-        assert params["process_type"][0].operator == "__null__"
-        assert params["process_type"][0].operator_not is False
+        assert len(params["process_type"]) == 2
+        assert params["process_type"][0].value == "parent"
+        assert params["process_type"][1].value == [""]
+        assert params["process_type"][1].operator == "__null__"
+        assert params["process_type"][1].operator_not is False
 
     def test_hang_type_parameter_correction(self):
         search = SearchBaseWithFields()

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -291,7 +291,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 PROCESS_TYPES = (
     "any",
     "parent",
-    "browser",
     "plugin",
     "content",
     ("gpu", "GPU"),


### PR DESCRIPTION
After the process_type changes, the TopCrasher report had a "parent"
filter and a "browser" filter. If you were looking at TopCrashers by
process type, that split the parent process crash reports into two
separate lists. That would eventually fix itself as data expired, but
it's incredibly inconvenient right now.

This changes the TopCrashers report filters by changing Supersearch to
treat "process_type=parent" and "process_type=browser" filters as "crash
reports where process_type is parent OR has no ProcessType".

That makes TopCrashers report "parent" type filter work correctly
regardless of when the crash report was processed.