### PR TITLE
bug 1749561: fix supersearch form and refining search

### DIFF
--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
@@ -38,7 +38,7 @@
                     {% for val in crash[column] %}
                       {{ refine_link(column, val) }}
                     {% endfor %}
-                  {% elif column in ('product', 'version', 'platform', 'process_type') %}
+                  {% elif column in simple_search_data_fields %}
                     {{ refine_link(column, crash[column], use_is_query=False) }}
                   {% elif column == 'install_time' %}
                     {{ refine_link(column, crash[column], crash[column] | timestamp_to_date) }}
@@ -79,7 +79,7 @@
                   {{ signature_link(facet, hit.term) }}
                   &nbsp;
                   {{ refine_link(facet, hit.term, "Add term") }}
-                {% elif facet in ('product', 'version', 'platform', 'process_type') %}
+                {% elif facet in simple_search_data_fields %}
                   {{ refine_link(facet, hit.term, use_is_query=False) }}
                 {% else %}
                   {{ refine_link(facet, hit.term) }}

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
@@ -48,6 +48,8 @@
    * Create a new dynamic form or run an action on an existing form.
    *
    * Actions:
+   *     removeLine - Remove a line from the dynamic form that has a specified
+   *         field, operator, and value
    *     newLine - Add a new line to this dynamic form
    *     getParams - Return an object with the content of this dynamic form
    *     setParams - Change the content of this dynamic form
@@ -75,12 +77,16 @@
       return Object.keys(OPERATORS);
     }
 
-    if (action === 'newLine' || action === 'getParams' || action === 'setParams') {
+    if (action === 'removeLine' || action === 'newLine' || action === 'getParams' || action === 'setParams') {
       if (!dynamic) {
         throw new Error('Impossible to call ' + action + ' on an object that was not initialized first');
       }
 
-      if (action === 'newLine') {
+      if (action === 'removeLine') {
+        if (initialParams) {
+          return dynamic.removeLine(initialParams.field, initialParams.operator, initialParams.value);
+        }
+      } else if (action === 'newLine') {
         if (initialParams) {
           // there is some data, this should not be a blank line
           return dynamic.createLine(initialParams.field, initialParams.operator, initialParams.value);
@@ -296,6 +302,29 @@
       }
 
       lines.push(line);
+    }
+
+    /**
+     * Remove a single line matching field/operator/value criteria from the
+     * form if it exists.
+     */
+    function removeLine(field, operator, value) {
+      // Find the FormLine in question and remove it if it exists
+      for (var i in lines) {
+        var line = lines[i];
+        var filter = line.get();
+
+        // Skip lines that have a null filter
+        if (filter === null) {
+          continue;
+        }
+
+        // If everything matches, remove this one line and stop iterating
+        if (filter.field === field && filter.operator === operator && filter.value === value) {
+          line.remove();
+          return;
+        }
+      }
     }
 
     /**
@@ -557,6 +586,7 @@
     // Expose the public functions of this form so the context is kept.
     form.data('dynamic', {
       newLine: newLine,
+      removeLine: removeLine,
       createLine: createLine,
       getParams: getParams,
       setParams: setParams,

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -305,6 +305,17 @@ $(function () {
   }
 
   /**
+   * Remove any "exists" filters by field name.
+   */
+  function removeExists(name) {
+    form.dynamicForm('removeLine', {
+      field: name,
+      operator: '!__null__',
+      value: '',
+    });
+  }
+
+  /**
    * Handler for browser history state changes.
    */
   window.onpopstate = function (e) {
@@ -503,7 +514,12 @@ $(function () {
     contentElt.on('click', '.term', function (e) {
       e.preventDefault();
 
-      addTerm($(this).data('field'), $(this).data('content'));
+      // First remove any existing filters for this field
+      removeExists($(this).data('field'));
+
+      // Using .attr() here prevents the value from being converted
+      var contentVal = $(this).attr('data-content');
+      addTerm($(this).data('field'), contentVal);
 
       // And then run the new, corresponding search.
       search();

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -139,6 +139,7 @@ def search(request, default_context=None):
         )
         for x in settings.SIMPLE_SEARCH_FIELDS
     ]
+    context["simple_search_data_fields"] = list(settings.SIMPLE_SEARCH_FIELDS)
 
     # Default dates for the date filters.
     now = timezone.now()
@@ -235,6 +236,8 @@ def search_results(request):
                         hit["bugs"] = bugs[sig]
                     # most recent bugs first
                     hit["bugs"].sort(reverse=True)
+
+    context["simple_search_data_fields"] = list(settings.SIMPLE_SEARCH_FIELDS)
 
     search_results["total_pages"] = int(
         math.ceil(search_results["total"] / float(results_per_page))


### PR DESCRIPTION
This fixes the javascript parts of the supersearch form when you go to refine the search.
    
It correctly removes the "exists" filters if they exist for the field. It no longer messes up adding a filter for mac_crash_info or other fields where the values get coerced into other things.

It still adds filters for product, product_type, platform, and version rather than adding those to the simple form. I thought about trying to figure that out and then decided it's not _critical_, so I'd leave it.