### PR TITLE
bug 1757270: add core::ops::function::FnOnce::call_once<T> to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -15,6 +15,7 @@ __assert_rtn
 app_process@0x
 AppleIntelHD3000GraphicsGLDriver@
 core\.odex@0x
+core::ops::function::FnOnce::call_once<T>
 core::panicking::
 CrashReporter::TerminateHandler
 CrashStatsLogForwarder::CrashAction


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature bp-aaf62815-e6ea-4f4f-8251-cda5c0220226
Crash id: aaf62815-e6ea-4f4f-8251-cda5c0220226
Original: OOM | large | mozalloc_abort | core::ops::function::FnOnce::call_once<T>
New:      OOM | large | mozalloc_abort | core::intrinsics::const_eval_select<T>
Same?:    False
```