### PR TITLE
bug 1748248: remove mac_crash_info if it's there

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -457,6 +457,9 @@ class MacCrashInfoRule(Rule):
     """
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
+        if "mac_crash_info" in processed_crash:
+            del processed_crash["mac_crash_info"]
+
         mac_crash_info = glom(processed_crash, "json_dump.mac_crash_info", default={})
 
         if mac_crash_info.get("num_records", 0) > 0:

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -462,7 +462,7 @@ class MacCrashInfoRule(Rule):
 
         mac_crash_info = glom(processed_crash, "json_dump.mac_crash_info", default={})
 
-        if mac_crash_info.get("num_records", 0) > 0:
+        if mac_crash_info and mac_crash_info.get("num_records", 0) > 0:
             processed_crash["mac_crash_info"] = json.dumps(
                 mac_crash_info, indent=2, sort_keys=True
             )

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -743,6 +743,7 @@ class TestMacCrashInfoRule:
             # These shouldn't result in a mac_crash_info
             ({}, False),
             ({"json_dump": {}}, False),
+            ({"json_dump": {"mac_crash_info": None}}, False),
             ({"json_dump": {"mac_crash_info": {}}}, False),
             ({"json_dump": {"mac_crash_info": {"num_records": 0}}}, False),
             # This should


### PR DESCRIPTION
This fixes the `MacCrashInfoRule` to remove any `mac_crash_info` that's in the processed crash before it does its work. This cleans up from previous problems.