### PR TITLE
bug 1748685: add {virtual override thunk} to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -142,6 +142,7 @@ std::__terminate
 std::terminate
 system@framework@.*\.jar@classes\.dex@0x
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
+{virtual override thunk}
 
 # These frames have platform variants and bucket poorly so we nix them
 # from the signature


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 85387491-2b2e-4bd8-9b50-e16f10220105
Crash id: 85387491-2b2e-4bd8-9b50-e16f10220105
Original: {virtual override thunk}
New:      nsTimerImpl::Fire
Same?:    False
```