### PR TITLE
bug 1732414: extract distributionId

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1541,6 +1541,20 @@ FIELDS = {
             "type": "date",
         },
     },
+    "distribution_id": {
+        "data_validation_type": "enum",
+        "description": "The TelemetryEnvironment.partner.distributionId value.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "distribution_id",
+        "is_exposed": True,
+        "is_returned": True,
+        "name": "distribution_id",
+        "namespace": "processed_crash",
+        "permissions_needed": [],
+        "query_type": "enum",
+        "storage_mapping": {"analyzer": "keyword", "type": "string"},
+    },
     "dom_fission_enabled": {
         "data_validation_type": "str",
         "description": (

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -38,6 +38,7 @@ from socorro.processor.rules.mozilla import (
     ConvertModuleSignatureInfoRule,
     CopyFromRawCrashRule,
     DatesAndTimesRule,
+    DistributionIdRule,
     EnvironmentRule,
     ESRVersionRewrite,
     ExploitablityRule,
@@ -226,6 +227,7 @@ class ProcessorPipeline(RequiredConfig):
                 # post processing of the processed crash
                 CrashingThreadRule(),
                 CPUInfoRule(),
+                DistributionIdRule(),
                 OSInfoRule(),
                 BetaVersionRule(
                     version_string_api=config.betaversion.version_string_api


### PR DESCRIPTION
This pulls out the `TelemetryEnvironment.partner.distributionId` value and puts it in the `processed_crash` as `distribution_id`. This value represents which vendor build the product.

If it's not there at all (no `TelemetryEnvironment`, etc), we don't know and mark "unknown".

If it's null, we mark "mozilla".

We use the value as is for everything else.

This allows us to search and aggregate on `distribution_id`.