### PR TITLE
bug 1745816: strip leading zeros for addresses in signature generation

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -16,6 +16,7 @@ from .utils import (
     get_crashing_thread,
     override_values,
     parse_source_file,
+    strip_leading_zeros,
 )
 
 
@@ -198,10 +199,10 @@ class CSignatureTool:
     ):
         """Normalizes a single frame
 
-        Returns a structured conglomeration of the input parameters to serve as
-        a signature. The parameter names of this function reflect the exact
-        names of the fields from the jsonMDSW frame output. This allows this
-        function to be invoked by passing a frame as ``**a_frame``.
+        Returns a structured conglomeration of the input parameters to serve as a
+        signature. The parameter names of this function reflect the exact names of the
+        fields from the JSON MDSW frame output. This allows this function to be invoked
+        by passing a frame as ``**a_frame``.
 
         """
         if function:
@@ -224,10 +225,10 @@ class CSignatureTool:
 
         # If there's an offset and no module/module_offset, use that
         if not module and not module_offset and offset:
-            return f"@{offset}"
+            return f"@{strip_leading_zeros(offset)}"
 
         # Return module/module_offset
-        return "{}@{}".format(module or "", module_offset)
+        return "{}@{}".format(module or "", strip_leading_zeros(module_offset))
 
     def generate(self, source_list, hang_type=0, crashed_thread=None, delimiter=" | "):
         """Iterate over frames in the crash stack and generate a signature.

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -81,15 +81,15 @@ class TestCSignatureTool:
         """test_normalize: bunch of variations"""
         s = self.setup_config_c_sig_tool()
         a = [
-            (("module", "", "source/", "23", "0xFFF"), "source#23"),
-            (("module", "", "source\\", "23", "0xFFF"), "source#23"),
-            (("module", "", "/a/b/c/source", "23", "0xFFF"), "source#23"),
-            (("module", "", "\\a\\b\\c\\source", "23", "0xFFF"), "source#23"),
-            (("module", "", "\\a\\b\\c\\source", "23", "0xFFF"), "source#23"),
-            (("module", "", "\\a\\b\\c\\source", "", "0xFFF"), "module@0xFFF"),
-            (("module", "", "", "23", "0xFFF"), "module@0xFFF"),
-            (("module", "", "", "", "0xFFF"), "module@0xFFF"),
-            ((None, "", "", "", "0xFFF"), "@0xFFF"),
+            (("module", "", "source/", "23", "0xfff"), "source#23"),
+            (("module", "", "source\\", "23", "0xfff"), "source#23"),
+            (("module", "", "/a/b/c/source", "23", "0xfff"), "source#23"),
+            (("module", "", "\\a\\b\\c\\source", "23", "0xfff"), "source#23"),
+            (("module", "", "\\a\\b\\c\\source", "23", "0xfff"), "source#23"),
+            (("module", "", "\\a\\b\\c\\source", "", "0xfff"), "module@0xfff"),
+            (("module", "", "", "23", "0xfff"), "module@0xfff"),
+            (("module", "", "", "", "0xfff"), "module@0xfff"),
+            ((None, "", "", "", "0xfff"), "@0xfff"),
             # Make sure frame normalization uses the right function: normalize
             # Rust frame (has a Rust fingerprint)
             (
@@ -98,7 +98,7 @@ class TestCSignatureTool:
                     "expect_failed::h7f635057bfba806a",
                     "hg:hg.mozilla.org/a/b:servio/wrapper.rs:44444444444",
                     "23",
-                    "0xFFF",
+                    "0xfff",
                 ),
                 "expect_failed",
             ),

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -15,6 +15,7 @@ from ..utils import (
     override_values,
     parse_crashid,
     parse_source_file,
+    strip_leading_zeros,
 )
 
 
@@ -329,3 +330,22 @@ def test_drop_prefix_and_return_type(function, expected):
 )
 def test_parse_crashid(item, expected):
     assert parse_crashid(item) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # Bad data begets itself
+        (None, None),
+        (16, 16),
+        # Good hex things get fixed correctly
+        ("0x32ec0", "0x32ec0"),
+        ("0x0000000000032ec0", "0x32ec0"),
+        # This is a weird case where it looks like a decimal and should probably be
+        # a decimal, but our code strips it and puts 0x in front. I'm going to leave
+        # it like this for now.
+        ("40", "0x40"),
+    ],
+)
+def test_strip_leading_zeros(text, expected):
+    assert strip_leading_zeros(text) == expected

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -404,3 +404,22 @@ def parse_crashid(item):
             crash_id = path.split("/")[-1]
             if is_crash_id_valid(crash_id):
                 return crash_id
+
+
+def strip_leading_zeros(text):
+    """Strips leading zeros from a hex string.
+
+    Example:
+
+    >>> strip_leading_zeros("0x0000000000032ec0")
+    "0x32ec0"
+
+    :param text: the text to strip leading zeros from
+
+    :returns: stripped text
+
+    """
+    try:
+        return hex(int(text, base=16))
+    except (ValueError, TypeError):
+        return text


### PR DESCRIPTION
When using offsets or module_offsets in a signature, we now strip
leading 0s in the hex so regardless of what generated the frame data, it
ends up in the signature the same way.

For example, 0x0000000000032ec0 and 0x32ec0 now get normalized to
0x32ec0.