### PR TITLE
bug 1742869: remove fission indicators

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
+++ b/webapp-django/crashstats/crashstats/jinja2/macros/signature_startup_icons.html
@@ -1,11 +1,3 @@
-{% macro fission_icon() %}
-  <i class="status-icon fas fa-atom" title="Fission Crash"></i>
-{%- endmacro %}
-
-{% macro potential_fission_icon() %}
-  <i class="status-icon fas fa-atom" title="Potential Fission Crash"></i>
-{%- endmacro %}
-
 {% macro startup_crash_icon() %}
   <img src="{{ static('img/3rdparty/silk/flag_red.png') }}"
        alt="red flag"

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -204,13 +204,6 @@ def generate_create_bug_url(
         "description": comment,
     }
 
-    # If this crash report has DOMFissionEnabled=1, then we prepend a note to the
-    # description. This is probably temporary. Bug #1659175, #1661573.
-    if raw_crash.get("DOMFissionEnabled"):
-        kwargs["description"] = (
-            "Maybe Fission related. (DOMFissionEnabled=1)\n\n" + kwargs["description"]
-        )
-
     # Truncate the title
     if len(kwargs["title"]) > 255:
         kwargs["title"] = kwargs["title"][: 255 - 3] + "..."

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -547,14 +547,6 @@ class Test_generate_create_bug_url:
         assert quote_plus("MOZ_CRASH Reason: ```good_data```") in url
         assert quote_plus("bad_data") not in url
 
-    def test_fission_enabled(self):
-        """DOMFissionEnabled appends note to description."""
-        req = RequestFactory().get("/report/index")
-        raw_crash = {"DOMFissionEnabled": "1"}
-        report = self._create_report()
-        url = generate_create_bug_url(req, self.TEMPLATE, raw_crash, report, {}, 0)
-        assert "comment=Maybe+Fission+related.+%28DOMFissionEnabled%3D1%29" in url
-
     @pytest.mark.parametrize("fn", productlib.get_product_files())
     def test_product_bug_links(self, fn):
         """Verify bug links templates are well-formed."""

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -167,25 +167,6 @@ class SignatureStats:
         )
 
     @cached_property
-    def num_fission_crashes(self):
-        return sum(
-            row["count"] for row in self.signature["facets"]["dom_fission_enabled"]
-        )
-
-    @cached_property
-    def is_fission_crash(self):
-        return self.num_fission_crashes == self.num_crashes
-
-    @cached_property
-    def is_potential_fission_crash(self):
-        # It's only a potential fission crash if > 50% are fission-enabled.  Otherwise
-        # it'll create too many false positives.
-        return (
-            self.num_fission_crashes > (self.num_crashes / 2)
-            and self.num_fission_crashes < self.num_crashes
-        )
-
-    @cached_property
     def is_startup_window_crash(self):
         is_startup_window_crash = False
         for row in self.signature["facets"]["histogram_uptime"]:

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -1,6 +1,4 @@
 {% from "macros/signature_startup_icons.html" import startup_crash_icon,
-                                                     fission_icon,
-                                                     potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
                                                      plugin_crash_icon,
@@ -8,19 +6,6 @@
 
 {% if signature_stats %}
   <div class="panel tab-inner-panel crash-type-indicators-panel {% if signature_stats.is_startup_related_crash %} startup-crash-warning {% endif %}">
-    {% if signature_stats.is_fission_crash %}
-      <div class="crash-type-indicator-container">
-        {{ fission_icon() }}
-        Fission Crash, all crashes have Fission enabled
-      </div>
-    {% elif signature_stats.is_potential_fission_crash %}
-      <div class="crash-type-indicator-container">
-        {{ potential_fission_icon() }}
-        Potential Fission Crash, {{signature_stats.num_fission_crashes}}
-        out of {{signature_stats.num_crashes}} crashes have Fission enabled
-      </div>
-    {% endif %}
-
     {% if signature_stats.is_startup_crash %}
       <div class="crash-type-indicator-container">
         {{ startup_crash_icon() }}

--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -1,6 +1,4 @@
 {% from "macros/signature_startup_icons.html" import startup_crash_icon,
-                                                     fission_icon,
-                                                     potential_fission_icon,
                                                      potential_startup_crash_icon,
                                                      potential_startup_window_crash_icon,
                                                      plugin_crash_icon,
@@ -168,12 +166,6 @@
                       <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ topcrashers_stats_item.signature_term }}" />
                     </div>
                     <div class="signature-icons">
-                      {% if topcrashers_stats_item.is_fission_crash %}
-                        {{ fission_icon() }}
-                      {% elif topcrashers_stats_item.is_potential_fission_crash %}
-                        {{ potential_fission_icon() }}
-                      {% endif %}
-
                       {% if topcrashers_stats_item.is_startup_crash %}
                         {{ startup_crash_icon() }}
                       {% elif topcrashers_stats_item.is_potential_startup_crash %}

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -159,9 +159,6 @@ class TestTopCrasherViews(BaseTestViews):
             in smart_str(response.content)
         )
 
-        # Check the fission icon.
-        assert "Fission Crash" in smart_str(response.content)
-
     def test_product_sans_featured_version(self):
         def mocked_supersearch_get(**params):
             if "_columns" not in params:


### PR DESCRIPTION
We're done with the Fission project for Firefox Desktop so we can remove
the Fission indicators.