### PR TITLE
bug 1750759: add page view tracking

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -142,7 +142,10 @@ class TestViews(BaseTestViews):
         with MetricsMock() as metrics_mock:
             response = self.client.get(url, {"product": "good"})
         assert response.status_code == 200
-        metrics_mock.assert_incr("webapp.api.pageview", tags=["endpoint:apiNoOp"])
+        metrics_mock.assert_timing(
+            "webapp.view.pageview",
+            tags=["status:200", "ajax:false", "api:true", "path:/api/noop/"],
+        )
 
     def test_param_exceptions(self):
         # missing required parameter

--- a/webapp-django/crashstats/api/urls.py
+++ b/webapp-django/crashstats/api/urls.py
@@ -2,17 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.api import views
 
 
 app_name = "api"
 urlpatterns = [
-    re_path(r"^$", views.documentation, name="documentation"),
-    re_path(r"^CrashVerify/$", views.CrashVerifyAPI.as_view(), name="crash_verify"),
-    re_path(
-        r"^CrashSignature/$", views.CrashSignatureAPI.as_view(), name="crash_signature"
-    ),
-    re_path(r"^(?P<model_name>\w+)/$", views.model_wrapper, name="model_wrapper"),
+    path("", views.documentation, name="documentation"),
+    path("CrashVerify/", views.CrashVerifyAPI.as_view(), name="crash_verify"),
+    path("CrashSignature/", views.CrashSignatureAPI.as_view(), name="crash_signature"),
+    path("<str:model_name>/", views.model_wrapper, name="model_wrapper"),
 ]

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -31,7 +31,7 @@ from django.views.decorators.csrf import csrf_exempt
 from crashstats.api.cleaner import Cleaner
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
-from crashstats.crashstats.decorators import track_api_pageview, pass_default_context
+from crashstats.crashstats.decorators import track_view, pass_default_context
 from crashstats.supersearch import models as supersearch_models
 from crashstats.tokens import models as tokens_models
 from socorro.external.crashstorage_base import CrashIDNotFound
@@ -158,6 +158,7 @@ def no_csrf_i_mean_it(fun):
     return _no_csrf
 
 
+@track_view
 @anonymous_csrf_exempt
 @csrf_exempt
 @clear_empty_session
@@ -165,7 +166,6 @@ def no_csrf_i_mean_it(fun):
 @ratelimit(
     key="ip", method=["GET", "POST", "PUT"], rate=utils.ratelimit_rate, block=True
 )
-@track_api_pageview
 @utils.json_view
 def model_wrapper(request, model_name):
     model = None

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -153,11 +153,9 @@ def track_view(view):
             request.resolver_match
             and request.resolver_match.url_name not in USE_PATH_VIEWS
         ):
-            path = request.resolver_match.route
+            path = "/" + request.resolver_match.route
         else:
             path = request.path
-
-        path = path or "home"
 
         delta = (time.time() - start_time) * 1000
         VIEW_METRICS.timing(

--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -29,7 +29,7 @@ class SetRemoteAddrFromRealIP:
         return self.get_response(request)
 
     def process_request(self, request):
-        real_ip = request.META.get("HTTP_X_REAL_IP")
+        real_ip = request.headers.get("X-Real-Ip")
         if real_ip:
             request.META["REMOTE_ADDR"] = real_ip
 

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.urls import re_path
+from django.urls import path, register_converter
 from django.views.generic import RedirectView
 
 from crashstats.crashstats import views
@@ -16,35 +16,44 @@ version = r"/versions/(?P<version>[;\w\.()]+)"
 perm_legacy_redirect = settings.PERMANENT_LEGACY_REDIRECTS
 
 
+class CrashID:
+    regex = r"(bp-)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+
+register_converter(CrashID, "crashid")
+
+
 app_name = "crashstats"
 urlpatterns = [
-    re_path(r"^contribute\.json$", views.contribute_json, name="contribute_json"),
-    re_path(r"^favicon\.ico$", views.favicon_ico, name="favicon_ico"),
-    re_path(r"^robots\.txt$", views.robots_txt, name="robots_txt"),
-    re_path(
-        r"^report/index/(?P<crash_id>[\w-]+)$", views.report_index, name="report_index"
-    ),
-    re_path(r"^search/quick/$", views.quick_search, name="quick_search"),
-    re_path(r"^buginfo/bug", views.buginfo, name="buginfo"),
-    re_path(r"^login/$", views.login, name="login"),
-    re_path(r"^about/throttling/$", views.about_throttling, name="about_throttling"),
-    re_path(
-        r"^home/product/(?P<product>\w+)$", views.product_home, name="product_home"
-    ),
+    path("contribute.json", views.contribute_json, name="contribute_json"),
+    path("favicon.ico", views.favicon_ico, name="favicon_ico"),
+    path("robots.txt", views.robots_txt, name="robots_txt"),
+    path("report/index/<crashid:crash_id>", views.report_index, name="report_index"),
+    path("search/quick/", views.quick_search, name="quick_search"),
+    path("buginfo/bug", views.buginfo, name="buginfo"),
+    path("login/", views.login, name="login"),
+    path("about/throttling/", views.about_throttling, name="about_throttling"),
+    path("home/product/<str:product>", views.product_home, name="product_home"),
     # Home page
-    re_path(r"^$", views.home, name="home"),
+    path("", views.home, name="home"),
     # Redirect deceased Advanced Search URL to Super Search
-    re_path(
-        r"^query/$",
+    path(
+        "query/",
         RedirectView.as_view(url="/search/", query_string=True, permanent=True),
     ),
     # Redirect old independant pages to the unified Profile page.
-    re_path(
-        r"^your-crashes/$",
+    path(
+        "your-crashes/",
         RedirectView.as_view(url="/profile/", permanent=perm_legacy_redirect),
     ),
-    re_path(
-        r"^permissions/$",
+    path(
+        "permissions/",
         RedirectView.as_view(url="/profile/", permanent=perm_legacy_redirect),
     ),
 ]

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -19,7 +19,7 @@ from csp.decorators import csp_update
 
 from crashstats import productlib
 from crashstats.crashstats import forms, models, utils
-from crashstats.crashstats.decorators import pass_default_context
+from crashstats.crashstats.decorators import track_view, pass_default_context
 from crashstats.supersearch.models import SuperSearchFields
 from socorro.external.crashstorage_base import CrashIDNotFound
 
@@ -74,6 +74,7 @@ def build_id_to_date(build_id):
     return "{}-{}-{}".format(yyyymmdd[:4], yyyymmdd[4:6], yyyymmdd[6:8])
 
 
+@track_view
 @csp_update(CONNECT_SRC="analysis-output.telemetry.mozilla.org")
 @pass_default_context
 def report_index(request, crash_id, default_context=None):
@@ -275,6 +276,7 @@ def login(request, default_context=None):
     return render(request, "crashstats/login.html", context)
 
 
+@track_view
 def quick_search(request):
     query = request.GET.get("query", "").strip()
     crash_id = utils.find_crash_id(query)
@@ -309,12 +311,14 @@ def about_throttling(request, default_context=None):
     return render(request, "crashstats/about_throttling.html", context)
 
 
+@track_view
 @pass_default_context
 def home(request, default_context=None):
     context = default_context or {}
     return render(request, "crashstats/home.html", context)
 
 
+@track_view
 @pass_default_context
 def product_home(request, product, default_context=None):
     context = default_context or {}

--- a/webapp-django/crashstats/documentation/tests/test_views.py
+++ b/webapp-django/crashstats/documentation/tests/test_views.py
@@ -2,51 +2,121 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from markus.testing import MetricsMock
+
 from django.urls import reverse
 from django.utils.encoding import smart_str
 
-from crashstats.crashstats.tests.test_views import BaseTestViews
+
+def test_home_metrics(client, db):
+    url = reverse("documentation:home")
+    with MetricsMock() as metrics_mock:
+        resp = client.get(url)
+    assert resp.status_code == 200
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/",
+        ],
+    )
 
 
-class TestViews(BaseTestViews):
-    def test_supersearch_home(self):
-        url = reverse("documentation:supersearch_home")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert "What is Super Search?" in smart_str(response.content)
+def test_supersearch_home(client, db):
+    url = reverse("documentation:supersearch_home")
+    with MetricsMock() as metrics_mock:
+        response = client.get(url)
+    assert response.status_code == 200
+    assert "What is Super Search?" in smart_str(response.content)
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/supersearch/",
+        ],
+    )
 
-    def test_whatsnew(self):
-        url = reverse("documentation:whatsnew")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert "What's New in Crash Stats" in smart_str(response.content)
 
-    def test_supersearch_examples(self):
-        url = reverse("documentation:supersearch_examples")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert "Examples" in smart_str(response.content)
+def test_whatsnew(client, db):
+    url = reverse("documentation:whatsnew")
+    with MetricsMock() as metrics_mock:
+        response = client.get(url)
+    assert response.status_code == 200
+    assert "What's New in Crash Stats" in smart_str(response.content)
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/whatsnew/",
+        ],
+    )
 
-    def test_supersearch_api(self):
-        url = reverse("documentation:supersearch_api")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert "_results_number" in smart_str(response.content)
-        assert "_aggs.*" in smart_str(response.content)
-        assert "signature" in smart_str(response.content)
 
-    def test_memory_dump_access_redirect(self):
-        """Verify memory_dump_access url redirects
+def test_supersearch_examples(client, db):
+    url = reverse("documentation:supersearch_examples")
+    with MetricsMock() as metrics_mock:
+        response = client.get(url)
+    assert response.status_code == 200
+    assert "Examples" in smart_str(response.content)
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/supersearch/examples/",
+        ],
+    )
 
-        This is the old url to the data access policy. In order to keep those links
-        working, we need it to redirect to the new url.
 
-        """
-        response = self.client.get("/documentation/memory_dump_access/")
-        assert response.status_code == 302
-        assert response.url == reverse("documentation:protected_data_access")
+def test_supersearch_api(client, db):
+    url = reverse("documentation:supersearch_api")
+    with MetricsMock() as metrics_mock:
+        response = client.get(url)
+    assert response.status_code == 200
+    assert "_results_number" in smart_str(response.content)
+    assert "_aggs.*" in smart_str(response.content)
+    assert "signature" in smart_str(response.content)
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/supersearch/api/",
+        ],
+    )
 
-    def test_signup_renders(self):
-        url = reverse("documentation:signup")
-        response = self.client.get(url)
-        assert response.status_code == 200
+
+def test_memory_dump_access_redirect(client, db):
+    """Verify memory_dump_access url redirects
+
+    This is the old url to the data access policy. In order to keep those links
+    working, we need it to redirect to the new url.
+
+    """
+    response = client.get("/documentation/memory_dump_access/")
+    assert response.status_code == 302
+    assert response.url == reverse("documentation:protected_data_access")
+
+
+def test_signup_renders(client, db):
+    url = reverse("documentation:signup")
+    with MetricsMock() as metrics_mock:
+        response = client.get(url)
+    assert response.status_code == 200
+    metrics_mock.assert_timing(
+        "webapp.view.pageview",
+        tags=[
+            "status:200",
+            "ajax:false",
+            "api:false",
+            "path:/documentation/signup/",
+        ],
+    )

--- a/webapp-django/crashstats/documentation/urls.py
+++ b/webapp-django/crashstats/documentation/urls.py
@@ -3,38 +3,38 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.shortcuts import redirect
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.documentation import views
 
 
 app_name = "documentation"
 urlpatterns = [
-    re_path(r"^supersearch/$", views.supersearch_home, name="supersearch_home"),
-    re_path(
-        r"^supersearch/examples/$",
+    path("supersearch/", views.supersearch_home, name="supersearch_home"),
+    path(
+        "supersearch/examples/",
         views.supersearch_examples,
         name="supersearch_examples",
     ),
-    re_path(r"^supersearch/api/$", views.supersearch_api, name="supersearch_api"),
-    re_path(r"^signup/$", views.signup, name="signup"),
-    re_path(
-        r"^protected_data_access/$",
+    path("supersearch/api/", views.supersearch_api, name="supersearch_api"),
+    path("signup/", views.signup, name="signup"),
+    path(
+        "protected_data_access/",
         views.protected_data_access,
         name="protected_data_access",
     ),
     # NOTE(willkg): Need to keep this redirect because it's linked to in a lot of
     # places like agreements in Bugzilla.
-    re_path(
-        r"^memory_dump_access/$",
+    path(
+        "memory_dump_access/",
         lambda request: redirect("documentation:protected_data_access"),
     ),
-    re_path(
-        r"^products/$",
+    path(
+        "products/",
         lambda request: redirect(
             "https://socorro.readthedocs.io/en/latest/products.html"
         ),
     ),
-    re_path(r"^whatsnew/$", views.whatsnew, name="whatsnew"),
-    re_path(r"^$", views.home, name="home"),
+    path("whatsnew/", views.whatsnew, name="whatsnew"),
+    path("", views.home, name="home"),
 ]

--- a/webapp-django/crashstats/documentation/views.py
+++ b/webapp-django/crashstats/documentation/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.shortcuts import render
 
 from crashstats import productlib
-from crashstats.crashstats.decorators import pass_default_context
+from crashstats.crashstats.decorators import pass_default_context, track_view
 from crashstats.supersearch.models import SuperSearchFields
 
 
@@ -31,6 +31,7 @@ OPERATORS_MAP = {
 }
 
 
+@track_view
 @pass_default_context
 def home(request, default_context=None):
     context = default_context or {}
@@ -54,6 +55,7 @@ def read_whatsnew():
     return parts["html_body"]
 
 
+@track_view
 @pass_default_context
 def whatsnew(request, default_context=None):
     context = default_context or {}
@@ -61,6 +63,7 @@ def whatsnew(request, default_context=None):
     return render(request, "documentation/whatsnew.html", context)
 
 
+@track_view
 @pass_default_context
 def protected_data_access(request, default_context=None):
     context = default_context or {}
@@ -87,6 +90,7 @@ def get_valid_version(active_versions, product_name):
     return versions[0]["version"]
 
 
+@track_view
 @pass_default_context
 def supersearch_home(request, default_context=None):
     context = default_context or {}
@@ -98,6 +102,7 @@ def supersearch_home(request, default_context=None):
     return render(request, "documentation/supersearch/home.html", context)
 
 
+@track_view
 @pass_default_context
 def supersearch_examples(request, default_context=None):
     context = default_context or {}
@@ -112,6 +117,7 @@ def supersearch_examples(request, default_context=None):
     return render(request, "documentation/supersearch/examples.html", context)
 
 
+@track_view
 @pass_default_context
 def supersearch_api(request, default_context=None):
     context = default_context or {}
@@ -144,6 +150,7 @@ def supersearch_api(request, default_context=None):
     return render(request, "documentation/supersearch/api.html", context)
 
 
+@track_view
 @pass_default_context
 def signup(request, default_context=None):
     context = default_context or {}

--- a/webapp-django/crashstats/exploitability/urls.py
+++ b/webapp-django/crashstats/exploitability/urls.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.exploitability import views
 
 
 app_name = "exploitability"
-urlpatterns = [
-    re_path(r"^exploitability/$", views.exploitability_report, name="report")
-]
+urlpatterns = [path("exploitability/", views.exploitability_report, name="report")]

--- a/webapp-django/crashstats/exploitability/views.py
+++ b/webapp-django/crashstats/exploitability/views.py
@@ -13,11 +13,12 @@ from django.urls import reverse
 
 from crashstats import productlib
 from crashstats.crashstats import models
-from crashstats.crashstats.decorators import pass_default_context
+from crashstats.crashstats.decorators import pass_default_context, track_view
 from crashstats.exploitability.forms import ExploitabilityReportForm
 from crashstats.supersearch.models import SuperSearchUnredacted
 
 
+@track_view
 @pass_default_context
 @permission_required("crashstats.view_exploitability")
 def exploitability_report(request, default_context=None):

--- a/webapp-django/crashstats/manage/admin_urls.py
+++ b/webapp-django/crashstats/manage/admin_urls.py
@@ -2,32 +2,32 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.manage import admin
 
 
 app_name = "manage"
 urlpatterns = [
-    re_path(
-        "^analyze-model-fetches/$",
+    path(
+        "analyze-model-fetches/",
         admin.analyze_model_fetches,
         name="analyze_model_fetches",
     ),
-    re_path("^crash-me-now/$", admin.crash_me_now, name="crash_me_now"),
-    re_path("^sitestatus/$", admin.site_status, name="site_status"),
-    re_path(
-        "^supersearch-fields/missing/$",
+    path("crash-me-now/", admin.crash_me_now, name="crash_me_now"),
+    path("sitestatus/", admin.site_status, name="site_status"),
+    path(
+        "supersearch-fields/missing/",
         admin.supersearch_fields_missing,
         name="supersearch_fields_missing",
     ),
-    re_path(
-        "^supersearch-status/$",
+    path(
+        "supersearch-status/",
         admin.supersearch_status,
         name="supersearch_status",
     ),
-    re_path(
-        "^protected-data-users/$",
+    path(
+        "protected-data-users/",
         admin.protected_data_users,
         name="protected_data_users",
     ),

--- a/webapp-django/crashstats/monitoring/urls.py
+++ b/webapp-django/crashstats/monitoring/urls.py
@@ -2,24 +2,22 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.monitoring import views
 
 
 app_name = "monitoring"
 urlpatterns = [
-    re_path(r"^monitoring/$", views.index, name="index"),
-    re_path(r"^monitoring/cron/$", views.cron_status, name="cron_status"),
-    re_path(r"^__broken__$", views.broken, name="broken"),
+    path("monitoring/cron/", views.cron_status, name="cron_status"),
+    path("monitoring/", views.index, name="index"),
+    path("__broken__", views.broken, name="broken"),
     # Dockerflow endpoints
-    re_path(
-        r"^__heartbeat__$", views.dockerflow_heartbeat, name="dockerflow_heartbeat"
-    ),
-    re_path(
-        r"^__lbheartbeat__$",
+    path("__heartbeat__", views.dockerflow_heartbeat, name="dockerflow_heartbeat"),
+    path(
+        "__lbheartbeat__",
         views.dockerflow_lbheartbeat,
         name="dockerflow_lbheartbeat",
     ),
-    re_path(r"^__version__$", views.dockerflow_version, name="dockerflow_version"),
+    path("__version__", views.dockerflow_version, name="dockerflow_version"),
 ]

--- a/webapp-django/crashstats/profile/urls.py
+++ b/webapp-django/crashstats/profile/urls.py
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.profile import views
 
 
 app_name = "profile"
-urlpatterns = [re_path(r"^$", views.profile, name="profile")]
+urlpatterns = [path("", views.profile, name="profile")]

--- a/webapp-django/crashstats/profile/views.py
+++ b/webapp-django/crashstats/profile/views.py
@@ -5,9 +5,14 @@
 from django.shortcuts import render
 from django.contrib.auth.models import Permission
 
-from crashstats.crashstats.decorators import pass_default_context, login_required
+from crashstats.crashstats.decorators import (
+    login_required,
+    pass_default_context,
+    track_view,
+)
 
 
+@track_view
 @pass_default_context
 @login_required
 def profile(request, default_context=None):

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_comments.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_comments.html
@@ -16,7 +16,7 @@
         {% for crash in query.hits %}
           <tr>
             <td>
-              <a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link crash-id">
+              <a href="{{ url('crashstats:report_index', crash_id=crash.uuid) }}" class="external-link crash-id">
                 {{ crash.uuid }}
               </a>
             </td>

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_reports.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_reports.html
@@ -16,7 +16,7 @@
         {% for crash in query.hits %}
           <tr>
             <td>
-              <a href="{{ url('crashstats:report_index', crash.uuid) }}" class="external-link crash-id">{{ crash.uuid }}</a>
+              <a href="{{ url('crashstats:report_index', crash_id=crash.uuid) }}" class="external-link crash-id">{{ crash.uuid }}</a>
               {% if crash.cpu_info %}
                 {% if is_dangerous_cpu(crash.cpu_arch, crash.cpu_info) %}
                   <span class="label" title="Possible AMD CPU bug related crash report">AMD</span>

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -53,7 +53,7 @@ class TestViews(BaseTestViews):
                     "hits": [
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa1",
+                            "uuid": "f74a5763-3270-4151-9c49-853710220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -62,7 +62,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa2",
+                            "uuid": "63e199c4-d0a6-4386-93c7-8d72a0220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -71,7 +71,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa3",
+                            "uuid": "e325b443-1b51-402b-b2c5-ccd630220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -79,7 +79,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa4",
+                            "uuid": "2e982308-dc57-41a1-b997-b56f40220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -113,7 +113,7 @@ class TestViews(BaseTestViews):
         )
         assert response.status_code == 200
         assert 'table id="reports-list"' in smart_str(response.content)
-        assert "aaaaaaaaaaaaa1" in smart_str(response.content)
+        assert "f74a5763-3270-4151-9c49-853710220208" in smart_str(response.content)
         assert "888981" in smart_str(response.content)
         assert "Linux" in smart_str(response.content)
         assert "2017-01-31 23:12:57" in smart_str(response.content)
@@ -135,7 +135,7 @@ class TestViews(BaseTestViews):
         assert "888981" in smart_str(response.content)
         assert "Linux" in smart_str(response.content)
         # The crash id is always shown
-        assert "aaaaaaaaaaaaa1" in smart_str(response.content)
+        assert "f74a5763-3270-4151-9c49-853710220208" in smart_str(response.content)
         # The version and date do not appear
         assert "1.0" not in smart_str(response.content)
         assert "2017" not in smart_str(response.content)
@@ -194,11 +194,12 @@ class TestViews(BaseTestViews):
 
             hits = []
             for i in range(140):
+                crash_id = f"{i:04d}b443-1b51-402b-b2c5-ccd630220208"
                 hits.append(
                     {
                         "signature": "nsASDOMWindowEnumerator::GetNext()",
                         "date": "2017-01-31T23:12:57",
-                        "uuid": i,
+                        "uuid": crash_id,
                         "product": "WaterWolf",
                         "version": "1.0",
                         "platform": "Linux",
@@ -375,7 +376,7 @@ class TestViews(BaseTestViews):
                     "hits": [
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa1",
+                            "uuid": "2e982308-dc57-41a1-b997-b56f40220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -384,7 +385,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa2",
+                            "uuid": "e325b443-1b51-402b-b2c5-ccd630220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -393,7 +394,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa3",
+                            "uuid": "63e199c4-d0a6-4386-93c7-8d72a0220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -402,7 +403,7 @@ class TestViews(BaseTestViews):
                         },
                         {
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa4",
+                            "uuid": "f74a5763-3270-4151-9c49-853710220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -438,7 +439,7 @@ class TestViews(BaseTestViews):
             url, {"signature": DUMB_SIGNATURE, "product": "WaterWolf"}
         )
         assert response.status_code == 200
-        assert "aaaaaaaaaaaaa1" in smart_str(response.content)
+        assert "2e982308-dc57-41a1-b997-b56f40220208" in smart_str(response.content)
         assert "Crash ID" in smart_str(response.content)
         assert "hello there" in smart_str(response.content)
         assert "WaterWolf Y U SO GOOD" in smart_str(response.content)
@@ -457,8 +458,13 @@ class TestViews(BaseTestViews):
 
             hits = []
             for i in hits_range:
+                crash_id = f"{i:04d}b443-1b51-402b-b2c5-ccd630220208"
                 hits.append(
-                    {"date": "2017-01-31T23:12:57", "uuid": i, "user_comments": "hi"}
+                    {
+                        "date": "2017-01-31T23:12:57",
+                        "uuid": crash_id,
+                        "user_comments": "hi",
+                    }
                 )
 
             return {

--- a/webapp-django/crashstats/signature/urls.py
+++ b/webapp-django/crashstats/signature/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.signature import views
 
@@ -10,20 +10,16 @@ from crashstats.signature import views
 # NOTE(willkg): make sure to update settings.OIDC_EXEMPT_URLS with xhr urls
 app_name = "signature"
 urlpatterns = [
-    re_path(r"^reports/$", views.signature_reports, name="signature_reports"),
-    re_path(r"^comments/$", views.signature_comments, name="signature_comments"),
-    re_path(
-        r"^correlations/$", views.signature_correlations, name="signature_correlations"
-    ),
-    re_path(
-        r"^aggregation/(?P<aggregation>\w+)/$",
+    path("reports/", views.signature_reports, name="signature_reports"),
+    path("comments/", views.signature_comments, name="signature_comments"),
+    path("correlations/", views.signature_correlations, name="signature_correlations"),
+    path(
+        "aggregation/<str:aggregation>/",
         views.signature_aggregation,
         name="signature_aggregation",
     ),
-    re_path(
-        r"^graphs/(?P<field>\w+)/$", views.signature_graphs, name="signature_graphs"
-    ),
-    re_path(r"^summary/$", views.signature_summary, name="signature_summary"),
-    re_path(r"^bugzilla/$", views.signature_bugzilla, name="signature_bugzilla"),
-    re_path(r"^$", views.signature_report, name="signature_report"),
+    path("graphs/<str:field>/", views.signature_graphs, name="signature_graphs"),
+    path("summary/", views.signature_summary, name="signature_summary"),
+    path("bugzilla/", views.signature_bugzilla, name="signature_bugzilla"),
+    path("", views.signature_report, name="signature_report"),
 ]

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -15,7 +15,7 @@ from socorro.lib import BadArgumentError
 
 from crashstats import productlib
 from crashstats.crashstats import models, utils
-from crashstats.crashstats.decorators import pass_default_context
+from crashstats.crashstats.decorators import pass_default_context, track_view
 from crashstats.crashstats.utils import SignatureStats, render_exception, urlencode_obj
 from crashstats.supersearch.utils import get_date_boundaries
 
@@ -71,6 +71,7 @@ def pass_validated_params(view):
     return inner
 
 
+@track_view
 @csp_update(CONNECT_SRC="analysis-output.telemetry.mozilla.org")
 @pass_validated_params
 @pass_default_context
@@ -115,6 +116,7 @@ def signature_report(request, params, default_context=None):
     return render(request, "signature/signature_report.html", context)
 
 
+@track_view
 @pass_validated_params
 def signature_reports(request, params):
     """Return the results of a search."""
@@ -211,6 +213,7 @@ def signature_reports(request, params):
     return render(request, "signature/signature_reports.html", context)
 
 
+@track_view
 @pass_validated_params
 def signature_aggregation(request, params, aggregation):
     """Return the aggregation of a field."""
@@ -255,6 +258,7 @@ def signature_aggregation(request, params, aggregation):
     return render(request, "signature/signature_aggregation.html", context)
 
 
+@track_view
 @utils.json_view
 @pass_validated_params
 def signature_graphs(request, params, field):
@@ -298,6 +302,7 @@ def signature_graphs(request, params, field):
     return context
 
 
+@track_view
 @pass_validated_params
 def signature_comments(request, params):
     """Return a list of non-empty comments."""
@@ -359,6 +364,7 @@ def signature_comments(request, params):
     return render(request, "signature/signature_comments.html", context)
 
 
+@track_view
 @pass_validated_params
 def signature_correlations(request, params):
     """Guess the best channel and product to use for correlations."""
@@ -385,6 +391,7 @@ def signature_correlations(request, params):
     return render(request, "signature/signature_correlations.html", context)
 
 
+@track_view
 @pass_validated_params
 def signature_summary(request, params):
     """Return a list of specific aggregations"""
@@ -549,6 +556,7 @@ def _transform_exploitability_summary(facets):
         )
 
 
+@track_view
 @pass_validated_params
 def signature_bugzilla(request, params):
     """Return a list of associated bugs"""

--- a/webapp-django/crashstats/sources/urls.py
+++ b/webapp-django/crashstats/sources/urls.py
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.sources import views
 
 
 app_name = "sources"
-urlpatterns = [re_path(r"^highlight/$", views.highlight_url, name="highlight_url")]
+urlpatterns = [path("highlight/", views.highlight_url, name="highlight_url")]

--- a/webapp-django/crashstats/sources/views.py
+++ b/webapp-django/crashstats/sources/views.py
@@ -11,6 +11,8 @@ import requests
 
 from django import http
 
+from crashstats.crashstats.decorators import track_view
+
 
 # List of hosts that we will fetch source files from that we syntax highlight and return to the
 # user in highlight_file view.
@@ -20,6 +22,7 @@ ALLOWED_SOURCE_HOSTS = ["gecko-generated-sources.s3.amazonaws.com"]
 ALLOWED_SCHEMES = ["http", "https"]
 
 
+@track_view
 def highlight_url(request):
     """Retrieves a generated source file and syntax highlights it
 

--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search_results.html
@@ -24,7 +24,7 @@
       <tbody>
         {% for crash in query.hits %}
           <tr>
-            <td><a href="{{ url('crashstats:report_index', crash.uuid) }}" class="crash-id">{{ crash.uuid }}</a></td>
+            <td><a href="{{ url('crashstats:report_index', crash_id=crash.uuid) }}" class="crash-id">{{ crash.uuid }}</a></td>
             {% for column in columns %}
               <td>
                 {% if crash[column] %}

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -87,7 +87,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "nsASDOMWindowEnumerator::GetNext()",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa1",
+                            "uuid": "f74a5763-3270-4151-9c49-853710220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "<Linux>",
@@ -96,7 +96,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "mySignatureIsCool",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa2",
+                            "uuid": "63e199c4-d0a6-4386-93c7-8d72a0220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -105,7 +105,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "mineIsCoolerThanYours",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa3",
+                            "uuid": "e325b443-1b51-402b-b2c5-ccd630220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -114,7 +114,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "EMPTY",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa4",
+                            "uuid": "2e982308-dc57-41a1-b997-b56f40220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -142,7 +142,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "nsASDOMWindowEnumerator::GetNext()",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa",
+                            "uuid": "663c9970-3f35-4b15-beaf-756d60220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -151,7 +151,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "mySignatureIsCool",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa",
+                            "uuid": "1c6f67c8-a6ff-45ab-b5c5-4d2c20220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -172,7 +172,7 @@ class TestViews(BaseTestViews):
                         {
                             "signature": "nsASDOMWindowEnumerator::GetNext()",
                             "date": "2017-01-31T23:12:57",
-                            "uuid": "aaaaaaaaaaaaa",
+                            "uuid": "ddb79c06-0d2f-4a7a-b2fc-d32a00220208",
                             "product": "WaterWolf",
                             "version": "1.0",
                             "platform": "Linux",
@@ -205,7 +205,7 @@ class TestViews(BaseTestViews):
         assert "mySignatureIsCool" in smart_str(response.content)
         assert "mineIsCoolerThanYours" in smart_str(response.content)
         assert "EMPTY" in smart_str(response.content)
-        assert "aaaaaaaaaaaaa1" in smart_str(response.content)
+        assert "f74a5763-3270-4151-9c49-853710220208" in smart_str(response.content)
         assert "888981" in smart_str(response.content)
         assert "Linux" in smart_str(response.content)
         assert "2017-01-31 23:12:57" in smart_str(response.content)
@@ -256,7 +256,7 @@ class TestViews(BaseTestViews):
         assert "888981" in smart_str(response.content)
         assert "Linux" in smart_str(response.content)
         # The crash id is always shown
-        assert "aaaaaaaaaaaaa1" in smart_str(response.content)
+        assert "f74a5763-3270-4151-9c49-853710220208" in smart_str(response.content)
         # The version and date do not appear
         assert "1.0" not in smart_str(response.content)
         assert "2017" not in smart_str(response.content)
@@ -319,7 +319,7 @@ class TestViews(BaseTestViews):
                     {
                         "signature": "nsASDOMWindowEnumerator::GetNext()",
                         "date": "2017-01-31T23:12:57",
-                        "uuid": "aaaaaaaaaaaaa1",
+                        "uuid": "f74a5763-3270-4151-9c49-853710220208",
                         "product": "WaterWolf",
                         "version": "1.0",
                         "platform": "Linux",
@@ -330,7 +330,7 @@ class TestViews(BaseTestViews):
                     {
                         "signature": "mySignatureIsCool",
                         "date": "2017-01-31T23:12:57",
-                        "uuid": "aaaaaaaaaaaaa2",
+                        "uuid": "63e199c4-d0a6-4386-93c7-8d72a0220208",
                         "product": "WaterWolf",
                         "version": "1.0",
                         "platform": "Linux",
@@ -341,7 +341,7 @@ class TestViews(BaseTestViews):
                     {
                         "signature": "mineIsCoolerThanYours",
                         "date": "2017-01-31T23:12:57",
-                        "uuid": "aaaaaaaaaaaaa3",
+                        "uuid": "e325b443-1b51-402b-b2c5-ccd630220208",
                         "product": "WaterWolf",
                         "version": "1.0",
                         "platform": "Linux",
@@ -459,11 +459,12 @@ class TestViews(BaseTestViews):
 
             hits = []
             for i in range(140):
+                crashid = f"{i:04d}5763-3270-4151-9c49-853710220208"
                 hits.append(
                     {
                         "signature": "hang | nsASDOMWindowEnumerator::GetNext()",
                         "date": "2017-01-31T23:12:57",
-                        "uuid": i,
+                        "uuid": crashid,
                         "product": "WaterWolf",
                         "version": "1.0",
                         "platform": "Linux",

--- a/webapp-django/crashstats/supersearch/urls.py
+++ b/webapp-django/crashstats/supersearch/urls.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.supersearch import views
 
@@ -10,9 +10,9 @@ from crashstats.supersearch import views
 # NOTE(willkg): make sure to update settings.OIDC_EXEMPT_URLS with xhr urls
 app_name = "supersearch"
 urlpatterns = [
-    re_path(r"^$", views.search, name="search"),
-    re_path(r"^custom/$", views.search_custom, name="search_custom"),
-    re_path(r"^results/$", views.search_results, name="search_results"),
-    re_path(r"^query/$", views.search_query, name="search_query"),
-    re_path(r"^fields/$", views.search_fields, name="search_fields"),
+    path("", views.search, name="search"),
+    path("custom/", views.search_custom, name="search_custom"),
+    path("results/", views.search_results, name="search_results"),
+    path("query/", views.search_query, name="search_query"),
+    path("fields/", views.search_fields, name="search_fields"),
 ]

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -19,6 +19,7 @@ from ratelimit.decorators import ratelimit
 
 from crashstats import productlib
 from crashstats.crashstats import models, utils
+from crashstats.crashstats.decorators import track_view
 from crashstats.crashstats.utils import render_exception, urlencode_obj
 from crashstats.crashstats.views import pass_default_context
 from crashstats.supersearch import forms
@@ -109,6 +110,7 @@ def get_params(request):
     return params
 
 
+@track_view
 @pass_default_context
 def search(request, default_context=None):
     allowed_fields = get_allowed_fields(request.user)
@@ -151,6 +153,7 @@ def search(request, default_context=None):
     return render(request, "supersearch/search.html", context)
 
 
+@track_view
 @ratelimit(key="ip", rate=utils.ratelimit_rate, method=ratelimit.ALL, block=True)
 def search_results(request):
     """Return the results of a search"""
@@ -249,6 +252,7 @@ def search_results(request):
     return render(request, "supersearch/search_results.html", context)
 
 
+@track_view
 @utils.json_view
 def search_fields(request):
     """Return JSON document describing fields used by JavaScript dynamic_form library"""
@@ -257,6 +261,7 @@ def search_fields(request):
     return form.get_fields_list(exclude=exclude)
 
 
+@track_view
 @permission_required("crashstats.run_custom_queries")
 @pass_default_context
 def search_custom(request, default_context=None):
@@ -299,6 +304,7 @@ def search_custom(request, default_context=None):
     return render(request, "supersearch/search_custom.html", context)
 
 
+@track_view
 @permission_required("crashstats.run_custom_queries")
 @require_POST
 @utils.json_view

--- a/webapp-django/crashstats/tokens/middleware.py
+++ b/webapp-django/crashstats/tokens/middleware.py
@@ -45,7 +45,7 @@ class APIAuthenticationMiddleware:
                 "before the RemoteUserMiddleware class."
             )
 
-        key = request.META.get("HTTP_AUTH_TOKEN")
+        key = request.headers.get("Auth-Token")
         if not key:
             return
 

--- a/webapp-django/crashstats/tokens/urls.py
+++ b/webapp-django/crashstats/tokens/urls.py
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.tokens import views
 
 
 app_name = "tokens"
 urlpatterns = [
-    re_path(r"^$", views.home, name="home"),
-    re_path(r"^delete/(?P<pk>\d+)/$", views.delete_token, name="delete_token"),
+    path("", views.home, name="home"),
+    path("delete/<int:pk>/", views.delete_token, name="delete_token"),
 ]

--- a/webapp-django/crashstats/tokens/views.py
+++ b/webapp-django/crashstats/tokens/views.py
@@ -9,12 +9,13 @@ from django.db import transaction
 from django.views.decorators.http import require_POST
 from django.shortcuts import render, get_object_or_404, redirect
 
-from crashstats.crashstats.decorators import login_required
+from crashstats.crashstats.decorators import login_required, track_view
 from crashstats.tokens import forms
 from crashstats.tokens import models
 
 
 @login_required
+@track_view
 @transaction.atomic
 def home(request):
     context = {}
@@ -66,6 +67,7 @@ def home(request):
 
 @require_POST
 @login_required
+@track_view
 @transaction.atomic
 def delete_token(request, pk):
     token = get_object_or_404(models.Token, pk=pk, user=request.user)

--- a/webapp-django/crashstats/topcrashers/urls.py
+++ b/webapp-django/crashstats/topcrashers/urls.py
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.urls import re_path
+from django.urls import path
 
 from crashstats.topcrashers import views
 
 
 app_name = "topcrashers"
-urlpatterns = [re_path(r"^$", views.topcrashers, name="topcrashers")]
+urlpatterns = [path("", views.topcrashers, name="topcrashers")]

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -15,7 +15,11 @@ from session_csrf import anonymous_csrf
 
 from crashstats import productlib
 from crashstats.crashstats import models
-from crashstats.crashstats.decorators import check_days_parameter, pass_default_context
+from crashstats.crashstats.decorators import (
+    check_days_parameter,
+    pass_default_context,
+    track_view,
+)
 from crashstats.crashstats.utils import get_comparison_signatures, SignatureStats
 from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.supersearch.utils import get_date_boundaries
@@ -97,6 +101,7 @@ def get_topcrashers_stats(**kwargs):
     return total_results, signatures_stats
 
 
+@track_view
 @pass_default_context
 @anonymous_csrf
 @check_days_parameter([1, 3, 7, 14, 28], default=7)

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -5,7 +5,6 @@
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, re_path
-from django.views.generic.base import RedirectView
 
 from crashstats.manage import admin_site
 from crashstats.crashstats.monkeypatches import patch
@@ -34,12 +33,6 @@ urlpatterns = [
     re_path(r"^sources/", include("crashstats.sources.urls", namespace="sources")),
     re_path(r"^api/tokens/", include("crashstats.tokens.urls", namespace="tokens")),
     re_path(r"^api/", include("crashstats.api.urls", namespace="api")),
-    # redirect all symbols/ requests to Tecken
-    re_path(
-        r"^symbols/.*",
-        RedirectView.as_view(url="https://symbols.mozilla.org/"),
-        name="redirect-to-tecken",
-    ),
     re_path(r"^profile/", include("crashstats.profile.urls", namespace="profile")),
     re_path(
         r"^documentation/",

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -4,7 +4,7 @@
 
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.urls import include, re_path
+from django.urls import include, path
 
 from crashstats.manage import admin_site
 from crashstats.crashstats.monkeypatches import patch
@@ -17,34 +17,28 @@ handler500 = "crashstats.crashstats.views.handler500"
 
 
 urlpatterns = [
-    re_path(r"", include("crashstats.crashstats.urls", namespace="crashstats")),
-    re_path(r"", include("crashstats.exploitability.urls", namespace="exploitability")),
-    re_path(r"", include("crashstats.monitoring.urls", namespace="monitoring")),
-    re_path(
-        r"^search/", include("crashstats.supersearch.urls", namespace="supersearch")
-    ),
-    re_path(
-        r"^signature/", include("crashstats.signature.urls", namespace="signature")
-    ),
-    re_path(
-        r"^topcrashers/",
+    path("", include("crashstats.crashstats.urls", namespace="crashstats")),
+    path("", include("crashstats.exploitability.urls", namespace="exploitability")),
+    path("", include("crashstats.monitoring.urls", namespace="monitoring")),
+    path("search/", include("crashstats.supersearch.urls", namespace="supersearch")),
+    path("signature/", include("crashstats.signature.urls", namespace="signature")),
+    path(
+        "topcrashers/",
         include("crashstats.topcrashers.urls", namespace="topcrashers"),
     ),
-    re_path(r"^sources/", include("crashstats.sources.urls", namespace="sources")),
-    re_path(r"^api/tokens/", include("crashstats.tokens.urls", namespace="tokens")),
-    re_path(r"^api/", include("crashstats.api.urls", namespace="api")),
-    re_path(r"^profile/", include("crashstats.profile.urls", namespace="profile")),
-    re_path(
-        r"^documentation/",
+    path("sources/", include("crashstats.sources.urls", namespace="sources")),
+    path("api/tokens/", include("crashstats.tokens.urls", namespace="tokens")),
+    path("api/", include("crashstats.api.urls", namespace="api")),
+    path("profile/", include("crashstats.profile.urls", namespace="profile")),
+    path(
+        "documentation/",
         include("crashstats.documentation.urls", namespace="documentation"),
     ),
     # Static pages in Django admin
-    re_path(
-        r"^siteadmin/", include("crashstats.manage.admin_urls", namespace="siteadmin")
-    ),
+    path("siteadmin/", include("crashstats.manage.admin_urls", namespace="siteadmin")),
     # Django-model backed pages in Django admin
-    re_path(r"^siteadmin/", admin_site.site.urls),
-    re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
+    path("siteadmin/", admin_site.site.urls),
+    path("oidc/", include("mozilla_django_oidc.urls")),
 ]
 
 # In DEBUG mode, serve media files through Django.


### PR DESCRIPTION
This adds page view tracking which captures time-to-generate, whether
it's an API endpoint, whether it's an AJAX request, and some other
things. No ip addresses or user information is captured. This isn't
remotely equivalent to Google Analytics.

Regardless, this will help us see site usage at a coarse level.

While doing that, I redid how paths are specified and fixed a bunch of
tests that were using fake data.

While doing that, I ran "django-upgrade --target-version=3.2" on all the
files which adjusted some code that looks at request HTTP headers.