### PR TITLE
bug 1728738: add windows guard stack functions to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -104,6 +104,8 @@ panic_abort::
 PR_WaitCondVar
 RaiseException
 RealMsgWaitFor
+_report_gsfailure
+__report_gsfailure
 _rust_alloc_error_handler
 __rust_alloc_error_handler
 rust_oom


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature=_report_gsfailure --num=1 | socorro-cmd signature
Crash id: c8251b18-f378-443d-ac40-234230210919
Original: _report_gsfailure
New:      mozilla::net::nsProtocolProxyService::AsyncResolveInternal
Same?:    False
```