### PR TITLE
bug 1713355: fix mac_crash_info "is" searches

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -468,8 +468,10 @@ class MacCrashInfoRule(Rule):
         mac_crash_info = glom(processed_crash, "json_dump.mac_crash_info", default={})
 
         if mac_crash_info and mac_crash_info.get("num_records", 0) > 0:
+            # NOTE(willkg): use sort_keys=True so this is stable and doesn't change
+            # between iterations
             processed_crash["mac_crash_info"] = json.dumps(
-                mac_crash_info, indent=2, sort_keys=True
+                mac_crash_info, sort_keys=True
             )
 
 

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -779,14 +779,7 @@ class TestMacCrashInfoRule:
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         assert processed_crash["mac_crash_info"] == (
-            "{\n"
-            '  "num_records": 1,\n'
-            '  "records": [\n'
-            "    {\n"
-            '      "thread": null\n'
-            "    }\n"
-            "  ]\n"
-            "}"
+            '{"num_records": 1, "records": [{"thread": null}]}'
         )
 
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -172,6 +172,14 @@ def report_index(request, crash_id, default_context=None):
         context["raw"], context["report"]
     )
 
+    # Fix processed_crash.mac_crash_info so it displays better
+    if "mac_crash_info" in context["report"]:
+        mac_crash_info = context["report"]["mac_crash_info"]
+        mac_crash_info = json.dumps(
+            json.loads(mac_crash_info), indent=2, sort_keys=True
+        )
+        context["report"]["mac_crash_info"] = mac_crash_info
+
     context["public_raw_keys"] = [
         x for x in context["raw"] if x in models.RawCrash.API_ALLOWLIST()
     ]


### PR DESCRIPTION
This fixes the processor code that extracts the mac_crash_info field to
encode it in a way that's good for indexing/searching and moving the
code to encode it in a way that's good for display to the report view.