### PR TITLE
bug 1759591: update rust-minidump to e954907c

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ RUN update-ca-certificates && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=b0af5b4ce2e8b5fb680ef006f415744f4a536d8a
-ARG MINIDUMPREVDATE=2022-03-17
+ARG MINIDUMPREV=e954907c9f5a69037df459cacb4d0846b0599479
+ARG MINIDUMPREVDATE=2022-03-23
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/rust-minidump/rust-minidump.git \

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -77,8 +77,9 @@ processor.minidumpstackwalk.symbol_tmp_path=/tmp/symbols/tmp
 # a long time
 processor.minidumpstackwalk.kill_timeout=30
 
-# Set symbols_urls to something helpful for local dev
-processor.minidumpstackwalk.symbols_urls=https://symbols.mozilla.org/
+# Set symbols_urls to two symbol servers so we make sure we can specify multiple
+# --symbols-url values in minidump-stackwalk
+processor.minidumpstackwalk.symbols_urls=https://symbols.mozilla.org/try,https://symbols.stage.mozaws.net/try
 
 # Set the telemetry bucket name explicitly
 destination.telemetry.bucket_name=telemetry-bucket


### PR DESCRIPTION
Update rust-minidump to e954907 to pick up fix for --symbols-url argument specification.

```
e954907 Add unit test
3e3ef4b fix: Fall back to timestamp + size CodeIds on Windows
8570b22 make system_info::Cpu non_exhaustive
1fbe55d feat: Add rudimentary MIPS support
6cec047 fixup cli from clap update
8274cfb ref: Rename efl to eflags
ebd5dd0 Make MinidumpStream::STREAM_TYPE a u32
1754f8f pull all the platform-specific error code enums into a new module
7eed71e 0.10.1 post-release
```