### PR TITLE
bug 1703252: fix sentry-wrap to increase timeout and exit with a 1

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -19,13 +19,12 @@ PRECMD=""
 # send errors to sentry.
 if [ -n "${SENTRY_DSN:-}" ]; then
     echo "SENTRY_DSN defined--enabling sentry."
-    PRECMD="python bin/sentry-wrap.py --"
+    PRECMD="python bin/sentry-wrap.py --timeout=600 --"
 else
     echo "SENTRY_DSN not defined--not enabling sentry."
 fi
 
-# Get a datestamp
-date
+echo "starting run_migrations.sh: $(date)"
 
 # Run Django migrations
 ${PRECMD} python webapp-django/manage.py migrate --no-input

--- a/bin/sentry-wrap.py
+++ b/bin/sentry-wrap.py
@@ -63,6 +63,7 @@ def main():
 
     except Exception as exc:
         capture_exception(exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This increases the timeout to 10 minutes. 5 minutes seems pretty short.

When an exception that's thrown gets captured, it should cause the
script to exit with a non-zero status code. This fixes that.