### PR TITLE
bug 1733910: add ERROR_NOT_ENOUGH_MEMORY as OOM indicator

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -577,6 +577,18 @@ class OOMSignature(Rule):
         "alloc::oom::oom",
     )
 
+    # These reason values indicate an OOM
+    oom_reason = [
+        "STATUS_FATAL_MEMORY_EXHAUSTION",
+        "STATUS_NO_MEMORY",
+    ]
+
+    # These last_error_value values indicate an OOM
+    oom_last_error_value = [
+        "ERROR_COMMITMENT_LIMIT",
+        "ERROR_NOT_ENOUGH_MEMORY",
+    ]
+
     def predicate(self, crash_data, result):
         if crash_data.get("oom_allocation_size"):
             return True
@@ -595,12 +607,12 @@ class OOMSignature(Rule):
         thread = glom(crash_data, "threads.%d" % crashing_thread, default={})
         if thread:
             last_error_value = thread.get("last_error_value", "")
-            if last_error_value == "ERROR_COMMITMENT_LIMIT":
+            if last_error_value in self.oom_last_error_value:
                 return True
 
         # Check the reason to see if it's one of a few values that indicate an OOM
         reason = crash_data.get("reason", None)
-        if reason in ["STATUS_FATAL_MEMORY_EXHAUSTION", "STATUS_NO_MEMORY"]:
+        if reason in self.oom_reason:
             return True
 
         return False

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1175,6 +1175,17 @@ class TestOOMSignature:
                 },
                 True,
             ),
+            (
+                {
+                    "crashing_thread": 0,
+                    "threads": [
+                        {
+                            "last_error_value": "ERROR_NOT_ENOUGH_MEMORY",
+                        },
+                    ],
+                },
+                True,
+            ),
         ],
     )
     def test_predicate_error_commitment_limit(self, crashdata, expected):


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 854ac3f3-c283-466c-a80a-df9030211002
Crash id: 854ac3f3-c283-466c-a80a-df9030211002
Original: abort | wasm_rt_allocate_memory
New:      OOM | unknown | abort | wasm_rt_allocate_memory
Same?:    False
```