### PR TITLE
bug 1716611: add pthreads_kill to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -261,6 +261,7 @@ pthread_cond_signal_thread_np
 pthread_mutex_lock
 pthread_mutex_trylock
 __pthread_kill
+pthread_kill
 __pthread_mutex_lock
 _purecall
 raise


### PR DESCRIPTION
Example:

```
app@socorro:/app$ socorro-cmd signature ca9e27c5-0239-479c-a271-033e90210713
Crash id: ca9e27c5-0239-479c-a271-033e90210713
Original: __pthread_kill | pthread_kill
New:      __pthread_kill | pthread_kill | abort | gpusGenerateCrashLog.cold.1
Same?:    False
```