### PR TITLE
bug 1761240: fix major/minor version figuring

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -988,6 +988,8 @@ class OSPrettyVersionRule(Rule):
 
     """
 
+    MAJOR_MINOR_RE = re.compile(r"^(\d+)\.(\d+)")
+
     WINDOWS_VERSIONS = {
         "3.5": "Windows NT",
         "4.0": "Windows NT",
@@ -1018,18 +1020,15 @@ class OSPrettyVersionRule(Rule):
         processed_crash["os_pretty_version"] = pretty_name
 
         os_version = processed_crash.get("os_version") or ""
-        if not os_version:
-            # The version number is missing, there's nothing more to do.
+        match = self.MAJOR_MINOR_RE.match(os_version)
+        if match is None:
+            # The version number is missing or invalid, there's nothing more to do
             return True
 
-        version_split = os_version.split(".")
-        if len(version_split) < 2:
-            # The version number is invalid, there's nothing more to do.
-            return
+        major_version = int(match.group(1))
+        minor_version = int(match.group(2))
 
         os_name = processed_crash.get("os_name") or ""
-        major_version = int(version_split[0])
-        minor_version = int(version_split[1])
 
         if os_name.lower().startswith("windows"):
             if (major_version, minor_version) == (10, 0) and os_version >= "10.0.21996":

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1847,6 +1847,10 @@ class TestOsPrettyName:
             ("Mac OS X", "11.2.1 20D74", "macOS 11"),
             # Generic Linux
             ("Linux", "0.0.12.13", "Linux"),
+            # Linux with - in version
+            ("Linux", "5.17-0.1 #2 SMP PREEMPT", "Linux"),
+            # Linux with - in version
+            ("Linux", "3.14-2-686-pae #1 SMP Debian 3.14.15-2", "Linux"),
         ],
     )
     def test_everything_we_hoped_for(self, os_name, os_version, expected):
@@ -1885,6 +1889,9 @@ class TestOsPrettyName:
             ("Linux", None, "Linux"),
             (None, None, None),
             ("Windows NT", "NaN", "Windows NT"),
+            ("Linux", "5.abc", "Linux"),
+            ("Linux", "5.", "Linux"),
+            ("Linux", "5", "Linux"),
         ],
     )
     def test_junk_data(self, os_name, os_version, expected):


### PR DESCRIPTION
The OSPrettyVersionRule extracts a major and minor version from the os
version. This improves that extraction code so it's more resilient to
interesting possibilities.