### PR TITLE
Improve uptime_ts and uptime field docs

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3110,8 +3110,9 @@ FIELDS = {
     "uptime": {
         "data_validation_type": "int",
         "description": (
-            "Length of time the process was running before it crashed. Small values (from 0 to "
-            "5 or so) usually indicate start-up crashes."
+            "Length of time the process was running before it crashed. Small values "
+            "(from 0 to 5 or so) usually indicate start-up crashes. Calculated by "
+            "the Socorro processor using CrashTime and StartupTime."
         ),
         "form_field_choices": [],
         "has_full_version": False,
@@ -3126,7 +3127,10 @@ FIELDS = {
     },
     "uptime_ts": {
         "data_validation_type": "int",
-        "description": "TimeStamp based uptime.",
+        "description": (
+            "Uptime in seconds. This annotation uses a string instead of an integer "
+            "because it has a fractional component."
+        ),
         "form_field_choices": [],
         "has_full_version": False,
         "in_database_name": "UptimeTS",


### PR DESCRIPTION
This improves the description of the uptime_ts field by copying the
description for the crash annotation it's based on from
`CrashAnnotations.yaml`.

This also improves the description for the uptime field by adding some
details for how the value is calculated.

This isn't great. We really need a way to annotate fields and expose
those annotations such that we can capture historical knowledge for
these fields, bugs related to them, etc. But this is good enough for
now.