### PR TITLE
bug 1737691: log /tmp/symbols contents and change localdev

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -69,11 +69,11 @@ processor.minidump_stackwalker=rust
 # In the docker local dev environment, we store symbol cache and other things in /tmp because
 # there's only one processor node. For server environments, we probably want to store that
 # in a volume. These three vars are all affected.
-companion_process.symbol_cache_path=/tmp/symbols/cache
-processor.minidumpstackwalk.symbol_cache_path=/tmp/symbols/cache
-processor.minidumpstackwalk.symbol_tmp_path=/tmp/symbols/tmp
-processor.breakpad.symbol_cache_path=/tmp/symbols/cache
-processor.breakpad.symbol_tmp_path=/tmp/symbols/tmp
+companion_process.symbol_cache_path=/data/symbols/cache
+processor.minidumpstackwalk.symbol_cache_path=/data/symbols/cache
+processor.minidumpstackwalk.symbol_tmp_path=/data/symbols/tmp
+processor.breakpad.symbol_cache_path=/data/symbols/cache
+processor.breakpad.symbol_tmp_path=/data/symbols/tmp
 
 # Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
 # a long time

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -92,6 +92,10 @@ def tmp_raw_crash_file(tmp_path, raw_crash, crash_id):
         LOGGER.error(
             f"OSError: no space: contents of {tmp_path}: {os.listdir(tmp_path)}"
         )
+        if "symbols" in os.listdir(tmp_path):
+            path = os.path.join(tmp_path, "symbols")
+            LOGGER.error(f"OSError: contents of {path}: {os.listdir(path)}")
+
         raise
 
     try:


### PR DESCRIPTION
This changes localdev to use /data for symbols things. This makes it
easier to debug configuration for directories that minidump-stackwalk
needs to use.

This adds some additional logging for the contents in /tmp when we hit
an OSError.