### PR TITLE
Set ReadTheDocs to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,7 @@ formats: []
 # Optionally set the version of Python and requirements required to build your
 # docs
 python:
-  version: 3.9
+  # FIXME(willkg): 2021-04-29: ReadTheDocs doesn't support 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
ReadTheDocs doesn't support Python 3.9, yet, so set it back to 3.8.