### PR TITLE
bug 1753044: update pip-tools to 6.5.0 and remove pip restriction

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,11 +70,8 @@ COPY --from=rustminidump /app/bin/* /stackwalk-rust/
 COPY ./webapp-django/package*.json /webapp-frontend-deps/
 RUN cd /webapp-frontend-deps/ && npm install
 
-# Install Socorro Python requirements using pip < 22 because pip 22
-# doesn't work with pip-tools. (2022-02-01)
-# https://github.com/jazzband/pip-tools/issues/1558
 COPY --chown=app:app requirements.txt /app/
-RUN pip install -U 'pip<22' && \
+RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # Install docs-building requirements
 COPY ./docs/requirements.txt /tmp
-RUN pip install -U 'pip>=8' && \
+RUN pip install -U 'pip>=20' && \
     pip install -r /tmp/requirements.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ markus[datadog]==4.0.0
 more-itertools==8.12.0
 mozilla-django-oidc==2.0.0
 oauth2client==4.1.3
-pip-tools==6.4.0
+pip-tools==6.5.0
 psycopg2==2.9.3
 pyinotify==0.9.6
 pyquery==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ django-cors-headers==3.10.1 \
     --hash=sha256:1390b5846e9835b0911e2574409788af87cd9154246aafbdc8ec546c93698fe6 \
     --hash=sha256:b5a874b492bcad99f544bb76ef679472259eb41ee5644ca62d1a94ddb26b7f6e
     # via -r requirements.in
-django_csp==3.7 \
+django-csp==3.7 \
     --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
     --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
     # via -r requirements.in
@@ -471,9 +471,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via pip-tools
-pip-tools==6.4.0 \
-    --hash=sha256:65553a15b1ba34be5e43889345062e38fb9b219ffa23b084ca0d4c4039b6f53b \
-    --hash=sha256:bb2c3272bc229b4a6d25230ebe255823aba1aa466a0d698c48ab7eb5ab7efdc9
+pip-tools==6.5.0 \
+    --hash=sha256:9cf69a020e3c208a7a1bcc78cbfd436dab323efc187919df6182eca98efbe3f2 \
+    --hash=sha256:d14ea4fc2c118db2a6af65a4345a8b9b355e792aedad6bf64dd3eb97c5fc5fee
     # via -r requirements.in
 platformdirs==2.4.1 \
     --hash=sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca \


### PR DESCRIPTION
This updates pip-tools to 6.5.0 which fixes the issue with pip 22
allowing us to remove the pip restriction.