### PR TITLE
bug 1768855: fix is_garbage_collecting in telemetry crash storage

### DIFF
--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -462,7 +462,8 @@
         "string",
         "null"
       ],
-      "description": "Whether there was a garbage collection in progress."
+      "description": "Whether there was a garbage collection in progress.",
+      "socorro_convert_to": "string"
     },
     "java_stack_trace": {
       "type": [


### PR DESCRIPTION
It was kicking up invalid document errors. We need to convert the
boolean True/False back to a string "1"/"0".