### PR TITLE
bug 1705573: fix correlations tab in signature report

### DIFF
--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -86,9 +86,7 @@
         <li><a href="#graphs" class="graphs" data-tab-name="graphs">Graphs</a></li>
         <li><a href="#bugzilla" class="bugzilla" data-tab-name="bugzilla">Bugzilla</a></li>
         <li><a href="#comments" class="comments" data-tab-name="comments">Comments</a></li>
-        {% if product in correlations_products %}
-          <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
-        {% endif %}
+        <li><a href="#correlations" class="correlations" data-tab-name="correlations">Correlations</a></li>
       </ul>
     </nav>
 

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from csp.decorators import csp_update
 from socorro.lib import BadArgumentError
 
+from crashstats import productlib
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.decorators import pass_default_context
 from crashstats.crashstats.utils import SignatureStats, render_exception, urlencode_obj
@@ -374,7 +375,12 @@ def signature_correlations(request, params):
         elif all("esr" in version for version in params["version"]):
             context["channel"] = "esr"
 
-    context["product_name"] = "Firefox"
+    default_product_name = productlib.get_default_product().name
+    product_name = params.get("product", default_product_name)
+    if isinstance(product_name, (list, tuple)):
+        product_name = product_name[0]
+
+    context["product_name"] = product_name
 
     return render(request, "signature/signature_correlations.html", context)
 


### PR DESCRIPTION
This fixes the correlations tab in the signature report so it shows up
all the time (no more hidden tabs) and also moves the "is this a
correlations product" check to JS.