### PR TITLE
Add Fenix crash monitoring documentation link

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -26,5 +26,11 @@
       "Application-Services",
       "https://github.com/mozilla/application-services/issues/new?title=%(title)s&body=%(description)s"
     ]
+  ],
+  "product_home_links": [
+    [
+      "Fenix crash monitoring documentation",
+      "https://github.com/mozilla-mobile/fenix/wiki/Crash-Monitoring"
+    ]
   ]
 }

--- a/product_details/Firefox.json
+++ b/product_details/Firefox.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/product_details/FirefoxReality.json
+++ b/product_details/FirefoxReality.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/product_details/Focus.json
+++ b/product_details/Focus.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/product_details/MozillaVPN.json
+++ b/product_details/MozillaVPN.json
@@ -4,5 +4,6 @@
   "home_page_sort": 4,
   "featured_versions": ["auto"],
   "in_buildhub": false,
-  "bug_links": []
+  "bug_links": [],
+  "product_home_links": []
 }

--- a/product_details/ReferenceBrowser.json
+++ b/product_details/ReferenceBrowser.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/product_details/SeaMonkey.json
+++ b/product_details/SeaMonkey.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/product_details/Thunderbird.json
+++ b/product_details/Thunderbird.json
@@ -25,5 +25,6 @@
       "GeckoView",
       "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
-  ]
+  ],
+  "product_home_links": []
 }

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/product_home.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/product_home.html
@@ -50,6 +50,24 @@
         </div>
         <br class="clear" />
       </div>
+
+      {% if product.product_home_links %}
+        <div class="title">
+          <h2>Other links</h2>
+        </div>
+        <div class="body">
+          <div id="release_channels">
+            <div class="release_channel">
+              <ul>
+                {% for text, link in product.product_home_links %}
+                  <li><a href="{{ link }}">{{ text }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+          <br class="clear" />
+        </div>
+      {% endif %}
     </div>
     <div class="tip">
       Are the featured versions wrong?

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -73,6 +73,7 @@ class ProductVersionsMixin:
                 featured_versions=["auto"],
                 in_buildhub=True,
                 bug_links=[["WaterWolf", "create-waterwolf-bug"]],
+                product_home_links=[["link", "http://example.com/"]],
             ),
             productlib.Product(
                 name="NightTrain",
@@ -81,6 +82,7 @@ class ProductVersionsMixin:
                 featured_versions=["auto"],
                 in_buildhub=False,
                 bug_links=[["NightTrain", "create-nighttrain-bug"]],
+                product_home_links=[],
             ),
             productlib.Product(
                 name="SeaMonkey",
@@ -89,6 +91,7 @@ class ProductVersionsMixin:
                 featured_versions=["auto"],
                 in_buildhub=False,
                 bug_links=[["SeaMonkey", "create-seamonkey-bug"]],
+                product_home_links=[],
             ),
         ]
 

--- a/webapp-django/crashstats/productlib.py
+++ b/webapp-django/crashstats/productlib.py
@@ -40,6 +40,9 @@ class Product:
     # view of a crash report
     bug_links: List[List[str]]
 
+    # List of [link name, link url] links to display on the product hom epage
+    product_home_links: List[List[str]]
+
 
 # In-memory cache of products files so we're not parsing them over-and-over
 _PRODUCTS = []
@@ -158,6 +161,18 @@ def validate_product_file(fn):
 
                 # NOTE(willkg): This doesn't verify templates are well formed. That's
                 # handled in a test in the code that uses the template.
+
+            for item in json_data["product_home_links"]:
+                if len(item) != 2:
+                    raise ProductValidationError(
+                        "product file %s has invalid product_home_links: %s"
+                        % (fn, repr(item))
+                    )
+                if not isinstance(item[0], str) or not isinstance(item[1], str):
+                    raise ProductValidationError(
+                        "product file %s has invalid product_home_links: %s"
+                        % (fn, repr(item))
+                    )
 
             # Try to build a Product out of it
             Product(**json_data)


### PR DESCRIPTION
This adds the ability to add additional links to the product home page. This is particularly useful for links to crash monitoring documentation for that specific product.

This also adds a link to Fenix crash monitoring documentation from Roger.