### PR TITLE
bug 1735815: add XPCOMSpinEventLoopStack to index

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3276,4 +3276,13 @@ FIELDS = {
         "query_type": "number",
         "storage_mapping": {"type": "long"},
     },
+    "xpcom_spin_event_loop_stack": keyword_field(
+        name="xpcom_spin_event_loop_stack",
+        description=(
+            "If we crash while some code is spinning manually the event loop, we will "
+            "see the stack of nested annotations here."
+        ),
+        in_database_name="xpcom_spin_event_loop_stack",
+        is_protected=False,
+    ),
 }

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -53,6 +53,12 @@ class CopyFromRawCrashRule(Rule):
             "MacMemoryPressureCriticalTime",
             "mac_memory_pressure_critical_time",
         ),
+        # Other things
+        (
+            "string",
+            "XPCOMSpinEventLoopStack",
+            "xpcom_spin_event_loop_stack",
+        ),
     ]
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -823,6 +823,7 @@ class RawCrash(SocorroMiddleware):
         "Version",
         "WindowsErrorReporting",
         "Winsock_LSP",
+        "XPCOMSpinEventLoopStack",
     )
 
     # The reason we use the old list and pass it into the more dynamic wrapper


### PR DESCRIPTION
This makes `XPCOMSpinEventLoopStack` public so you can see it in the crash
annotations tab.

This extracts the `XPCOMSpinEventLoopStack` from the raw crash and indexes
it in ES so it's searchable and aggregatable.