### PR TITLE
bug 1752424: update rust container to 1.58.1 and rust-minidump to 1c5f5f8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN groupadd --gid $groupid app && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=2dc7ecc384f8ed123387cace30157c5288b6b5f3
-ARG MINIDUMPREVDATE=2021-12-15
+ARG MINIDUMPREV=1c5f5f81f4431f358d5342c7e1114b0737949474
+ARG MINIDUMPREVDATE=2022-01-20
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/luser/rust-minidump.git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN ls -al /stackwalk/
 # =========================================================================
 
 # https://hub.docker.com/_/rust/
-FROM rust:1.57.0-buster@sha256:e6bb347e01ca274c3d4511b765f7cb9ce495d8bad3a3a99b46ae1337f7af52f6 as rustminidump
+FROM rust:1.58.1-buster@sha256:311d05f3823e7430bfeb2a743cd1a7895b05db643622d8d38ce18bffa2fa63bf as rustminidump
 
 RUN update-ca-certificates
 ARG groupid=10001


### PR DESCRIPTION
From the bug:

* streaming symbol parsing which speeds things up and cuts down on memory usage.
* A fix for broken STACKWIN entries. This was a slight regression compared to the old stackwalker.
* An extra check to better behave with malformed minidumps.
* Support for EXC_GUARD exceptions on macOS. This is another area where we regressed compared to the old stackwalker.
* A small improvement when handling EXC_BAD_ACCESS crashes on macOS.

Commits:

```
1c5f5f8 Add KERN_FAILURE to the possible types of EXC_BAD_ACCESS exceptions on macOS
1ca3e9e Add support for macOS EXC_GUARD exceptions.
04180c3 extract into utility
85eac34 fix: Guard memory reservations with bounds checks
f0bdcc9 Bump serde_json from 1.0.74 to 1.0.75
b2bc2af hacky fix for buggy STACKWIN inputs
1554fe3 Bump insta from 1.8.0 to 1.10.0
458b10f Bump serde_json from 1.0.73 to 1.0.74
d68f9e7 Bump serde from 1.0.132 to 1.0.133
f0353f8 Bump simplelog from 0.11.1 to 0.11.2
d943961 remove old cruft
7b51f4f Bump tempfile from 3.2.0 to 3.3.0
ccef1ac misc documentation updates
d8b246d Bump simplelog from 0.11.0 to 0.11.1
146625c Bump clap from 2.33.3 to 2.34.0
d2bcbc0 Bump serde_json from 1.0.72 to 1.0.73
2751adc Bump serde from 1.0.130 to 1.0.132
7409c7b WIP streaming symbol parser.
```