### PR TITLE
bug 1755993: set timeout and connect_timeout for cache

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -453,6 +453,12 @@ CACHES = {
         "LOCATION": config("CACHE_LOCATION", "127.0.0.1:11211"),
         "TIMEOUT": config("CACHE_TIMEOUT", 500),
         "KEY_PREFIX": config("CACHE_KEY_PREFIX", "socorro"),
+        "OPTIONS": {
+            # Seconds to wait for send/recv calls
+            "timeout": 5,
+            # Seconds to wait for a connection to go through
+            "connect_timeout": 5,
+        },
     }
 }
 


### PR DESCRIPTION
This changes `timeout` (send/recv) and `connect_timeout` (connect) from having no timeout to timing out in 5s.