### PR TITLE
Update rust-minidump to 6ccdead

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=c4617dc2b41133637a2e9b8b704db2320d7fc0d9
-ARG MINIDUMPREVDATE=2021-12-08
+ARG MINIDUMPREV=6ccdead2bffb0c9db60037b1ea6923c69afba023
+ARG MINIDUMPREVDATE=2021-12-10
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \


### PR DESCRIPTION
```
6ccdead confirm that unloaded module offsets are deduped
ecab5b5 Be more principled with output files in mdsw tests
de2209a Add tests for unloaded modules in mdsw
87b93fb do a better job computing unloaded_module offsets
d876fbe Unloaded modules fixes
52f112d you can never stop me from writing more docs
10d3dfd Add tests for minidump-stackwalk
13ffc20 post-release cleanup
664dcd1 0.9.6 release
1188157 Add some details and cleanup json-schema
c816898 update RELEASES.md
0bb785c Add minidump-stackwalk CLI docs to the README
```