### PR TITLE
bug 1738716: force `cargo install` to use lock file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN groupadd --gid $groupid app && \
 
 USER app
 
-RUN cargo install minidump-stackwalk --root=/app/ --version 0.9.0
+RUN cargo install --locked --root=/app/ minidump-stackwalk --version 0.9.0
 RUN ls -al /app/bin/
 
 


### PR DESCRIPTION
This forces `cargo install` to use the lock file in rust-minidump when
building `minidump-stackwalk`. That forces it to use the same versions
of things when building the binary.