### PR TITLE
bug 1747846: pull distribution_id from annotation as well

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1546,20 +1546,14 @@ FIELDS = {
             "type": "date",
         },
     },
-    "distribution_id": {
-        "data_validation_type": "enum",
-        "description": "The TelemetryEnvironment.partner.distributionId value.",
-        "form_field_choices": [],
-        "has_full_version": False,
-        "in_database_name": "distribution_id",
-        "is_exposed": True,
-        "is_returned": True,
-        "name": "distribution_id",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "query_type": "enum",
-        "storage_mapping": {"analyzer": "keyword", "type": "string"},
-    },
+    "distribution_id": keyword_field(
+        name="distribution_id",
+        description=(
+            "Product application's distribution ID. This is either the DistributionID "
+            "annotation or the TelemetryEnvironment.partner.distributionId value."
+        ),
+        is_protected=False,
+    ),
     "dom_fission_enabled": {
         "data_validation_type": "str",
         "description": (

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -2150,11 +2150,19 @@ class TestPHCRule:
 
 
 class TestDistributionIdRule:
-    def test_no_telemetry(self):
+    def test_no_annotation_and_no_telemetry(self):
+        raw_crash = {}
         processed_crash = {}
         rule = DistributionIdRule()
-        rule.action({}, {}, processed_crash, {})
+        rule.action(raw_crash, {}, processed_crash, {})
         assert processed_crash["distribution_id"] == "unknown"
+
+    def test_annotation(self):
+        raw_crash = {"DistributionID": "mint"}
+        processed_crash = {}
+        rule = DistributionIdRule()
+        rule.action(raw_crash, {}, processed_crash, {})
+        assert processed_crash["distribution_id"] == "mint"
 
     @pytest.mark.parametrize(
         "telemetry_value",


### PR DESCRIPTION
This adjusts the code to derive `distribution_id` from `DistributionID` annotation and if that doesn't exist, then look in the `TelemetryEnvironment` for it.

While doing that, I converted the super_search_field nonsense into a `keyword_field` function.