### PR TITLE
bug 1709024: clarify Installations count in Product table of signature report

### DIFF
--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -24,7 +24,14 @@ from crashstats.crashstats.utils import parse_isodate, urlencode_obj
 
 
 @library.global_function
+def minimum(item1, item2):
+    """Returns the minimum of two items"""
+    return min(item1, item2)
+
+
+@library.global_function
 def truncatechars(str_, max_length):
+    """Truncates a string to max_length and adds ... to the end"""
     if len(str_) < max_length:
         return str_
     else:

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -102,7 +102,7 @@
           <th class="header">Version</th>
           <th class="header">Count</th>
           <th class="header">Percentage</th>
-          <th class="header">Installations</th>
+          <th class="header">Installations (approx)</th>
         </tr>
       </thead>
       <tbody>
@@ -113,7 +113,7 @@
               <td>{{ version_facet.term }}</td>
               <td>{{ version_facet.count }}</td>
               <td>{{ (100.0 * version_facet.count / product_version_total) | round(1) }}%</td>
-              <td>{{ version_facet.facets.cardinality_install_time.value }}</td>
+              <td>{{ minimum(version_facet.facets.cardinality_install_time.value, version_facet.count) }}</td>
             </tr>
           {% endfor %}
         {% endfor %}


### PR DESCRIPTION
The signature report has a Product table that shows the count of crash
reports for a specific version and how many installations. The count is
a precise count of a value that has a small domain of options. The
number of installations is a cardinality aggregation of a datestamp
which has a very large domain of options and thus Elasticsearch computes
an approximate. It's possible for the number of installations to exceed
the number of crash reports which makes no sense and is confusing.

This adds "(approx)" to the column header label. It also caps the number
of installations displayed so it's never more than the number of crash
reports.