### PR TITLE
Adjust signature list for `oom_hook` rename

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -73,6 +73,7 @@ mnt@asec@org\.mozilla\.f.*-\d@pkg\.apk@classes\.dex@0x
 MOZ_Assert
 MOZ_Crash
 mozalloc_handle_oom
+mozglue_static::oom_hook::hook
 mozglue_static::panic_hook
 mozcrt19.dll@0x
 mozilla::CondVar::Wait

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -81,7 +81,6 @@ gfxPlatform::Init
 __GI___strlen_sse2
 __GI_memcpy
 __GI_strlen
-gkrust_shared::oom_hook::hook
 gsignal
 handle_errorf
 handle_response


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1582382 moved `gkrust_shared::oom_hook` to `mozglue_static::oom_hook`, so we need to add the latter to the irrelevant list to get better signatures for rust out-of-memory crashes.

Example crashes:
```
app@socorro:/app$ socorro-cmd signature 21420c42-fbcf-4df7-8256-da45c0210812 c3058341-138b-449b-87c4-ff89a0210812 a04eaddc-0175-419d-b70b-557530210812
Crash id: 21420c42-fbcf-4df7-8256-da45c0210812
Original: OOM | large | mozalloc_abort | mozglue_static::oom_hook::hook
New:      OOM | large | mozalloc_abort | webrender_api::display_list::DisplayListBuilder::with_capacity
Same?:    False

Crash id: c3058341-138b-449b-87c4-ff89a0210812
Original: OOM | large | mozalloc_abort | mozglue_static::oom_hook::hook
New:      OOM | large | mozalloc_abort | webrender_bindings::bindings::wr_state_new
Same?:    False

Crash id: a04eaddc-0175-419d-b70b-557530210812
Original: OOM | large | mozalloc_abort | mozglue_static::oom_hook::hook
New:      OOM | large | mozalloc_abort | cssparser::tokenizer::consume_ident_like
Same?:    False
```