### PR TITLE
Bug 1715634 - add get_fpsr to the irrelevant signature list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -39,6 +39,7 @@ g_assertion_message_error
 g_assertion_message_expr
 gdk_x_error
 _gdk_x11_display_error_event
+get_fpsr
 GetLCIDFromLangListNodeWithLICCheck
 gfxPlatform::GetPlatform
 gkrust_shared::oom_hook::hook


### PR DESCRIPTION
That signature is coalescing very different stacks/causes.

Example crash reports from the bug:

```
  app@socorro:/app$ socorro-cmd signature a9a647b0-cbec-4e80-9abc-1897e0210607
  Crash id: a9a647b0-cbec-4e80-9abc-1897e0210607
  Original: get_fpsr
  New:      NlsGetCacheUpdateCount
  Same?:    False
  app@socorro:/app$ socorro-cmd signature ba44bb89-ac6f-4ea2-81a2-99b780210609
  Crash id: ba44bb89-ac6f-4ea2-81a2-99b780210609
  Original: get_fpsr
  New:      CTopologyCache::MarkNotInUse
  Same?:    False
  app@socorro:/app$ socorro-cmd signature a69bb7de-33f0-422c-88a9-267680210609
  Crash id: a69bb7de-33f0-422c-88a9-267680210609
  Original: get_fpsr
  New:      DoMozStackWalkThread
  Same?:    False
```