### PR TITLE
bug 1697051: add crash_report_keys field

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -627,6 +627,11 @@ FIELDS = {
         "query_type": "number",
         "storage_mapping": {"type": "long"},
     },
+    "crash_report_keys": keyword_field(
+        name="crash_report_keys",
+        description="Crash annotation keys and dump filenames from the crash report.",
+        is_protected=False,
+    ),
     "bug_1541161": {
         "data_validation_type": "str",
         "description": (

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -25,6 +25,7 @@ from socorro.processor.rules.breakpad import (
 )
 from socorro.processor.rules.general import (
     CPUInfoRule,
+    CrashReportKeysRule,
     DeNoneRule,
     DeNullRule,
     IdentifierRule,
@@ -184,6 +185,7 @@ class ProcessorPipeline(RequiredConfig):
             # The default processing pipeline
             "default": [
                 # fix the raw crash removing null characters and Nones
+                CrashReportKeysRule(),
                 DeNullRule(),
                 DeNoneRule(),
                 # fix ModuleSignatureInfo if it needs fixing


### PR DESCRIPTION
This adds a field that we can search using contains/does-not-contain and
aggregate on to help us answer questions like:

1. Which crash reports have file named xyz? For example, which have a
   memory_report.
2. Which crash reports have crash annotation XYZ? For example, which
   have a new crash annotation field we're not indexing yet.

This also adds a processor note with "invalidkeys" to indicate when the
crash report has keys that are malformed.