### PR TITLE
bug 1762207: remove hang_type

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1950,26 +1950,6 @@ FIELDS = {
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },
-    "hang_type": {
-        "data_validation_type": "enum",
-        "description": (
-            "Tells if a report was caused by a crash or a hang. In the database, the value "
-            "is `0` if the problem was a crash of the software, and `1` or `-1` if the problem "
-            "was a hang of the software. \n\nNote: for querying, you should use `crash` or "
-            "`hang`, since those are automatically transformed into the correct underlying "
-            "values."
-        ),
-        "form_field_choices": ["any", "crash", "hang", "all"],
-        "has_full_version": False,
-        "in_database_name": "hang_type",
-        "is_exposed": True,
-        "is_returned": True,
-        "name": "hang_type",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "query_type": "enum",
-        "storage_mapping": {"type": "short"},
-    },
     "has_device_touch_screen": {
         "data_validation_type": "bool",
         "description": (

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -222,7 +222,6 @@ class SearchBase:
                         parameters[value.name].append(value)
 
         self.fix_date_parameter(parameters)
-        self.fix_hang_type_parameter(parameters)
         self.fix_version_parameter(parameters)
 
         return parameters
@@ -288,29 +287,6 @@ class SearchBase:
 
             parameters["date"].append(lower_than)
             parameters["date"].append(greater_than)
-
-    @staticmethod
-    def fix_hang_type_parameter(parameters):
-        """Correct the hang_type parameter.
-
-        If hang_type is 'crash', replace it with '0', if it's 'hang' replace it
-        with '-1, 1'.
-        """
-        if not parameters.get("hang_type"):
-            return
-
-        for hang_type in parameters["hang_type"]:
-            new_values = []
-            for val in hang_type.value:
-                if val == "crash":
-                    new_values.append(0)
-                elif val == "hang":
-                    new_values.extend([-1, 1])
-                else:
-                    new_values.append(val)
-
-            hang_type.value = new_values
-            hang_type.data_type = "int"
 
     @staticmethod
     def fix_version_parameter(parameters):

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -255,29 +255,9 @@ class ProcessTypeRule(Rule):
 
 
 class PluginRule(Rule):
-    """Handle plugin-related things and hang_type."""
+    """Handle plugin-related fields."""
 
     def action(self, raw_crash, dumps, processed_crash, processor_meta):
-        processed_crash["hangid"] = raw_crash.get("HangID", None)
-
-        # the processed_crash["hang_type"] has the following meaning:
-        #
-        # * hang_type == -1 is a plugin hang
-        # * hang_type ==  1 is a parent hang
-        # * hang_type ==  0 is not a hang at all, but a normal crash
-
-        try:
-            hang_as_int = int(raw_crash.get("Hang", False))
-        except ValueError:
-            hang_as_int = 0
-
-        if hang_as_int:
-            processed_crash["hang_type"] = 1
-        elif processed_crash["hangid"]:
-            processed_crash["hang_type"] = -1
-        else:
-            processed_crash["hang_type"] = 0
-
         process_type = raw_crash.get("ProcessType", "parent")
         if process_type == "plugin":
             processed_crash["plugin_filename"] = raw_crash.get("PluginFilename", "")

--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -412,7 +412,7 @@
         "integer",
         "null"
       ],
-      "description": "Tells if a report was caused by a crash or a hang. In the database, the value is `0` if the problem was a crash of the software, and `1` or `-1` if the problem was a hang of the software. \n\nNote: for querying, you should use `crash` or `hang`, since those are automatically transformed into the correct underlying values."
+      "description": "DEPRECATED EMPTY FIELD. See bug #1762207."
     },
     "install_age": {
       "type": [

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -230,7 +230,7 @@ class CSignatureTool:
         # Return module/module_offset
         return "{}@{}".format(module or "", strip_leading_zeros(module_offset))
 
-    def generate(self, source_list, hang_type=0, crashed_thread=None, delimiter=" | "):
+    def generate(self, source_list, crashed_thread=None, delimiter=" | "):
         """Iterate over frames in the crash stack and generate a signature.
 
         First, we look for a sentinel frame and if we find one, we start with that.
@@ -295,15 +295,6 @@ class CSignatureTool:
                 break
 
             debug_notes.append(f'prefix; continue iterating: "{a_signature}"')
-
-        # Add a special marker for hang crash reports.
-        if hang_type:
-            debug_notes.append(
-                "hang_type {}: prepending {}".format(
-                    hang_type, self.hang_prefixes[hang_type]
-                )
-            )
-            new_signature_list.insert(0, self.hang_prefixes[hang_type])
 
         signature = delimiter.join(new_signature_list)
 
@@ -545,7 +536,6 @@ class SignatureGenerationRule(Rule):
 
         signature, notes, debug_notes = self.c_signature_tool.generate(
             signature_list,
-            crash_data.get("hang_type"),
             crash_data.get("crashing_thread"),
         )
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -229,25 +229,6 @@ class TestCSignatureTool:
         sig, notes, debug_notes = s.generate(a)
         assert sig == "d | e | f | g"
 
-    def test_generate_2(self):
-        """test_generate_2: hang"""
-        s = self.setup_config_c_sig_tool(ig=["a", "b", "c"], pr=["d", "e", "f"])
-        a = list("abcdefghijklmnopqrstuvwxyz")
-        sig, notes, debug_notes = s.generate(a, hang_type=-1)
-        assert sig == "hang | d | e | f | g"
-
-        a = list("abcdaeafagahijklmnopqrstuvwxyz")
-        sig, notes, debug_notes = s.generate(a, hang_type=-1)
-        assert sig == "hang | d | e | f | g"
-
-        a = list("abcdaeafagahijklmnopqrstuvwxyz")
-        sig, notes, debug_notes = s.generate(a, hang_type=0)
-        assert sig == "d | e | f | g"
-
-        a = list("abcdaeafagahijklmnopqrstuvwxyz")
-        sig, notes, debug_notes = s.generate(a, hang_type=1)
-        assert sig == "chromehang | d | e | f | g"
-
     def test_generate_2a(self):
         """test_generate_2a: way too long"""
         s = self.setup_config_c_sig_tool(ig=["a", "b", "c"], pr=["d", "e", "f"])
@@ -264,15 +245,6 @@ class TestCSignatureTool:
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg"
         )
         sig, notes, debug_notes = s.generate(a)
-        assert sig == expected
-        expected = (
-            "hang | "
-            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd | "
-            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee | "
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff | "
-            "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg"
-        )
-        sig, notes, debug_notes = s.generate(a, hang_type=-1)
         assert sig == expected
 
     def test_generate_3(self):

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -37,10 +37,6 @@ def test_int_or_none(data, expected):
         ({}, 0),
         ({"crashing_thread": ""}, 0),
         ({"crashing_thread": "5"}, 5),
-        ({"hang_type": 0, "crashing_thread": "5"}, 5),
-        # If hang_type == 1, the crashing_thread is always 0
-        ({"hang_type": 1}, 0),
-        ({"hang_type": 1, "crashing_thread": "5"}, 0),
     ],
 )
 def test_get_crashing_thread(crash_data, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -22,22 +22,15 @@ def get_crashing_thread(crash_data):
     """
     Takes crash data and returns the crashing thread as an int.
 
-    If it's a chrome hang (hang_type=1), then use thread 0. Otherwise, use the crashing
-    thread specified in the crash data.
-
     :arg crash_data: crash data structure that conforms to the schema
 
     :returns: crashing thread as an int
 
     """
-    crashing_thread = 0
-    if crash_data.get("hang_type", None) != 1:
-        try:
-            crashing_thread = int(crash_data.get("crashing_thread", 0))
-        except (TypeError, ValueError):
-            pass
-
-    return crashing_thread
+    try:
+        return int(crash_data.get("crashing_thread", 0))
+    except (TypeError, ValueError):
+        return 0
 
 
 DOES_NOT_EXIST = object()
@@ -85,8 +78,6 @@ def convert_to_crash_data(processed_crash):
         "reason": glom(processed_crash, "json_dump.crash_info.type", default=None),
         # list of CStackTrace or None
         "threads": glom(processed_crash, "json_dump.threads", default=None),
-        # int or None
-        "hang_type": glom(processed_crash, "hang_type", default=None),
         # text or None
         "os": glom(processed_crash, "json_dump.system_info.os", default=None),
         # int or None

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -71,15 +71,6 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         "is_exposed": True,
         "is_returned": True,
     },
-    "hang_type": {
-        "name": "hang_type",
-        "data_validation_type": "enum",
-        "query_type": "enum",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "is_exposed": True,
-        "is_returned": True,
-    },
     "user_comments": {
         "name": "user_comments",
         "data_validation_type": "str",
@@ -113,7 +104,6 @@ class TestSearchBase:
         args = {
             "signature": "~js",
             "product": ["WaterWolf", "NightTrain"],
-            "hang_type": "=hang",
         }
         params = search.get_parameters(**args)
         assert params["signature"][0].operator == "~"
@@ -121,7 +111,6 @@ class TestSearchBase:
         assert params["product"][0].operator == ""
         # Test that params with no operator are stacked
         assert params["product"][0].value == ["WaterWolf", "NightTrain"]
-        assert params["hang_type"][0].operator == ""
 
         args = {"signature": ["~Mark", "$js"]}
         params = search.get_parameters(**args)
@@ -219,21 +208,6 @@ class TestSearchBase:
 
         with pytest.raises(BadArgumentError):
             search.get_parameters(date=">1999-01-01")
-
-    def test_hang_type_parameter_correction(self):
-        search = SearchBaseWithFields()
-
-        args = {"hang_type": "hang"}
-        params = search.get_parameters(**args)
-        assert "hang_type" in params
-        assert len(params["hang_type"]) == 1
-        assert params["hang_type"][0].value == [-1, 1]
-
-        args = {"hang_type": "crash"}
-        params = search.get_parameters(**args)
-        assert "hang_type" in params
-        assert len(params["hang_type"]) == 1
-        assert params["hang_type"][0].value == [0]
 
     def test_version_parameter_correction(self):
         search = SearchBaseWithFields()

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -426,7 +426,6 @@ class TestProcessTypeRule:
 class TestPluginRule:
     def test_browser_hang(self):
         raw_crash = {
-            "Hang": "1",
             "ProcessType": "parent",
         }
         dumps = {}
@@ -436,8 +435,6 @@ class TestPluginRule:
         rule = PluginRule()
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        assert processed_crash["hangid"] is None
-        assert processed_crash["hang_type"] == 1
         assert "plugin_filename" not in processed_crash
         assert "plugin_name" not in processed_crash
         assert "plugin_version" not in processed_crash
@@ -457,8 +454,6 @@ class TestPluginRule:
         rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
         expected = {
-            "hang_type": 0,
-            "hangid": None,
             "plugin_name": "name1",
             "plugin_filename": "filename1",
             "plugin_version": "1.0",

--- a/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
+++ b/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
@@ -36,16 +36,6 @@
   />
 {%- endmacro %}
 
-{% macro hang_crash_icon() %}
-  <img src="{{ static('img/3rdparty/fatcow/stop16x16.png') }}"
-       alt="stop sign"
-       title="Hanged Crash"
-       class="hang"
-       height="16"
-       width="16"
-  />
-{%- endmacro %}
-
 {% macro plugin_crash_icon() %}
   <img src="{{ static('img/3rdparty/fatcow/brick16x16.png') }}"
        alt="brick"

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -649,8 +649,6 @@ class ProcessedCrash(SocorroMiddleware):
         "date_processed",
         "dump",
         "flash_version",
-        "hangid",
-        "hang_type",
         "id",
         "install_age",
         "java_exception",

--- a/webapp-django/crashstats/crashstats/tests/test_utils.py
+++ b/webapp-django/crashstats/crashstats/tests/test_utils.py
@@ -410,7 +410,6 @@ class TestUtils:
                 "is_garbage_collecting": [],
                 "process_type": [],
                 "platform": [{"count": 2, "term": ""}],
-                "hang_type": [{"count": 2, "term": 0}],
             },
         }
         platforms = [
@@ -446,7 +445,6 @@ class TestUtils:
         assert signature_stats.is_startup_crash == 0
         assert signature_stats.is_potential_startup_crash == 0
         assert signature_stats.is_startup_window_crash is True
-        assert signature_stats.is_hang_crash is False
         assert signature_stats.is_plugin_crash is False
 
 

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -198,16 +198,6 @@ class SignatureStats:
         return is_startup_window_crash
 
     @cached_property
-    def is_hang_crash(self):
-        num_hang_crashes = 0
-        for row in self.signature["facets"]["hang_type"]:
-            # Hangs have weird values in the database: a value of 1 or -1
-            # means it is a hang, a value of 0 or missing means it is not.
-            if row["term"] in (1, -1):
-                num_hang_crashes += row["count"]
-        return num_hang_crashes > 0
-
-    @cached_property
     def is_plugin_crash(self):
         for row in self.signature["facets"]["process_type"]:
             if row["term"].lower() == "plugin":

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -3,7 +3,7 @@
                                                      potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
-                                                     hang_crash_icon, plugin_crash_icon,
+                                                     plugin_crash_icon,
                                                      browser_crash_icon %}
 
 {% if signature_stats %}
@@ -38,13 +38,6 @@
       <div class="crash-type-indicator-container">
         {{ potential_startup_window_crash_icon() }}
         Potential Startup Crash, more than half of the crashes happened during the first minute after launch
-      </div>
-    {% endif %}
-
-    {% if signature_stats.is_hang_crash %}
-      <div class="crash-type-indicator-container">
-        {{ hang_crash_icon() }}
-        Hanged Crash
       </div>
     {% endif %}
 

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -399,7 +399,6 @@ def signature_summary(request, params):
 
     params["signature"] = "=" + params["signature"][0]
     params["_aggs.signature"] = [
-        "hang_type",
         "process_type",
         "startup_crash",
         "dom_fission_enabled",

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -3,7 +3,7 @@
                                                      potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
-                                                     hang_crash_icon, plugin_crash_icon,
+                                                     plugin_crash_icon,
                                                      browser_crash_icon %}
 
 {% extends "crashstats_base.html" %}
@@ -182,10 +182,6 @@
 
                       {% if topcrashers_stats_item.is_startup_window_crash %}
                         {{ potential_startup_window_crash_icon() }}
-                      {% endif %}
-
-                      {% if topcrashers_stats_item.is_hang_crash %}
-                        {{ hang_crash_icon() }}
                       {% endif %}
 
                       {% if topcrashers_stats_item.is_plugin_crash %}

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -47,8 +47,8 @@ class TestTopCrasherViews(BaseTestViews):
             # the build id.
             assert "build_id" not in params
 
-            if "hang_type" not in params["_aggs.signature"]:
-                # Return results for the previous week.
+            if params["_aggs.signature"] == ["platform"]:
+                # Return results for the previous week for platform.
                 results = {
                     "hits": [],
                     "facets": {
@@ -65,7 +65,7 @@ class TestTopCrasherViews(BaseTestViews):
                     "total": 250,
                 }
             else:
-                # Return results for the current week.
+                # Return results for the current week for a variety of facets.
                 results = {
                     "hits": [],
                     "facets": {
@@ -78,7 +78,6 @@ class TestTopCrasherViews(BaseTestViews):
                                     "is_garbage_collecting": [
                                         {"term": "t", "count": 50}
                                     ],
-                                    "hang_type": [{"term": 1, "count": 50}],
                                     "process_type": [{"term": "plugin", "count": 50}],
                                     "startup_crash": [{"term": "T", "count": 100}],
                                     "dom_fission_enabled": [{"term": 1, "count": 50}],
@@ -94,7 +93,6 @@ class TestTopCrasherViews(BaseTestViews):
                                     "is_garbage_collecting": [
                                         {"term": "t", "count": 50}
                                     ],
-                                    "hang_type": [{"term": 1, "count": 50}],
                                     "process_type": [{"term": "parent", "count": 50}],
                                     "startup_crash": [{"term": "T", "count": 50}],
                                     "dom_fission_enabled": [{"term": 1, "count": 80}],
@@ -173,12 +171,7 @@ class TestTopCrasherViews(BaseTestViews):
             # the build id.
             assert "build_id" not in params
 
-            if "hang_type" not in params["_aggs.signature"]:
-                # Return results for the previous week.
-                results = {"hits": [], "facets": {"signature": []}, "total": 0}
-            else:
-                # Return results for the current week.
-                results = {"hits": [], "facets": {"signature": []}, "total": 0}
+            results = {"hits": [], "facets": {"signature": []}, "total": 0}
 
             results["hits"] = self.only_certain_columns(
                 results["hits"], params["_columns"]

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -41,7 +41,6 @@ def get_topcrashers_stats(**kwargs):
         "platform",
         "is_garbage_collecting",
         "dom_fission_enabled",
-        "hang_type",
         "process_type",
         "startup_crash",
         "_histogram.uptime",


### PR DESCRIPTION
hang_type is based on Hang and HangID crash annotations which were
removed 10 years ago. This removes them from Socorro.