### PR TITLE
bug 1751799: capture total ingestion time

### DIFF
--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -23,6 +23,22 @@ def str_hours_to_time_delta(hours_as_string):
     return datetime.timedelta(hours=int(hours_as_string))
 
 
+def isoformat_to_time(data):
+    """Convert an isoformat string to seconds since epoch
+
+    :arg str data: datetime in isoformat
+
+    :returns: time in seconds as a float (equivalent to time.time() return); or 0.0
+        if it's a bad datetime
+
+    """
+    try:
+        dt = datetime.datetime.fromisoformat(data)
+        return dt.timestamp()
+    except ValueError:
+        return 0.0
+
+
 def utc_now():
     """Return a timezone aware datetime instance in UTC timezone
 

--- a/socorro/unittest/lib/test_datetimeutil.py
+++ b/socorro/unittest/lib/test_datetimeutil.py
@@ -69,6 +69,19 @@ def test_string_to_datetime():
         datetimeutil.string_to_datetime(date)
 
 
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Good dates return good times
+        ("2011-09-06T00:00:00+00:00", 1315267200.0),
+        # Bad data returns 0.0
+        ("foo", 0.0),
+    ],
+)
+def test_isoformat_to_time(data, expected):
+    assert datetimeutil.isoformat_to_time(data) == expected
+
+
 def test_string_datetime_with_timezone():
     date = "2001-11-30T12:34:56Z"
     res = datetimeutil.string_to_datetime(date)


### PR DESCRIPTION
This adds some code to capture the total time it takes to ingest a crash
report from collection (submitted_timestamp) to the end of processing.
This coupled with the queue size helps us understand the backlog and the
effect it has on how up-to-date the data we're looking at is.