### PR TITLE
Add a useless hashbrown frame

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -86,6 +86,7 @@ gsignal
 handle_errorf
 handle_response
 HandleInvalidParameter
+hashbrown::raw::Fallibility::alloc_err
 hashbrown::raw::RawTable<T>::new_uninitialized<T>
 HeapFree
 huge_dalloc


### PR DESCRIPTION
This will separate out the signatures in https://bugzilla.mozilla.org/show_bug.cgi?id=1678409