### PR TITLE
bug 1705027: add NS_CycleCollectorSuspect3 to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -194,6 +194,7 @@ msvcr120\.dll@0x
 \<name omitted\>
 NP_Shutdown
 (NS_)?(Lossy)?(Copy|Append|Convert).*UTF
+NS_CycleCollectorSuspect3
 nsACString_internal::Assign
 nsAString_internal::Assign
 nsACString_internal::BeginWriting


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature d869361c-382f-420e-85e2-b42ce0210414 1cf5e9c6-0d2c-4b4f-a4bc-47ceb0210414 d554208b-f8c3-49bf-bc45-c6dd60210408 e5a88ff7-7bc8-4193-b527-cafa90210411 17a969a9-b000-47cf-a378-193e20210410
Crash id: d869361c-382f-420e-85e2-b42ce0210414
Original: NS_CycleCollectorSuspect3
New:      NS_CycleCollectorSuspect3 | <T>::operator() | __crt_seh_guarded_call<T>::operator()<T>
Same?:    False

Crash id: 1cf5e9c6-0d2c-4b4f-a4bc-47ceb0210414
Original: NS_CycleCollectorSuspect3
New:      NS_CycleCollectorSuspect3 | L10nRootTranslationHandler::Release
Same?:    False

Crash id: d554208b-f8c3-49bf-bc45-c6dd60210408
Original: NS_CycleCollectorSuspect3
New:      NS_CycleCollectorSuspect3 | std::_Tree<T>::_Erase
Same?:    False

Crash id: e5a88ff7-7bc8-4193-b527-cafa90210411
Original: NS_CycleCollectorSuspect3
New:      NS_CycleCollectorSuspect3 | mozilla::EventListenerManager::ListenerSignalFollower::AddRef
Same?:    False

Crash id: 17a969a9-b000-47cf-a378-193e20210410
Original: NS_CycleCollectorSuspect3
New:      NS_CycleCollectorSuspect3 | mozilla::TextServicesDocument::AddRef
Same?:    False
```