### PR TITLE
bug 974968, 1629943: improve Extensions tab

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -178,6 +178,7 @@ class AddonsRule(Rule):
 
         This is used because some addons are missing a version. In order to
         simplify subsequent queries, we make sure the format is consistent.
+
         """
         return addon if ":" in addon else addon + ":NO_VERSION"
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1051,20 +1051,21 @@
               <table class="data-table">
                 <thead>
                   <tr>
-                    <th scope="col">Extension</th>
                     <th scope="col">Extension Id</th>
+                    <th scope="col">Name</th>
                     <th scope="col">Version</th>
-                    <th scope="col">Current?</th>
+                    <th scope="col">System?</th>
+                    <th scope="col">Signed state</th>
                   </tr>
                 </thead>
                 <tbody>
                   {% for addon in report.addons %}
-                    {% set split = addon.split(':') %}
                     <tr>
-                      <td><a href=""></a></td>
-                      <td>{{ split[0] }}</td>
-                      <td>{{ split[1] }}</td>
-                      <td><b>{{ split[2] }}</b></td>
+                      <td>{{ addon.id or "" }}</td>
+                      <td>{{ addon.name or "" }}</td>
+                      <td>{{ addon.version or "" }}</td>
+                      <td>{{ addon.is_system or "" }}</td>
+                      <td>{{ addon.get_signed_state_name() }}</td>
                     </tr>
                   {% endfor %}
                 </tbody>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -172,6 +172,10 @@ def report_index(request, crash_id, default_context=None):
         .order_by("-bug_id")
     )
 
+    context["report"]["addons"] = utils.enhance_addons(
+        context["raw"], context["report"]
+    )
+
     context["public_raw_keys"] = [
         x for x in context["raw"] if x in models.RawCrash.API_ALLOWLIST()
     ]
@@ -260,20 +264,6 @@ def report_index(request, crash_id, default_context=None):
     context["make_raw_crash_key"] = make_raw_crash_key
     context["fields_desc"] = descriptions
     context["empty_desc"] = "No description for this field. Search: unknown"
-
-    # report.addons used to be a list of lists.
-    # In https://bugzilla.mozilla.org/show_bug.cgi?id=1250132
-    # we changed it from a list of lists to a list of strings, using
-    # a ':' to split the name and version.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1250132#c7
-    # Considering legacy, let's tackle both.
-    # In late 2017, this code is going to be useless and can be removed.
-    if context["report"].get("addons") and isinstance(
-        context["report"]["addons"][0], (list, tuple)
-    ):
-        # This is the old legacy format. This crash hasn't been processed
-        # the new way.
-        context["report"]["addons"] = [":".join(x) for x in context["report"]["addons"]]
 
     content = loader.render_to_string("crashstats/report_index.html", context, request)
     utf8_content = content.encode("utf-8", errors="backslashreplace")


### PR DESCRIPTION
This improves the data in the Extensions tab by combining the data in
the "Add-ons" crash report annotation with the data in the
"addons.activeAddons" Telemetry Environment section.