### PR TITLE
bug 1737691: add new MinidumpStackwalkRule

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@
 # Dokcer image with minidump-stackwalk
 # =========================================================================
 
+# https://hub.docker.com/r/mozilla/socorro-minidump-stackwalk
 FROM mozilla/socorro-minidump-stackwalk:2021.09.20@sha256:11dab7a81b6ff64ac16276ff1b1bd901b66cf61dce6cbfe1fbeb52b3508ac4d0 as breakpad
 RUN ls -al /stackwalk/
 
@@ -10,7 +11,8 @@ RUN ls -al /stackwalk/
 # Dokcer image with https://github.com/luser/rust-minidump
 # =========================================================================
 
-FROM rust:1.56-buster@sha256:b197d91205475e139d6c7f8782239e0d4160222039d2c66ec9ee80658123129c as rustminidump
+# https://hub.docker.com/_/rust/
+FROM rust:1.56.1-buster@sha256:3d9db19945008fe26137362e03b0571c1235f80b5ad9bce0310d800ff9ded86a as rustminidump
 
 RUN update-ca-certificates
 ARG groupid=10001
@@ -24,7 +26,8 @@ RUN groupadd --gid $groupid app && \
 
 USER app
 
-RUN cargo install --locked --root=/app/ minidump-stackwalk --version 0.9.0
+# https://crates.io/crates/minidump-stackwalk
+RUN cargo install --locked --root=/app/ minidump-stackwalk --version 0.9.2
 RUN ls -al /app/bin/
 
 
@@ -32,6 +35,7 @@ RUN ls -al /app/bin/
 # Building app image
 # =========================================================================
 
+# https://hub.docker.com/_/python
 FROM python:3.9.7-slim@sha256:cd1045dbabff11dab74379e25f7974aa7638bc5ad46755d67d0f1f1783aee101
 
 # Set up user and group

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -63,22 +63,27 @@ resource.boto.reprocessing_queue=local-dev-reprocessing
 # processor
 # ---------
 
+# Use the rust-minidump minidump-stackwalk binary
+processor.minidump_stackwalker=rust
+
 # In the docker local dev environment, we store symbol cache and other things in /tmp because
 # there's only one processor node. For server environments, we probably want to store that
 # in a volume. These three vars are all affected.
 companion_process.symbol_cache_path=/tmp/symbols/cache
+processor.minidumpstackwalk.symbol_cache_path=/tmp/symbols/cache
+processor.minidumpstackwalk.symbol_tmp_path=/tmp/symbols/tmp
 processor.breakpad.symbol_cache_path=/tmp/symbols/cache
 processor.breakpad.symbol_tmp_path=/tmp/symbols/tmp
 
 # Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
 # a long time
-processor.kill_timeout=30
+processor.breakpad.kill_timeout=30
+processor.minidumpstackwalk.kill_timeout=30
+processor.jit.kill_timeout=30
 
 # Set symbols_urls to something helpful for local dev
-processor.breakpad.symbols_urls=https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1
-
-# Stackwalker is in a different place in the new infra and local dev
-processor.command_pathname=/stackwalk/stackwalker
+processor.breakpad.symbols_urls=https://symbols.mozilla.org/
+processor.minidumpstackwalk.symbols_urls=https://symbols.mozilla.org/
 
 # Set the telemetry bucket name explicitly
 destination.telemetry.bucket_name=telemetry-bucket

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -14,6 +14,10 @@ resource.boto.bucket_name=crashstats-test
 destination.telemetry.bucket_name=telemetry-test
 telemetry.bucket_name=telemetry-test
 
+# test harness should always test with breakpad rule because that's what we run
+# in prod
+processor.minidump_stackwalk=breakpad
+
 resource.boto.standard_queue=test-standard
 resource.boto.priority_queue=test-priority
 resource.boto.reprocessing_queue=test-reprocessing

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -457,10 +457,13 @@ class MacCrashInfoRule(Rule):
     """
 
     def predicate(self, raw_crash, dumps, processed_crash, proc_meta):
-        return "mac_crash_info" in processed_crash.get("json_dump", {})
+        return (
+            glom(processed_crash, "json_dump.mac_crash_info", default=None) is not None
+        )
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
-        mac_crash_info = glom(processed_crash, "json_dump.mac_crash_info", default="")
+        mac_crash_info = processed_crash["json_dump"]["mac_crash_info"]
+        print(f">>> {mac_crash_info})")
         processed_crash["mac_crash_info"] = json.dumps(
             mac_crash_info, indent=2, sort_keys=True
         )
@@ -1158,7 +1161,7 @@ class ModuleURLRewriteRule(Rule):
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         modules = processed_crash["json_dump"]["modules"]
         for module in modules:
-            if "symbol_url" not in module:
+            if not module.get("symbol_url"):
                 continue
 
             url = module["symbol_url"]

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -506,7 +506,7 @@ class SignatureGenerationRule(Rule):
             # module in symbols files. This fixes that by adding the module.
             a_frame = fix_missing_module(a_frame)
 
-            if make_modules_lower_case and "module" in a_frame:
+            if make_modules_lower_case and a_frame.get("module"):
                 a_frame["module"] = a_frame["module"].lower()
 
             normalized_frame = self.c_signature_tool.normalize_frame(**a_frame)

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -288,23 +288,23 @@ def enhance_frame(frame, vcs_mappings):
     Add some additional info to a stack frame--signature
     and source links from vcs_mappings.
     """
-    if "function" in frame:
+    if frame.get("function"):
         # Remove spaces before all stars, ampersands, and commas
         function = re.sub(r" (?=[\*&,])", "", frame["function"])
         # Ensure a space after commas
         function = re.sub(r",(?! )", ", ", function)
         frame["function"] = function
         signature = function
-    elif "file" in frame and "line" in frame:
+    elif frame.get("file") and frame.get("line"):
         signature = "%s#%d" % (frame["file"], frame["line"])
-    elif "module" in frame and "module_offset" in frame:
+    elif frame.get("module") and frame.get("module_offset"):
         signature = "%s@%s" % (frame["module"], frame["module_offset"])
     else:
         signature = "@%s" % frame["offset"]
     frame["signature"] = signature
     frame["short_signature"] = re.sub(r"\(.*\)", "", signature)
 
-    if "file" in frame:
+    if frame.get("file"):
         vcsinfo = frame["file"].split(":")
         if len(vcsinfo) == 4:
             vcstype, root, vcs_source_file, revision = vcsinfo


### PR DESCRIPTION
This adds a new MinidumpStackwalkRule that runs the rust-minidump
minidump-stackwalk binary on minidumps to walk the stack, symbolicate
symbols, and extract other information.
    
This adds a configuration option `processor.minidump_stackwalk` for
flipping between BreakpadStackwalkerRule2015 and MinidumpStackwalkRule.
If it's set to "rust", then it uses MinidumpStackwalkRule. All other
values including being unset will use BreakpadStackwalkerRule2015.
    
This also fixes a bunch of code looking at the json_dump output to
better handle when a key exists, but the value is None.