### PR TITLE
bug 1746700: add libandroid to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -59,6 +59,7 @@ google_breakpad::ReceivePort::WaitForMessage
 # NOTE(willkg): we want to skip handle_error but not handle_errorf
 handle_error$
 KiFastSystemCallRet
+libandroid\.so@0x
 libandroid_runtime\.so@0x
 libbinder\.so@0x
 libEGL\.so@


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-700f3223-f1a4-4201-b25d-2ac700211217
Crash id: 700f3223-f1a4-4201-b25d-2ac700211217
Original: libandroid.so@0xea22
New:      aaudio_init
Same?:    False
```