### PR TITLE
bug 1762000: remove vestigial Winsock_LSP code

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -3503,27 +3503,6 @@ FIELDS = {
         ),
         is_protected=False,
     ),
-    "winsock_lsp": {
-        "data_validation_type": "str",
-        "description": (
-            "On Windows, a string of data from the Windows OS about the list of installed LSPs "
-            "(Layered Service Provider)."
-        ),
-        "form_field_choices": [],
-        "has_full_version": True,
-        "in_database_name": "Winsock_LSP",
-        "is_exposed": True,
-        "is_returned": True,
-        "name": "winsock_lsp",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "query_type": "string",
-        "storage_mapping": {
-            "fields": {"full": {"index": "not_analyzed", "type": "string"}},
-            "index": "analyzed",
-            "type": "string",
-        },
-    },
     "xpcom_spin_event_loop_stack": keyword_field(
         name="xpcom_spin_event_loop_stack",
         description=(

--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -1089,7 +1089,7 @@
         "string",
         "null"
       ],
-      "description": "On Windows, a string of data from the Windows OS about the list of installed LSPs (Layered Service Provider)."
+      "description": "DEPRECATED EMPTY FIELD. See bug #1762000."
     }
   }
 }

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -43,27 +43,6 @@ canonical_standard_raw_crash = {
         "Layers- D3D9 Layers? D3D9 Layers- "
     ),
     "CrashTime": "1336519554",
-    "Winsock_LSP": (
-        "MSAFD Tcpip [TCP/IPv6] : 2 : 1 :  \n "
-        "MSAFD Tcpip [UDP/IPv6] : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [RAW/IPv6] : 2 : 3 :  \n "
-        "MSAFD Tcpip [TCP/IP] : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [UDP/IP] : 2 : 2 :  \n "
-        "MSAFD Tcpip [RAW/IP] : 2 : 3 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCPv6 : 2 : 1 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCP : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDPv6 : 2 : 2 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDP : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll"
-    ),
     "AvailablePhysicalMemory": "2227773440",
     "StartupTime": "1336499438",
     "Add-ons": (

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -42,27 +42,6 @@ canonical_standard_raw_crash = {
         "Layers- D3D9 Layers? D3D9 Layers- "
     ),
     "CrashTime": "1336519554",
-    "Winsock_LSP": (
-        "MSAFD Tcpip [TCP/IPv6] : 2 : 1 :  \n "
-        "MSAFD Tcpip [UDP/IPv6] : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [RAW/IPv6] : 2 : 3 :  \n "
-        "MSAFD Tcpip [TCP/IP] : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [UDP/IP] : 2 : 2 :  \n "
-        "MSAFD Tcpip [RAW/IP] : 2 : 3 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCPv6 : 2 : 1 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCP : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDPv6 : 2 : 2 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDP : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll"
-    ),
     "AvailablePhysicalMemory": "2227773440",
     "StartupTime": "1336499438",
     "Add-ons": (

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -76,27 +76,6 @@ canonical_standard_raw_crash = {
         "Layers- D3D9 Layers? D3D9 Layers- "
     ),
     "CrashTime": "1336519554",
-    "Winsock_LSP": (
-        "MSAFD Tcpip [TCP/IPv6] : 2 : 1 :  \n "
-        "MSAFD Tcpip [UDP/IPv6] : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [RAW/IPv6] : 2 : 3 :  \n "
-        "MSAFD Tcpip [TCP/IP] : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "MSAFD Tcpip [UDP/IP] : 2 : 2 :  \n "
-        "MSAFD Tcpip [RAW/IP] : 2 : 3 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCPv6 : 2 : 1 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP TCP : 2 : 1 : "
-        "%SystemRoot%\\system32\\mswsock.dll \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDPv6 : 2 : 2 :  \n "
-        "\u041f\u043e\u0441\u0442\u0430\u0432\u0449\u0438\u043a "
-        "\u0443\u0441\u043b\u0443\u0433 RSVP UDP : 2 : 2 : "
-        "%SystemRoot%\\system32\\mswsock.dll"
-    ),
     "AvailablePhysicalMemory": "2227773440",
     "StartupTime": "1336499438",
     "Add-ons": (

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -687,7 +687,6 @@ class ProcessedCrash(SocorroMiddleware):
         "uuid",
         "version",
         "windows_error_reporting",
-        "Winsock_LSP",
     )
 
     # Same as for RawCrash, we supplement with the existing list, on top


### PR DESCRIPTION
In 2019, we removed the processor rule that copied Winsock_LSP from the
raw crash to the processed crash. However, we didn't delete the
super search field entry. This removes that.

This removes this field from the tests--it's not doing anything.

This changes the description in the telemetry_socorro_crash.json schema
to note that this field is empty and deprecated.

This removes the field from the allow list for the processed crash API
since the field isn't in the processed crash.