### PR TITLE
bug 1770722: use thread 0 in bug report

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -8,16 +8,18 @@ Java stack trace:
 ```
 {{ java_stack_trace|safe }}
 ```
-{% elif crashing_thread_frames -%}
+{% elif frames -%}
 {%- if moz_crash_reason -%}
 MOZ_CRASH Reason: ```{{ moz_crash_reason|safe }}```
 {%- elif reason -%}
 Reason: ```{{ reason|safe }}```
 {%- endif %}
-
-Top {{ crashing_thread_frames|length }} frames of crashing thread:
+{% if crashing_thread is none %}
+No crashing thread identified; using thread 0.
+{% endif %}
+Top {{ frames|length }} frames of crashing thread:
 ```
-{% for frame in crashing_thread_frames -%}
+{% for frame in frames -%}
 {{ frame.frame|safe}} {{ frame.module|safe }} {{ frame.signature|safe }} {{ frame.source|safe }}
 {% endfor -%}
 ```

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -173,11 +173,11 @@ def generate_create_bug_url(
     elif op_sys in ("Windows Unknown", "Windows 2000"):
         op_sys = "Windows"
 
-    crashing_thread_frames = None
-    if parsed_dump.get("threads") and crashing_thread is not None:
-        crashing_thread_frames = bugzilla_thread_frames(
-            parsed_dump["threads"][crashing_thread]
-        )
+    frames = None
+    threads = parsed_dump.get("threads")
+    if threads:
+        thread_index = crashing_thread or 0
+        frames = bugzilla_thread_frames(parsed_dump["threads"][thread_index])
 
     comment = render_to_string(
         "crashstats/bug_comment.txt",
@@ -191,7 +191,8 @@ def generate_create_bug_url(
             # can have PII in it
             "moz_crash_reason": report.get("moz_crash_reason", None),
             "reason": report.get("reason", None),
-            "crashing_thread_frames": crashing_thread_frames,
+            "frames": frames,
+            "crashing_thread": crashing_thread,
         },
     )
 

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -547,6 +547,32 @@ class Test_generate_create_bug_url:
         assert quote_plus("MOZ_CRASH Reason: ```good_data```") in url
         assert quote_plus("bad_data") not in url
 
+    def test_comment_crashing_thread_none(self):
+        """Verify Reason makes it into the comment."""
+        req = RequestFactory().get("/report/index")
+        raw_crash = {}
+        report = self._create_report()
+        parsed_dump = self._create_dump(
+            threads=[
+                self._create_thread(
+                    frames=[
+                        self._create_frame(
+                            frame=0,
+                            module="test_module",
+                            signature="foo::bar",
+                            file="foo.cpp",
+                            line=7,
+                        ),
+                    ]
+                ),
+            ]
+        )
+        url = generate_create_bug_url(
+            req, self.TEMPLATE, raw_crash, report, parsed_dump, None
+        )
+        assert quote_plus("No crashing thread identified; using thread 0.") in url
+        assert quote_plus("0 test_module foo::bar") in url
+
     @pytest.mark.parametrize("fn", productlib.get_product_files())
     def test_product_bug_links(self, fn):
         """Verify bug links templates are well-formed."""


### PR DESCRIPTION
If crashing_thread is None, then use thread 0 instead when creating the
bug report.