### PR TITLE
bug 1743680: update minidump-stackwalk to 5069ee3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,9 +26,9 @@ RUN groupadd --gid $groupid app && \
 
 USER app
 
-# https://crates.io/crates/minidump-stackwalk
-ARG MINIDUMPREV=e010de7678948eed4190f410e4c680053862c548
-ARG MINIDUMPREVDATE=2021-11-19
+# From: https://github.com/luser/rust-minidump
+ARG MINIDUMPREV=5069ee30611c06ca7672f74cbfa055b089c84880
+ARG MINIDUMPREVDATE=2021-11-30
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \


### PR DESCRIPTION
```
5069ee3 (HEAD -> master, official/master) Fix multi named argument bug
d6407f1 Add JSON schema document
ac28159 Remove legacy truncation fields
d50640b update RELEASES.md
4f5d185 Implement --brief argument
f3408b3 Implement cyborg output
6615352 minindump-stackwalk interface cleanup
a224c91 add a bunch of docs to minidump
833db4a Bump serde_json from 1.0.71 to 1.0.72
f934420 Give better feedback on corrupt minidumps
9d0aa9f fix a couple README whoopsies
0c90e02 post-0.9.4 release cleanup
101e9b1 0.9.4 release
```