### PR TITLE
bug 1776923: add Thunderbird version rewrite support

### DIFF
--- a/webapp-django/crashstats/crashstats/management/commands/archivescraper.py
+++ b/webapp-django/crashstats/crashstats/management/commands/archivescraper.py
@@ -17,6 +17,10 @@ Rough directory structure::
     devedition/      DevEdition (aka Firefox aurora)
       candidates/    beta builds for Firefox b1 and b2
 
+    thunderbird/
+      candidates/    beta, rc, release, and esr builds
+      nightly/       nightly builds
+
 
 This job only looks for build information for the en-US locale for the first
 platform in a build directory that has build information. Once it's found some
@@ -254,7 +258,11 @@ class Downloader:
             # directories
             for json_link in json_links:
                 json_file = self.download(json_link)
-                data = json.loads(json_file)
+                try:
+                    data = json.loads(json_file)
+                except json.decoder.JSONDecodeError:
+                    self.worker_write(f"not valid json: {json_link}")
+                    continue
 
                 if "buildhub" in json_link:
                     # We have a buildhub.json file to use, so we use that
@@ -507,6 +515,15 @@ class Command(BaseCommand):
             verbose=verbose,
             product_name="Firefox",
             archive_directory="firefox",
+        )
+
+        # Capture Thunderbird beta and release builds
+        self.scrape_and_insert_build_info(
+            base_url=base_url,
+            num_workers=num_workers,
+            verbose=verbose,
+            product_name="Thunderbird",
+            archive_directory="thunderbird",
         )
 
         # Pick up DevEdition beta builds for which b1 and b2 are "Firefox builds"

--- a/webapp-django/crashstats/crashstats/tests/test_archivescraper.py
+++ b/webapp-django/crashstats/crashstats/tests/test_archivescraper.py
@@ -181,11 +181,12 @@ class TestArchiveScraper:
         )
         req_mock.get(HOST + "/pub/firefox/releases/", text=release_page)
 
+        req_mock.get(HOST + "/pub/thunderbird/releases/", text="<html></html>")
+        req_mock.get(HOST + "/pub/thunderbird/candidates/", text="<html></html>")
+
         # Fill out the top-level urls with blank documents
         req_mock.get(HOST + "/pub/devedition/releases/", text="<html></html>")
         req_mock.get(HOST + "/pub/devedition/candidates/", text="<html></html>")
-        req_mock.get(HOST + "/pub/mobile/releases/", text="<html></html>")
-        req_mock.get(HOST + "/pub/mobile/candidates/", text="<html></html>")
 
         expected_data = [
             # 63.0 should have a 63.0rc1/beta, a 63.rc2/beta, and a 63.0/release


### PR DESCRIPTION
This fixes the BetaVersionRule which was written for a time when we
didn't have normalized, validated data. Thank goodness those days are
over-ish.

This adds Thunderbird to archivescraper scraping so we have data in the
table. This also fixes the BetaVersionRule to fix versions for
Thunderbird betas, too.