### PR TITLE
bug 1750759: undo path value cleansing

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -144,7 +144,7 @@ class TestViews(BaseTestViews):
         assert response.status_code == 200
         metrics_mock.assert_timing(
             "webapp.view.pageview",
-            tags=["ajax:false", "api:true", "path:api_noop_", "status:200"],
+            tags=["ajax:false", "api:true", "path:/api/noop/", "status:200"],
         )
 
     def test_param_exceptions(self):

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -128,7 +128,6 @@ def cached_generate_tag(key, value):
     :returns: tag set item
 
     """
-    value = value.lstrip("/").strip().replace("/", "_").lower()
     value = value or "novalue"
     return generate_tag(key, value=value)
 
@@ -171,11 +170,9 @@ def track_view(view):
             request.resolver_match
             and request.resolver_match.url_name not in USE_PATH_VIEWS
         ):
-            path = request.resolver_match.route
+            path = "/" + request.resolver_match.route
         else:
             path = request.path
-
-        path = path or "home"
 
         delta = (time.time() - start_time) * 1000
         VIEW_METRICS.timing(

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -371,7 +371,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:search_quick_",
+                "path:/search/quick/",
                 "status:302",
             ],
         )
@@ -476,7 +476,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:report_index__crashid_crash_id_",
+                "path:/report/index/_crashid_crash_id_",
                 "status:200",
             ],
         )
@@ -1802,7 +1802,7 @@ class TestProductHomeViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:home_product_waterwolf",
+                "path:/home/product/waterwolf",
                 "status:200",
             ],
         )
@@ -1816,5 +1816,5 @@ class TestHomeView:
         assert resp.status_code == 200
         metrics_mock.assert_timing(
             "webapp.view.pageview",
-            tags=["ajax:false", "api:false", "path:home", "status:200"],
+            tags=["ajax:false", "api:false", "path:/", "status:200"],
         )

--- a/webapp-django/crashstats/documentation/tests/test_views.py
+++ b/webapp-django/crashstats/documentation/tests/test_views.py
@@ -18,7 +18,7 @@ def test_home_metrics(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_",
+            "path:/documentation/",
             "status:200",
         ],
     )
@@ -35,7 +35,7 @@ def test_supersearch_home(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_supersearch_",
+            "path:/documentation/supersearch/",
             "status:200",
         ],
     )
@@ -52,7 +52,7 @@ def test_whatsnew(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_whatsnew_",
+            "path:/documentation/whatsnew/",
             "status:200",
         ],
     )
@@ -69,7 +69,7 @@ def test_supersearch_examples(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_supersearch_examples_",
+            "path:/documentation/supersearch/examples/",
             "status:200",
         ],
     )
@@ -88,7 +88,7 @@ def test_supersearch_api(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_supersearch_api_",
+            "path:/documentation/supersearch/api/",
             "status:200",
         ],
     )
@@ -116,7 +116,7 @@ def test_signup_renders(client, db):
         tags=[
             "ajax:false",
             "api:false",
-            "path:documentation_signup_",
+            "path:/documentation/signup/",
             "status:200",
         ],
     )

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -47,7 +47,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:search_",
+                "path:/search/",
                 "status:200",
             ],
         )
@@ -103,7 +103,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:search_fields_",
+                "path:/search/fields/",
                 "status:200",
             ],
         )
@@ -317,7 +317,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:search_results_",
+                "path:/search/results/",
                 "status:200",
             ],
         )
@@ -617,7 +617,7 @@ class TestViews(BaseTestViews):
             tags=[
                 "ajax:false",
                 "api:false",
-                "path:search_custom_",
+                "path:/search/custom/",
                 "status:200",
             ],
         )


### PR DESCRIPTION
This undoes the path value cleansing, but keeps caching the tag
generation and the tag order. Turns out we don't need to cleanse the
path values--I had a bug in the graph I was building.