### PR TITLE
bug 1711897: add stackwalk_version to index

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -609,6 +609,7 @@ class ESCrashStorageRedactedJsonDump(ESCrashStorageRedactedSave):
             "largest_free_vm_block",
             "tiny_block_size",
             "write_combine_size",
+            "stackwalk_version",
             "system_info",
         ],
         from_string_converter=list_converter,

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2868,6 +2868,12 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"type": "string"},
     },
+    "stackwalk_version": keyword_field(
+        name="stackwalk_version",
+        description="binary and version for stackwalker used to process report",
+        namespace="processed_crash.json_dump",
+        is_protected=False,
+    ),
     "startup_crash": {
         "data_validation_type": "bool",
         "description": (
@@ -3291,7 +3297,6 @@ FIELDS = {
             "If we crash while some code is spinning manually the event loop, we will "
             "see the stack of nested annotations here."
         ),
-        in_database_name="xpcom_spin_event_loop_stack",
         is_protected=False,
     ),
 }

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -330,6 +330,10 @@ class BreakpadStackwalkerRule2015(Rule):
         self.symbol_cache_path = symbol_cache_path
         self.tmp_path = tmp_path
 
+        # NOTE(willkg): we can't get a version from the binary without a lot of work
+        # which we're not going to do now because this is not long for this world
+        self.stackwalk_version = "stackwalker unknown"
+
         self.metrics = markus.get_metrics("processor.breakpadstackwalkerrule")
 
     def __repr__(self):
@@ -385,6 +389,9 @@ class BreakpadStackwalkerRule2015(Rule):
             processor_meta["processor_notes"].append(msg)
             self.logger.warning(msg + " (%s)" % crash_id)
             output = {}
+
+        # Add the stackwalk_version to the stackwalk output
+        output["stackwalk_version"] = self.stackwalk_version
 
         stackwalker_data = {
             "json_dump": output,

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -279,13 +279,16 @@ class TestBreakpadTransformRule2015:
         )
         mocked_subprocess_handle.wait.return_value = 0
 
+        expected_output = copy.deepcopy(canonical_stackwalker_output)
+        expected_output["stackwalk_version"] = "stackwalker unknown"
+
         with MetricsMock() as mm:
             rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
             assert processed_crash["mdsw_return_code"] == 0
             assert processed_crash["mdsw_status_string"] == "OK"
             assert processed_crash["success"] is True
-            assert processed_crash["json_dump"] == canonical_stackwalker_output
+            assert processed_crash["json_dump"] == expected_output
 
             mm.assert_incr(
                 "processor.breakpadstackwalkerrule.run",
@@ -308,7 +311,9 @@ class TestBreakpadTransformRule2015:
         with MetricsMock() as mm:
             rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-            assert processed_crash["json_dump"] == {}
+            assert processed_crash["json_dump"] == {
+                "stackwalk_version": "stackwalker unknown",
+            }
             assert processed_crash["mdsw_return_code"] == 124
             assert processed_crash["mdsw_status_string"] == "unknown error"
             assert processed_crash["success"] is False
@@ -335,7 +340,9 @@ class TestBreakpadTransformRule2015:
 
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        assert processed_crash["json_dump"] == {}
+        assert processed_crash["json_dump"] == {
+            "stackwalk_version": "stackwalker unknown",
+        }
         assert processed_crash["mdsw_return_code"] == -1
         assert processed_crash["mdsw_status_string"] == "unknown error"
         assert not processed_crash["success"]


### PR DESCRIPTION
This adds a value for when breakpad stackwalker processes the minidump.
It also adds the field as a keyword field to the index so we can search
and aggregate on it.