### PR TITLE
bug 1711897: fix get_version() to capture date

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,14 +27,14 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # https://crates.io/crates/minidump-stackwalk
-# 2021-11-19
 ARG MINIDUMPREV=e010de7678948eed4190f410e4c680053862c548
+ARG MINIDUMPREVDATE=2021-11-19
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \
     --rev $MINIDUMPREV \
     minidump-stackwalk
-RUN echo $MINIDUMPREV > /app/bin/minidump-stackwalk.sha
+RUN echo "{\"sha\":\"$MINIDUMPREV\",\"date\":\"$MINIDUMPREVDATE\"}" > /app/bin/minidump-stackwalk.version.json
 RUN ls -al /app/bin/
 
 

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -191,13 +191,16 @@ class MinidumpStackwalkRule(Rule):
             )
         version = output.decode("utf-8").strip()
 
-        # If there's a sha file, then that's the commit sha of the version of
-        # minidump-stackwalk that we installed, so tack that on
-        shafile = self.command_path + ".sha"
+        # If there's a JSON file, then that has version information about the
+        # minidump-stackwalk that we installed, so tack that information on
+        shafile = self.command_path + ".version.json"
         if os.path.exists(shafile):
             with open(shafile, "r") as fp:
-                sha = fp.read().strip()[:8]
-            version = f"{version} ({sha})"
+                data = json.load(fp)
+            if data:
+                rev = data["sha"][:8]
+                revdate = data["date"]
+                version = f"{version} ({revdate} {rev})"
         return version
 
     def build_directories(self):


### PR DESCRIPTION
This fixes get_version() in MinidumpStackwalkRule to capture the sha and
the date of the revision we're using. This makes it easier to eyeball
the age of the thing we're using.