### PR TITLE
bug 1749727: rename variables with same name but different types

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -428,9 +428,11 @@ def get_fields_by_item(fields, key, val):
                     return True
         return False
 
-    fields = [field for field in fields.values() if has_key_val(key, val, field)]
-    _FIELDS_CACHE[map_key] = fields
-    return fields
+    fields_by_item = [
+        field for field in fields.values() if has_key_val(key, val, field)
+    ]
+    _FIELDS_CACHE[map_key] = fields_by_item
+    return fields_by_item
 
 
 def flag_field(


### PR DESCRIPTION
I saw a single instance where the `get_fields_by_item` kicked up a
RuntimeError saying the dictionary had changed while it was iterating
through it. I don't see how that's possible with the code (maybe bad
imagination).

However, there were too many things named the same name but with
different types, so I tweaked the code to reduce that.