### PR TITLE
bug 1546800: fix supersearch status to show dates for indices

### DIFF
--- a/webapp-django/crashstats/manage/templates/admin/supersearch_status.html
+++ b/webapp-django/crashstats/manage/templates/admin/supersearch_status.html
@@ -25,12 +25,13 @@
         <thead>
           <tr>
             <th>Name</th>
+            <th>Start date</th>
             <th>Count</th>
           </tr>
         </thead>
         <tbody>
-          {% for index_name, count in indices %}
-            <tr><td>{{ index_name }}</td><td>{{ count }}</td>
+          {% for item in indices %}
+            <tr><td>{{ item.name }}</td><td>{{ item.start_date }}</td><td>{{ item.count }}</td>
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
The template for index names is `socorro%Y%W`. The `%W` is the week number.
It's hard for me to figure out what the date is for a week, so I tweaked
the code to figure out the start date for that week and show that in the
indices list, too.