### PR TITLE
bug 1774110: add mozilla::dom::AutoJSAPI::Init to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -158,6 +158,7 @@ mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
 mozilla::detail::InvalidArrayIndex_CRASH
 mozilla::detail::nsTStringRepr<T>::
+mozilla::dom::AutoJSAPI::Init
 mozilla::dom::ToJSValue
 mozilla::DOMEventTargetHelper::AddRef
 mozilla::MozPromise<T>::ThenCommand<T>::Track


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature-contains='mozilla::dom::AutoJSAPI::Init' | socorro-cmd signature
Crash id: 1034e676-ab3d-4311-af67-27d030220613
Original: mozilla::dom::AutoJSAPI::Init
New:      mozilla::dom::AutoJSAPI::Init | mozilla::ClientWebGLContext::JsWarning
Same?:    False

Crash id: cfef8995-8855-42c4-aa8e-6479a0220613
Original: mozilla::dom::AutoJSAPI::Init
New:      mozilla::dom::AutoJSAPI::Init | nsQueryJSActor::operator()
Same?:    False

Crash id: 250bc756-52d1-4330-88fa-dab290220613
Original: mozilla::dom::AutoJSAPI::Init
New:      mozilla::dom::AutoJSAPI::Init | _tailMerge_d3dcompiler_47.dll | mozilla::xpcom::ConstructJSMComponent
Same?:    False
```