### PR TITLE
bug 1745663: fix KeyError caused by CrashingThreadRule

### DIFF
--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -33,7 +33,7 @@ class CrashingThreadInfoRule(Rule):
     """
 
     def predicate(self, raw_crash, dumps, processed_crash, proc_meta):
-        return bool(processed_crash.get("json_dump", None))
+        return processed_crash.get("json_dump", None) is not None
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         processed_crash["crashing_thread"] = glom.glom(
@@ -333,12 +333,9 @@ class MinidumpStackwalkRule(Rule):
                     # running minidump-stackwalker.
                     #
                     # This is a bad case, so we want to add a note. However, since this
-                    # is a shortcut, we also include a basic stackwalker_data.
+                    # is a shortcut, we also include some stackwalker_data.
                     stackwalker_data = {
-                        "json_dump": {},
-                        "mdsw_return_code": 0,
                         "mdsw_status_string": "EmptyMinidump",
-                        "success": True,
                         "mdsw_stderr": "Shortcut for 0-bytes minidump.",
                     }
 

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -204,13 +204,13 @@ class TestCrashingThreadInfoRule:
         """If there's no dump data, then this rule doesn't do anything"""
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
-        processed_crash = {"json_dump": {}}
+        processed_crash = {}
         processor_meta = get_basic_processor_meta()
 
         rule = CrashingThreadInfoRule()
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        assert processed_crash == {"json_dump": {}}
+        assert processed_crash == {}
         assert processor_meta["processor_notes"] == []
 
 
@@ -940,7 +940,5 @@ class TestMinidumpStackwalkRule:
 
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        assert processed_crash["mdsw_return_code"] == 0
         assert processed_crash["mdsw_status_string"] == "EmptyMinidump"
-        assert processed_crash["success"] is True
         assert processed_crash["mdsw_stderr"] == "Shortcut for 0-bytes minidump."


### PR DESCRIPTION
I made a change to handle 0-byte minidumps and skip running
minidump-stackwalk. That's fine, but I thought it made sense to "fake"
the stackwalker_data output. That turns out to cause problems with other
processor rules that have expectations for what is and isn't in the
minidump.

This scales that back a bit so that json_dump isn't set to {} which
caused the events that lead to a KeyError.
