### PR TITLE
bug 1732662: add mozilla::detail::InvalidArrayIndex_CRASH to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -156,6 +156,7 @@ mozilla::CheckCheckedUnsafePtrs<T>::Check
 mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
+mozilla::detail::InvalidArrayIndex_CRASH
 mozilla::detail::nsTStringRepr<T>::
 mozilla::dom::ToJSValue
 mozilla::DOMEventTargetHelper::AddRef


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature f215fecd-0cb9-49f3-92d1-a5aee0210924
Crash id: f215fecd-0cb9-49f3-92d1-a5aee0210924
Original: mozilla::detail::InvalidArrayIndex_CRASH
New:      mozilla::detail::InvalidArrayIndex_CRASH | mozilla::widget::ScreenGetterWayland::GetScreenForWindow
Same?:    False
```