### PR TITLE
bug 1755528: fix flag/boolean fields that are shorts

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -194,32 +194,32 @@ def build_mapping(doctype, fields=None):
     return mapping
 
 
-def is_doc_values_friendly(field_value):
-    """Predicate denoting whether this field should have doc_values added
+def is_doc_values_friendly(storage_value):
+    """Predicate denoting whether this storage should have doc_values added
 
-    ``doc_values=True`` is a thing we can add to certain fields to reduce the
+    ``doc_values=True`` is a thing we can add to certain storages to reduce the
     memory they use in Elasticsearch.
 
     This predicate determines whether we should add it or not for a given
-    field.
+    storage.
 
-    :arg field_value: a field value from super search fields
+    :arg storage_value: a storage value from super search storages
 
     :returns: True if ``doc_values=True` should be added; False otherwise
 
     """
-    field_type = field_value.get("type")
+    storage_type = storage_value.get("type")
 
     # No clue what type this is--probably false
-    if not field_type:
+    if not storage_type:
         return False
 
-    # object, and multi_fields fields don't work with doc_values=True
-    if field_type in ("object", "multi_field"):
+    # object, and multi_field storages don't work with doc_values=True
+    if storage_type in ("object", "multi_field"):
         return False
 
-    # analyzed string fields don't work with doc_values=True
-    if field_type == "string" and field_value.get("index") != "not_analyzed":
+    # analyzed string storages don't work with doc_values=True
+    if storage_type == "string" and storage_value.get("index") != "not_analyzed":
         return False
 
     # Everything is fine! Yay!

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1434,6 +1434,7 @@ FIELDS = {
             "type": "string",
         },
     },
+    # DEPRECATED -- remove in 8/2022
     "contains_memory_report": {
         "data_validation_type": "str",
         "description": "Has content for processed_crash.memory_report or not.",
@@ -1447,6 +1448,31 @@ FIELDS = {
         "permissions_needed": [],
         "query_type": "flag",
         "storage_mapping": {"type": "short"},
+    },
+    # NOTE(willkg): This populates the new location in processed_crash with data with
+    # the right type. In 8/2022, we can:
+    #
+    # 1. remove contains_memory_report (deprecated)
+    # 2. rename this one to contains_memory_report
+    # 3. change is_exposed and is_returned to True
+    # 4. change the namespace and in_database_name and remove source/destination keys
+    "contains_memory_report_future": {
+        "data_validation_type": "bool",
+        "description": "Has content for processed_crash.memory_report or not.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "ContainsMemoryReport",
+        "is_exposed": False,
+        "is_returned": True,
+        "name": "contains_memory_report_future",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "source_key": "processed_crash.contains_memory_report",
+        "destination_keys": [
+            "processed_crash.contains_memory_report",
+        ],
+        "query_type": "bool",
+        "storage_mapping": {"type": "boolean"},
     },
     # FIXME(willkg): We have this indexed as an integer, but the annotation is listed as
     # a string. The actual value is an int converted to a string so in indexing we
@@ -1631,6 +1657,7 @@ FIELDS = {
         ),
         is_protected=False,
     ),
+    # DEPRECATED -- remove in 8/2022
     "dom_fission_enabled": {
         "data_validation_type": "str",
         "description": (
@@ -1648,6 +1675,35 @@ FIELDS = {
         "query_type": "flag",
         "storage_mapping": {"None_value": 0, "type": "short"},
     },
+    # NOTE(willkg): This populates the new location in processed_crash with data with
+    # the right type. In 8/2022, we can:
+    #
+    # 1. remove dom_fission_enabled (deprecated)
+    # 2. rename this one to dom_fission_enabled
+    # 3. change is_exposed and is_returned to True
+    # 4. change the namespace and in_database_name and remove source/destination keys
+    "dom_fission_enabled_future": {
+        "data_validation_type": "bool",
+        "description": (
+            "Set to 1 when DOM fission is enabled, and subframes are potentially "
+            "loaded in a separate process."
+        ),
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "DOMFissionEnabled",
+        "is_exposed": False,
+        "is_returned": True,
+        "name": "dom_fission_enabled_future",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "source_key": "processed_crash.dom_fission_enabled",
+        "destination_keys": [
+            "processed_crash.dom_fission_enabled",
+        ],
+        "query_type": "bool",
+        "storage_mapping": {"type": "boolean"},
+    },
+    # DEPRECATED -- remove in 8/2022
     "dom_ipc_enabled": {
         "data_validation_type": "str",
         "description": "Set to 1 when a tab is running in a content process.",
@@ -1661,6 +1717,31 @@ FIELDS = {
         "permissions_needed": [],
         "query_type": "flag",
         "storage_mapping": {"None_value": 0, "type": "short"},
+    },
+    # NOTE(willkg): This populates the new location in processed_crash with data with
+    # the right type. In 8/2022, we can:
+    #
+    # 1. remove dom_ipc_enabled (deprecated)
+    # 2. rename this one to dom_ipc_enabled
+    # 3. change is_exposed and is_returned to True
+    # 4. change the namespace and in_database_name and remove source/destination keys
+    "dom_ipc_enabled_future": {
+        "data_validation_type": "bool",
+        "description": "Set to 1 when a tab is running in a content process.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "DOMIPCEnabled",
+        "is_exposed": False,
+        "is_returned": True,
+        "name": "dom_ipc_enabled_future",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "source_key": "processed_crash.dom_ipc_enabled",
+        "destination_keys": [
+            "processed_crash.dom_ipc_enabled",
+        ],
+        "query_type": "bool",
+        "storage_mapping": {"type": "boolean"},
     },
     "dumper_error": {
         "data_validation_type": "str",
@@ -1761,6 +1842,7 @@ FIELDS = {
         "query_type": "string",
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
+    # DEPRECATED -- remove in 8/2022
     "gmp_plugin": {
         "data_validation_type": "str",
         "description": "Whether it is a GMP plugin crash.",
@@ -1774,6 +1856,31 @@ FIELDS = {
         "permissions_needed": [],
         "query_type": "flag",
         "storage_mapping": {"type": "short"},
+    },
+    # NOTE(willkg): This populates the new location in processed_crash with data with
+    # the right type. In 8/2022, we can:
+    #
+    # 1. remove contains_memory_report (deprecated)
+    # 2. rename this one to contains_memory_report
+    # 3. change is_exposed and is_returned to True
+    # 4. change the namespace and in_database_name and remove source/destination keys
+    "gmp_plugin_future": {
+        "data_validation_type": "bool",
+        "description": "Whether it is a GMP plugin crash.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "GMPPlugin",
+        "is_exposed": False,
+        "is_returned": True,
+        "name": "gmp_plugin_future",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "source_key": "processed_crash.gmp_plugin",
+        "destination_keys": [
+            "processed_crash.gmp_plugin",
+        ],
+        "query_type": "bool",
+        "storage_mapping": {"type": "boolean"},
     },
     "graphics_critical_error": {
         "data_validation_type": "str",
@@ -1798,6 +1905,7 @@ FIELDS = {
             "type": "string",
         },
     },
+    # DEPRECATED -- remove in 8/2022
     "graphics_startup_test": {
         "data_validation_type": "str",
         "description": "Whether the crash occured in the DriverCrashGuard.",
@@ -1811,6 +1919,31 @@ FIELDS = {
         "permissions_needed": [],
         "query_type": "flag",
         "storage_mapping": {"type": "short"},
+    },
+    # NOTE(willkg): This populates the new location in processed_crash with data with
+    # the right type. In 8/2022, we can:
+    #
+    # 1. remove graphics_startup_test (deprecated)
+    # 2. rename this one to graphics_startup_test
+    # 3. change is_exposed and is_returned to True
+    # 4. change the namespace and in_database_name and remove source/destination keys
+    "graphics_startup_test_future": {
+        "data_validation_type": "bool",
+        "description": "Whether the crash occured in the DriverCrashGuard.",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "GraphicsStartupTest",
+        "is_exposed": False,
+        "is_returned": True,
+        "name": "graphics_startup_test_future",
+        "namespace": "raw_crash",
+        "permissions_needed": [],
+        "source_key": "processed_crash.graphics_startup_test",
+        "destination_keys": [
+            "processed_crash.graphics_startup_test",
+        ],
+        "query_type": "bool",
+        "storage_mapping": {"type": "boolean"},
     },
     "hang_type": {
         "data_validation_type": "enum",

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -82,6 +82,7 @@ class CopyFromRawCrashRule(Rule):
         ("int", "AvailableVirtualMemory", "available_virtual_memory"),
         ("string", "BIOS_Manufacturer", "bios_manufacturer"),
         ("string", "CoMarshalInterfaceFailure", "co_marshal_interface_failure"),
+        ("boolean", "ContainsMemoryReport", "contains_memory_report"),
         ("int", "ContentSandboxCapabilities", "content_sandbox_capabilities"),
         ("boolean", "ContentSandboxCapable", "content_sandbox_capable"),
         ("boolean", "ContentSandboxEnabled", "content_sandbox_enabled"),

--- a/socorro/scripts/es.py
+++ b/socorro/scripts/es.py
@@ -144,7 +144,7 @@ def cmd_delete(ctx, index):
     """Delete indices."""
     conn = get_conn()
     if index:
-        indices_to_delete = index
+        indices_to_delete = [index]
     else:
         indices_to_delete = conn.get_indices()
 

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -398,11 +398,11 @@ def test_is_doc_values_friendly(value, expected):
 
 
 def test_add_doc_values():
-    data = {"type": "short"}
-    add_doc_values(data)
-    assert data == {"type": "short", "doc_values": True}
+    storage_mapping = {"type": "short"}
+    add_doc_values(storage_mapping)
+    assert storage_mapping == {"type": "short", "doc_values": True}
 
-    data = {
+    storage_mapping = {
         "fields": {
             "AsyncShutdownTimeout": {
                 "analyzer": "standard",
@@ -413,8 +413,8 @@ def test_add_doc_values():
         },
         "type": "multi_field",
     }
-    add_doc_values(data)
-    assert data == {
+    add_doc_values(storage_mapping)
+    assert storage_mapping == {
         "fields": {
             "AsyncShutdownTimeout": {
                 "analyzer": "standard",


### PR DESCRIPTION
There are 5 flag/boolean fields that are being indexed as shorts:

* contains_memory_report
* dom_fission_enabled
* dom_ipc_enabled
* gmp_plugin
* graphics_startup_test

I tested out whether search would work across indexes where these fields were shorts in one index and booleans in another and that doesn't work. It doesn't kick up errors, but it doesn't match values correctly.

We're going to need to migrate from one type to another. This starts accumulating the data in temporary fields. In August 2022, we can delete the old fields and switch to the new fields permanently.

This also fixes `socorro-cmd es delete` which didn't work right.