### PR TITLE
bug 973894: fix super search so all fields can use exists filter

### DIFF
--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -35,17 +35,18 @@ import socorro.lib.external_common as extern
 """
 OPERATOR_NOT = "!"
 OPERATORS_BASE = [""]
+OPERATORS_EXISTENCE = ["__null__"]
 OPERATORS_BOOL = ["__true__"]
-OPERATORS_STRING = ["__null__", "=", "~", "$", "^", "@"]
+OPERATORS_STRING = ["=", "~", "$", "^", "@"]
 OPERATORS_NUMBER = [">=", "<=", "<", ">"]
 OPERATORS_MAP = {
-    "str": OPERATORS_STRING + OPERATORS_BASE,
-    "int": OPERATORS_NUMBER + OPERATORS_BASE,
-    "date": OPERATORS_NUMBER,
-    "datetime": OPERATORS_NUMBER,
-    "bool": OPERATORS_BOOL,
-    "enum": OPERATORS_BASE,
-    "default": OPERATORS_BASE,
+    "str": OPERATORS_STRING + OPERATORS_EXISTENCE + OPERATORS_BASE,
+    "int": OPERATORS_NUMBER + OPERATORS_EXISTENCE + OPERATORS_BASE,
+    "date": OPERATORS_NUMBER + OPERATORS_EXISTENCE,
+    "datetime": OPERATORS_NUMBER + OPERATORS_EXISTENCE,
+    "bool": OPERATORS_BOOL + OPERATORS_EXISTENCE,
+    "enum": OPERATORS_EXISTENCE + OPERATORS_BASE,
+    "default": OPERATORS_EXISTENCE + OPERATORS_BASE,
 }
 
 
@@ -133,7 +134,6 @@ class SearchBase:
         parameters = {}
 
         fields = kwargs["_fields"]
-        assert fields
         if fields:
             self.build_filters(fields)
 

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -187,6 +187,7 @@ class StringField(MultipleValueField):
 
 class BooleanField(forms.CharField):
     truthy_strings = ("__true__", "true", "t", "1", "y", "yes")
+    existence_strings = ("__null__", "!__null__")
 
     def to_python(self, value):
         """Return None if the value is None. Return 'true' if the value is one
@@ -198,6 +199,9 @@ class BooleanField(forms.CharField):
         if value is None:
             return None
 
-        if smart_str(value).lower() in self.truthy_strings:
+        value = smart_str(value).lower()
+        if value in self.truthy_strings:
             return "__true__"
+        if value in self.existence_strings:
+            return value
         return "!__true__"

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
@@ -34,14 +34,15 @@
   var OPERATORS_RANGE = ['>', '>=', '<', '<='];
   var OPERATORS_REGEX = ['~', '=', '$', '^', '@', '!=', '!~', '!$', '!^', '!@'];
   var OPERATORS_EXISTENCE = ['__null__', '!__null__'];
-  var OPERATORS_BOOLEAN = ['__true__', '!__true__'];
+  var OPERATORS_BOOL = ['__true__', '!__true__'];
 
-  var OPERATORS_ENUM = OPERATORS_BASE;
-  var OPERATORS_NUMBER = OPERATORS_BASE.concat(OPERATORS_RANGE);
-  var OPERATORS_DATE = OPERATORS_RANGE;
+  var OPERATORS_BOOLEAN = OPERATORS_BOOL.concat(OPERATORS_EXISTENCE);
+  var OPERATORS_ENUM = OPERATORS_BASE.concat(OPERATORS_EXISTENCE);
+  var OPERATORS_NUMBER = OPERATORS_BASE.concat(OPERATORS_RANGE).concat(OPERATORS_EXISTENCE);
+  var OPERATORS_DATE = OPERATORS_RANGE.concat(OPERATORS_EXISTENCE);
   var OPERATORS_STRING = OPERATORS_BASE.concat(OPERATORS_REGEX).concat(OPERATORS_EXISTENCE);
 
-  var OPERATORS_NO_VALUE = OPERATORS_EXISTENCE.concat(OPERATORS_BOOLEAN);
+  var OPERATORS_NO_VALUE = OPERATORS_EXISTENCE.concat(OPERATORS_BOOL);
 
   /**
    * Create a new dynamic form or run an action on an existing form.


### PR DESCRIPTION
This fixes super search so all fields can use "exist/does not exist" filter. Previously, only string fields could.

This makes it a lot easier to search for crash reports that have or don't have a specific field. Previously, you'd have to hack it in some cases and in others, it wasn't possible.

For example, `ProcessType` annotation isn't included in main process crash reports. Previously, you'd have to do a facet on the `process_type` field and then subtract the total number from the total number of crash reports in that same datetime range because there  was no way to search for "crash reports that have no `process_type` field".

I tested this out by processing 50 Firefox crashes and then looking at "exists/does not exist" for these fields:

* boolean: `record_replay`
* str: `phc_kind`
* long: `phc_usable_size`
* enum: `bios_manufacturer`