### PR TITLE
bug 1671636: handle malformed search filter values

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -436,6 +436,7 @@ class SuperSearch(RequiredConfig, SearchBase):
                 shards = getattr(results, "_shards", {})
 
                 break  # Yay! Results!
+
             except NotFoundError as e:
                 missing_index = re.findall(BAD_INDEX_REGEX, e.error)[0]
                 if missing_index in indices:
@@ -462,6 +463,7 @@ class SuperSearch(RequiredConfig, SearchBase):
                     aggregations = {}
                     shards = None
                     break
+
             except RequestError as exception:
                 # Try to handle it gracefully if we can find out what
                 # input was bad and caused the exception.
@@ -477,6 +479,11 @@ class SuperSearch(RequiredConfig, SearchBase):
                 except IndexError:
                     # Not an ElasticsearchParseException exception
                     pass
+
+                # If it's a search parse exception, but we don't know what key is the
+                # problem, raise a general BadArgumentError
+                if "Failed to parse source" in str(exception):
+                    raise BadArgumentError("Malformed supersearch query.")
 
                 # Re-raise the original exception
                 raise

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1492,6 +1492,14 @@ class TestIntegrationSuperSearch(ElasticsearchTestCase):
         with pytest.raises(BadArgumentError):
             self.api.get(_results_number=1001)
 
+    def test_get_with_bad_regex(self):
+        # A bad regex kicks up a SearchParseException which supersearch converts
+        # to a BadArgumentError
+        with pytest.raises(BadArgumentError):
+            self.api.get(
+                signature='@"OOM | ".*" | ".*"()&%<acx><ScRiPt >sruq(9393)</ScRiPt'
+            )
+
     def test_get_with_failing_shards(self):
         # NOTE(willkg): We're asserting on a url which includes the indexes being
         # searched. If the index template includes a date, then the indexes could be in


### PR DESCRIPTION
If a user is using a regex operator and the value is malformed, this
will fix the response so it's an HTTP 400.