### PR TITLE
bug 828452: add "this is unstable" note to signature api

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -648,6 +648,9 @@ class CrashSignatureAPI(SocorroAPIView):
     IS_PUBLIC = True
 
     HELP_TEXT = """
+    Note: This is currently unsupported and in flux. It's being stabilitized. See:
+    https://bugzilla.mozilla.org/show_bug.cgi?id=828452
+
     Takes memory address, module information, and crash annotation data and generates a
     crash signature.
 


### PR DESCRIPTION
I'm adding this now because it's live in stage, but I'm probably going
to make non-trivial changes to the payload so I want to make it clear
it's in flux.
