### PR TITLE
bug 1759591: update rust-minidump to b0af5b4 (0.10.1)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,11 @@ RUN update-ca-certificates && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=1c5f5f81f4431f358d5342c7e1114b0737949474
-ARG MINIDUMPREVDATE=2022-01-20
+ARG MINIDUMPREV=b0af5b4ce2e8b5fb680ef006f415744f4a536d8a
+ARG MINIDUMPREVDATE=2022-03-17
 
 RUN cargo install --locked --root=/app/ \
-    --git https://github.com/luser/rust-minidump.git \
+    --git https://github.com/rust-minidump/rust-minidump.git \
     --rev $MINIDUMPREV \
     minidump-stackwalk
 RUN echo "{\"sha\":\"$MINIDUMPREV\",\"date\":\"$MINIDUMPREVDATE\"}" > /app/bin/minidump-stackwalk.version.json

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,15 +3,15 @@
 # =========================================================================
 
 # https://hub.docker.com/_/rust/
-FROM rust:1.58.1-buster@sha256:311d05f3823e7430bfeb2a743cd1a7895b05db643622d8d38ce18bffa2fa63bf as rustminidump
+FROM rust:1.59.0-buster@sha256:6621dabc8666228c23d4b7f09caeb8f0a9073d80b4b4932393c493fadaa74fe4 as rustminidump
 
-RUN update-ca-certificates
 ARG groupid=10001
 ARG userid=10001
 
 WORKDIR /app/
 
-RUN groupadd --gid $groupid app && \
+RUN update-ca-certificates && \
+    groupadd --gid $groupid app && \
     useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \
     chown app:app /app/
 

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -97,7 +97,7 @@ class ProcessorPipeline(RequiredConfig):
         default=(
             "timeout --signal KILL {kill_timeout} "
             "{command_path} "
-            "--raw-json={raw_crash_path} "
+            "--evil-json={raw_crash_path} "
             "--symbols-cache={symbol_cache_path} "
             "--symbols-tmp={symbol_tmp_path} "
             "{symbols_urls} "


### PR DESCRIPTION
This does a few things:

1. update rust to 1.59.0
2. update rust-minidump to b0af5b4 aka 0.10.1 and fix the command line arguments to minidump-stackwalk
3. rewrite ModuleURLRewriteRule

To test, process some crashes, check the symbol urls for modules, and make sure stacks look ok.