### PR TITLE
bug 1758701: add sentry-test mode to sentry-wrap

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -19,7 +19,7 @@ PRECMD=""
 # send errors to sentry.
 if [ -n "${SENTRY_DSN:-}" ]; then
     echo "SENTRY_DSN defined--enabling sentry."
-    PRECMD="python bin/sentry-wrap.py --timeout=600 --"
+    PRECMD="python bin/sentry-wrap.py wrap-process --timeout=600 --"
 else
     echo "SENTRY_DSN not defined--not enabling sentry."
 fi

--- a/bin/sentry-wrap.py
+++ b/bin/sentry-wrap.py
@@ -26,8 +26,31 @@ import sentry_sdk
 from sentry_sdk import capture_exception, capture_message
 
 
-@click.command()
-@click.option("--timeout", default=300, help="Timeout in seconds to wait for process before giving up.")
+@click.group()
+def cli_main():
+    pass
+
+
+@cli_main.command()
+@click.pass_context
+def sentry_test(ctx):
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+
+    if not sentry_dsn:
+        print("SENTRY_DSN is not defined. Exiting.")
+        sys.exit(1)
+
+    sentry_sdk.init(sentry_dsn)
+    capture_message("Sentry test")
+    print("Success. Check Sentry.")
+
+
+@cli_main.command()
+@click.option(
+    "--timeout",
+    default=300,
+    help="Timeout in seconds to wait for process before giving up.",
+)
 @click.argument("cmd", nargs=-1)
 @click.pass_context
 def wrap_process(ctx, timeout, cmd):
@@ -83,4 +106,4 @@ def wrap_process(ctx, timeout, cmd):
 
 
 if __name__ == "__main__":
-    wrap_process()
+    cli_main()

--- a/bin/sentry-wrap.py
+++ b/bin/sentry-wrap.py
@@ -7,10 +7,10 @@
 # Wraps a command such that if it fails, an error report is sent to the Sentry service
 # specified by SENTRY_DSN in the environment.
 #
-# Usage: python bin/sentry-wrap.py wrap -- [CMD]
+# Usage: python bin/sentry-wrap.py wrap-process -- [CMD]
 #    Wraps a process in error-reporting Sentry goodness.
 #
-# Usage: python bin/sentry-wrap.py test
+# Usage: python bin/sentry-wrap.py test-sentry
 #    Tests Sentry configuration and connection.
 
 
@@ -33,7 +33,7 @@ def cli_main():
 
 @cli_main.command()
 @click.pass_context
-def sentry_test(ctx):
+def test_sentry(ctx):
     sentry_dsn = os.environ.get("SENTRY_DSN")
 
     if not sentry_dsn:

--- a/bin/sentry-wrap.py
+++ b/bin/sentry-wrap.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -5,47 +7,49 @@
 # Wraps a command such that if it fails, an error report is sent to the Sentry service
 # specified by SENTRY_DSN in the environment.
 #
-# Usage: python bin/sentry-wrap.py -- [CMD]
+# Usage: python bin/sentry-wrap.py wrap -- [CMD]
+#    Wraps a process in error-reporting Sentry goodness.
+#
+# Usage: python bin/sentry-wrap.py test
+#    Tests Sentry configuration and connection.
 
 
-import argparse
 import os
 import shlex
 import subprocess
 import sys
+import time
+import traceback
 
+import click
 import sentry_sdk
 from sentry_sdk import capture_exception, capture_message
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Python-based cli for sentry error reporting."
-    )
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=300,
-        help="Timeout to wait for process before giving up.",
-    )
-    parser.add_argument("cmd", nargs="+", help="The process to run.")
-
-    args = parser.parse_args()
-
+@click.command()
+@click.option("--timeout", default=300, help="Timeout in seconds to wait for process before giving up.")
+@click.argument("cmd", nargs=-1)
+@click.pass_context
+def wrap_process(ctx, timeout, cmd):
     sentry_dsn = os.environ.get("SENTRY_DSN")
 
     if not sentry_dsn:
         print("SENTRY_DSN is not defined. Exiting.")
         sys.exit(1)
 
+    if not cmd:
+        raise click.UsageError("CMD required")
+
+    start_time = time.time()
+
     sentry_sdk.init(sentry_dsn)
 
-    cmd = " ".join(args.cmd)
+    cmd = " ".join(cmd)
     cmd_args = shlex.split(cmd)
     print(f"Running: {cmd_args}")
 
     try:
-        ret = subprocess.run(cmd_args, capture_output=True, timeout=args.timeout)
+        ret = subprocess.run(cmd_args, capture_output=True, timeout=timeout)
         if ret.returncode != 0:
             sentry_sdk.set_context(
                 "status",
@@ -55,16 +59,28 @@ def main():
                     "stderr": ret.stderr.decode("utf-8"),
                 },
             )
-            capture_message(f"Command {args.cmd} failed.")
+            capture_message(f"Command {cmd!r} failed.")
+            print(ret.stdout.decode("utf-8"))
+            print(ret.stderr.decode("utf-8"))
+            time_delta = (time.time() - start_time) / 1000
+            print(f"Fail. {time_delta:.2f}s")
+            ctx.exit(1)
 
         else:
             print(ret.stdout.decode("utf-8"))
-            print("Success!")
+            time_delta = (time.time() - start_time) / 1000
+            print(f"Success! {time_delta:.2f}s")
+
+    except click.exceptions.Exit:
+        raise
 
     except Exception as exc:
         capture_exception(exc)
-        sys.exit(1)
+        traceback.print_exc()
+        time_delta = (time.time() - start_time) / 1000
+        print(f"Fail. {time_delta:.2f}s")
+        ctx.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    wrap_process()

--- a/bin/sentry-wrap.py
+++ b/bin/sentry-wrap.py
@@ -37,12 +37,12 @@ def test_sentry(ctx):
     sentry_dsn = os.environ.get("SENTRY_DSN")
 
     if not sentry_dsn:
-        print("SENTRY_DSN is not defined. Exiting.")
+        click.echo("SENTRY_DSN is not defined. Exiting.")
         sys.exit(1)
 
     sentry_sdk.init(sentry_dsn)
     capture_message("Sentry test")
-    print("Success. Check Sentry.")
+    click.echo("Success. Check Sentry.")
 
 
 @cli_main.command()
@@ -57,7 +57,7 @@ def wrap_process(ctx, timeout, cmd):
     sentry_dsn = os.environ.get("SENTRY_DSN")
 
     if not sentry_dsn:
-        print("SENTRY_DSN is not defined. Exiting.")
+        click.echo("SENTRY_DSN is not defined. Exiting.")
         sys.exit(1)
 
     if not cmd:
@@ -69,7 +69,7 @@ def wrap_process(ctx, timeout, cmd):
 
     cmd = " ".join(cmd)
     cmd_args = shlex.split(cmd)
-    print(f"Running: {cmd_args}")
+    click.echo(f"Running: {cmd_args}")
 
     try:
         ret = subprocess.run(cmd_args, capture_output=True, timeout=timeout)
@@ -83,25 +83,25 @@ def wrap_process(ctx, timeout, cmd):
                 },
             )
             capture_message(f"Command {cmd!r} failed.")
-            print(ret.stdout.decode("utf-8"))
-            print(ret.stderr.decode("utf-8"))
+            click.echo(ret.stdout.decode("utf-8"))
+            click.echo(ret.stderr.decode("utf-8"))
             time_delta = (time.time() - start_time) / 1000
-            print(f"Fail. {time_delta:.2f}s")
+            click.echo(f"Fail. {time_delta:.2f}s")
             ctx.exit(1)
 
         else:
-            print(ret.stdout.decode("utf-8"))
+            click.echo(ret.stdout.decode("utf-8"))
             time_delta = (time.time() - start_time) / 1000
-            print(f"Success! {time_delta:.2f}s")
+            click.echo(f"Success! {time_delta:.2f}s")
 
     except click.exceptions.Exit:
         raise
 
     except Exception as exc:
         capture_exception(exc)
-        traceback.print_exc()
+        click.echo(traceback.format_exc())
         time_delta = (time.time() - start_time) / 1000
-        print(f"Fail. {time_delta:.2f}s")
+        click.echo(f"Fail. {time_delta:.2f}s")
         ctx.exit(1)
 
 

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -38,7 +38,7 @@ resource.metrics.markus_backends=markus.backends.logging.LoggingMetrics,markus.b
 # sentry
 # ------
 
-secrets.sentry.dsn=http://public@fakesentry:8090/1
+SENTRY_DSN=http://public@fakesentry:8090/1
 
 # elasticsearch
 # -------------
@@ -90,7 +90,6 @@ telemetry.bucket_name=telemetry-bucket
 ALLOWED_HOSTS=localhost,webapp
 CACHE_LOCATION=memcached:11211
 DATABASE_URL=postgres://postgres:aPassword@postgresql:5432/breakpad
-SENTRY_DSN=http://public@fakesentry:8090/1
 SECRET_KEY=secretkey
 STATSD_HOST=statsd
 OVERVIEW_VERSION_URLS=http://localhost:8000/__version__
@@ -119,7 +118,6 @@ SESSION_COOKIE_SECURE=False
 # fake sentry
 # -----------
 SENTRY_PORT=8090
-
 
 # oidcprovider
 # ------------

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -8,7 +8,6 @@ STATSD_CLIENT=django_statsd.clients.null
 
 # Sentry
 SENTRY_DSN=http://public@fakesentry:8090/1
-secrets.sentry.dsn=http://public@fakesentry:8090/1
 
 # boto (s3/sqs)
 resource.boto.bucket_name=crashstats-test

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -110,7 +110,7 @@ class App(RequiredConfig):
     required_config.namespace("sentry")
     required_config.sentry.add_option(
         "dsn",
-        doc="DSN for Sentry",
+        doc="DEPRECATED: set SENTRY_DSN in environment instead",
         default="",
         reference_value_from="secrets.sentry",
         secret=True,
@@ -319,8 +319,13 @@ def setup_crash_reporting(config, version):
     """Setup Sentry crash reporting."""
 
     if config.sentry and config.sentry.dsn:
+        sentry_dsn = config.sentry.dsn
+    else:
+        sentry_dsn = os.environ.get("SENTRY_DSN", "")
+
+    if sentry_dsn:
         sentry_sdk.init(
-            dsn=config.sentry.dsn,
+            dsn=sentry_dsn,
             release=version,
             debug=config.sentry.debug,
             send_default_pii=False,

--- a/socorro/external/boto/upload_telemetry_schema.py
+++ b/socorro/external/boto/upload_telemetry_schema.py
@@ -37,7 +37,7 @@ class UploadTelemetrySchema(App):
     metadata = ""
 
     required_config = Namespace()
-    required_config.telemetry = Namespace()
+    required_config.namespace("telemetry")
     required_config.telemetry.add_option(
         "resource_class",
         default="socorro.external.boto.connection_context.S3Connection",


### PR DESCRIPTION
This improves error handling in sentry-wrap, switches it to use click instead of argparse, and adds "sentry-test" and "wrap-process" subcommands.

This updates the `bin/run_migrations.sh` script accordingly.

This also switches all parts of Socorro to use `SENTRY_DSN` environment variable to specify the Sentry host to use. Previously, crontabber and the webapp used `SENTRY_DSN` and the processor and upload_telemetry_schema apps used `secrets.sentry.dsn`.