### PR TITLE
Update rust-minidump to 2dc7ecc3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=cf2031c837810b55fc813ace2a8c7fd71e8f201d
+ARG MINIDUMPREV=2dc7ecc384f8ed123387cace30157c5288b6b5f3
 ARG MINIDUMPREVDATE=2021-12-15
 
 RUN cargo install --locked --root=/app/ \


### PR DESCRIPTION
```
2dc7ecc misc doc cleanups
76db048 Don't trust high bits of crash addresses
8bce21d disable racey test
```

This fixes rust-minidump #360.
