### PR TITLE
bug 1737691: more minidumpstackwalkrule fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN groupadd --gid $groupid app && \
 # Install OS-level things
 COPY ./docker/set_up_ubuntu.sh /tmp/
 RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
+RUN rm /tmp/set_up_ubuntu.sh
 
 # Copy stackwalk bits from mozilla/socorro-minidump-stackwalk image
 COPY --from=breakpad /stackwalk/* /stackwalk/
@@ -81,9 +82,6 @@ USER app
 
 # Copy everything over
 COPY --chown=app:app . /app/
-
-# Build tmp directories for minidump stackwalker
-RUN mkdir -p /tmp/symbols/cache /tmp/symbols/tmp
 
 # Run collectstatic in container which puts files in the default place for
 # static files

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -66,14 +66,14 @@ resource.boto.reprocessing_queue=local-dev-reprocessing
 # Use the rust-minidump minidump-stackwalk binary
 processor.minidump_stackwalker=rust
 
-# In the docker local dev environment, we store symbol cache and other things in /tmp because
-# there's only one processor node. For server environments, we probably want to store that
-# in a volume. These three vars are all affected.
-companion_process.symbol_cache_path=/data/symbols/cache
-processor.minidumpstackwalk.symbol_cache_path=/data/symbols/cache
-processor.minidumpstackwalk.symbol_tmp_path=/data/symbols/tmp
-processor.breakpad.symbol_cache_path=/data/symbols/cache
-processor.breakpad.symbol_tmp_path=/data/symbols/tmp
+# In the docker local dev environment, we store symbol cache and other things
+# in /tmp because there's only one processor node. For server environments, we
+# probably want to store that in a volume. These vars are all affected.
+companion_process.symbol_cache_path=/tmp/symbols/cache
+processor.minidumpstackwalk.symbol_cache_path=/tmp/symbols/cache
+processor.minidumpstackwalk.symbol_tmp_path=/tmp/symbols/tmp
+processor.breakpad.symbol_cache_path=/tmp/symbols/cache
+processor.breakpad.symbol_tmp_path=/tmp/symbols/tmp
 
 # Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
 # a long time

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -181,6 +181,7 @@ class MinidumpStackwalkRule(Rule):
         self.tmp_path = tmp_path
 
         self.stackwalk_version = self.get_version()
+        self.build_directories()
 
         self.metrics = markus.get_metrics("processor.minidumpstackwalk")
 
@@ -206,6 +207,10 @@ class MinidumpStackwalkRule(Rule):
                 + f"{return_code} {output}"
             )
         return output.decode("utf-8").strip()
+
+    def build_directories(self):
+        os.makedirs(self.symbol_tmp_path, exist_ok=True)
+        os.makedirs(self.symbol_cache_path, exist_ok=True)
 
     def expand_commandline(self, dump_file_path, raw_crash_path):
         """Expands the command line parameters and returns the final command line

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -83,20 +83,8 @@ def tmp_raw_crash_file(tmp_path, raw_crash, crash_id):
     path = os.path.join(
         tmp_path, f"{crash_id}.{threading.currentThread().getName()}.TEMPORARY.json"
     )
-    try:
-        with open(path, "w") as fp:
-            json.dump(dotdict_to_dict(raw_crash), fp)
-    except OSError:
-        # If we can't save the file because there isn't enough space, we want to log
-        # what's there so we can see what's going on
-        LOGGER.error(
-            f"OSError: no space: contents of {tmp_path}: {os.listdir(tmp_path)}"
-        )
-        if "symbols" in os.listdir(tmp_path):
-            path = os.path.join(tmp_path, "symbols")
-            LOGGER.error(f"OSError: contents of {path}: {os.listdir(path)}")
-
-        raise
+    with open(path, "w") as fp:
+        json.dump(dotdict_to_dict(raw_crash), fp)
 
     try:
         yield path


### PR DESCRIPTION
This removes some cruft from the Dockerfile that I noticed while I was tinkering with things.

This undoes the changes to localdev configuration and sets the symbols cache and symbols tmp directories to be `/tmp` based. If we point them to `/data`, then we have to have something with root access in the container to create the directories. We could do that in the Dockerfile, but then there's a mismatch between what the Dockerfile does and what configuration specifies. That's more trouble than it's worth in the local dev environment because it's unclear what we'd actually be validating. Better off defaulting everything to `/tmp`.

This also changes `MinidumpStackwalkRule` to create the symbols cache and symbols tmp directories. That way if the directories don't exist, it should be easier to see in the logs.