### PR TITLE
bug 1706075: add Windows functions to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -113,6 +113,8 @@ JS_DHashTableEnumerate
 JS_DHashTableOperate
 JS_NewStringCopyZ
 js_strlen
+KiFastSystemCall
+KiRaiseUserExceptionDispatcher
 KiUserExceptionDispatcher
 kill
 __libc_android_abort
@@ -281,6 +283,7 @@ SECKEY_
 __semwait_signal
 send
 servo_arc::Arc<T>::drop_slow
+SetEvent
 setjmp
 sigblock
 sigprocmask


### PR DESCRIPTION
This adds KiRaiseUserExceptionDispatcher, KiFastSystemCall, and SetEvent
to the prefix list so that signature continues past them to Firefox
frames.

```
app@socorro:/app$ socorro-cmd signature 1e66cc1e-a574-4a16-9baf-fdc7f0210421
Crash id: 1e66cc1e-a574-4a16-9baf-fdc7f0210421
Original: KiRaiseUserExceptionDispatcher
New:      KiRaiseUserExceptionDispatcher | KiFastSystemCall | sbupd.dll
Same?:    False

app@socorro:/app$ socorro-cmd signature 6818b0d9-28d0-454f-924a-4efa10210421
Crash id: 6818b0d9-28d0-454f-924a-4efa10210421
Original: KiRaiseUserExceptionDispatcher
New:      KiRaiseUserExceptionDispatcher | SetEvent | (anonymous namespace)::wasapi_stream_reset_default_device
Same?:    False
```