### PR TITLE
bug 1764395: fixes minor related things

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2087,6 +2087,7 @@ FIELDS = {
         "query_type": "number",
         "storage_mapping": {"type": "long"},
     },
+    # FIXME(willkg): what is this for? can we remove it?
     "memory_measures": {
         "data_validation_type": "enum",
         "description": "",
@@ -2650,6 +2651,7 @@ FIELDS = {
             "type": "multi_field",
         },
     },
+    # FIXME(willkg): where does this come from?
     "skunk_classification": {
         "data_validation_type": "enum",
         "description": (
@@ -2714,6 +2716,7 @@ FIELDS = {
         ),
         is_protected=False,
     ),
+    # FIXME(willkg): where does this come from?
     "support_classification": {
         "data_validation_type": "enum",
         "description": (
@@ -2819,6 +2822,7 @@ FIELDS = {
         "query_type": "number",
         "storage_mapping": {"type": "long"},
     },
+    # FIXME(willkg): what's this here for?
     "upload_file_minidump_browser": {
         "data_validation_type": "enum",
         "description": "",
@@ -2833,6 +2837,7 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": None,
     },
+    # FIXME(willkg): what's this here for?
     "upload_file_minidump_flash1": {
         "data_validation_type": "enum",
         "description": "",
@@ -2847,6 +2852,7 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": None,
     },
+    # FIXME(willkg): what's this here for?
     "upload_file_minidump_flash2": {
         "data_validation_type": "enum",
         "description": "",

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1388,8 +1388,14 @@ FIELDS = {
         "is_exposed": True,
         "is_returned": True,
         "name": "cpu_count",
-        "namespace": "processed_crash.json_dump.system_info",
+        "namespace": "processed_crash",
         "permissions_needed": [],
+        # FIXME(willkg): We can stop pulling from the old location in 12/2022
+        "source_key": "processed_crash.json_dump.system_info.cpu_count",
+        "destination_keys": [
+            "processed_crash.json_dump.system_info.cpu_count",
+            "processed_crash.cpu_count",
+        ],
         "query_type": "number",
         "storage_mapping": {"type": "short"},
     },
@@ -2671,7 +2677,7 @@ FIELDS = {
     "stackwalk_version": keyword_field(
         name="stackwalk_version",
         description="binary and version for stackwalker used to process report",
-        namespace="processed_crash.json_dump",
+        namespace="processed_crash",
         is_protected=False,
     ),
     "startup_crash": {

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -277,14 +277,12 @@ class MinidumpStackwalkRule(Rule):
                 self.logger.warning(f"{msg} ({crash_id})")
                 output = {}
 
-        # Add the stackwalk_version to the stackwalk output
-        output["stackwalk_version"] = self.stackwalk_version
-
         stackwalker_data = {
             "json_dump": output,
             "mdsw_return_code": returncode,
             "mdsw_status_string": output.get("status", "unknown error"),
             "success": output.get("status", "") == "OK",
+            "stackwalk_version": self.stackwalk_version,
             # Note: this may contain proected data
             "mdsw_stderr": stderr,
         }

--- a/socorro/schemas/processed_crash.1.schema.yaml
+++ b/socorro/schemas/processed_crash.1.schema.yaml
@@ -726,7 +726,8 @@ properties:
       timestamp of the form YYYYMMDDHHMMSS.
     type: string
   client_crash_date:
-    description: ''
+    description: >
+      Crash time as a datestamp in UTC.
     type: string
   collector_notes:
     description: >

--- a/socorro/schemas/processed_crash.1.schema.yaml
+++ b/socorro/schemas/processed_crash.1.schema.yaml
@@ -835,6 +835,19 @@ properties:
       'TelemetryEnvironment.partner.distributionId' value. If there isn't a
       value in either place, this defaults to 'mozilla'.
     type: string
+  dom_fission_enabled:
+    description: >
+      Set to 1 when DOM fission is enabled and subframes are potentially loaded
+      in a separate process.
+    type: boolean
+    socorro:
+      sourceAnnotation: DOMFissionEnabled
+  dom_ipc_enabled:
+    description: >
+      Set to 1 when a tab is running in a content process.
+    type: boolean
+    socorro:
+      sourceAnnotation: DOMIPCEnabled
   dumper_error:
     description: >
       Error message of the minidump writer in case there was an error during

--- a/socorro/schemas/processed_crash.1.schema.yaml
+++ b/socorro/schemas/processed_crash.1.schema.yaml
@@ -258,9 +258,6 @@ definitions:
       pid:
         description: Process ID of the crashing process.
         type: ["integer", "null"]
-      stackwalk_version:
-        description: Version of the stackwalker that walked this stack.
-        type: ["string", "null"]
       status:
         description: >
           Status of the output of the stackwalker. Currently, this is always
@@ -1239,6 +1236,11 @@ properties:
       generating the signature for this crash report. Useful for debugging
       signature generation algorithm problems.
     type: string
+  stackwalk_version:
+    description: >
+      Version of the stackwalker that walked the stack for the
+      upload_file_minidump file.
+    type: string
   started_datetime:
     description: >
       Datestamp indicating the start of processing for the most recent
@@ -1345,6 +1347,10 @@ properties:
         description: >
           stderr output from the stackwalker when processing this minidump.
         type: string
+      stackwalk_version:
+        description: >
+          Version of the stackwalker that walked this stack.
+        type: ["string", "null"]
       success:
         description: >
           Whether or not the status field in the stackwalker output was 'OK'.

--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -363,14 +363,16 @@
         "string",
         "null"
       ],
-      "description": "Set to 1 when DOM fission is enabled."
+      "description": "Set to 1 when DOM fission is enabled.",
+      "socorroConvertTo": "string"
     },
     "dom_ipc_enabled": {
       "type": [
         "string",
         "null"
       ],
-      "description": "The value of the 'dom.ipc.enabled' preference (in other terms, whether e10s is enabled)."
+      "description": "The value of the 'dom.ipc.enabled' preference (in other terms, whether e10s is enabled).",
+      "socorroConvertTo": "string"
     },
     "e10s_cohort": {
       "type": [

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -357,9 +357,17 @@ def test_validate_super_search_fields(name, properties):
 
     # We occasionally do multi-step migrations that change data types where we need to
     # accumulate data in a new field and specify it in a way that otherwise breaks
-    # super_search_fields validation. If the field name has "_future" at the end, it's
-    # one of these cases, so ignore these checks.
-    if not properties["name"].endswith("_future"):
+    # super_search_fields validation.
+    #
+    # If the field name has "_future" at the end, it's one of these cases, so ignore
+    # these checks.
+    #
+    # If the field has "json_dump" in the source_key, then it's another special case
+    # where we're moving it from a nested location in the processed_crash to a top-level
+    # location.
+    if not properties["name"].endswith("_future") and "json_dump" not in properties.get(
+        "source_key", ""
+    ):
         if properties["is_exposed"] is False:
             assert properties["storage_mapping"] is None
 

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -388,12 +388,12 @@ class TestMinidumpStackwalkRule:
                 rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
             expected_output = copy.deepcopy(MINIMAL_STACKWALKER_OUTPUT)
-            expected_output["stackwalk_version"] = rule.stackwalk_version
 
             assert processed_crash["mdsw_return_code"] == 0
             assert processed_crash["mdsw_status_string"] == "OK"
             assert processed_crash["success"] is True
             assert processed_crash["json_dump"] == expected_output
+            assert processed_crash["stackwalk_version"] == rule.stackwalk_version
 
             mm.assert_incr(
                 "processor.minidumpstackwalk.run",
@@ -421,11 +421,9 @@ class TestMinidumpStackwalkRule:
 
                 rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-            assert processed_crash["json_dump"] == {
-                "stackwalk_version": rule.stackwalk_version
-            }
             assert processed_crash["mdsw_return_code"] == 124
             assert processed_crash["mdsw_status_string"] == "unknown error"
+            assert processed_crash["stackwalk_version"] == rule.stackwalk_version
             assert processed_crash["success"] is False
             assert processor_meta["processor_notes"] == [
                 "MinidumpStackwalkRule: minidump-stackwalk: timeout (SIGKILL)"
@@ -456,12 +454,10 @@ class TestMinidumpStackwalkRule:
 
             rule.act(raw_crash, dumps, processed_crash, processor_meta)
 
-        assert processed_crash["json_dump"] == {
-            "stackwalk_version": rule.stackwalk_version
-        }
         assert processed_crash["mdsw_return_code"] == -1
         assert processed_crash["mdsw_status_string"] == "unknown error"
         assert processed_crash["mdsw_stderr"] == "boo hiss"
+        assert processed_crash["stackwalk_version"] == rule.stackwalk_version
         assert not processed_crash["success"]
         assert (
             processor_meta["processor_notes"][0]

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1174,6 +1174,10 @@
                         <tr>
                           <th scope="row">version:</th>
                           <td>
+                            {% if report and report.stackwalk_version %}
+                              {{ report.stackwalk_version }}
+                            {% endif %}
+                            {# FIXME(willkg): this is the old locaion; remove in December 2022 #}
                             {% if report and report.json_dump and report.json_dump.stackwalk_version %}
                               {{ report.json_dump.stackwalk_version }}
                             {% endif %}


### PR DESCRIPTION
While redoing how permissions are handled, I hit some other issues. Rather than have them clutter up an overly large PR, I pulled them out into this one.

* add description to `client_crash_date`
* fix `cpu_count` so it's in the top level of the processed crash and super search pulls it from there
* fix `stackwalk_version` so it's in the top level of the processed crash and super search and other things pull it from there
* re-add `dom_ipc_enabled` and `dom_fission_enabled`

  This probably deserves a bug, but if so, I'll create one later. The gist of the issue is that I fixed these two fields in e311379ebfa8c7b09c973709b8ec48a19e12327b (March 25, 2022) so they were getting converted correctly. Then I finished up that work in ae60bf448de57cf61f99942ba08e5c901f1a0297 (July 26th, 2022) at which point these two fields no longer showed up in super search fields so they're no longer searchable as well as removed from the data that gets ingested into telemetry. This re-adds them.

* add comments to `super_search_fields.py` for weird fields that should probably be removed--future me can figure that out