### PR TITLE
bug 17885331: fix Accessibility processing

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -32,6 +32,7 @@ from socorro.processor.rules.general import (
 )
 from socorro.processor.rules.memory_report_extraction import MemoryReportExtraction
 from socorro.processor.rules.mozilla import (
+    AccessibilityRule,
     AddonsRule,
     BetaVersionRule,
     BreadcrumbsRule,
@@ -192,6 +193,7 @@ class ProcessorPipeline(RequiredConfig):
                 ProductRule(),
                 MajorVersionRule(),
                 PluginRule(),
+                AccessibilityRule(),
                 AddonsRule(),
                 DatesAndTimesRule(),
                 OutOfMemoryBinaryRule(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -184,6 +184,22 @@ class CopyFromRawCrashRule(Rule):
                     )
 
 
+class AccessibilityRule(Rule):
+    """Add accessibility data to processed crash
+
+    The Accessibility annotation is set to "Active" by the accessibility service when it
+    is active and doesn't appear in the crash report when it is not.
+
+    This converts that state of affairs to a True if the field exists and is "Active",
+    and False if not.
+
+    """
+
+    def action(self, raw_crash, dumps, processed_crash, processor_meta_data):
+        value = raw_crash.get("Accessibility", "")
+        processed_crash["accessibility"] = value == "Active"
+
+
 class ConvertModuleSignatureInfoRule(Rule):
     """Make ModuleSignatureInfo to a string.
 

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -778,10 +778,10 @@ properties:
     source_annotation: AbortMessage
   accessibility:
     description: >
-      Set to 'Active' by the accessibility service when it is active.
+      Set to True in the processed crash if the annotation exists and is set to
+      'Active' by the accessibility service when it is active.
     type: boolean
     permissions: ["public"]
-    source_annotation: Accessibility
   accessibility_client:
     description: >
       Out-of-process accessibility client program name and version information.

--- a/socorro/schemas/telemetry_socorro_crash.json
+++ b/socorro/schemas/telemetry_socorro_crash.json
@@ -79,7 +79,8 @@
         "string",
         "null"
       ],
-      "description": "The presence of this field indicates that accessibility services were accessed."
+      "description": "The presence of this field indicates that accessibility services were accessed. Previously, the value sent to Telemetry was 'Active'. Now the value sent is '1'.",
+      "socorroConvertTo": "string"
     },
     "adapter_device_id": {
       "type": [

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -12,6 +12,7 @@ import requests_mock
 import pytest
 
 from socorro.processor.rules.mozilla import (
+    AccessibilityRule,
     AddonsRule,
     BetaVersionRule,
     BreadcrumbsRule,
@@ -566,6 +567,30 @@ class TestPluginRule:
             "plugin_version": "1.0",
         }
         assert processed_crash == expected
+
+
+class TestAccessibilityRule:
+    def test_not_there(self):
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta_data()
+
+        rule = AccessibilityRule()
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+
+        assert processed_crash["accessibility"] is False
+
+    def test_active(self):
+        raw_crash = {"Accessibility": "Active"}
+        dumps = {}
+        processed_crash = {}
+        processor_meta = get_basic_processor_meta_data()
+
+        rule = AccessibilityRule()
+        rule.act(raw_crash, dumps, processed_crash, processor_meta)
+
+        assert processed_crash["accessibility"] is True
 
 
 class TestAddonsRule:


### PR DESCRIPTION
The Accessibility field is in a crash report and set to "Active" by the accessibility service when it is active. Otherwise it's not in the crash report at all. The processed crash schema expects a boolean. Super Search expects a boolean. The telemetry schema expects a string and the value that Socorro sent to telemetry was "Active".

This reconciles all this down to setting the value in the processed crash to True if the annotation exists and the value is "Active" and False otherwise. It converts that to a "1" for Telemetry.