### PR TITLE
Add __rust_end_short_backtrace to ignored frames

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -137,6 +137,7 @@ std::_Atomic_fetch_add_4
 std::alloc::rust_oom
 std::io::stdio::_eprint
 std::panicking::
+std::sys_common::backtrace::__rust_end_short_backtrace<T>
 std::__terminate
 std::terminate
 system@framework@.*\.jar@classes\.dex@0x


### PR DESCRIPTION
This was a sentinel frame added in rust 1.47 for trimming backtraces. We don't want to add it to the sentinel frame list because it doesn't actually communicate that it's a panic.

https://crash-stats.mozilla.org/report/index/6768f24b-e431-4f10-9cbf-c4b3c0211009 is a crash affected by this.