### PR TITLE
bug 1731255: add support for Windows 11 to platform_pretty_version

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -960,6 +960,7 @@ class OSPrettyVersionRule(Rule):
         "6.2": "Windows 8",
         "6.3": "Windows 8.1",
         "10.0": "Windows 10",
+        # NOTE(willkg): Windows 11 is 10.0.21996 and higher, so it's not in this map
     }
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
@@ -990,9 +991,15 @@ class OSPrettyVersionRule(Rule):
         minor_version = int(version_split[1])
 
         if os_name.lower().startswith("windows"):
-            processed_crash["os_pretty_version"] = self.WINDOWS_VERSIONS.get(
-                "%s.%s" % (major_version, minor_version), "Windows Unknown"
-            )
+            if (major_version, minor_version) == (10, 0) and os_version >= "10.0.21996":
+                windows_version = "Windows 11"
+
+            else:
+                windows_version = self.WINDOWS_VERSIONS.get(
+                    "%s.%s" % (major_version, minor_version), "Windows Unknown"
+                )
+
+            processed_crash["os_pretty_version"] = windows_version
             return
 
         elif os_name == "Mac OS X":

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1809,8 +1809,11 @@ class TestOsPrettyName:
     @pytest.mark.parametrize(
         "os_name, os_version, expected",
         [
-            # Known windows version
-            ("Windows NT", "10.0.11.7600", "Windows 10"),
+            # Known windows versions
+            ("Windows NT", "6.1.7601 Service Pack 2", "Windows 7"),
+            ("Windows NT", "6.3.9600 Service Pack 1", "Windows 8.1"),
+            ("Windows NT", "10.0.17758", "Windows 10"),
+            ("Windows NT", "10.0.21996", "Windows 11"),
             # Unknown windows version
             ("Windows NT", "15.2", "Windows Unknown"),
             # A valid version of Mac OS X


### PR DESCRIPTION
Windows 11 shows up as versions >= 10.0.21996. That doesn't fit well
with our map-based figuring, so I tweaked the rule to cover that with an
explicit check.

This also fixes the tests so that the versions tested look like actual
versions we're getting.