### PR TITLE
bug 1733907: add glib functions to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -45,9 +45,13 @@ GetLCIDFromLangListNodeWithLICCheck
 gfxPlatform::GetPlatform
 gkrust_shared::oom_hook::hook
 _g_log_abort
+g_log
+g_log_default_handler
+g_log_structured
 g_log_structured_array
 g_log_structured_standard
 g_log_writer_default
+g_logv
 google_breakpad::CrashGenerationClient::RequestDumpForException
 google_breakpad::ExceptionHandler::SignalHandler
 google_breakpad::ExceptionHandler::WriteMinidumpWithException


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature f2856f7c-9727-4ddd-8df7-e898b0211004 a22dc1e7-e2cd-4500-8f3b-521d40211001 7b8fb40c-411e-45e6-a3c3-7f9660210930
Crash id: f2856f7c-9727-4ddd-8df7-e898b0211004
Original: g_log_default_handler
New:      g_settings_schema_get_value
Same?:    False

Crash id: a22dc1e7-e2cd-4500-8f3b-521d40211001
Original: mozalloc_abort | abort | g_logv.cold
New:      mozalloc_abort | abort | g_malloc
Same?:    False

Crash id: 7b8fb40c-411e-45e6-a3c3-7f9660210930
Original: g_log_structured
New:      libX11.so.6@0x4532c
Same?:    False
```