### PR TITLE
bug 1745663: fix error codes in crash signatures

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=6ccdead2bffb0c9db60037b1ea6923c69afba023
-ARG MINIDUMPREVDATE=2021-12-10
+ARG MINIDUMPREV=ebb603f59a774fe8921100b9794070effdc2cfa3
+ARG MINIDUMPREVDATE=2021-12-13
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -925,3 +925,22 @@ class TestMinidumpStackwalkRule:
             processor_meta["processor_notes"][0]
             == "MinidumpStackwalkRule: minidump-stackwalk: failed with -1: unknown error"
         )
+
+    def test_empty_minidump_shortcut(self, tmp_path):
+        rule = self.build_rule()
+
+        # Write a 0-byte minidump file with the correct name
+        dumppath = tmp_path / "upload_file_minidump"
+        dumppath.write_text("")
+
+        raw_crash = {"uuid": example_uuid}
+        dumps = {rule.dump_field: str(dumppath)}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta()
+
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+
+        assert processed_crash["mdsw_return_code"] == 0
+        assert processed_crash["mdsw_status_string"] == "EmptyMinidump"
+        assert processed_crash["success"] is True
+        assert processed_crash["mdsw_stderr"] == "Shortcut for 0-bytes minidump."


### PR DESCRIPTION
When minidump-stackwalk encounters an error (empty minidump, no threads
stream, etc), the MinidumpStackwalkerRule should stomp on the
mdsw_status_string with that error code and then signature generation
can grab it to use in the signature.

This updates rust-minidump to ebb603f5:

```
ebb603f Start top-level errors with an error name.
```

Note that this changes some crash signatures.

With breakpad stackwalker, we'd have signatures like:

* EMPTY: no crashing thread identified; ERROR_NO_MINIDUMP_HEADER
* EMPTY: no crashing thread identified; ERROR_NO_THREAD_LIST

With rust-minidump minidump-stackwalker and these changes, we'll now
have:

* EMPTY: no crashing thread identified; EmptyMinidump
* EMPTY: no crashing thread identified; MissingThreadList
