### PR TITLE
bug 1723474: look at reason for OOM indicator

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -598,6 +598,11 @@ class OOMSignature(Rule):
             if last_error_value == "ERROR_COMMITMENT_LIMIT":
                 return True
 
+        # Check the reason to see if it's one of a few values that indicate an OOM
+        reason = crash_data.get("reason", None)
+        if reason in ["STATUS_FATAL_MEMORY_EXHAUSTION", "STATUS_NO_MEMORY"]:
+            return True
+
         return False
 
     def action(self, crash_data, result):

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1147,6 +1147,57 @@ class TestOOMSignature:
         rule = rules.OOMSignature()
         assert rule.predicate(crash_data, result) is True
 
+    @pytest.mark.parametrize(
+        "crashdata, expected",
+        [
+            ({}, False),
+            ({"crashing_thread": 5}, False),
+            ({"crashing_thread": 5, "threads": []}, False),
+            (
+                {
+                    "crashing_thread": 0,
+                    "threads": [
+                        {
+                            "last_error_value": "FOO",
+                        },
+                    ],
+                },
+                False,
+            ),
+            (
+                {
+                    "crashing_thread": 0,
+                    "threads": [
+                        {
+                            "last_error_value": "ERROR_COMMITMENT_LIMIT",
+                        },
+                    ],
+                },
+                True,
+            ),
+        ],
+    )
+    def test_predicate_error_commitment_limit(self, crashdata, expected):
+        result = generator.Result()
+        result.signature = "Text"
+        rule = rules.OOMSignature()
+        assert rule.predicate(crashdata, result) is expected
+
+    @pytest.mark.parametrize(
+        "reason, expected",
+        [
+            ("FOO", False),
+            ("STATUS_NO_MEMORY", True),
+            ("STATUS_FATAL_MEMORY_EXHAUSTION", True),
+        ],
+    )
+    def test_predicate_reason(self, reason, expected):
+        crash_data = {"reason": reason}
+        result = generator.Result()
+        result.signature = "Text"
+        rule = rules.OOMSignature()
+        assert rule.predicate(crash_data, result) is expected
+
     def test_action_success(self):
         crash_data = {}
         result = generator.Result()

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -83,6 +83,8 @@ def convert_to_crash_data(raw_crash, processed_crash):
         "crashing_thread": glom(
             processed_crash, "json_dump.crash_info.crashing_thread", default=None
         ),
+        # string or None
+        "reason": glom(processed_crash, "json_dump.crash_info.type", default=None),
         # list of CStackTrace or None
         "threads": glom(processed_crash, "json_dump.threads", default=None),
         # int or None


### PR DESCRIPTION
This adds a signature generation rule that looks at crash_info.type reason and uses that as an indicator that the crash is an OOM.
`STATUS_FATAL_MEMORY_EXHAUSTION` and `STATUS_NO_MEMORY` are both OOM indicators.

This also adds a test for another OOM indicator I added recently but didn't add a test for.