### PR TITLE
bug 1745454: redo cors support; fix api responses

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,7 @@ django-pipeline==2.0.7
 django-ratelimit==3.0.1
 django-session-csrf==0.7.1
 django-waffle==2.2.1
+django-cors-headers==3.10.1
 django_csp==3.7
 dockerflow==2021.7.0
 enforce-typing==1.0.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -166,9 +166,14 @@ django==2.2.25 \
     --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
+    #   django-cors-headers
     #   django-csp
     #   django-jinja
     #   mozilla-django-oidc
+django-cors-headers==3.10.1 \
+    --hash=sha256:1390b5846e9835b0911e2574409788af87cd9154246aafbdc8ec546c93698fe6 \
+    --hash=sha256:b5a874b492bcad99f544bb76ef679472259eb41ee5644ca62d1a94ddb26b7f6e
+    # via -r requirements.in
 django_csp==3.7 \
     --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
     --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -115,10 +115,10 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    def test_CORS(self):
-        """any use of model_wrapper should return a CORS header"""
+    def test_option_CORS(self):
+        """OPTIONS request for model_wrapper returns CORS headers"""
         url = reverse("api:model_wrapper", args=("NoOp",))
-        response = self.client.get(url, {"product": "good"})
+        response = self.client.options(url, HTTP_ORIGIN="http://example.com")
         assert response.status_code == 200
         assert response["Access-Control-Allow-Origin"] == "*"
 
@@ -203,7 +203,7 @@ class TestViews(BaseTestViews):
         url = reverse("api:model_wrapper", args=("ProcessedCrash",))
         response = self.client.get(url)
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
         dump = json.loads(response.content)
         assert dump["errors"]["crash_id"]
 
@@ -270,7 +270,7 @@ class TestViews(BaseTestViews):
 
         response = self.client.get(url, HTTP_AUTH_TOKEN=token.key)
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
         dump = json.loads(response.content)
         assert dump["errors"]["crash_id"]
 
@@ -359,7 +359,7 @@ class TestViews(BaseTestViews):
         url = reverse("api:model_wrapper", args=("RawCrash",))
         response = self.client.get(url)
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
         dump = json.loads(response.content)
         assert dump["errors"]["crash_id"]
 
@@ -391,7 +391,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(url, {"crash_id": "abc", "format": "wrong"})  # note
         # invalid format
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
 
         user = self._login()
         self._add_permission(user, "view_pii")
@@ -421,7 +421,7 @@ class TestViews(BaseTestViews):
         url = reverse("api:model_wrapper", args=("Bugs",))
         response = self.client.get(url)
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
         dump = json.loads(response.content)
         assert dump["errors"]["signatures"]
 
@@ -438,7 +438,7 @@ class TestViews(BaseTestViews):
         url = reverse("api:model_wrapper", args=("SignaturesByBugs",))
         response = self.client.get(url)
         assert response.status_code == 400
-        assert response["Content-Type"] == "application/json; charset=UTF-8"
+        assert response["Content-Type"] == "application/json"
         dump = json.loads(response.content)
         assert dump["errors"]["bug_ids"]
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -436,6 +436,9 @@ class SocorroMiddleware(SocorroCommon):
     def post(self, url, payload):
         return self._post(url, payload)
 
+    def options(self):
+        return self._options()
+
     def put(self, url, payload):
         return self._post(url, payload, method="put")
 
@@ -446,6 +449,9 @@ class SocorroMiddleware(SocorroCommon):
     def _post(self, url, payload, method="post"):
         # set dont_cache=True here because the request depends on the payload
         return self.fetch(url, method=method, data=payload, dont_cache=True)
+
+    def _options(self, method="options"):
+        return {}, False
 
     def parse_parameters(self, kwargs):
         defaults = getattr(self, "defaults", {})

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -227,9 +227,7 @@ class Test404:
         assert response.status_code == 404
         assert response["Content-Type"] == "application/json"
         result = json.loads(response.content)
-        assert result["error"] == "Page not found"
-        assert result["path"] == url
-        assert result["query_string"] == "foo=bar"
+        assert result["error"] == "No service called 'Unknown'"
 
 
 class TestContributeJson:

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -687,16 +687,6 @@ def find_crash_id(input_str):
             pass  # will return None
 
 
-def add_CORS_header(f):
-    @functools.wraps(f)
-    def wrapper(request, *args, **kw):
-        response = f(request, *args, **kw)
-        response["Access-Control-Allow-Origin"] = "*"
-        return response
-
-    return wrapper
-
-
 def ratelimit_rate(group, request):
     """return None if we don't want to set any rate limit.
     Otherwise return a number according to

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -71,6 +71,7 @@ ROOT_URLCONF = "crashstats.urls"
 INSTALLED_APPS = (
     "whitenoise.runserver_nostatic",
     "pipeline",
+    "corsheaders",
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
@@ -101,6 +102,8 @@ INSTALLED_APPS = (
 
 
 MIDDLEWARE = [
+    # CORS needs to go before other response-generating middlewares
+    "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -284,6 +287,10 @@ LOGIN_URL = "/login/"
 
 # Use memcached for session storage
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
+# django-cors-headers should kick in for all API requests and support all origins
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_URLS_REGEX = r"^/api/.*$"
 
 # Process types to allow in queries.
 # If tuple, the second option is human readable label.

--- a/webapp-django/crashstats/tokens/jinja2/tokens/home.html
+++ b/webapp-django/crashstats/tokens/jinja2/tokens/home.html
@@ -150,7 +150,7 @@ import requests
 headers = {'Auth-Token': '58af2acef8a74dbca9580e2bb8ba9c9x'}
 url = '{{ absolute_base_url }}{{ url('api:model_wrapper', 'RawCrash') }}?crash_id=fb27d0f3-db8e-4835-9311-288bb0170829'
 response = requests.get(url, headers=headers)
-print response.json()</pre>
+print(response.json())</pre>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This redoes CORS support to use django-cors-headers middleware. This
adds support for OPTIONS requests as well, which fix preflight issues.

This fixes all the responses from the API to be JSON so we're not doing
some in JSON and some in HTML.
