### PR TITLE
Add instructions for filling out data review request

### DIFF
--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -4,9 +4,8 @@
 Crash Annotations
 =================
 
-A crash report contains one or more minidumps plus a series of *crash
-annotations*. For example, a crash report may contain the following
-annotations:
+A crash report contains a set of *crash annotations* and zero or more
+minidumps. For example, a crash report may contain the following annotations:
 
 * **ProductName**: Firefox
 * **Version**: 77.0a1
@@ -23,15 +22,49 @@ Adding new crash annotations to a crash report
    `CrashAnnotations.yaml <https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml>`_.
 
    Verify your annotation doesn't already exist with a different name. You can't
-   change the meaning of an existing annotation.
+   change the meaning or type of an existing annotation.
 
 2. New annotations need to undergo data collection review:
    https://wiki.mozilla.org/Firefox/Data_Collection
 
-   .. Note::
+   Some things to keep in mind when filling out the review request:
 
-      If the field will be available in crash pings sent to Telemetry, make
+   1. If the field will be available in crash pings sent to Telemetry, make
       sure that's mentioned in the data collection review request.
+
+   2. Collection of crash annotation data never expires.
+
+      The answer to:
+
+          How long will this data be collected?
+
+      is:
+
+          I want to permanently monitor this data.
+
+      And the data request must specify an owner for this data collection.
+
+   3. Crash annotation data sent in crash reports is opt-in by default, bug
+      crash pings are opt-out by default.
+
+      If you only want the crash annotation data showing up in crash reports
+      and showing up in Crash Stats, then:
+
+          If this data collection is default on, what is the opt-out mechanism
+          for users?
+
+      is answered as:
+
+          No mechanism is required.
+
+      If you also want the crash annotation data showing up in crash pings, then:
+
+          If this data collection is default on, what is the opt-out mechanism
+          for users?
+
+      is answered as:
+
+          This data is opt-out via the normal telemetry opt-out mechanism.
 
 3. Once a new annotation is approved, details about the annotation need to be
    added to the ``CrashAnnotations.yaml`` file.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,9 +16,9 @@ certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
     # via requests
-charset-normalizer==2.0.9 \
-    --hash=sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721 \
-    --hash=sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c
+charset-normalizer==2.0.12 \
+    --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
+    --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
     # via requests
 docutils==0.17.1 \
     --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \
@@ -33,6 +33,10 @@ idna==3.3 \
 imagesize==1.3.0 \
     --hash=sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c \
     --hash=sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d
+    # via sphinx
+importlib-metadata==4.11.1 \
+    --hash=sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c \
+    --hash=sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094
     # via sphinx
 jinja2==3.0.3 \
     --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
@@ -113,13 +117,13 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via sphinx
-pygments==2.11.1 \
-    --hash=sha256:59b895e326f0fb0d733fd28c6839bd18ad0687ba20efc26d4277fd1d30b971f4 \
-    --hash=sha256:9135c1af61eec0f650cd1ea1ed8ce298e54d56bcd8cc2ef46edd7702c171337c
+pygments==2.11.2 \
+    --hash=sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65 \
+    --hash=sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
     # via sphinx
-pyparsing==3.0.6 \
-    --hash=sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4 \
-    --hash=sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81
+pyparsing==3.0.7 \
+    --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
+    --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
     # via packaging
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
@@ -137,12 +141,12 @@ sphinx==4.4.0 \
     --hash=sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe \
     --hash=sha256:6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc
     # via
-    #   -r docs/requirements.in
+    #   -r requirements.in
     #   sphinx-rtd-theme
-sphinx_rtd_theme==1.0.0 \
+sphinx-rtd-theme==1.0.0 \
     --hash=sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8 \
     --hash=sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c
-    # via -r docs/requirements.in
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
     --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58
@@ -167,7 +171,11 @@ sphinxcontrib-serializinghtml==1.1.5 \
     --hash=sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd \
     --hash=sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
     # via sphinx
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.8 \
+    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
+    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
     # via requests
+zipp==3.7.0 \
+    --hash=sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d \
+    --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375
+    # via importlib-metadata


### PR DESCRIPTION
This adds some instructions for filling out the data review request for new crash annotations. Hopefully this makes it a little easier to fill out.

This also updates docs requirements.