### PR TITLE
Fix .readthedocs.yml file and update to python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 # .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
@@ -13,8 +14,9 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: []
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally set the version of Python and requirements required to build your
+# docs
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
This updates building docs to use Python 3.9 and also fixes linting
errors in `.readthedocs.yml` file.