### PR TITLE
bug 1731972: add `__GI___pthread_mutex_lock` to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -33,6 +33,7 @@ exp2
 framework\.odex@0x
 __fixunsdfsi
 __GI___assert_fail
+__GI___pthread_mutex_lock
 g_assertion_message
 g_assertion_message.cold
 g_assertion_message_error


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature=__GI___pthread_mutex_lock --num=1 | socorro-cmd signature
Crash id: 2e39ca47-e04c-4036-bc84-0d20c0210921
Original: __GI___pthread_mutex_lock
New:      BaseAllocator::malloc | malloc | alloc::raw_vec::finish_grow
Same?:    False
```