### PR TITLE
bug 1737691: update minidump-stackwalk to e010de76

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,14 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # https://crates.io/crates/minidump-stackwalk
-RUN cargo install --locked --root=/app/ minidump-stackwalk --version 0.9.2
+# 2021-11-19
+ARG MINIDUMPREV=e010de7678948eed4190f410e4c680053862c548
+
+RUN cargo install --locked --root=/app/ \
+    --git https://github.com/luser/rust-minidump.git \
+    --rev $MINIDUMPREV \
+    minidump-stackwalk
+RUN echo $MINIDUMPREV > /app/bin/minidump-stackwalk.sha
 RUN ls -al /app/bin/
 
 
@@ -55,7 +62,8 @@ RUN rm /tmp/set_up_ubuntu.sh
 # Copy stackwalk bits from mozilla/socorro-minidump-stackwalk image
 COPY --from=breakpad /stackwalk/* /stackwalk/
 
-# Copy stackwalk bits from rust-minidump minidump-stackwalker
+# Copy stackwalk bits from rust-minidump minidump-stackwalker; this picks
+# up minidump-stackwalk.sha as well
 COPY --from=rustminidump /app/bin/* /stackwalk-rust/
 
 # Install frontend JS deps

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -194,7 +194,16 @@ class MinidumpStackwalkRule(Rule):
                 "MinidumpStackwalkRule: unknown error when getting version: "
                 + f"{return_code} {output}"
             )
-        return output.decode("utf-8").strip()
+        version = output.decode("utf-8").strip()
+
+        # If there's a sha file, then that's the commit sha of the version of
+        # minidump-stackwalk that we installed, so tack that on
+        shafile = self.command_path + ".sha"
+        if os.path.exists(shafile):
+            with open(shafile, "r") as fp:
+                sha = fp.read().strip()[:8]
+            version = f"{version} ({sha})"
+        return version
 
     def build_directories(self):
         os.makedirs(self.symbol_tmp_path, exist_ok=True)


### PR DESCRIPTION
This changes building minidump-stackwalk to build it from a specified
rev in git.

This modifies get_version() to include the commit sha of
minidump-stackwalk installed.

This updates minidump-stackwalk to
e010de7678948eed4190f410e4c680053862c548 which picks up:

```
* 9d0aa9f fix a couple README whoopsies
* 0c90e02 post-0.9.4 release cleanup
* 101e9b1 0.9.4 release
* 5e3e346 Cleanup READMEs
* bd1a95d Be more strict about stack pointers on non-leaf ARM functions
* 66f8e16 remove miniump-tools
* 23c3ddc garbage-collect, update, and unify some dependencies
* 87eb0b4 remove dwarf_symbolizer and its dependencies
* c52bd22 post-0.9.3 RELEASES.md update
* 1e7cc1a 0.9.3 release
* df1b200 Add a timeout to symbol downloads
* 7783de7 Bump serde_json from 1.0.70 to 1.0.71
* 91a4abe Bump openssl from 0.10.34 to 0.10.38
* a142f20 add optional vendored-openssl feature
* 8b46228 Bump serde_json from 1.0.69 to 1.0.70
* 91b22f2 Bump simplelog from 0.10.2 to 0.11.0
* 26eb76e post-0.9.2 release RELEASES.md update
```