### PR TITLE
bug 1699492: fix mutation issues in signature generation

### DIFF
--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -28,14 +28,6 @@ def convert_to_crash_data(raw_crash, processed_crash):
     :returns: crash data structure that conforms to the schema
 
     """
-    # We want to generate fresh signatures, so we remove the "normalized" field
-    # from stack frames from the processed crash because this is essentially
-    # cached data from previous processing
-    for thread in glom(processed_crash, "json_dump.threads", default=[]):
-        for frame in thread.get("frames", []):
-            if "normalized" in frame:
-                del frame["normalized"]
-
     crash_data = {
         # JavaStackTrace or None
         "java_stack_trace": glom(processed_crash, "java_stack_trace", default=None),


### PR DESCRIPTION
Signature generation used to mutate the stack frames adding a
"normalized" key to them. Not only do we not use that, but there's
another bit of code elsewhere that used to remove it because it was
unhelpful.

This gets rid of the normalized caching altogether. It adds a test to
make sure we're not mutating in the future. It reduces some code around
generating signatures from a stack which suggested that these tools had
the same API but was a lie.