### PR TITLE
bug 1723465: add more windows symbols to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -144,9 +144,16 @@ _ZdlPv
 zero
 
 # Windows-specific fastfail frames
+KiFastSystemCall
 KiRaiseUserExceptionDispatcher
+KiUserApcDispatch
+KiUserApcDispatcher
+KiUserCallbackDispatch
+KiUserCallbackDispatcher
 KiUserExceptionDispatch
 KiUserExceptionDispatcher
+LdrpDispatchUserCallTarget
+LdrpHandleInvalidUserCallTarget
 LdrpICallHandler
 LdrpValidateUserCallTarget
 RtlDispatchException


### PR DESCRIPTION
This adds:

* KiFastSystemCall
* KiUserApcDispatch
* KiUserApcDispatcher
* KiUserCallbackDispatch
* KiUserCallbackDispatcher
* LdrpDispatchUserCallTarget
* LdrpHandleInvalidUserCallTarget

Output:

```
app@socorro:/app$ socorro-cmd signature 43c6e4f0-cc39-4a29-8dd0-5ea770210804 ceed976b-4458-4c9b-8619-0f7490210730 8cacdf33-176c-4221-91bd-ee4d80210730 3be5e8e4-1153-4cb0-ae77-44cf00210804 14165c39-c22e-4562-aae9-6e6a90210804 20ce8912-5e38-4180-b569-f63680210729 a69913dd-d123-42cc-8a79-795470210731
Crash id: 43c6e4f0-cc39-4a29-8dd0-5ea770210804
Original: KiFastSystemCall | sbupd.dll
New:      sbupd.dll
Same?:    False

Crash id: ceed976b-4458-4c9b-8619-0f7490210730
Original: RtlReleaseActivationContext | RtlDispatchAPC | KiUserApcDispatch
New:      RtlReleaseActivationContext | RtlDispatchAPC | NtDelayExecution
Same?:    False

Crash id: 8cacdf33-176c-4221-91bd-ee4d80210730
Original: cap3rdn.dll | RtlUnwind | KiUserApcDispatcher
New:      cap3rdn.dll | RtlUnwind | __std_type_info_name
Same?:    False

Crash id: 3be5e8e4-1153-4cb0-ae77-44cf00210804
Original: shutdownhang | KiUserCallbackDispatch
New:      shutdownhang | NtUserPeekMessage | _PeekMessage
Same?:    False

Crash id: 14165c39-c22e-4562-aae9-6e6a90210804
Original: shutdownhang | KiUserCallbackDispatcher
New:      shutdownhang | NtUserPeekMessage | PeekMessageW
Same?:    False

Crash id: 20ce8912-5e38-4180-b569-f63680210729
Original: shutdownhang | LdrpDispatchUserCallTarget
New:      shutdownhang | DispatchHookW
Same?:    False

Crash id: a69913dd-d123-42cc-8a79-795470210731
Original: LdrpHandleInvalidUserCallTarget
New:      RtlFreeHeap | LRPC_CCALL::`scalar deleting destructor'
Same?:    False
```