### PR TITLE
bug 1704872: fix operands for percent_of_total_crashes_diff calculation

### DIFF
--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -122,15 +122,19 @@ class SignatureStats:
     @cached_property
     def percent_of_total_crashes_diff(self):
         if self.previous_signature:
+            # The number should go "up" when moving towards 100 and "down" when moving
+            # towards 0
             return (
-                self.previous_signature.percent_of_total_crashes
-                - self.percent_of_total_crashes
+                self.percent_of_total_crashes
+                - self.previous_signature.percent_of_total_crashes
             )
         return "new"
 
     @cached_property
     def rank_diff(self):
         if self.previous_signature:
+            # The number should go "up" when moving towards 1 and "down" when moving
+            # towards infinity
             return self.previous_signature.rank - self.rank
         return 0
 

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -146,6 +146,7 @@
                     <td title="This is a new signature">new</td>
                   {% else %}
                     <td title="A change of {{ topcrashers_stats_item.percent_of_total_crashes_diff | round(2) }}% from {{ topcrashers_stats_item.previous_percent_of_total_crashes | round(2) }}%">
+                      {{ "⬆️" if topcrashers_stats_item.percent_of_total_crashes_diff > 0 else "⬇️"}}
                       {{ topcrashers_stats_item.percent_of_total_crashes_diff | round(2) }}%
                     </td>
                   {% endif %}


### PR DESCRIPTION
The percent of total crashes diff between previous and current should go
"up" when moving towards 100 and "down" when moving towards 0. Given
that, We want current - previous to figure out the difference.

This also adds "helpful" up/down arrows to make the TopCrashers lines
easier to skim without having to read the hover text.