### PR TITLE
bug #1703407: remove handling for "browser" as a process type

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2828,7 +2828,6 @@ FIELDS = {
         "form_field_choices": [
             "any",
             "parent",
-            "browser",
             "plugin",
             "content",
             "gpu",

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -143,7 +143,7 @@ class PluginRule(Rule):
         # the processed_crash["hang_type"] has the following meaning:
         #
         # * hang_type == -1 is a plugin hang
-        # * hang_type ==  1 is a browser hang
+        # * hang_type ==  1 is a parent hang
         # * hang_type ==  0 is not a hang at all, but a normal crash
 
         try:

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -220,48 +220,6 @@ class TestSearchBase:
         with pytest.raises(BadArgumentError):
             search.get_parameters(date=">1999-01-01")
 
-    def test_process_type_parameter_correction_parent(self):
-        search = SearchBaseWithFields()
-
-        args = {"process_type": "parent"}
-        params = search.get_parameters(**args)
-        assert "process_type" in params
-        assert len(params["process_type"]) == 2
-        assert params["process_type"][0].value == ["parent"]
-        assert params["process_type"][1].value == [""]
-        assert params["process_type"][1].operator == "__null__"
-        assert params["process_type"][1].operator_not is False
-
-        args = {"process_type": "=parent"}
-        params = search.get_parameters(**args)
-        assert "process_type" in params
-        assert len(params["process_type"]) == 2
-        assert params["process_type"][0].value == "parent"
-        assert params["process_type"][1].value == [""]
-        assert params["process_type"][1].operator == "__null__"
-        assert params["process_type"][1].operator_not is False
-
-    def test_process_type_parameter_correction_browser(self):
-        search = SearchBaseWithFields()
-
-        args = {"process_type": "browser"}
-        params = search.get_parameters(**args)
-        assert "process_type" in params
-        assert len(params["process_type"]) == 2
-        assert params["process_type"][0].value == ["parent"]
-        assert params["process_type"][1].value == [""]
-        assert params["process_type"][1].operator == "__null__"
-        assert params["process_type"][1].operator_not is False
-
-        args = {"process_type": "=browser"}
-        params = search.get_parameters(**args)
-        assert "process_type" in params
-        assert len(params["process_type"]) == 2
-        assert params["process_type"][0].value == "parent"
-        assert params["process_type"][1].value == [""]
-        assert params["process_type"][1].operator == "__null__"
-        assert params["process_type"][1].operator_not is False
-
     def test_hang_type_parameter_correction(self):
         search = SearchBaseWithFields()
 

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -382,7 +382,7 @@ class TestPluginRule:
     def test_browser_hang(self):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Hang"] = 1
-        raw_crash["ProcessType"] = "browser"
+        raw_crash["ProcessType"] = "parent"
         dumps = {}
         processed_crash = {}
         processor_meta = get_basic_processor_meta()

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -296,7 +296,7 @@
                 <tr title="{{ fields_desc['processed_crash.process_type'] }}">
                   <th scope="row">Process Type</th>
                   <td>
-                    {{ report.process_type or "browser" }}
+                    {{ report.process_type or "parent" }}
                     {% if report.process_type == "content" and request.user.has_perm("crashstats.view_pii") -%}
                       ({{ raw.RemoteType or 'web' }}) - {{ protected_warning() }}
                     {%- endif %}

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -519,7 +519,7 @@ class TestViews(BaseTestViews):
                 "facets": {
                     "platform_pretty_version": [{"count": 4, "term": "Windows 7"}],
                     "cpu_arch": [{"count": 4, "term": "x86"}],
-                    "process_type": [{"count": 4, "term": "browser"}],
+                    "process_type": [{"count": 4, "term": "parent"}],
                     "product": [
                         {
                             "count": 4,
@@ -635,7 +635,7 @@ class TestViews(BaseTestViews):
         assert "x86" in smart_text(response.content)
         assert "WaterWolf" in smart_text(response.content)
         assert "2.1b99" in smart_text(response.content)
-        assert "browser" in smart_text(response.content)
+        assert "parent" in smart_text(response.content)
         assert "1.1.1.14" in smart_text(response.content)
         assert "&lt; 1 min" in smart_text(response.content)
         assert "1-5 min" in smart_text(response.content)


### PR DESCRIPTION
A long time ago, we used "browser" as the default and did some shenanigans to make it work as such. We transitioned to using "parent" as the default value and added a processor rule to fill in the default process type if there wasn't one already. Now all crash reports have a process type and we no longer use "browser".

This removes the special casing for handling "browser" as a process type and covering crash reports that didn't have one in the crash annotations.