### PR TITLE
bug 1727149: back out shutdownkill signature changes

### DIFF
--- a/socorro/signature/pipeline.rst
+++ b/socorro/signature/pipeline.rst
@@ -62,13 +62,9 @@ This is the signature generation pipeline defined at ``socorro.signature.generat
 
 7. **Rule: SignatureIPCChannelError**
    
-   Either stomp on or prepend signature for IPCError
+   Stomps on signature with shutdownkill signature
    
-   If the IPCError is a ShutDownKill, then this prepends the signature with
-   "IPCError-browser | ShutDownKill".
-   
-   Otherwise it stomps on the signature with "IPCError-browser/content" and the error
-   message.
+   Either "IPCError-browser | ShutDownKill" or "IPCError-content | ShutDownKill".
 
 8. **Rule: SignatureIPCMessageName**
    

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -809,13 +809,9 @@ class SignatureJitCategory(Rule):
 
 
 class SignatureIPCChannelError(Rule):
-    """Either stomp on or prepend signature for IPCError
+    """Stomps on signature with shutdownkill signature
 
-    If the IPCError is a ShutDownKill, then this prepends the signature with
-    "IPCError-browser | ShutDownKill".
-
-    Otherwise it stomps on the signature with "IPCError-browser/content" and the error
-    message.
+    Either "IPCError-browser | ShutDownKill" or "IPCError-content | ShutDownKill".
 
     """
 
@@ -829,12 +825,7 @@ class SignatureIPCChannelError(Rule):
             new_sig = "IPCError-content | {}"
         new_sig = new_sig.format(crash_data["ipc_channel_error"][:100])
 
-        if crash_data["ipc_channel_error"] == "ShutDownKill":
-            # If it's a ShutDownKill, append the rest of the signature
-            result.info(self.name, "IPC Channel Error prepended")
-            new_sig = f"{new_sig} | {result.signature}"
-        else:
-            result.info(self.name, "IPC Channel Error stomped on signature")
+        result.info(self.name, "IPC Channel Error stomped on signature")
 
         result.set_signature(self.name, new_sig)
         return True

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1529,25 +1529,6 @@ class TestSignatureIPCChannelError:
             "SignatureIPCChannelError: IPC Channel Error stomped on signature"
         ]
 
-    def test_shutdownkill(self):
-        rule = rules.SignatureIPCChannelError()
-
-        original_signature = "foo::bar"
-        crash_data = {
-            "ipc_channel_error": "ShutDownKill",
-            "additional_minidumps": "browser",
-        }
-        result = generator.Result()
-        result.signature = original_signature
-
-        action_result = rule.action(crash_data, result)
-        assert action_result is True
-
-        assert result.signature == "IPCError-browser | ShutDownKill | {}".format(
-            original_signature
-        )
-        assert result.notes == ["SignatureIPCChannelError: IPC Channel Error prepended"]
-
 
 class TestSignatureShutdownTimeout:
     def test_predicate_no_match(self):


### PR DESCRIPTION
This backs out the changes made for bug 1612569 so that shutdownkill
signatures all end up in the same bucket again.

```
app@socorro:/app$ socorro-cmd signature af1ff5c9-4cfa-4795-a0c2-279480210920
Crash id: af1ff5c9-4cfa-4795-a0c2-279480210920
Original: IPCError-browser | ShutDownKill | mozilla::ipc::MessagePump::Run
New:      IPCError-browser | ShutDownKill
Same?:    False
Notes:    (1)
          SignatureIPCChannelError: IPC Channel Error stomped on signature
```