### PR TITLE
bug 1750759: fix path tag value and sort tags

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -144,7 +144,7 @@ class TestViews(BaseTestViews):
         assert response.status_code == 200
         metrics_mock.assert_timing(
             "webapp.view.pageview",
-            tags=["status:200", "ajax:false", "api:true", "path:/api/noop/"],
+            tags=["ajax:false", "api:true", "path:api_noop_", "status:200"],
         )
 
     def test_param_exceptions(self):

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -369,10 +369,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:302",
                 "ajax:false",
                 "api:false",
-                "path:/search/quick/",
+                "path:search_quick_",
+                "status:302",
             ],
         )
 
@@ -474,10 +474,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/report/index/_crashid_crash_id_",
+                "path:report_index__crashid_crash_id_",
+                "status:200",
             ],
         )
 
@@ -1800,10 +1800,10 @@ class TestProductHomeViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/home/product/waterwolf",
+                "path:home_product_waterwolf",
+                "status:200",
             ],
         )
 
@@ -1816,5 +1816,5 @@ class TestHomeView:
         assert resp.status_code == 200
         metrics_mock.assert_timing(
             "webapp.view.pageview",
-            tags=["status:200", "ajax:false", "api:false", "path:/"],
+            tags=["ajax:false", "api:false", "path:home", "status:200"],
         )

--- a/webapp-django/crashstats/documentation/tests/test_views.py
+++ b/webapp-django/crashstats/documentation/tests/test_views.py
@@ -16,10 +16,10 @@ def test_home_metrics(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/",
+            "path:documentation_",
+            "status:200",
         ],
     )
 
@@ -33,10 +33,10 @@ def test_supersearch_home(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/supersearch/",
+            "path:documentation_supersearch_",
+            "status:200",
         ],
     )
 
@@ -50,10 +50,10 @@ def test_whatsnew(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/whatsnew/",
+            "path:documentation_whatsnew_",
+            "status:200",
         ],
     )
 
@@ -67,10 +67,10 @@ def test_supersearch_examples(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/supersearch/examples/",
+            "path:documentation_supersearch_examples_",
+            "status:200",
         ],
     )
 
@@ -86,10 +86,10 @@ def test_supersearch_api(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/supersearch/api/",
+            "path:documentation_supersearch_api_",
+            "status:200",
         ],
     )
 
@@ -114,9 +114,9 @@ def test_signup_renders(client, db):
     metrics_mock.assert_timing(
         "webapp.view.pageview",
         tags=[
-            "status:200",
             "ajax:false",
             "api:false",
-            "path:/documentation/signup/",
+            "path:documentation_signup_",
+            "status:200",
         ],
     )

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -45,10 +45,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/search/",
+                "path:search_",
+                "status:200",
             ],
         )
 
@@ -101,10 +101,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/search/fields/",
+                "path:search_fields_",
+                "status:200",
             ],
         )
 
@@ -315,10 +315,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/search/results/",
+                "path:search_results_",
+                "status:200",
             ],
         )
 
@@ -615,10 +615,10 @@ class TestViews(BaseTestViews):
         metrics_mock.assert_timing(
             "webapp.view.pageview",
             tags=[
-                "status:200",
                 "ajax:false",
                 "api:false",
-                "path:/search/custom/",
+                "path:search_custom_",
+                "status:200",
             ],
         )
 


### PR DESCRIPTION
This sorts the tags alphabetically because influxdb docs say that's a
good thing.

This also removes the / from the tag path values. I think that's the
cause of the issue I'm hitting in stage where tag path values are all
showing as "undefined" in Grafana. This is a bit of a guess, though,
since I can't find good documentation on what makes a valid tag value.