### PR TITLE
bug 1768220: improve crash annotation docs

### DIFF
--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -118,7 +118,13 @@ Adding new crash annotations to a crash report
    Stats and require protected data access.
 
 5. (Optional) If you want the field to show up in crash pings sent to Telemetry,
-   you have to update their schema, too.
+   we have to update the crash ping schema.
+
+   `File a bug in Data Platform and Tools :: Datasets: General <https://bugzilla.mozilla.org/enter_bug.cgi?comment=Please%20add%20the%20following%20crash%20annotations%20to%20the%20crash%20ping%20schema%3A%0D%0A%0D%0A%2A%20%0D%0A%0D%0AThe%20data%20review%20for%20these%20annotations%20is%20bug%20%23XYZ.&component=Datasets%3A%20General&bug_type=task&product=Data%20Platform%20and%20Tools&rep_platform=Unspecified&short_desc=add%20crash%20annotation%20XYZ%20to%20crash%20ping%20schema>`_
+   to add the annotation to the crash ping schema.
+
+   You can either wait for someone to update the schema or make the changes
+   yourself following these steps:
 
    1. From a mozilla-pipeline-schemas (https://github.com/mozilla-services/mozilla-pipeline-schemas/)
       checkout, run::
@@ -128,18 +134,13 @@ Adding new crash annotations to a crash report
       If any exist, you will get a list of crash annotations that are contained
       in the ping but are not yet in the schema.
 
-   2. File a bug to add the annotation to crash pings under ``Data Platform and
-      Tools :: Datasets: General``.
-
-      Example: https://bugzilla.mozilla.org/show_bug.cgi?id=1745803
-
-   3. Add the annotation to ``templates/telemetry/crash/crash.4.schema.json`` under
+   2. Add the annotation to ``templates/telemetry/crash/crash.4.schema.json`` under
       the ``payload/metadata`` section.
 
-   4. Follow `<https://github.com/mozilla-services/mozilla-pipeline-schemas#cmake-build-instructions>`_ to
+   3. Follow `<https://github.com/mozilla-services/mozilla-pipeline-schemas#cmake-build-instructions>`_ to
       build the schema files.
 
-   5. Create a pull request against the main branch in mozilla-pipeline-schemas
+   4. Create a pull request against the main branch in mozilla-pipeline-schemas
       referencing that bug.
 
       Example: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/711

--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -11,63 +11,91 @@ minidumps. For example, a crash report may contain the following annotations:
 * **Version**: 77.0a1
 * **ReleaseChannel**: nightly
 
-Annotations are documented in
-`CrashAnnotations.yaml <https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml>`_.
+Annotations are documented in `CrashAnnotations.yaml`_.
+
+
+.. _CrashAnnotations.yaml: https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml
 
 
 Adding new crash annotations to a crash report
 ==============================================
 
 1. First, check
-   `CrashAnnotations.yaml <https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml>`_.
+   `CrashAnnotations.yaml`_
 
-   Verify your annotation doesn't already exist with a different name. You can't
-   change the meaning or type of an existing annotation.
+   Verify that the annotation you want to add doesn't already exist with a
+   different name and that there isn't an annotation with that name already.
+
+   You can't change the meaning or type of an existing annotation.
 
 2. New annotations need to undergo data collection review:
    https://wiki.mozilla.org/Firefox/Data_Collection
 
-   Some things to keep in mind when filling out the review request:
+   If you're creating a new annotation or adjusting an existing annotation, you
+   should use:
+   `<https://github.com/mozilla/data-review/blob/main/request.md>`_.
 
-   1. If the field will be available in crash pings sent to Telemetry, make
-      sure that's mentioned in the data collection review request.
+   Here are some things to keep in mind when filling out the review request:
 
-   2. Collection of crash annotation data never expires.
+   1. If the field will be available in crash reports AND crash pings, make
+      sure that's mentioned in the data collection review request. It's
+      easiest if it's noted at the top.
 
-      The answer to:
+      ::
 
-          How long will this data be collected?
+          This data review covers a crash annotation to be sent in both crash
+          reports and crash pings.
 
-      is:
+   2. Link to the documentation can be a link to `CrashAnnotations.yaml`_.
 
-          I want to permanently monitor this data.
+      ::
 
-      And the data request must specify an owner for this data collection.
+          6. Please provide a link to the documentation for this data
+             collection which describes the ultimate data set in a
+             public, complete, and accurate way.
 
-   3. Crash annotation data sent in crash reports is opt-in by default, bug
-      crash pings are opt-out by default.
+          Documentation is in
+          https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml
 
-      If you only want the crash annotation data showing up in crash reports
-      and showing up in Crash Stats, then:
+   3. Crash annotation data is collected forever.
 
-          If this data collection is default on, what is the opt-out mechanism
-          for users?
+      ::
 
-      is answered as:
+          7. How long will this data be collected? Choose one of the following:
 
-          No mechanism is required.
+          I want to permanently monitor this data. (put someone's name here)
 
-      If you also want the crash annotation data showing up in crash pings, then:
+      Make sure to specify someone.
 
-          If this data collection is default on, what is the opt-out mechanism
-          for users?
+   4. Crash annotation data sent in crash reports is *opt-in by default*, but
+      crash pings are *opt-out by default*.
 
-      is answered as:
+      If you want the annotation ONLY in crash reports, answer this way::
 
-          This data is opt-out via the normal telemetry opt-out mechanism.
+          9. If this data collection is default on, what is the opt-out
+             mechanism for users?
 
-3. Once a new annotation is approved, details about the annotation need to be
-   added to the ``CrashAnnotations.yaml`` file.
+          No mechanism is required for crash report data.
+
+      If you want the annotation showing up in crash reports AND in crash pings,
+      answer this way::
+
+          9. If this data collection is default on, what is the opt-out
+             mechanism for users?
+
+          This data is opt-out via the normal telemetry opt-out mechanism for
+          crash ping data.
+
+
+   .. Note::
+
+      If you need any help with this step, ask on #crashreporting on Matrix.
+
+      Any data steward can review a data review request, but feel free to tag
+      ``:willkg`` with the data review requests for crash annotations.
+
+3. Once the data review for the new annotation is approved, details about the
+   annotation need to be added to the `CrashAnnotations.yaml`_ file.
 
    If the field also needs to be available in crash pings sent to Telemetry,
    you need to add ``ping: true`` to ``CrashAnnotations.yaml``
@@ -83,10 +111,13 @@ Adding new crash annotations to a crash report
         ping: true
 
 
-3. Add the code to put the annotation in the crash report. Once a new
-   annotation is added to a crash report, Socorro will save it with crash data.
+4. Add the code to put the annotation in the crash report.
 
-4. (Optional) If you want the field to show up in crash pings sent to Telemetry,
+   As soon as that code is merged and new builds are created and crash reports
+   start adding the annotation, the annotation data will be available in Crash
+   Stats and require protected data access.
+
+5. (Optional) If you want the field to show up in crash pings sent to Telemetry,
    you have to update their schema, too.
 
    1. From a mozilla-pipeline-schemas (https://github.com/mozilla-services/mozilla-pipeline-schemas/)
@@ -94,14 +125,31 @@ Adding new crash annotations to a crash report
 
          scripts/extract_crash_annotation_fields /path/to/mozilla-unified/toolkit/crashreporter/CrashAnnotations.yaml
 
-      If any exist, you will get a list of crash annotations that are contained in the ping but are not yet in the schema.
+      If any exist, you will get a list of crash annotations that are contained
+      in the ping but are not yet in the schema.
 
-   3. Copy them into ``templates/telemetry/crash/crash.4.schema.json`` under the ``payload/metadata`` section.
+   2. File a bug to add the annotation to crash pings under ``Data Platform and
+      Tools :: Datasets: General``.
 
-   4. File a bug to add them under ``Data Platform and Tools :: Datasets General``.
-      Then create a pull request against mozilla-pipeline-schemas referencing that bug.
+      Example: https://bugzilla.mozilla.org/show_bug.cgi?id=1745803
 
-5. (Optional) `File a "support field" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=support%20XXX%20field>`_
+   3. Add the annotation to ``templates/telemetry/crash/crash.4.schema.json`` under
+      the ``payload/metadata`` section.
+
+   4. Follow `<https://github.com/mozilla-services/mozilla-pipeline-schemas#cmake-build-instructions>`_ to
+      build the schema files.
+
+   5. Create a pull request against the main branch in mozilla-pipeline-schemas
+      referencing that bug.
+
+      Example: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/711
+
+   .. Note::
+
+      If you need any help with this step, ask on #telemetry on Matrix. or
+      #data-help on Slack, or needinfo :willkg in a bug.
+
+6. (Optional) `File a "support new annotation" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=support%20XXX%20field>`_
    to request support for your crash annotation in Crash Stats to:
 
    * make it public
@@ -109,6 +157,14 @@ Adding new crash annotations to a crash report
    * make it aggregatable in Super Search
    * add any additional processing in Socorro for the field
 
-6. (Optional) `File a "send field to telemetry" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=send%20XXX%20field%20to%20telemetry>`_
-   to make it available in ``telemetry.crash_reports`` and correlations on
-   Crash Stats.
+   .. Note::
+
+      If you need any help with this step, ask on #crashreporting on Matrix.
+
+7. (Optional) `File a "send field to telemetry" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=send%20XXX%20field%20to%20telemetry>`_
+   to make it available in ``telemetry.socorro_crash`` (BigQuery table for
+   crash report data exported from Socorro) and correlations on Crash Stats.
+
+   .. Note::
+
+      If you need any help with this step, ask on #crashreporting on Matrix.


### PR DESCRIPTION
This improves the crash annotation docs in a few ways:

1. fixes some typos
2. clarifies which data review form to use
3. adds "for help on this step, ask in ..." notes