### PR TITLE
Add support for unloaded_modules in signatures

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -238,13 +238,26 @@ class CSignatureTool:
             #
             # Both arrays are pre-sorted to keep the output stable.
 
+            # We want to generate an output like this:
+            #
+            # @0xf800 (unloaded many.dll@0x460,0x700) (unloaded solo.dll@0x5e0)
+            #
+            # * prefixed with raw address
+            # * parenthetical unloaded modules
+            # * if multiple offsets, comma separated
+
+            prefix = ""
+            if offset:
+                prefix = f"@{strip_leading_zeros(offset)}"
+
+            parts = []
             for unloaded in unloaded_modules:
                 if unloaded.module and unloaded.offsets:
-                    for unloaded_offset in unloaded.offsets:
-                        # For now, just grab the first entry and return it.
-                        return "unloaded {}@{}".format(
-                            unloaded.module, strip_leading_zeros(unloaded_offset)
-                        )
+                    stripped = map(strip_leading_zeros, unloaded.offsets)
+                    offsets = ",".join(stripped)
+                    part = "(unloaded {}@{})".format(unloaded.module, offsets)
+                    parts.append(part)
+            return "{} {}".format(prefix, " ".join(parts))
 
         # If there's an offset and no module/module_offset, use that
         if not module and not module_offset and offset:

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -242,7 +242,7 @@ class CSignatureTool:
                 if unloaded.module and unloaded.offsets:
                     for unloaded_offset in unloaded.offsets:
                         # For now, just grab the first entry and return it.
-                        return "{}@{}".format(
+                        return "unloaded {}@{}".format(
                             unloaded.module, strip_leading_zeros(unloaded_offset)
                         )
 


### PR DESCRIPTION
This is done in 3 commits of increasing "completeness", and you can choose whichever one you want to deploy

1. basic support, reproduces current behaviour
2. adds "unloaded " in front of the module name to make it clear it's unloaded (because it's important!)
3. implements a version of the "full information" signature [rust-minidump spits out in human output](https://github.com/luser/rust-minidump/blob/3bc49b07a094bad2e8c130a82b86fad017952689/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-unloaded.snap#L16)

Assumptions I Am Making In This PR:

* the frame is sent to this python script with unloaded_modules in-tact (nothing else needs to be told the schema)
* post-processing in the caller won't mess this up or choke on any of these format
* that somehow stacktraces also use this code? (we want those to get updated too)
* that this works at all (haven't compiled/tested it, dunno how)

It's fine if you throw this out, I hope it at least is a usable starting point (I am very bad at python formatting / list comprehensions so I'm sure there's a more elegant approach).