### PR TITLE
Stop adding ReleaseChannel to processed crash

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -258,8 +258,6 @@ class ProductRule(Rule):
         processed_crash["version"] = raw_crash.get("Version", "")
         processed_crash["productid"] = raw_crash.get("ProductID", "")
         processed_crash["release_channel"] = raw_crash.get("ReleaseChannel", "")
-        # FIXME(willkg): We should remove this
-        processed_crash["ReleaseChannel"] = raw_crash.get("ReleaseChannel", "")
         processed_crash["build"] = raw_crash.get("BuildID", "")
 
         # NOTE(willkg): ApplicationBuildID is for Fenix which sends the GeckoView build


### PR DESCRIPTION
The processed crash has release_channel. ReleaseChannel isn't used by
Socorro. I think it's a holdover from a different time.