### PR TITLE
bug 1730948: improve raw data tab

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -964,26 +964,37 @@
           <!-- /modules -->
 
           <div id="rawdump" class="ui-tabs-hide">
-            <h3>Download raw crash, processed crash, minidump, and memory report data</h3>
+            <h3>Download crash annotations, processed crash, minidump, and memory report data</h3>
             {% if request.user.has_perm('crashstats.view_pii') or request.user.has_perm('crashstats.view_rawdump') %}
               <p>
                 {{ protected_warning() }}
-                Raw and processed crash reports contain protected data.
+                Crash annotations and processed crash report contain protected data.
                 Please don't share minidumps with third-parties.
                 See <a href="{{ url('documentation:protected_data_access') }}">Protected data policy</a> for details.
               </p>
-              <ul class="list-inside list-disc">
-                {% if request.user.has_perm('crashstats.view_pii') %}
+              {% if request.user.has_perm('crashstats.view_pii') %}
+                <ul class="list-inside list-disc">
                   {% for name, url in raw_data_urls %}
-                    <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
+                    <li><a href="{{ url }}">{{ name }}</a></li>
                   {% endfor %}
+                </ul>
+              {% endif %}
+              {% if request.user.has_perm('crashstats.view_rawdump') %}
+                {% if raw_dump_urls %}
+                  <p>
+                    Dumps:
+                  </p>
+                  <ul class="list-inside list-disc">
+                    {% for name, url in raw_dump_urls %}
+                      <li><a href="{{ url }}">{{ name }}</a></li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                  <p>
+                    No dumps available.
+                  </p>
                 {% endif %}
-                {% if request.user.has_perm('crashstats.view_rawdump') %}
-                  {% for name, url in raw_dump_urls %}
-                    <li>{{ name }}: <a href="{{ url }}">{{ url }}</a></li>
-                  {% endfor %}
-                {% endif %}
-              </ul>
+              {% endif %}
               {% if request.user.has_perm('crashstats.view_rawdump') and not raw_dump_urls %}
                 <p>
                   There are no dumps or memory report to download.

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -192,7 +192,7 @@ def report_index(request, crash_id, default_context=None):
         # Add Raw Crash link
         data_urls.append(
             (
-                "raw crash",
+                "crash annotations",
                 "%s?crash_id=%s"
                 % (
                     reverse("api:model_wrapper", kwargs={"model_name": "RawCrash"}),


### PR DESCRIPTION
This makes the raw data tab a little easier:

1. it drops use of "raw crash" which is an internal Socorro name for
   "crash annotations" which is more widely understood
2. it removes the API urls which reduces some of the clutter
3. it breaks the dumps out into a separate section