### PR TITLE
bug 1777258: treat multi_field as string when truncating

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -246,6 +246,13 @@ def build_document(src, crash_document, fields, all_keys):
         # Fix values so they index correctly
         storage_type = field.get("type", field["storage_mapping"].get("type"))
 
+        if (
+            storage_type == "multi_field"
+            and glom.glom(field, "storage_mapping.fields.full.type", default="")
+            == "string"
+        ):
+            storage_type = "string"
+
         if storage_type == "string":
             analyzer = field.get("analyzer", field["storage_mapping"].get("analyzer"))
             if analyzer == "keyword":


### PR DESCRIPTION
We have a series of fields where the `storage_mapping` is `multi_field`, so
they're not being treated as strings and not getting truncated.

This adds some code to treat fields where the `storage_mapping` is
`multi_field` and the `full` version is a string as strings for truncation.