### PR TITLE
bug 1713104: update minidump-stackwalk to 2021.06.01

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-# FROM mozilla/socorro-minidump-stackwalk:2021.05.05@sha256:82c3ae75e37acebca69585bfe44425e95f7a79704fcc19d4b46fa6341f49d1b6 as breakpad
-FROM mozilla/socorro-minidump-stackwalk:2021.05.27@sha256:a4bfa3f7451f84ff37d2a61b96ff093495e30f74cbe5f6ad9b7f00d760643025 as breakpad
+FROM mozilla/socorro-minidump-stackwalk:2021.06.01@sha256:56328ec18ba63c4cf5927b08aee6636f09213da9a1697a0f5caeeaf7ebc1c768 as breakpad
 
 FROM python:3.9.5-slim@sha256:80b238ba357d98813bcc425f505dfa238f49cf5f895492fc2667af118dccaa44
 


### PR DESCRIPTION
This picks up another segfault fix where the minidump doesn't have a system info stream and the leftpad code looks at the system info stream to determine the arch.

I tested it with these crash reports:

* fef248b7-cd01-498a-bc77-353b80210527
* 6caa9e0b-c983-4225-9e2d-0c5c00210526
* 3ebab252-01ff-4646-bbd4-9c3c30210527

The first two caused segfaults that were fixed last week. The last of those three had a segfault that's fixed by minidump-stackwalk 2021.06.01.