### PR TITLE
bug 1753044: restrict pip<22

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,9 +70,11 @@ COPY --from=rustminidump /app/bin/* /stackwalk-rust/
 COPY ./webapp-django/package*.json /webapp-frontend-deps/
 RUN cd /webapp-frontend-deps/ && npm install
 
-# Install Socorro Python requirements
+# Install Socorro Python requirements using pip < 22 because pip 22
+# doesn't work with pip-tools. (2022-02-01)
+# https://github.com/jazzband/pip-tools/issues/1558
 COPY --chown=app:app requirements.txt /app/
-RUN pip install -U 'pip>=8' && \
+RUN pip install -U 'pip<22' && \
     pip install --no-cache-dir -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/docker/Dockerfile.fakesentry
+++ b/docker/Dockerfile.fakesentry
@@ -12,7 +12,7 @@ RUN addgroup -g $groupid app && \
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-RUN pip install -U 'pip>=8' && \
+RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir 'kent==0.2.0'
 
 USER app


### PR DESCRIPTION
This restricts upgrading pip to <22 so pip-tools works. When pip-tools
fixes the issue they've got, we can remove the restriction.