### PR TITLE
bug 1723691: make windows_error_reporting searchable

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -433,6 +433,45 @@ def get_fields_by_item(fields, key, val):
     return fields
 
 
+def flag_field(
+    name,
+    description,
+    namespace,
+    in_database_name,
+    is_protected=True,
+):
+    """Generates a flag field.
+
+    Flag fields are one of a few things:
+
+    1. a boolean value that is either true and false
+    2. a crash annotation flag that is "1" or missing
+
+    These can be searched and aggregated, but documents that are missing the field won't
+    show up in aggregations.
+
+    """
+    if is_protected:
+        permissions_needed = ["crashstats.view_pii"]
+    else:
+        permissions_needed = []
+
+    return {
+        "name": name,
+        "description": description,
+        "data_validation_type": "bool",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "namespace": namespace,
+        "in_database_name": in_database_name,
+        "is_exposed": True,
+        "is_returned": True,
+        "query_type": "bool",
+        "permissions_needed": permissions_needed,
+        "storage_mapping": {"type": "boolean"},
+    }
+
+
 # Tree of super search fields
 FIELDS = {
     "ActiveExperiment": {
@@ -3431,6 +3470,16 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
+    "windows_error_reporting": flag_field(
+        name="windows_error_reporting",
+        description=(
+            "Set to 1 if this crash was intercepted via the Windows Error Reporting "
+            "runtime exception module."
+        ),
+        namespace="processed_crash",
+        in_database_name="windows_error_reporting",
+        is_protected=False,
+    ),
     "winsock_lsp": {
         "data_validation_type": "str",
         "description": (

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -36,6 +36,7 @@ from socorro.processor.rules.mozilla import (
     BetaVersionRule,
     BreadcrumbsRule,
     ConvertModuleSignatureInfoRule,
+    CopyFromRawCrashRule,
     DatesAndTimesRule,
     EnvironmentRule,
     ESRVersionRewrite,
@@ -191,10 +192,11 @@ class ProcessorPipeline(RequiredConfig):
                 # rules to change the internals of the raw crash
                 FenixVersionRewriteRule(),
                 ESRVersionRewrite(),
-                ProcessTypeRule(),
                 PluginContentURL(),
                 PluginUserComment(),
                 # rules to transform a raw crash into a processed crash
+                CopyFromRawCrashRule(),
+                ProcessTypeRule(),
                 IdentifierRule(),
                 MinidumpSha256Rule(),
                 BreakpadStackwalkerRule2015(

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -31,6 +31,29 @@ from socorro.signature.utils import convert_to_crash_data
 MAXINT = 9223372036854775807
 
 
+class CopyFromRawCrashRule(Rule):
+    """Copy data from raw crash to processed crash with correct name
+
+    This copies and normalizes crash annotations from the raw crash.
+
+    """
+    FLAGS = [
+        ("WindowsErrorReporting", "windows_error_reporting"),
+    ]
+
+    def action(self, raw_crash, dumps, processed_crash, processor_meta):
+        # FIXME(willkg): This is currently hard-coded. We should change it to work from
+        # a schema.
+
+        for raw_key, processed_key in self.FLAGS:
+            if raw_key in raw_crash:
+                flag_value = raw_crash[raw_key]
+                if flag_value == "1":
+                    processed_crash[processed_key] = "1"
+                else:
+                    processor_meta["processor_notes"].append(f"{raw_key} has non-1 value")
+
+
 class ConvertModuleSignatureInfoRule(Rule):
     """Make ModuleSignatureInfo to a string.
 

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -37,6 +37,7 @@ class CopyFromRawCrashRule(Rule):
     This copies and normalizes crash annotations from the raw crash.
 
     """
+
     FLAGS = [
         ("WindowsErrorReporting", "windows_error_reporting"),
     ]
@@ -51,7 +52,9 @@ class CopyFromRawCrashRule(Rule):
                 if flag_value == "1":
                     processed_crash[processed_key] = "1"
                 else:
-                    processor_meta["processor_notes"].append(f"{raw_key} has non-1 value")
+                    processor_meta["processor_notes"].append(
+                        f"{raw_key} has non-1 value"
+                    )
 
 
 class ConvertModuleSignatureInfoRule(Rule):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -17,6 +17,7 @@ from socorro.processor.rules.mozilla import (
     BetaVersionRule,
     BreadcrumbsRule,
     ConvertModuleSignatureInfoRule,
+    CopyFromRawCrashRule,
     DatesAndTimesRule,
     ESRVersionRewrite,
     EnvironmentRule,
@@ -160,6 +161,42 @@ canonical_processed_crash = {
         ],
     }
 }
+
+
+class TestCopyFromRawCrashRule:
+    def test_empty(self):
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule = CopyFromRawCrashRule()
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+        assert raw_crash == {}
+        assert processed_crash == {}
+        assert processor_meta["processor_notes"] == []
+
+    @pytest.mark.parametrize("flag", CopyFromRawCrashRule.FLAGS)
+    def test_flags(self, flag):
+        raw_key, processed_key = flag
+        rule = CopyFromRawCrashRule()
+
+        raw_crash = {raw_key: "1"}
+        dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+        assert raw_crash == {raw_key: "1"}
+        assert processed_crash == {processed_key: "1"}
+        assert processor_meta["processor_notes"] == []
+
+        raw_crash = {raw_key: "foo"}
+        dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+        assert raw_crash == {raw_key: "foo"}
+        assert processed_crash == {}
+        assert processor_meta["processor_notes"] == [f"{raw_key} has non-1 value"]
 
 
 class TestConvertModuleSignatureInfoRule:

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -214,6 +214,14 @@
                     </td>
                   </tr>
                 {% endif %}
+                {% if report.windows_error_reporting == "1" %}
+                  <tr title="{{ fields_desc['processed_crash.windows_error_reporting'] }}">
+                    <th scope="row">Windows Error Reporting</th>
+                    <td>
+                      <pre>{{ report.windows_error_reporting }}</pre>
+                    </td>
+                  </tr>
+                {% endif %}
 
                 {# Hardware #}
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -661,6 +661,7 @@ class ProcessedCrash(SocorroMiddleware):
         "uptime",
         "uuid",
         "version",
+        "windows_error_reporting",
         "Winsock_LSP",
     )
 
@@ -815,6 +816,7 @@ class RawCrash(SocorroMiddleware):
         "Vendor",
         "version",
         "Version",
+        "WindowsErrorReporting",
         "Winsock_LSP",
     )
 


### PR DESCRIPTION
I tested with 66f3bbb9-75cb-45ba-979b-b4cea0210806. It works with "is true", "is false", "exists", and "does not exist" as expected.