### PR TITLE
Updates 20220204

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,2 +1,2 @@
-Sphinx==4.3.2
+Sphinx==4.4.0
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -133,9 +133,9 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
-sphinx==4.3.2 \
-    --hash=sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c \
-    --hash=sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851
+sphinx==4.4.0 \
+    --hash=sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe \
+    --hash=sha256:6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc
     # via
     #   -r docs/requirements.in
     #   sphinx-rtd-theme
@@ -171,7 +171,3 @@ urllib3==1.26.7 \
     --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
     --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
     # via requests
-
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -125,9 +125,9 @@ pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
     --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
     # via babel
-requests==2.27.0 \
-    --hash=sha256:8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5 \
-    --hash=sha256:f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df
+requests==2.27.1 \
+    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
+    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
     # via sphinx
 snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
@@ -137,12 +137,12 @@ sphinx==4.3.2 \
     --hash=sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c \
     --hash=sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851
     # via
-    #   -r requirements.in
+    #   -r docs/requirements.in
     #   sphinx-rtd-theme
 sphinx_rtd_theme==1.0.0 \
     --hash=sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8 \
     --hash=sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c
-    # via -r requirements.in
+    # via -r docs/requirements.in
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
     --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58

--- a/requirements.in
+++ b/requirements.in
@@ -43,7 +43,7 @@ pytest==6.2.5
 python-decouple==3.5
 pymemcache==3.5.0
 requests-mock==1.9.3
-requests==2.26.0
+requests==2.27.1
 semver==2.13.0
 sentry-sdk==1.5.1
 statsd==3.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-waffle==2.3.0
 django-cors-headers==3.10.1
 django_csp==3.7
 djangorestframework==3.13.1
-dockerflow==2021.7.0
+dockerflow==2022.1.0
 enforce-typing==1.0.0.post1
 flake8==4.0.1
 freezegun==1.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-pipeline==2.0.7
 django-ratelimit==3.0.1
 django-session-csrf==0.7.1
 django-waffle==2.3.0
-django-cors-headers==3.10.1
+django-cors-headers==3.11.0
 django_csp==3.7
 djangorestframework==3.13.1
 dockerflow==2022.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -209,9 +209,9 @@ djangorestframework==3.13.1 \
     --hash=sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee \
     --hash=sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa
     # via -r requirements.in
-dockerflow==2021.7.0 \
-    --hash=sha256:9f309fdf72a897290878f97cc30fd4bb3609b13cf74bfce4268f5e368e466070 \
-    --hash=sha256:e47bbca06c261a5c3d97e5e0990aa71dafed41b723d0e0009c32e1d2f9b92db4
+dockerflow==2022.1.0 \
+    --hash=sha256:ec723cedb853043a0c7cada32f46f8f7eadfaf6bd7dee718e9a373b6b577d249 \
+    --hash=sha256:f40bad2d465533b1949261e5cd3ffa23fd1dd0c12f32f4e4608040ec6ad502a5
     # via -r requirements.in
 docutils==0.15.2 \
     --hash=sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,9 +174,9 @@ django==3.2.12 \
     #   django-jinja
     #   djangorestframework
     #   mozilla-django-oidc
-django-cors-headers==3.10.1 \
-    --hash=sha256:1390b5846e9835b0911e2574409788af87cd9154246aafbdc8ec546c93698fe6 \
-    --hash=sha256:b5a874b492bcad99f544bb76ef679472259eb41ee5644ca62d1a94ddb26b7f6e
+django-cors-headers==3.11.0 \
+    --hash=sha256:a22be2befd4069c4fc174f11cf067351df5c061a3a5f94a01650b4e928b0372b \
+    --hash=sha256:eb98389bf7a2afc5d374806af4a9149697e3a6955b5a2dc2bf049f7d33647456
     # via -r requirements.in
 django-csp==3.7 \
     --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \

--- a/requirements.txt
+++ b/requirements.txt
@@ -633,9 +633,9 @@ pyyaml==5.4.1 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
     # via awscli
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.27.1 \
+    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
+    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
     # via
     #   -r requirements.in
     #   datadog


### PR DESCRIPTION
Update dependencies. This covers:

* Bump sphinx from 4.3.2 to 4.4.0 (from PR #5991)
* Bump django-cors-headers from 3.10.1 to 3.11.0 (from PR #5990)
* Bump requests from 2.26.0 to 2.27.1 (from PR #5989)
* Bump dockerflow from 2021.7.0 to 2022.1.0 (from PR #5988)
