### PR TITLE
bug 1744999: update minidump-stackwalk add --json flag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=5069ee30611c06ca7672f74cbfa055b089c84880
-ARG MINIDUMPREVDATE=2021-11-30
+ARG MINIDUMPREV=c4617dc2b41133637a2e9b8b704db2320d7fc0d9
+ARG MINIDUMPREVDATE=2021-12-08
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -109,6 +109,7 @@ class ProcessorPipeline(RequiredConfig):
             "--symbols-cache={symbol_cache_path} "
             "--symbols-tmp={symbol_tmp_path} "
             "{symbols_urls} "
+            "--json "
             "--verbose=error "
             "{dump_file_path}"
         ),

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -144,6 +144,7 @@ class MinidumpStackwalkRule(Rule):
             "--symbols-cache={symbol_cache_path} "
             "--symbols-tmp={symbol_tmp_path} "
             "{symbols_urls} "
+            "--json "
             "--verbose=error "
             "{dump_file_path}"
         ),


### PR DESCRIPTION
This updates minidump-stackwalk to c4617dc. Changes:

```
c4617dc Make --human the default output of minidump-stackwalk
2dc160d fixup new lints
06d2e42 Json Schema Breaking Change: rename crashing_thread.thread_index to threads_index
445431c 0.9.5 release
13463d0 Document the Symbolizer interface and shim better
```

This picks up the fix for the last issue from bug #1744323. It also
changes how we run minidump-stackwalk to always pass the `--json` flag.