### PR TITLE
bug 1730463: add mozilla::widget::WlCrashHandler to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -83,6 +83,7 @@ mozilla::ipc::RPCChannel::Call
 mozilla::ipc::WriteIPDLParam
 mozilla::ipc::IPDLParamTraits<T>::Write
 mozilla::ThreadEventQueue
+mozilla::widget::WlCrashHandler
 nsEventQueue::GetEvent
 _NSRaiseError
 nsThread::GetEvent


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 484fa5f4-f0f3-4246-b997-c99e10210913
Crash id: 484fa5f4-f0f3-4246-b997-c99e10210913
Original: mozilla::widget::WlCrashHandler
New:      wl_array_copy | wl_log_set_handler_client
Same?:    False
```