### PR TITLE
bug 1741764: add RaiseFailFastException to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -266,6 +266,7 @@ pthread_kill
 __pthread_mutex_lock
 _purecall
 raise
+RaiseFailFastException
 RpcpRaiseException
 RpcRaiseException
 realloc


### PR DESCRIPTION
Examples:

```
app@socorro:/app$ socorro-cmd fetch_crashids --num=10 --signature=RaiseFailFastException | socorro-cmd signature
Crash id: 3615db47-200f-476f-975d-918c50211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: b8f17a20-184f-4d69-b6c6-3dad80211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 3b1ee90a-8294-482b-b995-af03b0211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 6ed324f9-6bb0-40d9-ba96-6e1650211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: b89bc708-d0cd-4407-b14b-9bc370211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 909baf54-6dc1-435e-9f00-5db4e0211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 85999f7d-9259-448d-ad3e-9cf8b0211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 2e3e17ff-7351-49e4-9eaa-90b9d0211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False

Crash id: 47d9a2d8-e54b-4970-846e-0f3e90211117
Original: RaiseFailFastException
New:      RaiseFailFastException | wil::details::WilDynamicLoadRaiseFailFastException
Same?:    False

Crash id: 6374b0c3-c8d7-4896-b9c1-b886d0211117
Original: RaiseFailFastException
New:      RaiseFailFastException | FailFastWithHR
Same?:    False
```