### PR TITLE
bug 1743510: capture minidump-stackwalk output and surface it

### DIFF
--- a/bin/process_crashes.sh
+++ b/bin/process_crashes.sh
@@ -56,5 +56,5 @@ mkdir "${DATADIR}" || echo "${DATADIR} already exists."
 # Print urls to make it easier to look at them
 for crashid in "$@"
 do
-    echo "Check webapp: http://localhost:8000/report/index/${crashid}"
+    echo "Check webapp: http://localhost:8000/report/index/${crashid}?refresh=cache"
 done

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -103,11 +103,13 @@ class ProcessorPipeline(RequiredConfig):
             "format syntax"
         ),
         default=(
-            "timeout --signal KILL {kill_timeout} {command_path} "
-            "--raw-json {raw_crash_path} "
+            "timeout --signal KILL {kill_timeout} "
+            "{command_path} "
+            "--raw-json={raw_crash_path} "
+            "--symbols-cache={symbol_cache_path} "
+            "--symbols-tmp={symbol_tmp_path} "
             "{symbols_urls} "
-            "--symbols-cache {symbol_cache_path} "
-            "--symbols-tmp {symbol_tmp_path} "
+            "--verbose=error "
             "{dump_file_path}"
         ),
     )

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1174,6 +1174,10 @@
                     <td>{{ report.mdsw_status_string }}</td>
                   </tr>
                   <tr>
+                    <th scope="row">MDSW stderr</th>
+                    <td><pre>{{ report.mdsw_stderr }}</pre></td>
+                  </tr>
+                  <tr>
                     <th scope="row">Processor notes</th>
                     <td><pre>{{ report.processor_notes }}</pre></td>
                   </tr>


### PR DESCRIPTION
This reworks `execute_process` so that the `MinidumpStackwalkRule` can
surface stderr as `mdsw_stderr`. It adds that to the Debug tab so it's
visible.

The combination of the exit code plus the last lines of stderr will make
debugging minidump-stackwalk easier plus it tells us a lot more about
what's bad about specific minidumps.