### PR TITLE
bug 1737691: skip processing for 0-byte dump files

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -618,16 +618,14 @@ class PluginUserComment(Rule):
 
 
 class ExploitablityRule(Rule):
+    """Copies exploitability bits in json_dump to processed_crash"""
+
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         try:
-            processed_crash["exploitability"] = processed_crash["json_dump"][
-                "sensitive"
-            ]["exploitability"]
+            val = processed_crash["json_dump"]["sensitive"]["exploitability"]
+            processed_crash["exploitability"] = val
         except KeyError:
             processed_crash["exploitability"] = "unknown"
-            processor_meta["processor_notes"].append(
-                "exploitability information missing"
-            )
 
 
 class FlashVersionRule(Rule):
@@ -741,18 +739,11 @@ class TopMostFilesRule(Rule):
         processed_crash["topmost_filenames"] = None
         try:
             crashing_thread = processed_crash["crashing_thread"]
-            stack_frames = processed_crash["json_dump"]["threads"][crashing_thread][
-                "frames"
-            ]
-        except (IndexError, TypeError, KeyError) as x:
-            # guess we don't have frames or crashing_thread or json_dump we have to give
-            # up
-            processor_meta["processor_notes"].append(
-                "no 'topmost_file' name because '%s' is missing" % x
-            )
+            frames = processed_crash["json_dump"]["threads"][crashing_thread]["frames"]
+        except (IndexError, TypeError, KeyError):
             return
 
-        for a_frame in stack_frames:
+        for a_frame in frames:
             source_filename = a_frame.get("file", None)
             if source_filename:
                 processed_crash["topmost_filenames"] = source_filename

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -309,15 +309,11 @@ class CSignatureTool:
         # Handle empty signatures to explain why we failed generating them.
         if signature == "" or signature is None:
             if crashed_thread is None:
-                notes.append(
-                    "CSignatureTool: No signature could be created because we do not know which "
-                    "thread crashed"
-                )
+                notes.append("CSignatureTool: no crashing thread identified")
                 signature = "EMPTY: no crashing thread identified"
             else:
                 notes.append(
-                    "CSignatureTool: No proper signature could be created because no good data "
-                    "for the crashing thread ({}) was found".format(crashed_thread)
+                    f"CSignatureTool: no frame data for crashing thread ({crashed_thread})"
                 )
                 try:
                     signature = source_list[0]

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1090,7 +1090,7 @@ class TestSignatureGenerationRule:
         assert "proto_signature" not in result.extra
         assert "normalized_frames" not in result.extra
         assert result.notes == [
-            "SignatureGenerationRule: CSignatureTool: No signature could be created because we do not know which thread crashed"  # noqa
+            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
         ]
 
     def test_lower_case_modules(self):

--- a/socorro/signature/tests/test_signature_generator.py
+++ b/socorro/signature/tests/test_signature_generator.py
@@ -23,7 +23,7 @@ class TestSignatureGenerator:
         # SignatureGenerator and the rules in the default pipeline don't fall over.
         assert ret.signature == "EMPTY: no crashing thread identified"
         assert ret.notes == [
-            "SignatureGenerationRule: CSignatureTool: No signature could be created because we do not know which thread crashed"  # noqa
+            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
         ]
 
     def test_failing_rule(self):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -2053,7 +2053,7 @@ class TestSignatureGeneratorRule:
         assert processed_crash["signature"] == "EMPTY: no crashing thread identified"
         assert "proto_signature" not in processed_crash
         assert processor_meta["processor_notes"] == [
-            "SignatureGenerationRule: CSignatureTool: No signature could be created because we do not know which thread crashed"  # noqa
+            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
         ]
 
     @mock.patch("socorro.lib.sentry_client.get_hub")


### PR DESCRIPTION
This tweaks the code to skip minidump processing for 0-byte dump files.
There's no reason to do all the work if there's nothing there to
process.

This also improves the processor notes for downstream rules that look
for data generated by minidump processing. If the data ain't there, then
there's nothing for those rules to do. I reduced the language, added
prefixes, and in some cases, nixed the notes altogether.