### PR TITLE
Update minidump-stackwalk to 2021.04.19

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/socorro-minidump-stackwalk:2021.03.24@sha256:c665e82bb5695630973bee87f0a1529d3cdaa56e22900255ade75bdc92b312d3 as breakpad
+FROM mozilla/socorro-minidump-stackwalk:2021.04.19@sha256:8068606a6d0a46cd1c12ead6f0e7ed5d08a55d6c3beffa6b2c8dd5872628ab3a as breakpad
 
 FROM python:3.9.4-slim@sha256:de9482638c1354f5178efc90431de2a42e863a12bf3df41d7fa30d5c10fe543d
 

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -750,6 +750,7 @@ class TestESCrashStorage(ElasticsearchTestCase):
                 processed_crash=deepcopy(processed_crash),
             )
 
+    @pytest.mark.skip(reason="the raw_crash value is flapping. bug 1706076")
     def test_crash_size_capture(self):
         """Verify we capture raw/processed crash sizes in ES crashstorage"""
         raw_crash = {"ProductName": "Firefox", "ReleaseChannel": "nightly"}


### PR DESCRIPTION
https://github.com/mozilla-services/minidump-stackwalk/releases/tag/2021.04.19

`18140ad`: Include the list of unloaded modules in the output (#22) (gabrielesvelto)
`dc9ecb5`: Print out subcodes when dealing with __fastfail() exceptions on Windows (gabrielesvelto)
`6d0ace7`: Add the unpacked PGO data to the list of ignored files (gabrielesvelto)
`e91df29`: Make the stackwalker print out the name of NTSTATUS error codes (gabrielesvelto)