### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/socorro/lib/cache.py
+++ b/socorro/lib/cache.py
@@ -6,7 +6,8 @@
 In-memory caching utilities.
 """
 
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping
 import datetime
 import threading
 

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import collections
+import collections.abc
 from functools import wraps
 import time
 
@@ -18,13 +18,13 @@ def dotdict_to_dict(sdotdict):
     """
 
     def _dictify(thing):
-        if isinstance(thing, collections.Mapping):
+        if isinstance(thing, collections.abc.Mapping):
             return {key: _dictify(val) for key, val in thing.items()}
         elif isinstance(thing, str):
             # NOTE(willkg): Need to do this because strings are sequences but
             # we don't want to convert them into lists in the next clause
             return thing
-        elif isinstance(thing, collections.Sequence):
+        elif isinstance(thing, collections.abc.Sequence):
             return [_dictify(item) for item in thing]
         return thing
 

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from collections import Mapping
+from collections.abc import Mapping
 from contextlib import contextmanager
 import json
 import logging


### PR DESCRIPTION
Importing ABC from `collections` was deprecated since Python 3.4 and removed in Python 3.10 . Use `collections.abc` instead.