### PR TITLE
bug 1705469: add support for multiple rulesets in a processing pipeline

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -222,7 +222,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         except self.conn.KeyNotFound as x:
             raise CrashIDNotFound("%s not found: %s" % (crash_id, x))
 
-    def get_raw_dumps(self, crash_id):
+    def get_dumps(self, crash_id):
         """Get all the dump files for a given crash id.
 
         :returns MemoryDumpsMapping:
@@ -245,7 +245,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         except self.conn.KeyNotFound as x:
             raise CrashIDNotFound("%s not found: %s" % (crash_id, x))
 
-    def get_raw_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id):
         """Get the dump files for given crash id and save them to tmp.
 
         :returns: dict of dumpname -> file path
@@ -253,7 +253,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         :raises CrashIDNotFound: if file does not exist
 
         """
-        in_memory_dumps = self.get_raw_dumps(crash_id)
+        in_memory_dumps = self.get_dumps(crash_id)
         # convert our native memory dump mapping into a file dump mapping.
         return in_memory_dumps.as_file_dumps_mapping(
             crash_id,

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -222,7 +222,7 @@ class CrashStorageBase(RequiredConfig):
         """
         raise NotImplementedError("get_raw_dump is not implemented")
 
-    def get_raw_dumps(self, crash_id):
+    def get_dumps(self, crash_id):
         """Fetch all dumps for a crash report
 
         :param crash_id: crash report id
@@ -230,9 +230,9 @@ class CrashStorageBase(RequiredConfig):
         :returns: MemoryDumpsMapping of dumps
 
         """
-        raise NotImplementedError("get_raw_dumps is not implemented")
+        raise NotImplementedError("get_dumps is not implemented")
 
-    def get_raw_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id):
         """Fetch all dumps for a crash report and save as files.
 
         :param crash_id: crash report id
@@ -240,7 +240,7 @@ class CrashStorageBase(RequiredConfig):
         :returns: dict of dumpname -> file path
 
         """
-        raise NotImplementedError("get_raw_dumps is not implemented")
+        raise NotImplementedError("get_dumps is not implemented")
 
     def get_processed(self, crash_id):
         """Fetch processed crash.
@@ -541,20 +541,18 @@ class BenchmarkingCrashStorage(CrashStorageBase):
         self.logger.debug("%s get_raw_dump %s", self.tag, end_time - start_time)
         return result
 
-    def get_raw_dumps(self, crash_id):
+    def get_dumps(self, crash_id):
         start_time = self.start_timer()
-        result = self.wrapped_crashstore.get_raw_dumps(crash_id)
+        result = self.wrapped_crashstore.get_dumps(crash_id)
         end_time = self.end_timer()
-        self.logger.debug("%s get_raw_dumps %s", self.tag, end_time - start_time)
+        self.logger.debug("%s get_dumps %s", self.tag, end_time - start_time)
         return result
 
-    def get_raw_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id):
         start_time = self.start_timer()
-        result = self.wrapped_crashstore.get_raw_dumps_as_files(crash_id)
+        result = self.wrapped_crashstore.get_dumps_as_files(crash_id)
         end_time = self.end_timer()
-        self.logger.debug(
-            "%s get_raw_dumps_as_files %s", self.tag, end_time - start_time
-        )
+        self.logger.debug("%s get_dumps_as_files %s", self.tag, end_time - start_time)
         return result
 
     def get_unredacted_processed(self, crash_id):

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -214,7 +214,7 @@ class FSPermanentStorage(CrashStorageBase):
         ) as f:
             return f.read()
 
-    def get_raw_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id):
         parent_dir = self._get_radixed_parent_directory(crash_id)
         if not os.path.exists(parent_dir):
             raise CrashIDNotFound
@@ -231,8 +231,8 @@ class FSPermanentStorage(CrashStorageBase):
             zip(self._dump_names_from_paths(dump_paths), dump_paths)
         )
 
-    def get_raw_dumps(self, crash_id):
-        file_dump_mapping = self.get_raw_dumps_as_files(crash_id)
+    def get_dumps(self, crash_id):
+        file_dump_mapping = self.get_dumps_as_files(crash_id)
         # ensure that we return a name/blob mapping
         return file_dump_mapping.as_memory_dumps_mapping()
 
@@ -258,7 +258,7 @@ class FSPermanentStorage(CrashStorageBase):
             raise CrashIDNotFound
 
         removal_candidates = [os.sep.join([parent_dir, crash_id + ".json"])] + list(
-            self.get_raw_dumps_as_files(crash_id).values()
+            self.get_dumps_as_files(crash_id).values()
         )
 
         # Remove all the files related to the crash

--- a/socorro/processor/rules/base.py
+++ b/socorro/processor/rules/base.py
@@ -21,11 +21,11 @@ class Rule:
     def __init__(self):
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
-    def predicate(self, raw_crash, raw_dumps, processed_crash, processor_meta_data):
+    def predicate(self, raw_crash, dumps, processed_crash, processor_meta_data):
         """Determines whether to run the action for this crash
 
         :arg raw_crash: the raw crash data
-        :arg raw_dumps: any minidumps associated with this crash
+        :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
         :arg processor_meta_data: any notes or bookkeeping we need to keep about
             processing as we process
@@ -35,11 +35,11 @@ class Rule:
         """
         return True
 
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta_data):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta_data):
         """Executes the rule transforming the crash data
 
         :arg raw_crash: the raw crash data
-        :arg raw_dumps: any minidumps associated with this crash
+        :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
         :arg processor_meta_data: any notes or bookkeeping we need to keep about
             processing as we process
@@ -47,11 +47,11 @@ class Rule:
         """
         return
 
-    def act(self, raw_crash, raw_dumps, processed_crash, processor_meta_data):
+    def act(self, raw_crash, dumps, processed_crash, processor_meta_data):
         """Runs predicate and action for a rule
 
         :arg raw_crash: the raw crash data
-        :arg raw_dumps: any minidumps associated with this crash
+        :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
         :arg processor_meta_data: any notes or bookkeeping we need to keep about
             processing as we process
@@ -59,10 +59,8 @@ class Rule:
         """
         rule_name = self.__class__.__name__
         with metrics.timer("act.timing", tags=["rule:%s" % rule_name]):
-            if self.predicate(
-                raw_crash, raw_dumps, processed_crash, processor_meta_data
-            ):
-                self.action(raw_crash, raw_dumps, processed_crash, processor_meta_data)
+            if self.predicate(raw_crash, dumps, processed_crash, processor_meta_data):
+                self.action(raw_crash, dumps, processed_crash, processor_meta_data)
 
     def close(self):
         pass

--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -37,7 +37,7 @@ class DeNullRule(Rule):
         # return it as is
         return s
 
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         had_nulls = False
 
         # Go through the raw crash and de-null keys and values
@@ -64,7 +64,7 @@ class DeNoneRule(Rule):
 
     """
 
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         had_nones = False
 
         # Remove keys that have None values
@@ -78,14 +78,14 @@ class DeNoneRule(Rule):
 
 
 class IdentifierRule(Rule):
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         if "uuid" in raw_crash:
             processed_crash["crash_id"] = raw_crash["uuid"]
             processed_crash["uuid"] = raw_crash["uuid"]
 
 
 class CPUInfoRule(Rule):
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         # This is the CPU that the product was built for
         processed_crash["cpu_arch"] = glom(
             processed_crash, "json_dump.system_info.cpu_arch", default=""
@@ -101,7 +101,7 @@ class CPUInfoRule(Rule):
 
 
 class OSInfoRule(Rule):
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         os_name = glom(
             processed_crash, "json_dump.system_info.os", default="Unknown"
         ).strip()

--- a/socorro/processor/rules/memory_report_extraction.py
+++ b/socorro/processor/rules/memory_report_extraction.py
@@ -20,7 +20,7 @@ class MemoryReportExtraction(Rule):
 
     """
 
-    def predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+    def predicate(self, raw_crash, dumps, processed_crash, proc_meta):
         try:
             # Verify that...
             return (
@@ -36,7 +36,7 @@ class MemoryReportExtraction(Rule):
         except KeyError:
             return False
 
-    def action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
         pid = processed_crash["json_dump"]["pid"]
         memory_report = processed_crash["memory_report"]
 

--- a/socorro/scripts/reprocess.py
+++ b/socorro/scripts/reprocess.py
@@ -47,6 +47,11 @@ def main(argv=None):
         "--host", help="host for system to reprocess in", default=DEFAULT_HOST
     )
     parser.add_argument(
+        "--ruleset",
+        help="name of ruleset to reprocess these crash reports with",
+        default="",
+    )
+    parser.add_argument(
         "crashid",
         help="one or more crash ids to fetch data for",
         nargs="*",
@@ -67,6 +72,8 @@ def main(argv=None):
     print("Sending reprocessing requests to: %s" % url)
     session = session_with_retries()
 
+    ruleset = args.ruleset
+
     crash_ids = args.crashid
     print(
         "Reprocessing %s crashes sleeping %s seconds between groups..."
@@ -79,6 +86,10 @@ def main(argv=None):
             "Processing group ending with %s ... (%s/%s)"
             % (group[-1], i + 1, len(groups))
         )
+
+        if ruleset:
+            group = [f"{crash_id}:{ruleset}" for crash_id in group]
+
         resp = session.post(
             url, data={"crash_ids": group}, headers={"Auth-Token": api_token}
         )

--- a/socorro/unittest/app/test_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_fetch_transform_save_app.py
@@ -97,7 +97,7 @@ class TestFetchTransformSaveApp:
             def get_raw_crash(self, ooid):
                 return self.store[ooid]
 
-            def get_raw_dumps(self, ooid):
+            def get_dumps(self, ooid):
                 return {"upload_file_minidump": "this is a fake dump"}
 
             def new_crashes(self):
@@ -146,7 +146,7 @@ class TestFetchTransformSaveApp:
 
         assert source.store == destination.store
         assert len(destination.dumps) == 4
-        assert destination.dumps["1237"] == source.get_raw_dumps("1237")
+        assert destination.dumps["1237"] == source.get_dumps("1237")
         # ensure that each storage system had its close called
         assert source.number_of_close_calls == 1
         assert destination.number_of_close_calls == 1

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -210,7 +210,7 @@ class TestBotoS3CrashStorage:
         )
         assert result == b"this is a raw dump"
 
-    def test_get_raw_dumps(self, boto_helper):
+    def test_get_dumps(self, boto_helper):
         boto_s3_store = self.get_s3_store()
         bucket = boto_s3_store.conn.bucket
         boto_helper.create_bucket(bucket)
@@ -236,22 +236,22 @@ class TestBotoS3CrashStorage:
             data=b'this is "city_dump", the last one',
         )
 
-        result = boto_s3_store.get_raw_dumps("936ce666-ff3b-4c7a-9674-367fe2120408")
+        result = boto_s3_store.get_dumps("936ce666-ff3b-4c7a-9674-367fe2120408")
         assert result == {
             "dump": b'this is "dump", the first one',
             "flash_dump": b'this is "flash_dump", the second one',
             "city_dump": b'this is "city_dump", the last one',
         }
 
-    def test_get_raw_dumps_not_found(self, boto_helper):
+    def test_get_dumps_not_found(self, boto_helper):
         boto_s3_store = self.get_s3_store()
         bucket = boto_s3_store.conn.bucket
         boto_helper.create_bucket(bucket)
 
         with pytest.raises(CrashIDNotFound):
-            boto_s3_store.get_raw_dumps("0bba929f-dead-dead-dead-a43c20071027")
+            boto_s3_store.get_dumps("0bba929f-dead-dead-dead-a43c20071027")
 
-    def test_get_raw_dumps_as_files(self, boto_helper, tmpdir):
+    def test_get_dumps_as_files(self, boto_helper, tmpdir):
         boto_s3_store = self.get_s3_store(tmpdir=tmpdir)
         bucket = boto_s3_store.conn.bucket
         boto_helper.create_bucket(bucket)
@@ -277,7 +277,7 @@ class TestBotoS3CrashStorage:
             data=b'this is "city_dump", the last one',
         )
 
-        result = boto_s3_store.get_raw_dumps_as_files(
+        result = boto_s3_store.get_dumps_as_files(
             "936ce666-ff3b-4c7a-9674-367fe2120408"
         )
 

--- a/socorro/unittest/external/fs/test_fspermanentstorage.py
+++ b/socorro/unittest/external/fs/test_fspermanentstorage.py
@@ -105,15 +105,15 @@ class TestFSPermanentStorage:
         with pytest.raises(IOError):
             self.fsrts.get_raw_dump(self.CRASH_ID_1, "foor")
 
-    def test_get_raw_dumps(self):
+    def test_get_dumps(self):
         self._make_test_crash()
         expected = MemoryDumpsMapping(
             {"foo": b"bar", self.fsrts.config.dump_field: b"baz"}
         )
-        assert self.fsrts.get_raw_dumps(self.CRASH_ID_1) == expected
+        assert self.fsrts.get_dumps(self.CRASH_ID_1) == expected
 
         with pytest.raises(CrashIDNotFound):
-            self.fsrts.get_raw_dumps(self.CRASH_ID_2)
+            self.fsrts.get_dumps(self.CRASH_ID_2)
 
     def test_remove(self):
         self._make_test_crash()

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -298,16 +298,16 @@ class TestBench:
             assert "test get_raw_dump 1" in [rec.message for rec in caplogpp.records]
             caplogpp.clear()
 
-            crashstorage.get_raw_dumps("uuid")
-            crashstorage.wrapped_crashstore.get_raw_dumps.assert_called_with("uuid")
-            assert "test get_raw_dumps 1" in [rec.message for rec in caplogpp.records]
+            crashstorage.get_dumps("uuid")
+            crashstorage.wrapped_crashstore.get_dumps.assert_called_with("uuid")
+            assert "test get_dumps 1" in [rec.message for rec in caplogpp.records]
             caplogpp.clear()
 
-            crashstorage.get_raw_dumps_as_files("uuid")
-            crashstorage.wrapped_crashstore.get_raw_dumps_as_files.assert_called_with(
+            crashstorage.get_dumps_as_files("uuid")
+            crashstorage.wrapped_crashstore.get_dumps_as_files.assert_called_with(
                 "uuid"
             )
-            assert "test get_raw_dumps_as_files 1" in [
+            assert "test get_dumps_as_files 1" in [
                 rec.message for rec in caplogpp.records
             ]
             caplogpp.clear()

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -172,24 +172,24 @@ class TestIdentifierRule:
     def test_everything_we_hoped_for(self):
         uuid = "00000000-0000-0000-0000-000002140504"
         raw_crash = {"uuid": uuid}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = IdentifierRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["crash_id"] == uuid
         assert processed_crash["uuid"] == uuid
 
     def test_uuid_missing(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = IdentifierRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         # raw crash and processed crashes should be unchanged
         assert raw_crash == {}
@@ -199,14 +199,14 @@ class TestIdentifierRule:
 class TestCPUInfoRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = copy.copy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = CPUInfoRule()
 
         # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["cpu_arch"] == "x86"
         assert (
@@ -219,7 +219,7 @@ class TestCPUInfoRule:
 
     def test_missing_cpu_count(self):
         raw_crash = copy.copy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         system_info = copy.copy(canonical_processed_crash["json_dump"]["system_info"])
         del system_info["cpu_count"]
         processed_crash = {"json_dump": {"system_info": system_info}}
@@ -228,7 +228,7 @@ class TestCPUInfoRule:
         rule = CPUInfoRule()
 
         # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert (
             processed_crash["cpu_info"] == "GenuineIntel family 6 model 42 stepping 7"
@@ -240,14 +240,14 @@ class TestCPUInfoRule:
 
     def test_missing_json_dump(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = CPUInfoRule()
 
         # the call to be tested
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["cpu_info"] == ""
         assert processed_crash["cpu_arch"] == ""

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -165,45 +165,45 @@ canonical_processed_crash = {
 class TestConvertModuleSignatureInfoRule:
     def test_no_value(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash == {}
         assert processed_crash == {}
 
     def test_string_value(self):
         raw_crash = {"ModuleSignatureInfo": "{}"}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash == {"ModuleSignatureInfo": "{}"}
         assert processed_crash == {}
 
     def test_object_value(self):
         raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
         assert processed_crash == {}
 
     def test_object_value_with_dict(self):
         raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
         assert processed_crash == {}
 
@@ -214,41 +214,41 @@ class TestSubmittedFromInfobarFixRule:
     )
     def test_predicate(self, value, expected):
         raw_crash = {"SubmittedFromInfobar": value}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
         rule = SubmittedFromInfobarFixRule()
-        ret = rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+        ret = rule.predicate(raw_crash, dumps, processed_crash, processor_meta)
         assert ret == expected
 
     def test_predicate_with_not_there(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
         rule = SubmittedFromInfobarFixRule()
-        ret = rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+        ret = rule.predicate(raw_crash, dumps, processed_crash, processor_meta)
         assert ret is False
 
     def test_action(self):
         raw_crash = {"SubmittedFromInfobar": "true"}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
         rule = SubmittedFromInfobarFixRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash == {"SubmittedFromInfobar": "1"}
 
 
 class TestProductRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ProductRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["product"] == "Firefox"
         assert processed_crash["version"] == "12.0"
@@ -263,12 +263,12 @@ class TestProductRule:
         del raw_crash["Distributor_version"]
         del raw_crash["ReleaseChannel"]
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ProductRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["product"] == "Firefox"
         assert processed_crash["version"] == ""
@@ -280,12 +280,12 @@ class TestProductRule:
 class TestUserDataRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = UserDataRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["url"] == "http://www.mozilla.com"
         assert processed_crash["user_comments"] == "why did my browser crash?  #fail"
@@ -297,12 +297,12 @@ class TestUserDataRule:
         del raw_crash["Comments"]
         del raw_crash["Email"]
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = UserDataRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["url"] is None
         assert processed_crash["user_comments"] is None
@@ -312,12 +312,12 @@ class TestUserDataRule:
 class TestEnvironmentRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = EnvironmentRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["app_notes"] == raw_crash["Notes"]
 
@@ -325,12 +325,12 @@ class TestEnvironmentRule:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash["Notes"]
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = EnvironmentRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["app_notes"] == ""
 
@@ -339,23 +339,23 @@ class TestProcessTypeRule:
     def test_process_type(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ProcessType"] = "gpu"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ProcessTypeRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["process_type"] == "gpu"
 
     def test_no_process_type_is_parent(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ProcessTypeRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["process_type"] == "parent"
 
@@ -369,12 +369,12 @@ class TestPluginRule:
         raw_crash["PluginFilename"] = "x.exe"
         raw_crash["PluginName"] = "X"
         raw_crash["PluginVersion"] = "0.0"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["hangid"] == "fake-00000000-0000-0000-0000-000002140504"
         assert processed_crash["hang_type"] == -1
@@ -386,12 +386,12 @@ class TestPluginRule:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Hang"] = 1
         raw_crash["ProcessType"] = "browser"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["hangid"] is None
         assert processed_crash["hang_type"] == 1
@@ -403,16 +403,16 @@ class TestPluginRule:
 class TestAddonsRule:
     def test_action_nothing_unexpected(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        addons_rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        # the raw crash & raw_dumps should not have changed
+        # the raw crash & dumps should not have changed
         assert raw_crash == canonical_standard_raw_crash
-        assert raw_dumps == {}
+        assert dumps == {}
 
         expected_addon_list = [
             "adblockpopups@jessehakanen.net:0.3",
@@ -434,12 +434,12 @@ class TestAddonsRule:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Add-ons"] = "adblockpopups@jessehakanen.net:0:3:1"
         raw_crash["EMCheckCompatibility"] = "Nope"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        addons_rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected_addon_list = ["adblockpopups@jessehakanen.net:0:3:1"]
         assert processed_crash["addons"] == expected_addon_list
@@ -448,12 +448,12 @@ class TestAddonsRule:
     def test_action_addon_is_nonsense(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Add-ons"] = "naoenut813teq;mz;<[`19ntaotannn8999anxse `"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        addons_rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected_addon_list = ["naoenut813teq;mz;<[`19ntaotannn8999anxse `:NO_VERSION"]
         assert processed_crash["addons"] == expected_addon_list
@@ -504,12 +504,12 @@ class TestDatesAndTimesRule:
 
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash["submitted_timestamp"])
         assert processed_crash["submitted_timestamp"] == expected
@@ -526,12 +526,12 @@ class TestDatesAndTimesRule:
     def test_no_crash_time(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash["CrashTime"]
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime.datetime.fromisoformat(raw_crash["submitted_timestamp"])
         expected_timestamp = int(expected.timestamp())
@@ -556,12 +556,12 @@ class TestDatesAndTimesRule:
     def test_no_startup_time(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash["StartupTime"]
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash["submitted_timestamp"])
         assert processed_crash["submitted_timestamp"] == expected
@@ -579,12 +579,12 @@ class TestDatesAndTimesRule:
     def test_bad_startup_time(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["StartupTime"] = "feed the goats"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash["submitted_timestamp"])
         assert processed_crash["submitted_timestamp"] == expected
@@ -604,12 +604,12 @@ class TestDatesAndTimesRule:
     def test_bad_install_time(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["InstallTime"] = "feed the goats"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash["submitted_timestamp"])
         assert processed_crash["submitted_timestamp"] == expected
@@ -629,12 +629,12 @@ class TestDatesAndTimesRule:
     def test_bad_seconds_since_last_crash(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["SecondsSinceLastCrash"] = "feed the goats"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = datetime_from_isodate_string(raw_crash["submitted_timestamp"])
         assert processed_crash["submitted_timestamp"] == expected
@@ -669,12 +669,12 @@ class TestMajorVersionRule:
         raw_crash = {}
         if version is not None:
             raw_crash["Version"] = version
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = MajorVersionRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["major_version"] == expected
 
@@ -707,12 +707,12 @@ class TestBreadcrumbRule:
     def test_basic(self):
         raw_crash = {"Breadcrumbs": json.dumps([{"timestamp": "2021-01-07T16:09:31"}])}
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = BreadcrumbsRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
 
@@ -723,33 +723,33 @@ class TestBreadcrumbRule:
             )
         }
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = BreadcrumbsRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
 
     def test_missing(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
         rule = BreadcrumbsRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash == {}
 
     def test_malformed(self):
         raw_crash = {"Breadcrumbs": "{}"}
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = BreadcrumbsRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash == {}
         assert processor_meta == {
@@ -767,12 +767,12 @@ class TestJavaProcessRule:
                 "\t\tat org.File.function(File.java:100)"
             )
         }
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         # The entire JavaStackTrace blob
         assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
@@ -787,12 +787,12 @@ class TestJavaProcessRule:
     def test_malformed_javastacktrace(self):
         raw_crash = {"JavaStackTrace": "junk\n\tat org.File.function\njunk"}
 
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         # The entire JavaStackTrace blob
         assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
@@ -820,12 +820,12 @@ class TestJavaProcessRule:
         }
 
         raw_crash = {"JavaException": json.dumps(java_exception)}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         # The entire JavaException structure
         assert processed_crash["java_exception_raw"] == java_exception
@@ -840,12 +840,12 @@ class TestJavaProcessRule:
         java_exception = {"exception": {}}
 
         raw_crash = {"JavaException": json.dumps(java_exception)}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         # The JavaException value is malformed, so we get a processor note and
         # that's it
@@ -939,22 +939,22 @@ class TestModuleURLRewriteRule:
 class TestMozCrashReasonRule:
     def test_no_mozcrashreason(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = MozCrashReasonRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash == {}
 
     def test_good_mozcrashreason(self):
         raw_crash = {"MozCrashReason": "MOZ_CRASH(OOM)"}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = MozCrashReasonRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash == {
             "moz_crash_reason_raw": "MOZ_CRASH(OOM)",
             "moz_crash_reason": "MOZ_CRASH(OOM)",
@@ -970,11 +970,11 @@ class TestMozCrashReasonRule:
         ]
         for reason in bad_reasons:
             raw_crash = {"MozCrashReason": reason}
-            raw_dumps = {}
+            dumps = {}
             processed_crash = {}
             processor_meta = get_basic_processor_meta()
 
-            rule.action(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.action(raw_crash, dumps, processed_crash, processor_meta)
             assert processed_crash == {
                 "moz_crash_reason_raw": reason,
                 "moz_crash_reason": "sanitized--see moz_crash_reason_raw",
@@ -1002,7 +1002,7 @@ class TestOutOfMemoryBinaryRule:
     def test_extract_memory_info_too_big(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
-        raw_dumps = {"memory_report": "a_pathname"}
+        dumps = {"memory_report": "a_pathname"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
@@ -1033,14 +1033,14 @@ class TestOutOfMemoryBinaryRule:
             assert processor_meta["processor_notes"] == [expected_error_message]
             opened.close.assert_called_with()
 
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
             assert "memory_report" not in processed_crash
             assert processed_crash["memory_report_error"] == expected_error_message
 
     def test_extract_memory_info_with_trouble(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
-        raw_dumps = {"memory_report": "a_pathname"}
+        dumps = {"memory_report": "a_pathname"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
@@ -1058,7 +1058,7 @@ class TestOutOfMemoryBinaryRule:
                 "error in gzip for a_pathname: OSError()"
             ]
 
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
             assert "memory_report" not in processed_crash
             assert (
                 processed_crash["memory_report_error"]
@@ -1068,7 +1068,7 @@ class TestOutOfMemoryBinaryRule:
     def test_extract_memory_info_with_json_trouble(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
-        raw_dumps = {"memory_report": "a_pathname"}
+        dumps = {"memory_report": "a_pathname"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
@@ -1090,7 +1090,7 @@ class TestOutOfMemoryBinaryRule:
                 assert processor_meta["processor_notes"] == expected
                 mocked_gzip_open.return_value.close.assert_called_with()
 
-                rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+                rule.act(raw_crash, dumps, processed_crash, processor_meta)
                 assert "memory_report" not in processed_crash
                 expected = "error in json for a_pathname: ValueError()"
                 assert processed_crash["memory_report_error"] == expected
@@ -1098,31 +1098,31 @@ class TestOutOfMemoryBinaryRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
-        raw_dumps = {"memory_report": "a_pathname"}
+        dumps = {"memory_report": "a_pathname"}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         class MyOutOfMemoryBinaryRule(OutOfMemoryBinaryRule):
             @staticmethod
             def _extract_memory_info(dump_pathname, processor_notes):
-                assert dump_pathname == raw_dumps["memory_report"]
+                assert dump_pathname == dumps["memory_report"]
                 assert processor_notes == []
                 return "mysterious-awesome-memory"
 
         with mock.patch("socorro.processor.rules.mozilla.temp_file_context"):
             rule = MyOutOfMemoryBinaryRule()
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
             assert processed_crash["memory_report"] == "mysterious-awesome-memory"
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OutOfMemoryBinaryRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert "memory_report" not in processed_crash
 
@@ -1144,12 +1144,12 @@ class TestFenixVersionRewriteRule:
             "ProductName": product,
             "Version": version,
         }
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = FenixVersionRewriteRule()
-        ret = rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+        ret = rule.predicate(raw_crash, dumps, processed_crash, processor_meta)
         assert ret == expected
 
     def test_act(self):
@@ -1157,12 +1157,12 @@ class TestFenixVersionRewriteRule:
             "ProductName": "Fenix",
             "Version": "Nightly 200315 05:05",
         }
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = FenixVersionRewriteRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert raw_crash["Version"] == "0.0a1"
         assert processor_meta["processor_notes"] == [
             "Changed version from 'Nightly 200315 05:05' to 0.0a1"
@@ -1173,12 +1173,12 @@ class TestESRVersionRewrite:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "esr"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["Version"] == "12.0esr"
 
@@ -1188,12 +1188,12 @@ class TestESRVersionRewrite:
     def test_this_is_not_the_crash_you_are_looking_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "not_esr"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["Version"] == "12.0"
 
@@ -1204,12 +1204,12 @@ class TestESRVersionRewrite:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "esr"
         del raw_crash["Version"]
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert "Version" not in raw_crash
         assert processor_meta["processor_notes"] == [
@@ -1225,12 +1225,12 @@ class TestPluginContentURL:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["PluginContentURL"] = "http://mozilla.com"
         raw_crash["URL"] = "http://google.com"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginContentURL()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["URL"] == "http://mozilla.com"
 
@@ -1240,12 +1240,12 @@ class TestPluginContentURL:
     def test_this_is_not_the_crash_you_are_looking_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["URL"] = "http://google.com"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginContentURL()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["URL"] == "http://google.com"
 
@@ -1258,12 +1258,12 @@ class TestPluginUserComment:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["PluginUserComment"] = "I hate it when this happens"
         raw_crash["Comments"] = "I wrote something here, too"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginUserComment()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["Comments"] == "I hate it when this happens"
 
@@ -1273,12 +1273,12 @@ class TestPluginUserComment:
     def test_this_is_not_the_crash_you_are_looking_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Comments"] = "I wrote something here"
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = PluginUserComment()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert raw_crash["Comments"] == "I wrote something here"
 
@@ -1289,12 +1289,12 @@ class TestPluginUserComment:
 class TestExploitablityRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = ExploitablityRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["exploitability"] == "high"
 
@@ -1303,12 +1303,12 @@ class TestExploitablityRule:
 
     def test_this_is_not_the_crash_you_are_looking_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = ExploitablityRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["exploitability"] == "unknown"
 
@@ -1363,12 +1363,12 @@ class TestFlashVersionRule:
 
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = copy.deepcopy(canonical_processed_crash)
         processor_meta = get_basic_processor_meta()
 
         rule = FlashVersionRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["flash_version"] == "9.1.3.08"
 
@@ -1379,7 +1379,7 @@ class TestFlashVersionRule:
 class TestTopMostFilesRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processed_crash["json_dump"] = {
             "crash_info": {"crashing_thread": 0},
@@ -1395,7 +1395,7 @@ class TestTopMostFilesRule:
         processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["topmost_filenames"] == "wilma.cpp"
 
@@ -1405,12 +1405,12 @@ class TestTopMostFilesRule:
     def test_missing_key(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         expected_raw_crash = copy.deepcopy(raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["topmost_filenames"] is None
 
@@ -1419,7 +1419,7 @@ class TestTopMostFilesRule:
 
     def test_missing_key_2(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processed_crash["json_dump"] = {
             "crashing_thread": {
@@ -1430,7 +1430,7 @@ class TestTopMostFilesRule:
         processor_meta = get_basic_processor_meta()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["topmost_filenames"] is None
 
@@ -1441,7 +1441,7 @@ class TestTopMostFilesRule:
 class TestModulesInStackRule:
     def test_basic(self):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "json_dump": {
                 "modules": [
@@ -1459,7 +1459,7 @@ class TestModulesInStackRule:
         processor_meta = get_basic_processor_meta()
 
         rule = ModulesInStackRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert (
             processed_crash["modules_in_stack"]
@@ -1533,7 +1533,7 @@ class TestBetaVersionRule:
     )
     def test_predicate(self, product, channel, expected):
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": product,
             "release_channel": channel,
@@ -1543,14 +1543,14 @@ class TestBetaVersionRule:
         processor_meta = get_basic_processor_meta()
         rule = self.build_rule()
         assert (
-            rule.predicate(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.predicate(raw_crash, dumps, processed_crash, processor_meta)
             == expected
         )
 
     def test_beta_channel_known_version(self):
         # Beta channel with known version gets converted correctly
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "release_channel": "beta",
@@ -1565,14 +1565,14 @@ class TestBetaVersionRule:
                 self.API_URL + "?product=Firefox&channel=beta&build_id=20001001101010",
                 json={"hits": [{"version_string": "3.0b1"}], "total": 1},
             )
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["version"] == "3.0b1"
         assert processor_meta["processor_notes"] == []
 
     def test_release_channel(self):
         """Release channel doesn't trigger rule"""
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "version": "2.0",
@@ -1583,7 +1583,7 @@ class TestBetaVersionRule:
 
         rule = self.build_rule()
         with requests_mock.Mocker():
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["version"] == "2.0"
         assert processor_meta["processor_notes"] == []
@@ -1591,7 +1591,7 @@ class TestBetaVersionRule:
     def test_nightly_channel(self):
         """Nightly channel doesn't trigger rule"""
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "version": "5.0a1",
@@ -1602,7 +1602,7 @@ class TestBetaVersionRule:
 
         rule = self.build_rule()
         with requests_mock.Mocker():
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["version"] == "5.0a1"
         assert processor_meta["processor_notes"] == []
@@ -1610,7 +1610,7 @@ class TestBetaVersionRule:
     def test_bad_buildid(self):
         """Invalid buildids don't cause errors"""
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "release_channel": "beta",
@@ -1627,7 +1627,7 @@ class TestBetaVersionRule:
                 self.API_URL + '?product=Firefox&channel=beta&build_id=2",381,,"',
                 json={"hits": [], "total": 0},
             )
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["version"] == "5.0b0"
         assert processor_meta["processor_notes"] == [
@@ -1638,7 +1638,7 @@ class TestBetaVersionRule:
     def test_beta_channel_unknown_version(self):
         """Beta crash that Socorro doesn't know about gets b0"""
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "version": "3.0.1",
@@ -1653,7 +1653,7 @@ class TestBetaVersionRule:
                 self.API_URL + "?product=Firefox&channel=beta&build_id=220000101101011",
                 json={"hits": [], "total": 0},
             )
-            rule.action(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.action(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["version"] == "3.0.1b0"
         assert processor_meta["processor_notes"] == [
@@ -1664,7 +1664,7 @@ class TestBetaVersionRule:
     def test_aurora_channel(self):
         """Test aurora channel lookup"""
         raw_crash = {}
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {
             "product": "Firefox",
             "version": "3.0",
@@ -1680,7 +1680,7 @@ class TestBetaVersionRule:
                 + "?product=Firefox&channel=aurora&build_id=20001001101010",
                 json={"hits": [{"version_string": "3.0b1"}], "total": 0},
             )
-            rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+            rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["version"] == "3.0b1"
         assert processor_meta["processor_notes"] == []
 
@@ -1705,21 +1705,21 @@ class TestOsPrettyName:
     )
     def test_everything_we_hoped_for(self, os_name, os_version, expected):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule()
 
         processed_crash = {"os_name": os_name, "os_version": os_version}
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["os_pretty_version"] == expected
 
     def test_lsb_release(self):
         # If this is Linux and there's data in json_dump.lsb_release.description,
         # use that
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule()
@@ -1730,7 +1730,7 @@ class TestOsPrettyName:
             "json_dump": {"lsb_release": {"description": "Ubuntu 18.04 LTS"}},
         }
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["os_pretty_version"] == "Ubuntu 18.04 LTS"
 
     @pytest.mark.parametrize(
@@ -1743,7 +1743,7 @@ class TestOsPrettyName:
     )
     def test_junk_data(self, os_name, os_version, expected):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule()
@@ -1755,36 +1755,36 @@ class TestOsPrettyName:
         if os_version is not None:
             processed_crash["os_version"] = os_version
 
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["os_pretty_version"] == expected
 
     def test_dotdict(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule()
 
         processed_crash = {"os_name": "Windows NT", "os_version": "10.0.11.7600"}
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["os_pretty_version"] == "Windows 10"
 
     def test_none(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processor_meta = get_basic_processor_meta()
 
         rule = OSPrettyVersionRule()
 
         processed_crash = {"os_name": None, "os_version": None}
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
         assert processed_crash["os_pretty_version"] is None
 
 
 class TestThemePrettyNameRule:
     def test_everything_we_hoped_for(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_dumps = {}
+        dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()
         processed_crash["addons"] = [
@@ -1802,11 +1802,11 @@ class TestThemePrettyNameRule:
         ]
 
         rule = ThemePrettyNameRule()
-        rule.act(raw_crash, raw_dumps, processed_crash, processor_meta)
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        # the raw crash & raw_dumps should not have changed
+        # the raw crash & dumps should not have changed
         assert raw_crash == canonical_standard_raw_crash
-        assert raw_dumps == {}
+        assert dumps == {}
 
         expected_addon_list = [
             "adblockpopups@jessehakanen.net:0.3",

--- a/socorro/unittest/processor/test_processor_pipeline.py
+++ b/socorro/unittest/processor/test_processor_pipeline.py
@@ -38,8 +38,8 @@ class TestProcessorPipeline:
         raw_crash = {"uuid": "1"}
         processed_crash = DotDict()
 
-        processor = ProcessorPipeline(config, rules=[BadRule()])
-        processor.process_crash(raw_crash, {}, processed_crash)
+        processor = ProcessorPipeline(config, rules={"default": [BadRule()]})
+        processor.process_crash("default", raw_crash, {}, processed_crash)
 
         # Notes were added
         assert (
@@ -70,8 +70,8 @@ class TestProcessorPipeline:
         raw_crash = {"uuid": "1"}
         processed_crash = DotDict()
 
-        processor = ProcessorPipeline(config, rules=[BadRule()])
-        processor.process_crash(raw_crash, {}, processed_crash)
+        processor = ProcessorPipeline(config, rules={"default": [BadRule()]})
+        processor.process_crash("default", raw_crash, {}, processed_crash)
 
         # Notes were added again
         assert (
@@ -82,7 +82,7 @@ class TestProcessorPipeline:
 
     def test_process_crash_existing_processed_crash(self):
         raw_crash = DotDict({"uuid": "1"})
-        raw_dumps = {}
+        dumps = {}
         processed_crash = DotDict(
             {
                 "processor_notes": "we've been here before; yep",
@@ -90,10 +90,14 @@ class TestProcessorPipeline:
             }
         )
 
-        p = ProcessorPipeline(self.get_config(), rules=[CPUInfoRule(), OSInfoRule()])
+        p = ProcessorPipeline(
+            self.get_config(), rules={"default": [CPUInfoRule(), OSInfoRule()]}
+        )
         with mock.patch("socorro.processor.processor_pipeline.utc_now") as faked_utcnow:
             faked_utcnow.return_value = "2015-01-01T00:00:00"
-            processed_crash = p.process_crash(raw_crash, raw_dumps, processed_crash)
+            processed_crash = p.process_crash(
+                "default", raw_crash, dumps, processed_crash
+            )
 
         assert processed_crash.success
         assert processed_crash.started_datetime == "2015-01-01T00:00:00"

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -553,6 +553,9 @@ if not implementations_database_url:
     implementations_database_url = database_url
 implementations_config = dj_database_url.parse(implementations_database_url)
 
+# The list of valid rulesets for the Reprocessing API
+VALID_RULESETS = ["default", "regenerate_signature"]
+
 # The CrashQueueBase class to use for submitting priority and reprocessing
 # requests
 CRASHQUEUE = config(


### PR DESCRIPTION
This adds basic support for multiple rulesets in a processing pipeline
and the ability to specify which ruleset to use when reprocessing a
crash report.

It adds a "regenerate_signature" ruleset which only runs the
SignatureGenerationRule.

It adds a "--ruleset" argument to the reprocess command.

It adds a "ruleset" tag to the process_crash timing metric so we can
differentiate between timings for different processing pipeline
rulesets.

The Reprocessing API validates ruleset names using a Django setting.
Invalid rulset names result in an HTTP 400.

If the processor gets a ruleset name that doesn't match a ruleset, then
it'll log an error, drop the crash id, and move on to the next one in
the queue.

This also renames "raw_dumps" to "dumps" in the processor. It's a
shorter name and we don't have "processed dumps", so we don't need to
specify whether they're raw or not.