### PR TITLE
bug 1755528: fix flag/boolean fields

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -253,16 +253,6 @@ def build_document(src, crash_document, fields, all_keys):
             else:
                 value = fix_string(value, max_size=MAX_STRING_FIELD_VALUE_SIZE)
 
-        elif storage_type == "boolean":
-            # FIXME(willkg): Previous iteration of the crash storage logic had a
-            # convert_booleans which was implemented wrong, so it didn't do anything.
-            # "booleans" is tricky since we have flags and booleans and they're
-            # different, so it requires more analysis to figure out what to do here.
-            # Meanwhile, I commented this out for now which returns us to the previous
-            # behavior.
-            # value = fix_boolean(value)
-            pass
-
         elif storage_type == "integer":
             value = fix_integer(value)
             if value is None:

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1502,8 +1502,13 @@ FIELDS = {
         "name": "content_sandbox_enabled",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.content_sandbox_enabled",
+        "destination_keys": [
+            "raw_crash.ContentSandboxEnabled",
+            "processed_crash.content_sandbox_enabled",
+        ],
         "query_type": "bool",
-        "storage_mapping": {"null_value": False, "type": "boolean"},
+        "storage_mapping": {"type": "boolean"},
     },
     "content_sandbox_level": {
         "data_validation_type": "int",

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -530,19 +530,14 @@ def get_fields_by_item(fields, key, val):
     return fields_by_item
 
 
-def flag_field(
+def boolean_field(
     name,
     description,
     namespace="processed_crash",
     in_database_name="",
     is_protected=True,
 ):
-    """Generates a flag field.
-
-    Flag fields are one of a few things:
-
-    1. a boolean value that is either true and false
-    2. a crash annotation flag that is "1" or missing
+    """Generates a boolean field.
 
     These can be searched and aggregated, but documents that are missing the field won't
     show up in aggregations.
@@ -3326,7 +3321,7 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
-    "windows_error_reporting": flag_field(
+    "windows_error_reporting": boolean_field(
         name="windows_error_reporting",
         description=(
             "Set to 1 if this crash was intercepted via the Windows Error Reporting "

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -971,7 +971,7 @@ FIELDS = {
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
     "addons_checked": {
-        "data_validation_type": "enum",
+        "data_validation_type": "bool",
         "description": "",
         "form_field_choices": [],
         "has_full_version": False,

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -820,6 +820,11 @@ FIELDS = {
         "name": "accessibility",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.accessibility",
+        "destination_keys": [
+            "raw_crash.Accessibility",
+            "processed_crash.accessibility",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3097,6 +3097,11 @@ FIELDS = {
         "name": "throttleable",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.throttleable",
+        "destination_keys": [
+            "raw_crash.Throttleable",
+            "processed_crash.throttleable",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1483,8 +1483,13 @@ FIELDS = {
         "name": "content_sandbox_capable",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.content_sandbox_capable",
+        "destination_keys": [
+            "raw_crash.ContentSandboxCapable",
+            "processed_crash.content_sandbox_capable",
+        ],
         "query_type": "bool",
-        "storage_mapping": {"null_value": False, "type": "boolean"},
+        "storage_mapping": {"type": "boolean"},
     },
     "content_sandbox_enabled": {
         "data_validation_type": "bool",

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2984,7 +2984,14 @@ FIELDS = {
         "name": "startup_crash",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.startup_crash",
+        "destination_keys": [
+            "raw_crash.StartupCrash",
+            "processed_crash.startup_crash",
+        ],
         "query_type": "bool",
+        # NOTE(willkg): startup_crash is used in signature report in some interesting
+        # ways so I think we need to have both T and F values in ES
         "storage_mapping": {"null_value": "False", "type": "boolean"},
     },
     "startup_time": {

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1846,6 +1846,11 @@ FIELDS = {
         "name": "has_device_touch_screen",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.has_device_touch_screen",
+        "destination_keys": [
+            "raw_crash.HasDeviceTouchScreen",
+            "processed_crash.has_device_touch_screen",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2896,6 +2896,11 @@ FIELDS = {
         "name": "safe_mode",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.safe_mode",
+        "destination_keys": [
+            "raw_crash.SafeMode",
+            "processed_crash.safe_mode",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3027,6 +3027,11 @@ FIELDS = {
         "name": "submitted_from_infobar",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.submitted_from_infobar",
+        "destination_keys": [
+            "raw_crash.SubmittedFromInfobar",
+            "processed_crash.submitted_from_infobar",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2050,6 +2050,11 @@ FIELDS = {
         "name": "is_garbage_collecting",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.is_garbage_collecting",
+        "destination_keys": [
+            "raw_crash.IsGarbageCollecting",
+            "processed_crash.is_garbage_collecting",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1699,6 +1699,11 @@ FIELDS = {
         "name": "em_check_compatibility",
         "namespace": "raw_crash",
         "permissions_needed": [],
+        "source_key": "processed_crash.em_check_compatibility",
+        "destination_keys": [
+            "raw_crash.EMCheckCompatibility",
+            "processed_crash.em_check_compatibility",
+        ],
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -103,6 +103,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "MemoryErrorCorrection", "memory_error_correction"),
         ("int", "OOMAllocationSize", "oom_allocation_size"),
         ("string", "RemoteType", "remote_type"),
+        ("boolean", "SafeMode", "safe_mode"),
         ("string", "ShutdownProgress", "shutdown_progress"),
         ("int", "StartupTime", "startup_time"),
         ("int", "SystemMemoryUsePercentage", "system_memory_use_percentage"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -105,6 +105,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "RemoteType", "remote_type"),
         ("boolean", "SafeMode", "safe_mode"),
         ("string", "ShutdownProgress", "shutdown_progress"),
+        ("boolean", "StartupCrash", "startup_crash"),
         ("int", "StartupTime", "startup_time"),
         ("int", "SystemMemoryUsePercentage", "system_memory_use_percentage"),
         ("int", "TotalPageFile", "total_page_file"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -84,6 +84,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "CoMarshalInterfaceFailure", "co_marshal_interface_failure"),
         ("int", "ContentSandboxCapabilities", "content_sandbox_capabilities"),
         ("boolean", "ContentSandboxCapable", "content_sandbox_capable"),
+        ("boolean", "ContentSandboxEnabled", "content_sandbox_enabled"),
         ("int", "ContentSandboxLevel", "content_sandbox_level"),
         ("string", "CPUMicrocodeVersion", "cpu_microcode_version"),
         ("string", "GMPLibraryPath", "gmp_library_path"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -57,6 +57,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "DumperError", "dumper_error"),
         ("string", "XPCOMSpinEventLoopStack", "xpcom_spin_event_loop_stack"),
         ("string", "AbortMessage", "abort_message"),
+        ("boolean", "Accessibility", "accessibility"),
         ("string", "AccessibilityClient", "accessibility_client"),
         ("string", "AccessibilityInProcClient", "accessibility_in_proc_client"),
         ("string", "AdapterDeviceID", "adapter_device_id"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -87,6 +87,7 @@ class CopyFromRawCrashRule(Rule):
         ("boolean", "ContentSandboxEnabled", "content_sandbox_enabled"),
         ("int", "ContentSandboxLevel", "content_sandbox_level"),
         ("string", "CPUMicrocodeVersion", "cpu_microcode_version"),
+        ("boolean", "EMCheckCompatibility", "em_check_compatibility"),
         ("string", "GMPLibraryPath", "gmp_library_path"),
         ("string", "GraphicsCriticalError", "graphics_critical_error"),
         ("int", "InstallTime", "install_time"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -109,6 +109,7 @@ class CopyFromRawCrashRule(Rule):
         ("int", "StartupTime", "startup_time"),
         ("boolean", "SubmittedFromInfobar", "submitted_from_infobar"),
         ("int", "SystemMemoryUsePercentage", "system_memory_use_percentage"),
+        ("boolean", "Throttleable", "throttleable"),
         ("int", "TotalPageFile", "total_page_file"),
         ("int", "TotalPhysicalMemory", "total_physical_memory"),
         ("int", "TotalVirtualMemory", "total_virtual_memory"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -107,6 +107,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "ShutdownProgress", "shutdown_progress"),
         ("boolean", "StartupCrash", "startup_crash"),
         ("int", "StartupTime", "startup_time"),
+        ("boolean", "SubmittedFromInfobar", "submitted_from_infobar"),
         ("int", "SystemMemoryUsePercentage", "system_memory_use_percentage"),
         ("int", "TotalPageFile", "total_page_file"),
         ("int", "TotalPhysicalMemory", "total_physical_memory"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -83,6 +83,7 @@ class CopyFromRawCrashRule(Rule):
         ("string", "BIOS_Manufacturer", "bios_manufacturer"),
         ("string", "CoMarshalInterfaceFailure", "co_marshal_interface_failure"),
         ("int", "ContentSandboxCapabilities", "content_sandbox_capabilities"),
+        ("boolean", "ContentSandboxCapable", "content_sandbox_capable"),
         ("int", "ContentSandboxLevel", "content_sandbox_level"),
         ("string", "CPUMicrocodeVersion", "cpu_microcode_version"),
         ("string", "GMPLibraryPath", "gmp_library_path"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -90,6 +90,7 @@ class CopyFromRawCrashRule(Rule):
         ("boolean", "EMCheckCompatibility", "em_check_compatibility"),
         ("string", "GMPLibraryPath", "gmp_library_path"),
         ("string", "GraphicsCriticalError", "graphics_critical_error"),
+        ("boolean", "HasDeviceTouchScreen", "has_device_touch_screen"),
         ("int", "InstallTime", "install_time"),
         ("string", "ipc_channel_error", "ipc_channel_error"),
         ("string", "IPCFatalErrorMsg", "ipc_fatal_error_msg"),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -41,7 +41,7 @@ class CopyFromRawCrashRule(Rule):
     FIELDS = [
         # type, crash annotation name, processed crash key
         # windows error reporting flag
-        ("flag", "WindowsErrorReporting", "windows_error_reporting"),
+        ("boolean", "WindowsErrorReporting", "windows_error_reporting"),
         # Mac memory pressure annotations
         ("int", "MacMemoryPressureSysctl", "mac_memory_pressure_sysctl"),
         ("int", "MacAvailableMemorySysctl", "mac_available_memory_sysctl"),
@@ -115,13 +115,16 @@ class CopyFromRawCrashRule(Rule):
         for value_type, raw_key, processed_key in self.FIELDS:
             if raw_key not in raw_crash:
                 continue
-            if value_type == "flag":
-                flag_value = raw_crash[raw_key]
-                if flag_value == "1":
-                    processed_crash[processed_key] = "1"
+
+            if value_type == "boolean":
+                value = str(raw_crash[raw_key]).lower()
+                if value in ("1", "true"):
+                    processed_crash[processed_key] = True
+                elif value in ("0", "false"):
+                    processed_crash[processed_key] = False
                 else:
                     processor_meta["processor_notes"].append(
-                        f"{raw_key} has non-1 value"
+                        f"{raw_key} has non-boolean value {raw_crash[raw_key]}"
                     )
 
             elif value_type == "int":

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -99,6 +99,7 @@ class CopyFromRawCrashRule(Rule):
         ("int", "IPCMessageSize", "ipc_message_size"),
         ("string", "IPCShutdownState", "ipc_shutdown_state"),
         ("int", "IPCSystemError", "ipc_system_error"),
+        ("boolean", "IsGarbageCollecting", "is_garbage_collecting"),
         ("string", "MemoryErrorCorrection", "memory_error_correction"),
         ("int", "OOMAllocationSize", "oom_allocation_size"),
         ("string", "RemoteType", "remote_type"),

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -359,6 +359,18 @@ def test_validate_super_search_fields(name, properties):
     # If is_exposed and is_returned are both False, then we should remove this field
     assert properties["is_exposed"] or properties["is_returned"]
 
+    # Make sure the source_key is processed_crash + name
+    if properties.get("source_key"):
+        assert properties["source_key"] == f"processed_crash.{properties['name']}"
+
+    if properties.get("destination_keys"):
+        for key in properties["destination_keys"]:
+            possible_keys = [
+                f"raw_crash.{properties['in_database_name']}",
+                f"processed_crash.{properties['name']}",
+            ]
+            assert key in possible_keys
+
 
 @pytest.mark.parametrize(
     "value, expected",

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -217,7 +217,7 @@
                     </td>
                   </tr>
                 {% endif %}
-                {% if report.windows_error_reporting == "1" %}
+                {% if report.windows_error_reporting in ("1", True) %}
                   <tr title="{{ fields_desc['processed_crash.windows_error_reporting'] }}">
                     <th scope="row">Windows Error Reporting</th>
                     <td>


### PR DESCRIPTION
* redo how we handle flag/boolean fields in the processor and Elasticsearch crashstorage
* fix throttleable
* fix submitted_from_infobar
* fix safe_mode
* fix is_garbage_collecting
* fix has_device_touch_screen
* fix em_check_compatibility
* fix content_sandbox_enabled
* fix content_sandbox_capable
* fix addons_checked to be bool
* fix accessibility

This also fixes startup_crash, but leaves it as "null_value is False" which differs from the rest of them. This is used in the signature reports and I didn't want to spend the time to figure out what effects changing that would have now.