### PR TITLE
bug 1748865: add mozilla::ipc::IProtocol::ChannelSend to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -181,6 +181,7 @@ mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame
 mozilla::ipc::RPCChannel::EnteredCxxStack
 mozilla::ipc::RPCChannel::Send
 mozilla::ipc::Shmem::OpenExisting
+mozilla::ipc::IProtocol::ChannelSend
 mozilla::ipc::IToplevelProtocol::ShmemCreated
 mozilla::layers::CompositorD3D11::Failed
 mozilla::layers::CompositorD3D11::HandleError


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-0a007ca9-7590-45b4-8c3e-dab230220106
Crash id: 0a007ca9-7590-45b4-8c3e-dab230220106
Original: mozilla::ipc::IProtocol::ChannelSend
New:      mozilla::ipc::IProtocol::ChannelSend | mozilla::dom::PContentParent::SendDispatchLocationChangeEvent
Same?:    False
```