### PR TITLE
bug 1748268: implement `/__broken__` view and clean up heartbeat view

### DIFF
--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1464,7 +1464,9 @@ class TestIntegrationSuperSearch(ElasticsearchTestCase):
         res = api.get(**params)
         assert res["total"] == 0
         assert len(res["hits"]) == 0
-        assert len(res["errors"]) == 3  # 3 weeks are missing
+        # NOTE(willkg): in the first week of the year, new years day could be such that
+        # this is either 3 or 4 weeks; fun times
+        assert len(res["errors"]) in [3, 4]
 
     def test_get_too_large_date_range(self):
         # this is a whole year apart

--- a/webapp-django/crashstats/monitoring/tests/test_views.py
+++ b/webapp-django/crashstats/monitoring/tests/test_views.py
@@ -167,3 +167,9 @@ class TestDockerflowVersionView:
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
         assert smart_text(resp.content) == text
+
+
+class TestBroken:
+    def test_broken(self, client):
+        with pytest.raises(Exception):
+            client.get(reverse("monitoring:broken"))

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -11,6 +11,7 @@ app_name = "monitoring"
 urlpatterns = [
     url(r"^monitoring/$", views.index, name="index"),
     url(r"^monitoring/cron/$", views.cron_status, name="cron_status"),
+    url(r"^__broken__$", views.broken, name="broken"),
     # Dockerflow endpoints
     url(r"^__heartbeat__$", views.dockerflow_heartbeat, name="dockerflow_heartbeat"),
     url(

--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -140,3 +140,8 @@ def dockerflow_heartbeat(request):
 def dockerflow_lbheartbeat(request):
     """Dockerflow endpoint for load balancer checks."""
     return {"ok": True}
+
+
+def broken(request):
+    """Throws an error to test Sentry connetivity."""
+    raise Exception("intentional exception")


### PR DESCRIPTION
This fixes the heartbeat view so it doesn't use assert statements and it's clearer about what's failing.

This also implements a `/__broken__` endpoint to test sentry connectivity.

Also, since this is the first week of the year, this fixes a test that fails because of the way new years day falls in relation to index creation.