### PR TITLE
bug 1757605: add mozilla::ipc::SentinelReadError to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -180,6 +180,7 @@ mozilla::ipc::RPCChannel::Call
 mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame
 mozilla::ipc::RPCChannel::EnteredCxxStack
 mozilla::ipc::RPCChannel::Send
+mozilla::ipc::SentinelReadError
 mozilla::ipc::Shmem::OpenExisting
 mozilla::ipc::IProtocol::ChannelSend
 mozilla::ipc::IToplevelProtocol::ShmemCreated


### PR DESCRIPTION
```
sapp@socorro:/app$ socorro-cmd signature bp-32f63301-804f-4e9d-ba52-bfb670220301
Crash id: 32f63301-804f-4e9d-ba52-bfb670220301
Original: mozilla::ipc::SentinelReadError
New:      mozilla::ipc::SentinelReadError | mozilla::ipc::SentinelReadError | mozilla::gmp::PGMPParent::OnMessageReceived
Same?:    False
```