### PR TITLE
bug 1749561: fix supersearch refine links

### DIFF
--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/macros/links.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/macros/links.html
@@ -1,0 +1,21 @@
+{% macro signature_link(name, val) %}
+  <a href="{{ url('signature:signature_report') }}{{ change_query_string(
+    _no_base=True,
+    signature=val,
+    page=None,
+    _columns=None,
+    _facets=None
+    ) }}"
+    title="View signature report"
+  >
+    {{ val }}
+  </a>
+{% endmacro %}
+
+{% macro refine_link(name, val, display_text=None, use_is_query=True) %}
+  {% set filter_val = '=%s' % val if use_is_query else val %}
+  {% set display_text = val if display_text == None else display_text %}
+  <a href="{{ change_query_string(_no_base=True, **{name: filter_val}) }}" class="term" data-field="{{ name }}" data-content="{{ val }}" title="Refine search">
+    {{ display_text }}
+  </a>
+{% endmacro %}

--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
@@ -1,4 +1,5 @@
 {% from "macros/pagination.html" import pagination %}
+{% from "supersearch/macros/links.html" import signature_link, refine_link with context %}
 
 {% if query.total > 0 %}
   <ul id="search_results-nav">
@@ -30,35 +31,19 @@
                   {% if column == 'date' %}
                     {{ crash[column] | human_readable_iso_date }}
                   {% elif column == 'signature' %}
-                    <a href="{{ url('signature:signature_report') }}{{ change_query_string(
-                       _no_base=True,
-                       signature=crash.signature,
-                       page=None,
-                       _columns=None,
-                       _facets=None
-                       ) }}"
-                       title="Click to leave this search and go to this signature report"
-                    >
-                      {{ crash[column] }}
-                    </a>
+                    {{ signature_link(column, crash[column]) }}
                     &nbsp;
-                    <a href="{{ current_url }}&amp;{{ column }}=%3D{{ crash[column] | urlencode }}" class="term" data-field="{{ column }}" data-content="{{ crash[column] }}" title="Add this term to the search form">
-                      Add term
-                    </a>
+                    {{ refine_link(column, crash[column], "Add term") }}
                   {% elif is_list(crash[column]) %}
                     {% for val in crash[column] %}
-                      <a href="{{ current_url }}&amp;{{ column }}=%3D{{ val | urlencode }}" class="term" data-field="{{ column }}" data-content="{{ val }}" title="Add this term to the search form">
-                        {{ val }}
-                      </a>
+                      {{ refine_link(column, val) }}
                     {% endfor %}
+                  {% elif column in ('product', 'version', 'platform', 'process_type') %}
+                    {{ refine_link(column, crash[column], use_is_query=False) }}
                   {% elif column == 'install_time' %}
-                    <a href="{{ current_url }}&amp;{{ column }}=%3D{{ crash[column] | urlencode }}" class="term" data-field="{{ column }}" data-content="{{ crash[column] }}" title="Add this term to the search form">
-                      {{ crash[column] | timestamp_to_date }}
-                    </a>
+                    {{ refine_link(column, crash[column], crash[column] | timestamp_to_date) }}
                   {% else %}
-                    <a href="{{ current_url }}&amp;{{ column }}=%3D{{ crash[column] | urlencode }}" class="term" data-field="{{ column }}" data-content="{{ crash[column] }}" title="Add this term to the search form">
-                      {{ crash[column] }}
-                    </a>
+                    {{ refine_link(column, crash[column]) }}
                   {% endif %}
                 {% endif %}
               </td>
@@ -90,22 +75,14 @@
             <tr>
               <td>{{ loop.index }}</td>
               <td>
-                {% if facet != 'signature' %}
-                  <a href="{{ current_url }}&amp;{{ facet }}=%3D{{ hit.term | urlencode }}" class="term" data-field="{{ facet }}" data-content="{{ hit.term }}" title="Add this term to the search form">{{ hit.term }}</a>
-                {% else %}
-                  <a href="{{ url('signature:signature_report') }}{{ change_query_string(
-                     _no_base=True,
-                     signature=hit.term,
-                     page=None,
-                     _columns=None,
-                     _facets=None
-                     ) }}"
-                     title="Click to leave this search and go to this signature report"
-                  >
-                    {{ hit.term }}
-                  </a>
+                {% if facet == 'signature' %}
+                  {{ signature_link(facet, hit.term) }}
                   &nbsp;
-                  <a href="{{ current_url }}&amp;{{ facet }}=%3D{{ hit.term | urlencode }}" class="term" data-field="{{ facet }}" data-content="{{ hit.term }}" title="Add this term to the search form">Add term</a>
+                  {{ refine_link(facet, hit.term, "Add term") }}
+                {% elif facet in ('product', 'version', 'platform', 'process_type') %}
+                  {{ refine_link(facet, hit.term, use_is_query=False) }}
+                {% else %}
+                  {{ refine_link(facet, hit.term) }}
                 {% endif %}
               </td>
               <td>{{ hit.count }}</td>

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -216,7 +216,9 @@ class TestViews(BaseTestViews):
         assert '<th scope="col">Bugs</th>' in smart_text(response.content)
         assert "123456" in smart_text(response.content)
         # Test links on terms are existing
-        assert "product=%3DWaterWolf" in smart_text(response.content)
+        assert "build_id=%3D888981" in smart_text(response.content)
+        # refine links to the product should not be "is" queries
+        assert "product=WaterWolf" in smart_text(response.content)
 
         # Test with empty results
         response = self.client.get(url, {"product": "NightTrain", "date": "2012-01-01"})


### PR DESCRIPTION
Previously, if you do a supersearch and refined the search by clicking
on one of the field values in the results or facet results, it would add
that as an "is" query to the search. That's fine, except when there's a
filter for that field. In that case, the "is" query is OR'd with the
existing filter and I can't think of a single case where that's what you
want.

Now the refine links replace any existing filters for the field with the
"is" query.

Further, it fixes product, version, and product_type refinements to use
a term query (no prefix) instead of an "is" query ("=" prefix) so that
it works correctly with the supersearch form and site navigation.

Then I moved the code to macros because the template is really messy and
hard to read and we have a lot of complex-looking repeated logic
everywhere.