### PR TITLE
bug 1762271: rewrite json schema reducer

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,6 @@ gunicorn==20.1.0
 humanfriendly==10.0
 isodate==0.6.1
 isoweek==1.3.3
-json-schema-reducer==0.1.4
 jsonschema==4.3.3
 lxml==4.7.1
 markus[datadog]==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -292,10 +292,6 @@ josepy==1.11.0 \
     --hash=sha256:40ef59f2f537ec01bafe698dad66281f6ccf4642f747411647db403ab8fa9a2d \
     --hash=sha256:8473f6674497383627621b40aacb4955afdd4e7b205dca45a68486aa989bab60
     # via mozilla-django-oidc
-json-schema-reducer==0.1.4 \
-    --hash=sha256:41c674275c2650dadb7f8af1193640ca41eb863926985ecda5bfee93aef265c0 \
-    --hash=sha256:b6fbe437361e0ec14f5c05daf752604834bd9abe5af9ab6bdcb05ea1f8df1df6
-    # via -r requirements.in
 jsonschema==4.3.3 \
     --hash=sha256:eb7a69801beb7325653aa8fd373abbf9ff8f85b536ab2812e5e8287b522fb6a2 \
     --hash=sha256:f210d4ce095ed1e8af635d15c8ee79b586f656ab54399ba87b8ab87e5bff0ade

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -9,7 +9,6 @@ import logging
 from configman import Namespace
 from configman.converters import class_converter
 from configman.dotdict import DotDict
-import json_schema_reducer
 
 from socorro.external.crashstorage_base import (
     CrashStorageBase,
@@ -17,6 +16,7 @@ from socorro.external.crashstorage_base import (
     MemoryDumpsMapping,
 )
 from socorro.external.es.super_search_fields import SuperSearchFieldsData
+from socorro.lib.libjson import schema_reduce
 from socorro.lib.ooid import date_from_ooid
 from socorro.lib.util import dotdict_to_dict
 from socorro.schemas import TELEMETRY_SOCORRO_CRASH_SCHEMA
@@ -328,8 +328,9 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
             crash_report[processed_fields_map.get(key, key)] = val
 
         # Validate crash_report
-        crash_report = json_schema_reducer.make_reduced_dict(
-            TELEMETRY_SOCORRO_CRASH_SCHEMA, crash_report
+        crash_report = schema_reduce(
+            schema=TELEMETRY_SOCORRO_CRASH_SCHEMA,
+            document=crash_report,
         )
 
         crash_id = crash_report["uuid"]

--- a/socorro/lib/libjson.py
+++ b/socorro/lib/libjson.py
@@ -1,0 +1,241 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Utilities for working with JSON schemas and JSON.
+"""
+
+
+class InvalidDocumentError(Exception):
+    """Raised when the document is invalid"""
+
+
+class InvalidSchemaError(Exception):
+    """Raised when the schema is invalid"""
+
+
+class UnknownConvertFormat(Exception):
+    """Raised when the schema specifies an unknown convert format"""
+
+
+def listify(item):
+    if isinstance(item, (tuple, list)):
+        return item
+
+    return [item]
+
+
+BASIC_TYPES = {
+    type(None): "null",
+    bool: "boolean",
+    str: "string",
+    int: ("integer", "number"),
+    float: "number",
+}
+BASIC_TYPES_KEYS = tuple(BASIC_TYPES.keys())
+
+
+def lookup_definition(schema, ref):
+    """Looks up a JSON pointer in the definitions.
+
+    .. Note::
+
+       This only supports definitions in the current document and doesn't
+       support URIs.
+
+    :arg dict schema: the full schema
+    :arg string ref: a ref like "#/definition/frames"
+
+    :returns: schema
+
+    """
+    ref_parts = ref.split("/")
+    if not ref_parts or ref_parts[0] != "#":
+        raise InvalidSchemaError("invalid: $ref must be in this document {ref!r}")
+
+    # Ignore first item which should be "#"
+    for part in ref_parts[1:]:
+        schema = schema.get(part, {})
+    return schema
+
+
+def expand_references(schema, schema_item):
+    """Expands $ref items
+
+    :arg dict schema: the schema
+    :arg dict schema_item: the sub-schema we're expanding a reference in
+
+    :returns: the new schema item with reference expanded
+
+    """
+    # FIXME(willkg): expanding references doesn't handle cycles, but we could handle
+    # that if we switched from recursion to iterative and maintaining context
+    if "$ref" in schema_item:
+        return lookup_definition(schema, schema_item["$ref"])
+    return schema_item
+
+
+def everything_predicate(schema_item):
+    """include_predicate that includes everything in the document"""
+    return True
+
+
+def convert_to(document_part, target_format):
+    """Conversion for handling historical schema goofs"""
+    # We never convert nulls
+    if document_part is None:
+        return document_part
+
+    if target_format == "string":
+        # Boolean gets convert to "0" or "1"
+        if document_part is True:
+            return "1"
+        elif document_part is False:
+            return "0"
+        return str(document_part)
+
+    raise UnknownConvertFormat(f"{target_format!r} is an unknown format")
+
+
+class Reducer:
+    def __init__(self, schema, include_predicate=everything_predicate):
+        self.schema = schema
+        self.include_predicate = include_predicate
+
+    def traverse(self, schema_part, document_part, path=""):
+        """Following the schema, traverses the document
+
+        This validates types and some type-related restrictions while reducing the
+        document to the schema.
+
+        :arg dict schema_part: the part of the schema we're looking at now
+        :arg dict document_part: the part of the document we're looking at now
+        :arg string path: the path in the structure for error reporting
+
+        :returns: new document
+
+        """
+        # Telemetry ingestion is marred by historical fun-ness, so we first look at the
+        # schema and if it defines a converter, we run the document part through that
+        # first.
+        if "socorro_convert_to" in schema_part:
+            document_part = convert_to(document_part, schema_part["socorro_convert_to"])
+
+        schema_part_types = listify(schema_part.get("type", "string"))
+
+        # FIXME(willkg): implement:
+        #
+        # * string: minLength, maxLength, pattern
+        # * integer/number: minimum, maximum, exclusiveMaximum, exclusiveMinimum, multipleOf
+        # * array: maxItems, minItems, uniqueItems
+        # * object: additionalProperties, minProperties, maxProperties, dependencies,
+        #   patternProperties, regexp
+        if isinstance(document_part, BASIC_TYPES_KEYS):
+            valid_schema_part_types = listify(BASIC_TYPES[type(document_part)])
+            for type_ in valid_schema_part_types:
+                if type_ in schema_part_types:
+                    return document_part
+
+            raise InvalidDocumentError(
+                f"invalid: {path}: type not in {schema_part_types}"
+            )
+
+        if isinstance(document_part, list):
+            if "array" not in schema_part_types:
+                raise InvalidDocumentError(
+                    f"invalid: {path}: type not in {schema_part_types}"
+                )
+
+            schema_items = schema_part.get("items", {"type": "string"})
+            if isinstance(schema_items, list):
+                # If schema_items is a list, then it's denoting a record like thing and the
+                # document must match the schema items in the list (or fewer)
+                schema_items = [
+                    expand_references(self.schema, schema_item)
+                    for schema_item in schema_items
+                ]
+                new_doc = []
+                if len(document_part) > len(schema_items):
+                    raise InvalidDocumentError(f"invalid: {path}: too many items")
+
+                for i in range(0, len(document_part)):
+                    new_part = self.traverse(
+                        schema_part=schema_items[i],
+                        document_part=document_part[i],
+                        path=f"{path}.{i}",
+                    )
+                    new_doc.append(new_part)
+                return new_doc
+
+            # If schema_items is not a list, then each document_part must match this
+            # schema
+            schema_item = expand_references(self.schema, schema_items)
+
+            new_doc = []
+            for i in range(0, len(document_part)):
+                new_part = self.traverse(
+                    schema_part=schema_item,
+                    document_part=document_part[i],
+                    path=f"{path}.{i}",
+                )
+                new_doc.append(new_part)
+            return new_doc
+
+        if isinstance(document_part, dict):
+            if "object" not in schema_part_types:
+                raise InvalidDocumentError(
+                    f"invalid: {path}: type not in {schema_part_types}"
+                )
+
+            properties = schema_part.get("properties", {})
+            new_doc = {}
+            for name, schema_property in properties.items():
+                required_properties = schema_part.get("required", [])
+
+                if not self.include_predicate(schema_property):
+                    continue
+
+                schema_property = expand_references(self.schema, schema_property)
+
+                if name in document_part:
+                    new_doc[name] = self.traverse(
+                        schema_part=schema_property,
+                        document_part=document_part[name],
+                        path=f"{path}.{name}",
+                    )
+                elif name in required_properties:
+                    raise InvalidDocumentError(
+                        f"invalid: {path}.{name}: required, but missing"
+                    )
+
+            return new_doc
+
+
+def schema_reduce(schema, document, include_predicate=everything_predicate):
+    """Reduce a given document to a structure specified in the schema
+
+    There's some overlap between reducing and validating the document. This does type
+    validation, but doesn't do other kinds of validation like minItems/maxItems,
+    additionalProperties, etc.
+
+    .. Note::
+
+       This does not validate that the schema is valid JSON schema. It's assumed
+       that's the case.
+
+    :arg dict schema: a JSON schema as a Python dict structure
+    :arg dict document: a Python dict structure
+    :arg function include_predicate: a function that takes a schema part
+        and returns whether to include the document part
+
+    :returns: a reduced Python dict structure and list of errors
+
+    :raises InvalidDocumentError: raised for anything in the document that doesn't
+        validate with the schema: type mismatches, JSON schema requirements fails, etc
+
+    :raises InvalidSchemaError: raised for issues with the schema
+
+    """
+    reducer = Reducer(schema, include_predicate)
+    return reducer.traverse(schema_part=schema, document_part=document)

--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -213,14 +213,16 @@
         "string",
         "null"
       ],
-      "description": "The amount of unreserved and uncommited (i.e. available) memory in the process's address space. Note that this memory may be fragmented into many separate segments, so an allocation attempt may fail even when this value is substantially greater than zero."
+      "description": "The amount of unreserved and uncommited (i.e. available) memory in the process's address space. Note that this memory may be fragmented into many separate segments, so an allocation attempt may fail even when this value is substantially greater than zero.\n\nNote: this is converted from an integer to a string for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "available_physical_memory": {
       "type": [
         "string",
         "null"
       ],
-      "description": "The amount of physical memory currently available. This is the amount of physical memory that can be immediately reused without having to write its contents to disk first."
+      "description": "The amount of physical memory currently available. This is the amount of physical memory that can be immediately reused without having to write its contents to disk first.\n\nNote: this is converted from an integer to a string for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "bios_manufacturer": {
       "type": [
@@ -318,7 +320,8 @@
         "string",
         "null"
       ],
-      "description": "Has content for processed_crash.memory_report or not."
+      "description": "Has content for processed_crash.memory_report or not.\n\nNote: this is converted from a boolean to '0' or '1' for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "cpu_arch": {
       "type": [
@@ -589,7 +592,7 @@
                 "description": "URL of the symbols for that module."
               },
               "version": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Version of the module."
               }
             }
@@ -893,7 +896,8 @@
         "string",
         "null"
       ],
-      "description": "The size of the allocation that caused the OOM crash."
+      "description": "The size of the allocation that caused the OOM crash.\n\nNote: this is converted from an integer to a string for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "platform": {
       "type": [
@@ -991,7 +995,8 @@
         "string",
         "null"
       ],
-      "description": "Whether Firefox was running in Safe Mode."
+      "description": "Whether Firefox was running in Safe Mode.\n\nNote: this is converted from a boolean to '0' or '1' for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "signature": {
       "type": [
@@ -1012,14 +1017,16 @@
         "string",
         "null"
       ],
-      "description": "Annotation that tells whether the crash happened before the startup phase was finished or not."
+      "description": "Annotation that tells whether the crash happened before the startup phase was finished or not.\n\nNote: this is converted from a boolean to '0' or '1' for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "submitted_from_infobar": {
       "type": [
         "string",
         "null"
       ],
-      "description": "Whether the crash report was submitted through the infobar."
+      "description": "Whether the crash report was submitted through the infobar.\n\nNote: this is converted from a boolean to '0' or '1' for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "theme": {
       "type": [
@@ -1040,14 +1047,16 @@
         "string",
         "null"
       ],
-      "description": "The total amount of physical memory."
+      "description": "The total amount of physical memory.\n\nNote: this is converted from an integer to a string for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "total_virtual_memory": {
       "type": [
         "string",
         "null"
       ],
-      "description": "The size of the user-mode portion of the virtual address space of the calling process. This value depends on the type of process, the type of processor, and the configuration of the operating system. 32-bit processes usually have values in the range 2--4 GiB. 64-bit processes usually have *much* larger values."
+      "description": "The size of the user-mode portion of the virtual address space of the calling process. This value depends on the type of process, the type of processor, and the configuration of the operating system. 32-bit processes usually have values in the range 2--4 GiB. 64-bit processes usually have *much* larger values.\n\nNote: this is converted from an integer to a string for historical reasons.",
+      "socorro_convert_to": "string"
     },
     "uptime": {
       "type": [

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -358,6 +358,23 @@ class TestTelemetryBotoS3CrashStorage:
                 "completed_datetime": "2012-04-08 10:56:50.902884",
                 "signature": "now_this_is_a_signature",
                 "os_name": "Linux",
+                "some_random_key": "should not appear",
+                "json_dump": {
+                    "crash_info": {
+                        "address": "0x6357737b",
+                        "some_random_key": "should not appear",
+                    },
+                    "crashing_thread": {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "xul.dll",
+                                "function": None,
+                                "some_random_key": "should not appear",
+                            },
+                        ],
+                    },
+                },
             },
         )
 
@@ -371,6 +388,20 @@ class TestTelemetryBotoS3CrashStorage:
             "platform": "Linux",
             "signature": "now_this_is_a_signature",
             "uuid": "0bba929f-8721-460c-dead-a43c20071027",
+            "json_dump": {
+                "crash_info": {
+                    "address": "0x6357737b",
+                },
+                "crashing_thread": {
+                    "frames": [
+                        {
+                            "frame": 0,
+                            "function": None,
+                            "module": "xul.dll",
+                        },
+                    ],
+                },
+            },
         }
 
     def test_get_unredacted_processed(self, boto_helper):

--- a/socorro/unittest/lib/test_libjson.py
+++ b/socorro/unittest/lib/test_libjson.py
@@ -1,0 +1,417 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import jsonschema
+import pytest
+
+from socorro.lib.libjson import schema_reduce, InvalidDocumentError, InvalidSchemaError
+
+
+class Test_schema_reduce:
+    def test_multiple_types_and_null(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "years": {"type": ["integer", "null"]},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"years": 10}
+        assert schema_reduce(schema, document) == document
+
+        document = {"years": None}
+        assert schema_reduce(schema, document) == document
+
+        document = {}
+        assert schema_reduce(schema, document) == document
+
+    def test_integer(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "years": {"type": "integer"},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"years": 10}
+        assert schema_reduce(schema, document) == document
+
+    def test_bad_integer(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "years": {"type": "integer"},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"years": "10"}
+        msg_pattern = r"invalid: .years: type not in \['integer'\]"
+        with pytest.raises(InvalidDocumentError, match=msg_pattern):
+            assert schema_reduce(schema, document) == document
+
+    @pytest.mark.parametrize("number", [-10, 10, 10.5])
+    def test_number(self, number):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "length": {"type": "number"},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"length": number}
+        assert schema_reduce(schema, document) == document
+
+    def test_string(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"name": "Joe"}
+        assert schema_reduce(schema, document) == document
+
+    def test_object(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "favorites": {
+                            "type": "object",
+                            "properties": {
+                                "color": {"type": "string"},
+                                "ice_cream": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {
+            "person": {
+                "name": "Janet",
+                "favorites": {
+                    "color": "blue",
+                    "ice_cream": "chocolate",
+                    "hobby": "napping",
+                },
+            }
+        }
+        expected_document = {
+            "person": {
+                "name": "Janet",
+                "favorites": {
+                    "color": "blue",
+                    "ice_cream": "chocolate",
+                },
+            }
+        }
+        assert schema_reduce(schema, document) == expected_document
+
+    def test_array(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"numbers": [1, 5, 10]}
+        assert schema_reduce(schema, document) == document
+
+    def test_array_invalid(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"numbers": [5, "Janice", 10]}
+        msg_pattern = r"invalid: .numbers.1: type not in \['integer'\]"
+        with pytest.raises(InvalidDocumentError, match=msg_pattern):
+            assert schema_reduce(schema, document) == document
+
+    def test_array_reference(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "definitions": {
+                "some_number": {"type": "integer"},
+            },
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/some_number"},
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"numbers": [1, 5, 10]}
+        assert schema_reduce(schema, document) == document
+
+    def test_array_position_restriction(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "record": {
+                    "type": "array",
+                    "items": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"record": ["Janice", 5]}
+        assert schema_reduce(schema, document) == document
+
+    def test_array_position_restriction_with_reference(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "definitions": {
+                "some_number": {"type": "integer"},
+            },
+            "properties": {
+                "record": {
+                    "type": "array",
+                    "items": [
+                        {"type": "string"},
+                        {"$ref": "#/definitions/some_number"},
+                    ],
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"record": ["Janice", 5]}
+        assert schema_reduce(schema, document) == document
+
+    def test_array_position_restriction_too_many_items(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "record": {
+                    "type": "array",
+                    "items": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"record": ["Janice", 5, 5]}
+        msg_pattern = r"invalid: .record: too many items"
+        with pytest.raises(InvalidDocumentError, match=msg_pattern):
+            assert schema_reduce(schema, document) == document
+
+    def test_array_position_restriction_invalid(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "record": {
+                    "type": "array",
+                    "items": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"record": [5, "Janice"]}
+        msg_pattern = r"invalid: .record.0: type not in \['string'\]"
+        with pytest.raises(InvalidDocumentError, match=msg_pattern):
+            assert schema_reduce(schema, document) == document
+
+    def test_references(self):
+        """Verify references are traversed."""
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "definitions": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": ["string", "null"],
+                        }
+                    },
+                }
+            },
+            "properties": {
+                "company": {
+                    "type": "object",
+                    "properties": {
+                        "employees": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/person"},
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {
+            "company": {
+                "employees": [
+                    {"name": "Fred", "desk": "front"},
+                    {"name": "Jim", "favorite_color": "red"},
+                ],
+            }
+        }
+        expected_document = {
+            "company": {
+                "employees": [
+                    {"name": "Fred"},
+                    {"name": "Jim"},
+                ],
+            }
+        }
+        assert schema_reduce(schema, document) == expected_document
+
+    def test_invalid_ref(self):
+        """Reducer only support json pointers to things in the schema"""
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {"$ref": "http://example.com/schema"},
+                }
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {"numbers": [1, 5, 10]}
+        with pytest.raises(InvalidSchemaError):
+            assert schema_reduce(schema, document) == document
+
+    def test_include_predicate(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "socorro_permissions": ["public"],
+                        },
+                        "favorites": {
+                            "type": "object",
+                            "properties": {
+                                "color": {
+                                    "type": "string",
+                                    "socorro_permissions": ["public"],
+                                },
+                                # ice_cream is not marked public
+                                "ice_cream": {"type": "string"},
+                            },
+                            "socorro_permissions": ["public"],
+                        },
+                    },
+                    "socorro_permissions": ["public"],
+                },
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        document = {
+            "person": {
+                "name": "Jha",
+                "favorites": {
+                    "color": "blue",
+                    # ice_cream is not marked public, so it will be removed
+                    "ice_cream": "vanilla",
+                },
+            }
+        }
+        expected_document = {
+            "person": {
+                "name": "Jha",
+                "favorites": {
+                    "color": "blue",
+                },
+            },
+        }
+
+        def only_public(schema_item):
+            return "public" in schema_item.get("socorro_permissions", [])
+
+        reduced_document = schema_reduce(
+            schema, document, include_predicate=only_public
+        )
+        assert reduced_document == expected_document
+
+    def test_convert_to(self):
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$target_version": 2,
+            "type": "object",
+            "properties": {
+                "years": {"type": ["string", "null"], "socorro_convert_to": "string"},
+            },
+        }
+        jsonschema.Draft4Validator.check_schema(schema)
+
+        assert schema_reduce(schema, {"years": "10"}) == {"years": "10"}
+        assert schema_reduce(schema, {"years": 10}) == {"years": "10"}
+        assert schema_reduce(schema, {"years": None}) == {"years": None}


### PR DESCRIPTION
This drops json-schema-reducer library for one we wrote that's more
correct in how it traverses the schema, does some light type checking,
and allows for an include predicate which we'll use later for redacting
protected data from documents.

This is based on the json schema draft-04 spec which is what our schemas
use.

It doesn't implement some of the data restrictions specified in
draft-04 (for example minItems, maxItems, etc) because we're not
currently using them.