### PR TITLE
bug 1755095: fix validate_telemetry_socorro_crash.py

### DIFF
--- a/socorro/schemas/validate_telemetry_socorro_crash.py
+++ b/socorro/schemas/validate_telemetry_socorro_crash.py
@@ -130,9 +130,7 @@ def validate_and_test(ctx, crashes_per_url, url):
 
     click.echo("Testing %s random recent crash reports." % len(uuids))
     for uuid in uuids:
-        resp = requests.get(API_BASE.format("RawCrash"), params={"crash_id": uuid})
-        click.echo("resp.url %s" % resp.url)
-        raw_crash = resp.json()
+        raw_crash = {}
         resp = requests.get(
             API_BASE.format("ProcessedCrash"), params={"crash_id": uuid}
         )


### PR DESCRIPTION
Since TelemetryBotoS3CrashStorage builds the crash data only using the
processed crash, we can stop fetching the raw crash in the validation
script.