### PR TITLE
bug 1546800: add supersearch status page to admin

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -808,7 +808,7 @@ API_MODEL_NAMES = [
 
 def test_api_model_names():
     """
-    Verify the expected API model list.
+    Verify the expected publicly exposed API model list.
 
     This allows parametrized testing of the API Models, for better failure messages.
     """

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -95,14 +95,18 @@ class MiddlewareModelForm(forms.Form):
 
 # Names of models we don't want to serve at all
 API_DONT_SERVE_LIST = (
-    # because it's only used for the admin
+    # Only used for the admin
     "Field",
     "SuperSearchMissingFields",
-    # because it's very sensitive and we don't want to expose it
+    # It's very sensitive and we don't want to expose it
     "Query",
-    # because it's an internal thing only
+    # This is only used to rapidly process crash reports that haven't been processed
+    # yet, but someone is trying to look at them
     "PriorityJob",
+    # This is used by another API to verify crash data
     "TelemetryCrash",
+    # This is internal and used in the Django admin
+    "SuperSearchStatus",
 )
 
 

--- a/webapp-django/crashstats/manage/admin.py
+++ b/webapp-django/crashstats/manage/admin.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
+import json
 from urllib.parse import urlparse
 
 import requests
@@ -14,7 +15,10 @@ from django.db import connection
 from django.shortcuts import render
 
 from crashstats.manage.decorators import superuser_required
-from crashstats.supersearch.models import SuperSearchMissingFields
+from crashstats.supersearch.models import (
+    SuperSearchMissingFields,
+    SuperSearchStatus,
+)
 
 
 @superuser_required
@@ -98,6 +102,18 @@ def supersearch_fields_missing(request):
     context["title"] = "Super search missing fields"
 
     return render(request, "admin/supersearch_fields_missing.html", context)
+
+
+@superuser_required
+def supersearch_status(request):
+    context = {}
+    status = SuperSearchStatus().get()
+    context["indices"] = status["indices"]
+    context["latest_index"] = status["latest_index"]
+    context["mapping"] = json.dumps(status["mapping"], indent=2)
+    context["title"] = "Supersearch status"
+
+    return render(request, "admin/supersearch_status.html", context)
 
 
 @superuser_required

--- a/webapp-django/crashstats/manage/admin_urls.py
+++ b/webapp-django/crashstats/manage/admin_urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         name="supersearch_fields_missing",
     ),
     url(
+        "^supersearch-status/$",
+        admin.supersearch_status,
+        name="supersearch_status",
+    ),
+    url(
         "^protected-data-users/$",
         admin.protected_data_users,
         name="protected_data_users",

--- a/webapp-django/crashstats/manage/templates/admin/socorro_admin_index.html
+++ b/webapp-django/crashstats/manage/templates/admin/socorro_admin_index.html
@@ -42,6 +42,13 @@
           </tr>
           <tr>
             <th scope="row">
+              <a href="{% url 'siteadmin:supersearch_status' %}">Super search status</a>
+            </th>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <th scope="row">
               <a href="{% url 'siteadmin:supersearch_fields_missing' %}">Super search fields missing</a>
             </th>
             <td></td>

--- a/webapp-django/crashstats/manage/templates/admin/supersearch_status.html
+++ b/webapp-django/crashstats/manage/templates/admin/supersearch_status.html
@@ -1,0 +1,42 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n admin_urls static admin_list %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css"%}">
+{% endblock %}
+
+{% if not is_popup %}
+  {% block breadcrumbs %}
+    <div class="breadcrumbs">
+      <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+      &rsaquo; Management pages
+      &rsaquo; Elasticsearch status
+    </div>
+  {% endblock %}
+{% endif %}
+
+{% block content %}
+  <div class="content-main">
+    <h2>Elasticsearch status</h2>
+    <div class="body">
+      <h3>Indices</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for index_name, count in indices %}
+            <tr><td>{{ index_name }}</td><td>{{ count }}</td>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <h3>Mapping ({{ latest_index }})</h3>
+      <pre>{{ mapping }}</pre>
+    </div>
+  </div>
+{% endblock %}

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -224,6 +224,12 @@ class SuperSearchMissingFields(ESSocorroMiddleware):
     cache_seconds = 60 * 60 * 12  # 12 hours
 
 
+class SuperSearchStatus(ESSocorroMiddleware):
+    implementation = super_search_fields.SuperSearchStatusModel
+
+    cache_seconds = 0
+
+
 class Query(ESSocorroMiddleware):
     # No API_ALLOWLIST because this can't be accessed through the public API.
 


### PR DESCRIPTION
This adds a super search status page to the admin where we can see the
list of indices available as well as the latest mapping. The latter will
help debug various super search problems because the mapping specifies
which fields are indexed and how.