### PR TITLE
bug 1764395: fix graphics_startup_test for telemetry ingestion

### DIFF
--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -408,7 +408,8 @@
         "string",
         "null"
       ],
-      "description": "Whether the crash occured in the DriverCrashGuard."
+      "description": "Whether the crash occured in the DriverCrashGuard.",
+      "socorroConvertTo": "string"
     },
     "hang_type": {
       "type": [


### PR DESCRIPTION
This is a boolean field and we need to convert it to a string for
telemetry ingestion.