### PR TITLE
bug 1787170: fix upload_telemetry_schema and docs

### DIFF
--- a/docs/telemetry_socorro_crash.rst
+++ b/docs/telemetry_socorro_crash.rst
@@ -12,7 +12,7 @@ Querying telemetry.socorro_crash data
 =====================================
 
 Please see the `telemetry.socorro_crash documentation
-<https://docs-origin.telemetry.mozilla.org/datasets/other/socorro_crash/reference.html>`_.
+<https://docs.telemetry.mozilla.org/datasets/other/socorro_crash/reference.html>`_.
 
 
 Adding fields to telemetry.socorro_crash
@@ -25,28 +25,24 @@ If the crash report annotations and haven't been documented, then we may ask
 you to document them before we proceed. See :ref:`annotations-chapter` for
 details.
 
-.. Note::
-
-   Fields can only be added--they can't be changed.
-
-.. Note::
-
-   When adding a new field, data cannot be backfilled.
-
 
 Things to know
 ==============
 
-1. The data in ``telemetry.socorro_crash`` is from the first time a crash
-   report is processed. If someone reprocesses a crash report, the changes will
-   not be reflected in ``telemetry.socorro_crash``.
+1. The data in ``telemetry.socorro_crash`` comes from the first time a crash
+   report is processed. If a crash report is re-processed, the changes will not
+   be reflected in ``telemetry.socorro_crash``.
 
-2. We can only add new fields to ``telemetry.socorro_crash``. We can't change
-   existing fields.
+2. Fields can only be added to ``telemetry.socorro_crash``--they can't be
+   changed.
 
-3. If the crash report annotation value doesn't conform to the schema, it will
+3. Only fields that contain non-sensitive data can be added to the schema.
+
+4. When new fields are added, data cannot be backfilled.
+
+5. If the crash report annotation value doesn't conform to the schema, it will
    either get dropped or result in the entire crash report getting dropped.
 
-4. Crash report data is ingested nightly. It's not ingested over the course of
-   the day. The ``telemetry.socorro_crash`` data set lags behind what you see
-   on Crash Stats website.
+6. Crash report data is ingested into Telemetry in a batch job that runs once a
+   day. The ``telemetry.socorro_crash`` data set lags behind what you see on
+   Crash Stats website.

--- a/socorro/unittest/external/boto/test_upload_telemetry_schema.py
+++ b/socorro/unittest/external/boto/test_upload_telemetry_schema.py
@@ -13,6 +13,6 @@ class TestUploadTelemetrySchema:
         app = UploadTelemetrySchema(config)
         boto_helper.create_bucket(app.config.telemetry.bucket_name)
 
-        assert app.main() == 0
+        assert app.run() == 0
         recs = [rec.message for rec in caplogpp.records]
         assert "Success: Schema uploaded!" in recs


### PR DESCRIPTION
This fixes `upload_telemetry_schema` so it doesn't fail with a
`configure_sentry` error. This fixes the unittest so it'll catch issues
like this in the future in CI.

This improves the docs for `telemetry.socorro_crash` and fixes one of
the links.