### PR TITLE
Update chat channel in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,7 @@ analysis tool is hosted at `<https://crash-stats.mozilla.org/>`_.
   * Documentation: https://antenna.readthedocs.io/
   * Bugs: `Report an Antenna bug <https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro&component=Antenna>`_
 
-* Mailing list: https://lists.mozilla.org/listinfo/tools-socorro
-* Chat: `#breakpad:mozilla.org <https://riot.im/app/#/room/#breakpad:mozilla.org>`_
+* Chat: `#crashreporting matrix channel <https://chat.mozilla.org/#/room/#crashreporting:mozilla.org>`_
 
 
 .. Note::

--- a/docs/products.rst
+++ b/docs/products.rst
@@ -48,7 +48,7 @@ Make sure crash reports for your product follow our guidelines. Otherwise Crash
 Stats and crash analysis may not work.
 
 If you have any questions, please ask in
-`#breakpad:mozilla.org <https://riot.im/app/#/room/#breakpad:mozilla.org>`_.
+`#crashreporting matrix channel <https://chat.mozilla.org/#/room/#crashreporting:mozilla.org>`_.
 
 
 Guidelines for crash report annotations


### PR DESCRIPTION
This updates the docs to point to the new crashreporting matrix channel
and removes the mention of the tools-socorro mailing list which is dead.