### PR TITLE
bug 1748340: handle empty list product_name situation

### DIFF
--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -376,7 +376,7 @@ def signature_correlations(request, params):
             context["channel"] = "esr"
 
     default_product_name = productlib.get_default_product().name
-    product_name = params.get("product", default_product_name)
+    product_name = params.get("product") or default_product_name
     if isinstance(product_name, (list, tuple)):
         product_name = product_name[0]
 


### PR DESCRIPTION
If the passed in product is an empty list (which I think is possible
because of the way the parameters are determined), then the correlations
page would die because there's no index 0 in an empty list.

This accounts for the empty list possibility by using the default
product if the determined product name is falsey (empty string, empty
list, not set, ...).