### PR TITLE
bug 1703252: fix re_path module, intermittently failing test, and rewrite some views

### DIFF
--- a/webapp-django/crashstats/api/urls.py
+++ b/webapp-django/crashstats/api/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.api import views
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -234,7 +234,7 @@ class TestContributeJson:
     def test_view(self, client):
         response = client.get("/contribute.json")
         assert response.status_code == 200
-        assert json.loads(response.content)
+        assert json.loads(response.getvalue())
         assert response["Content-Type"] == "application/json"
 
 

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.conf.urls import re_path
+from django.urls import re_path
 from django.views.generic import RedirectView
 
 from crashstats.crashstats import views

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from functools import cache as memoized
 import json
 from pathlib import Path
 from urllib.parse import quote
@@ -10,10 +9,11 @@ from urllib.parse import quote
 from django import http
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponse
+from django.http import FileResponse, HttpResponse
 from django.shortcuts import redirect, render
 from django.template import loader
 from django.urls import reverse
+from django.views.decorators.http import require_GET
 
 from csp.decorators import csp_update
 
@@ -53,28 +53,20 @@ def robots_txt(request):
     )
 
 
-@memoized
-def _load_contribute_json():
-    index_path = Path(settings.SOCORRO_ROOT) / "contribute.json"
-    return json.loads(index_path.read_bytes())
-
-
+@require_GET
 def contribute_json(request):
     """Serve contribute.json file"""
-    data = _load_contribute_json()
-    return http.JsonResponse(data, json_dumps_params={"indent": 2})
+    index_path = Path(settings.SOCORRO_ROOT) / "contribute.json"
+    fp = index_path.open("rb")
+    return FileResponse(fp)
 
 
-@memoized
-def _load_favicon():
-    index_path = Path(settings.ROOT) / "crashstats/crashstats/static/img/favicon.ico"
-    return index_path.read_bytes()
-
-
+@require_GET
 def favicon_ico(request):
     """Serve the favicon.ico file"""
-    data = _load_favicon()
-    return HttpResponse(data, content_type="image/vnd.microsoft.icon")
+    index_path = Path(settings.ROOT) / "crashstats/crashstats/static/img/favicon.ico"
+    fp = index_path.open("rb")
+    return FileResponse(fp)
 
 
 def build_id_to_date(build_id):

--- a/webapp-django/crashstats/documentation/urls.py
+++ b/webapp-django/crashstats/documentation/urls.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
 from django.shortcuts import redirect
+from django.urls import re_path
 
 from crashstats.documentation import views
 

--- a/webapp-django/crashstats/exploitability/urls.py
+++ b/webapp-django/crashstats/exploitability/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.exploitability import views
 

--- a/webapp-django/crashstats/manage/admin_urls.py
+++ b/webapp-django/crashstats/manage/admin_urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.manage import admin
 

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.monitoring import views
 

--- a/webapp-django/crashstats/profile/urls.py
+++ b/webapp-django/crashstats/profile/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.profile import views
 

--- a/webapp-django/crashstats/signature/urls.py
+++ b/webapp-django/crashstats/signature/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.signature import views
 

--- a/webapp-django/crashstats/sources/urls.py
+++ b/webapp-django/crashstats/sources/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.sources import views
 

--- a/webapp-django/crashstats/supersearch/urls.py
+++ b/webapp-django/crashstats/supersearch/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.supersearch import views
 

--- a/webapp-django/crashstats/tests/test_sentrylib.py
+++ b/webapp-django/crashstats/tests/test_sentrylib.py
@@ -5,6 +5,7 @@
 """Tests for Sentry event processing."""
 
 from copy import deepcopy
+import time
 import urllib
 
 import pytest
@@ -349,6 +350,9 @@ class TestIntegration(LiveServerTestCase):
             self.live_server_url + "/__broken__", params={"state": "badvalue"}
         )
         assert resp.status_code == 500
+
+        # Pause allowing sentry-sdk to send the error to fakesentry
+        time.sleep(1)
 
         resp = requests.get(fakesentry_api + "api/errorlist/")
         assert len(resp.json()["errors"]) == 1

--- a/webapp-django/crashstats/tokens/urls.py
+++ b/webapp-django/crashstats/tokens/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.tokens import views
 

--- a/webapp-django/crashstats/topcrashers/urls.py
+++ b/webapp-django/crashstats/topcrashers/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from crashstats.topcrashers import views
 

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.conf.urls import include, re_path
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import include, re_path
 from django.views.generic.base import RedirectView
 
 from crashstats.manage import admin_site


### PR DESCRIPTION
This fixes the module path for importing `re_path`.

This also fixes a test that intermittently fails in my local dev environment. I'm pretty sure it's a race condition. If it fails again, I'll look into it further.

This rewrites the views for `favicon.ico` and `contribute.json` to use `FileResponse`.