### PR TITLE
bug 1715747: add Windows fastfail frames to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -132,6 +132,7 @@ std::__terminate
 std::terminate
 system@framework@.*\.jar@classes\.dex@0x
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
+
 # These frames have platform variants and bucket poorly so we nix them
 # from the signature
 .*\$VARIANT\$
@@ -141,3 +142,15 @@ _XError
 _XReply
 _ZdlPv
 zero
+
+# Windows-specific fastfail frames
+KiRaiseUserExceptionDispatcher
+KiUserExceptionDispatch
+KiUserExceptionDispatcher
+LdrpICallHandler
+LdrpValidateUserCallTarget
+RtlDispatchException
+RtlFailFast2
+RtlpExecuteHandlerForException
+RtlpHandleInvalidUserCallTarget
+seh_filter_exe

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -115,8 +115,6 @@ JS_DHashTableOperate
 JS_NewStringCopyZ
 js_strlen
 KiFastSystemCall
-KiRaiseUserExceptionDispatcher
-KiUserExceptionDispatcher
 kill
 __libc_android_abort
 __libc_message


### PR DESCRIPTION
```
app@socorro:/app$ cat crashids.txt | socorro-cmd signature
Crash id: 18c190a7-4426-4f3e-a9c5-ed29e0210713
Original: KiRaiseUserExceptionDispatcher | GetHandleInformation
New:      GetHandleInformation
Same?:    False

Crash id: 0d5d9b1c-2885-4a5f-85b1-02bb60210713
Original: KiUserExceptionDispatch
New:      _TypeMatch
Same?:    False

Crash id: b8da1857-f8a7-4bf7-b7d1-c093f0210714
Original: RtlFailFast2 | RtlpHandleInvalidUserCallTarget | RtlDispatchException | KiUserExceptionDispatcher | LdrpValidateUserCallTarget
New:      mozilla::layout_telemetry::AutoRecord::~AutoRecord
Same?:    False

Crash id: ce3e50b9-565e-435f-ac4d-bd79f0210714
Original: LdrpICallHandler
New:      LdrpDispatchUserCallTarget
Same?:    False

Crash id: 4186b4c8-dec6-4f85-be63-e86ba0210714
Original: shutdownhang | LdrpValidateUserCallTargetBitMapCheck
New:      shutdownhang | ComPtr<T>::Deref
Same?:    False

Crash id: 92431161-87ef-4099-b9d9-fe6a00210714
Original: RtlLookupFunctionEntry | truncf | RtlDispatchException | RtlGuardCheckImageBase | <T>
New:      RtlLookupFunctionEntry | truncf | RtlGuardCheckImageBase | <T>
Same?:    False

Crash id: 651b0a00-52e8-414c-a836-e6c5c0210714
Original: RtlFailFast2 | RtlpHandleInvalidUserCallTarget | LdrpHandleInvalidUserCallTarget
New:      LdrpHandleInvalidUserCallTarget
Same?:    False

Crash id: 8f8b1d34-0e3c-4e69-8904-c1ff70210714
Original: dgapi64.dll | RtlpExecuteHandlerForException | RtlDispatchException | KiUserExceptionDispatch
New:      dgapi64.dll | floor
Same?:    False

Crash id: a5f0b266-9a18-4330-8ef8-dd32b0210714
Original: seh_filter_exe
New:      `thread_start<T>'::`1'::filt$0
Same?:    False
```