### PR TITLE
bug 1784095: remove contains_memory_report

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1301,20 +1301,6 @@ FIELDS = {
             "type": "string",
         },
     },
-    "contains_memory_report": {
-        "data_validation_type": "bool",
-        "description": "Has content for processed_crash.memory_report or not.",
-        "form_field_choices": [],
-        "has_full_version": False,
-        "in_database_name": "contains_memory_report",
-        "is_exposed": True,
-        "is_returned": True,
-        "name": "contains_memory_report",
-        "namespace": "processed_crash",
-        "permissions_needed": [],
-        "query_type": "bool",
-        "storage_mapping": {"type": "boolean"},
-    },
     # FIXME(willkg): We have this indexed as an integer, but the annotation is listed as
     # a string. The actual value is an int converted to a string so in indexing we
     # convert that to an integer and that's why this works at all. However, I think this

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -86,7 +86,6 @@ class CopyFromRawCrashRule(Rule):
         # rather than converting it to a decimal integer because I think it's going to
         # be more helpful.
         ("string", "CoUnmarshalInterfaceResult", "co_unmarshal_interface_result"),
-        ("boolean", "ContainsMemoryReport", "contains_memory_report"),
         ("int", "ContentSandboxCapabilities", "content_sandbox_capabilities"),
         ("boolean", "ContentSandboxCapable", "content_sandbox_capable"),
         ("boolean", "ContentSandboxEnabled", "content_sandbox_enabled"),


### PR DESCRIPTION
The annotation no longer exists and there are better and more reliable
ways to search for crash reports with a memory report, so we're removing
this field.