### PR TITLE
bug 1779630: update rust-minidump to 0.14.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,9 @@ RUN update-ca-certificates && \
 USER app
 
 # From: https://github.com/rust-minidump/rust-minidump
-ARG MINIDUMPREV=d553a2cb6ddfc002c9d2056582269e083376dd1b
-ARG MINIDUMPREVDATE=2022-05-02
+# This is 0.14.0
+ARG MINIDUMPREV=f9933c36c5f48bf806a428b06399242e1b170020
+ARG MINIDUMPREVDATE=2022-08-30
 
 RUN cargo install --locked --root=/app/ \
     --git https://github.com/rust-minidump/rust-minidump.git \

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -97,6 +97,7 @@ class ProcessorPipeline(RequiredConfig):
             "--evil-json={raw_crash_path} "
             "--symbols-cache={symbol_cache_path} "
             "--symbols-tmp={symbol_tmp_path} "
+            "--no-color "
             "{symbols_urls} "
             "--json "
             "--verbose=error "

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -144,9 +144,10 @@ class MinidumpStackwalkRule(Rule):
         command_line=(
             "timeout --signal KILL {kill_timeout} "
             "{command_path} "
-            "--raw-json={raw_crash_path} "
+            "--evil-json={raw_crash_path} "
             "--symbols-cache={symbol_cache_path} "
             "--symbols-tmp={symbol_tmp_path} "
+            "--no-color "
             "{symbols_urls} "
             "--json "
             "--verbose=error "
@@ -359,7 +360,7 @@ class MinidumpStackwalkRule(Rule):
 
                     stderr = stackwalker_data.get("mdsw_stderr", "").strip()
                     if stderr:
-                        if stderr.startswith("[ERROR]"):
+                        if stderr.startswith("ERROR"):
                             indicator = stderr.split(" ")[1]
                         else:
                             indicator = ""


### PR DESCRIPTION
This updates rust-minidump to 0.14.0. It adds the "--no-color" argument
to the command line. It fixes the parsing of the stderr ERROR line to
match the new format.