### PR TITLE
bug 1755523: end raw crash use in signature generation

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1131,7 +1131,7 @@ class SignatureGeneratorRule(Rule):
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
         # Generate a crash signature and capture the signature and notes
-        crash_data = convert_to_crash_data(raw_crash, processed_crash)
+        crash_data = convert_to_crash_data(processed_crash)
         result = self.generator.generate(crash_data)
         processed_crash["signature"] = result.signature
         processor_meta["processor_notes"].extend(result.notes)

--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -217,27 +217,6 @@ def main(argv=None):
 
             crash_id = parsed_crash_id
 
-            resp = fetch("/RawCrash/", crash_id, api_token)
-            if resp.status_code == 404:
-                out.warning(f"{crash_id}: does not exist.")
-                continue
-            if resp.status_code == 429:
-                out.warning(f"API rate limit reached. {resp.content}")
-                # FIXME(willkg): Maybe there's something better we could do here. Like maybe wait a
-                # few minutes.
-                return 1
-            if resp.status_code == 500:
-                out.warning(f"HTTP 500: {resp.content}")
-                continue
-
-            raw_crash = resp.json()
-
-            # If there's an error in the raw crash, then something is wrong--probably with the API
-            # token. So print that out and exit.
-            if "error" in raw_crash:
-                out.warning(f"Error fetching raw crash: {raw_crash['error']}")
-                return 1
-
             resp = fetch("/ProcessedCrash/", crash_id, api_token)
             if resp.status_code == 404:
                 out.warning(f"{crash_id}: does not have processed crash.")
@@ -262,7 +241,7 @@ def main(argv=None):
                 return 1
 
             old_signature = processed_crash["signature"]
-            crash_data = convert_to_crash_data(raw_crash, processed_crash)
+            crash_data = convert_to_crash_data(processed_crash)
 
             result = generator.generate(crash_data)
 

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -819,14 +819,13 @@ class SignatureIPCChannelError(Rule):
         return bool(crash_data.get("ipc_channel_error"))
 
     def action(self, crash_data, result):
-        if crash_data.get("additional_minidumps") == "browser":
+        minidumps = crash_data.get("additional_minidumps") or []
+        if "upload_file_minidump_browser" in minidumps:
             new_sig = "IPCError-browser | {}"
         else:
             new_sig = "IPCError-content | {}"
         new_sig = new_sig.format(crash_data["ipc_channel_error"][:100])
-
         result.info(self.name, "IPC Channel Error stomped on signature")
-
         result.set_signature(self.name, new_sig)
         return True
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1509,7 +1509,7 @@ class TestSignatureIPCChannelError:
         ]
 
         # Now test with a browser crash.
-        crash_data["additional_minidumps"] = "browser"
+        crash_data["additional_minidumps"] = ["upload_file_minidump_browser"]
         result = generator.Result()
         result.signature = original_signature
 

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -64,13 +64,11 @@ def override_values(crash_data, values):
     yield crash_data
 
 
-def convert_to_crash_data(raw_crash, processed_crash):
+def convert_to_crash_data(processed_crash):
     """
-    Takes a raw crash and a processed crash (these are Socorro-centric
-    data structures) and converts them to a crash data structure used
-    by signature generation.
+    Takes a processed crash (these are Socorro-centric data structures) and converts
+    them to a crash data structure used by signature generation.
 
-    :arg raw_crash: raw crash data from Socorro
     :arg processed_crash: processed crash data from Socorro
 
     :returns: crash data structure that conforms to the schema
@@ -109,8 +107,11 @@ def convert_to_crash_data(raw_crash, processed_crash):
         "ipc_message_name": glom(processed_crash, "ipc_message_name", default=None),
         # text
         "moz_crash_reason": glom(processed_crash, "moz_crash_reason", default=None),
-        # text; comma-delimited e.g. "browser,flash1,flash2"
-        "additional_minidumps": glom(raw_crash, "additional_minidumps", default=""),
+        # list of str; for example:
+        # ["upload_file_minidump_browser", "upload_file_minidump_flash1"]
+        "additional_minidumps": glom(
+            processed_crash, "additional_minidumps", default=[]
+        ),
         # pull out the original signature if there was one
         "original_signature": glom(processed_crash, "signature", default=""),
     }


### PR DESCRIPTION
This fixes signature generation so that it only uses processed crash
data.