### PR TITLE
bug 1763704: update rust-minidump to d915179e

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ RUN update-ca-certificates && \
 USER app
 
 # From: https://github.com/luser/rust-minidump
-ARG MINIDUMPREV=e954907c9f5a69037df459cacb4d0846b0599479
-ARG MINIDUMPREVDATE=2022-03-23
+ARG MINIDUMPREV=d915179ea369e58752d3256a2bc880122df0499f
+ARG MINIDUMPREVDATE=2022-04-07
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/rust-minidump/rust-minidump.git \


### PR DESCRIPTION
```
d915179 appease new clippy lint
b17a4b7 Make the parser much more robust to enormous symbols.
a5c70b8 Add trace-logging to symbol resolution
7cd02d5 0.10.3 release
cf3f594 Handle 0 frame pointers on ARM64-old
db19dcd 0.10.2 post-release
77b30fc 0.10.2 Release
0776f9a meta: Draft new changelog
```

This fixes issues with parsing XUL symbols file
(https://github.com/rust-minidump/rust-minidump/pull/529).

Example crash report: 9e5f6dd5-49ab-426e-b1c4-379bd0220407