### PR TITLE
bug 1716742: mark last_error_value ERROR_COMMITMENT_LEVEL as OOM

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -13,6 +13,8 @@ from .utils import (
     collapse,
     drop_bad_characters,
     drop_prefix_and_return_type,
+    get_crashing_thread,
+    override_values,
     parse_source_file,
 )
 
@@ -508,12 +510,6 @@ class SignatureGenerationRule(Rule):
             frame_signatures_list.append(normalized_frame)
         return frame_signatures_list
 
-    def _get_crashing_thread(self, crash_data):
-        try:
-            return int(crash_data.get("crashing_thread", 0))
-        except (TypeError, ValueError):
-            return 0
-
     def action(self, crash_data, result):
         # If this is a Java crash, then generate a Java signature
         if crash_data.get("java_stack_trace"):
@@ -530,13 +526,7 @@ class SignatureGenerationRule(Rule):
 
         result.debug(self.name, "using CSignatureTool")
         try:
-            # First, we need to figure out which thread to look at. If it's a
-            # chrome hang (1), then use thread 0. Otherwise, use the crashing
-            # thread specified in the crash data.
-            if crash_data.get("hang_type", None) == 1:
-                crashing_thread = 0
-            else:
-                crashing_thread = self._get_crashing_thread(crash_data)
+            crashing_thread = get_crashing_thread(crash_data)
 
             # If we have a thread to look at, pull the frames for that.
             # Otherwise we don't have frames to use.
@@ -578,6 +568,7 @@ class OOMSignature(Rule):
 
     """
 
+    # Fragments that are in the signature that indicate this is an OOM
     signature_fragments = (
         "NS_ABORT_OOM",
         "mozalloc_handle_oom",
@@ -596,6 +587,15 @@ class OOMSignature(Rule):
 
         for a_signature_fragment in self.signature_fragments:
             if a_signature_fragment in signature:
+                return True
+
+        # Check the last_error_value of the crashing thread to see if it's
+        # ERROR_COMMITMENT_LIMIT which indicates this is an OOM
+        crashing_thread = get_crashing_thread(crash_data)
+        thread = glom(crash_data, "threads.%d" % crashing_thread, default={})
+        if thread:
+            last_error_value = thread.get("last_error_value", "")
+            if last_error_value == "ERROR_COMMITMENT_LIMIT":
                 return True
 
         return False
@@ -727,24 +727,24 @@ class StackwalkerErrorSignatureRule(Rule):
         return True
 
 
-class SignatureRunWatchDog(SignatureGenerationRule):
+class SignatureRunWatchDog(Rule):
     """Prepends "shutdownhang" to signature for shutdown hang crashes."""
+
+    def __init__(self):
+        super().__init__()
+        self.signature_generation_rule = SignatureGenerationRule()
 
     def predicate(self, crash_data, result):
         return "RunWatchdog" in result.signature
 
-    def _get_crashing_thread(self, crash_data):
-        # Always use thread 0 in this case, because that's the thread that
-        # was hanging when the software was artificially crashed.
-        return 0
-
     def action(self, crash_data, result):
-        # For shutdownhang crashes, we need to use thread 0 instead of the
-        # crashing thread. The reason is because those crashes happen
-        # artificially when thread 0 gets stuck. So whatever the crashing
-        # thread is, we don't care about it and only want to know what was
-        # happening in thread 0 when it got stuck.
-        ret = super().action(crash_data, result)
+        # For shutdownhang crashes, we need to use thread 0 instead of the crashing
+        # thread. The reason is because those crashes happen artificially when thread 0
+        # gets stuck. So whatever the crashing thread is, we don't care about it and
+        # only want to know what was happening in thread 0 when it got stuck.
+        with override_values(crash_data, {"crashing_thread": 0}) as crash_data:
+            ret = self.signature_generation_rule.action(crash_data, result)
+
         result.set_signature(self.name, f"shutdownhang | {result.signature}")
         return ret
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1355,14 +1355,6 @@ class TestStackwalkerErrorSignatureRule:
 
 
 class TestSignatureWatchDogRule:
-    def test_instantiation(self):
-        srwd = rules.SignatureRunWatchDog()
-
-        assert isinstance(srwd.c_signature_tool, rules.CSignatureTool)
-        assert isinstance(srwd.java_signature_tool, rules.JavaSignatureTool)
-
-        assert srwd._get_crashing_thread({}) == 0
-
     def test_predicate(self):
         srwd = rules.SignatureRunWatchDog()
 


### PR DESCRIPTION
This marks crash reports from WER that don't have a `OOMAllocationSize` annotation, but do have a `last_error_value` as `ERROR_COMMITMENT_LEVEL` as OOM crashes.

To do that, I needed access to the crashing thread data. There was a bunch of code around accessing that which was different, so I centralized that and added tests.

While doing that, I reworked `SignatureRunWatchDog` rule so it didn't use subclassing but was instead its own rule.

```
app@socorro:/app$ socorro-cmd signature 220a1716-f404-42a0-9fb2-79a0c0210707
Crash id: 220a1716-f404-42a0-9fb2-79a0c0210707
Original: mozilla::wr::RenderCompositorD3D11SWGL::TileD3D11::Map
New:      OOM | unknown | mozilla::wr::RenderCompositorD3D11SWGL::TileD3D11::Map
Same?:    False
```