### PR TITLE
bug 1740397: rework CrashingThreadInfoRule

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -19,7 +19,7 @@ from socorro.lib import sentry_client
 from socorro.lib.datetimeutil import utc_now
 from socorro.processor.rules.breakpad import (
     BreakpadStackwalkerRule2015,
-    CrashingThreadRule,
+    CrashingThreadInfoRule,
     JitCrashCategorizeRule,
     MinidumpSha256Rule,
 )
@@ -213,6 +213,7 @@ class ProcessorPipeline(RequiredConfig):
                     tmp_storage_path=config.breakpad.tmp_storage_path,
                 ),
                 ModuleURLRewriteRule(),
+                CrashingThreadInfoRule(),
                 ProductRule(),
                 MajorVersionRule(),
                 UserDataRule(),
@@ -227,7 +228,6 @@ class ProcessorPipeline(RequiredConfig):
                 MacCrashInfoRule(),
                 MozCrashReasonRule(),
                 # post processing of the processed crash
-                CrashingThreadRule(),
                 CPUInfoRule(),
                 DistributionIdRule(),
                 OSInfoRule(),

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -18,12 +18,23 @@ from socorro.lib.util import dotdict_to_dict
 from socorro.processor.rules.base import Rule
 
 
-class CrashingThreadRule(Rule):
+class CrashingThreadInfoRule(Rule):
+    """Captures information about the crashing thread
+
+    Fills in:
+
+    * crashing_thread (int or None): index of the crashing thread
+    * truncated (bool): whether or not the crashing thread frames were truncated
+    * address (str or None): the address of the crash
+    * type (str): the crash reason
+
+    """
+
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
-        processed_crash["crashedThread"] = glom.glom(
+        processed_crash["crashing_thread"] = glom.glom(
             processed_crash, "json_dump.crash_info.crashing_thread", default=None
         )
-        if processed_crash["crashedThread"] is None:
+        if processed_crash["crashing_thread"] is None:
             processor_meta["processor_notes"].append(
                 "MDSW did not identify the crashing thread"
             )
@@ -37,7 +48,7 @@ class CrashingThreadRule(Rule):
         )
 
         processed_crash["reason"] = glom.glom(
-            processed_crash, "json_dump.crash_info.type", default=None
+            processed_crash, "json_dump.crash_info.type", default=""
         )
 
 

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -737,15 +737,13 @@ class TopMostFilesRule(Rule):
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         processed_crash["topmost_filenames"] = None
         try:
-            crashing_thread = processed_crash["json_dump"]["crash_info"][
-                "crashing_thread"
-            ]
+            crashing_thread = processed_crash["crashing_thread"]
             stack_frames = processed_crash["json_dump"]["threads"][crashing_thread][
                 "frames"
             ]
-        except KeyError as x:
-            # guess we don't have frames or crashing_thread or json_dump
-            # we have to give up
+        except (IndexError, TypeError, KeyError) as x:
+            # guess we don't have frames or crashing_thread or json_dump we have to give
+            # up
             processor_meta["processor_notes"].append(
                 "no 'topmost_file' name because '%s' is missing" % x
             )
@@ -784,10 +782,10 @@ class ModulesInStackRule(Rule):
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         json_dump = processed_crash["json_dump"]
-        try:
-            crashing_thread = json_dump["crash_info"]["crashing_thread"]
-        except KeyError:
-            # If there is no crashing thread, then there's nothing to do.
+        crashing_thread = processed_crash["crashing_thread"]
+
+        # If there is no crashing thread, then there's nothing to do.
+        if crashing_thread is None:
             return
 
         try:

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -48,7 +48,6 @@ SAMPLE_PROCESSED_CRASH = {
     "completeddatetime": "2012-04-08 10:56:50.902884",
     "cpu_info": "None | 0",
     "cpu_arch": "arm",
-    "crashedThread": 8,
     "date_processed": "2012-04-08 10:56:41.558922",
     "flash_version": "[blank]",
     "hangid": None,

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1502,6 +1502,7 @@ class TestTopMostFilesRule:
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {}
+        processed_crash["crashing_thread"] = 0
         processed_crash["json_dump"] = {
             "crash_info": {"crashing_thread": 0},
             "crashing_thread": {
@@ -1564,6 +1565,7 @@ class TestModulesInStackRule:
         raw_crash = {}
         dumps = {}
         processed_crash = {
+            "crashing_thread": 0,
             "json_dump": {
                 "modules": [
                     {"filename": "libxul.dll", "debug_id": "ABCDEF"},
@@ -1574,7 +1576,7 @@ class TestModulesInStackRule:
                 "threads": [
                     {"frames": [{"module": "libxul.dll"}, {"module": "mozglue.dll"}]}
                 ],
-            }
+            },
         }
 
         processor_meta = get_basic_processor_meta()
@@ -1590,19 +1592,27 @@ class TestModulesInStackRule:
     @pytest.mark.parametrize(
         "processed_crash",
         [
-            {},
-            {"json_dump": {}},
-            {"json_dump": {"crash_info": {}}},
-            {"json_dump": {"crash_info": {"crashing_thread": 0}}},
-            {"json_dump": {"crash_info": {"crashing_thread": 10}, "threads": []}},
-            {"json_dump": {"crash_info": {"crashing_thread": 0}, "threads": [{}]}},
+            {"crashing_thread": None},
+            {"crashing_thread": None, "json_dump": {}},
+            {"crashing_thread": None, "json_dump": {"crash_info": {}}},
+            {"crashing_thread": 0, "json_dump": {"crash_info": {"crashing_thread": 0}}},
             {
+                "crashing_thread": 10,
+                "json_dump": {"crash_info": {"crashing_thread": 10}, "threads": []},
+            },
+            {
+                "crashing_thread": 0,
+                "json_dump": {"crash_info": {"crashing_thread": 0}, "threads": [{}]},
+            },
+            {
+                "crashing_thread": 0,
                 "json_dump": {
                     "crash_info": {"crashing_thread": 0},
                     "threads": [{"frames": []}],
-                }
+                },
             },
             {
+                "crashing_thread": 0,
                 "modules": [],
                 "json_dump": {
                     "crash_info": {"crashing_thread": 0},


### PR DESCRIPTION
The CrashingThreadRule set crashedThread in the processed crash, but that's not used anywhere. We do have a bunch of places that need the crashing thread index and they do slightly different calculations to get it.

I changed this rule to set `processed_crash["crashing_thread"]` which has the index of the crashing thread or None.

I changed some other rules to use this information.

I didn't change anything in the webapp. Because this adds a new field `crashing_thread`, it won't be in any crash reports processed before this is deployed. I'll add a note to the bug to update the webapp side in 6 months after the old data has expired out of the system.