### PR TITLE
bug 1788971: fix jsonschema deprecation warning

### DIFF
--- a/socorro/lib/libsocorrodataschema.py
+++ b/socorro/lib/libsocorrodataschema.py
@@ -9,6 +9,8 @@ Utilities for working with socorro-data schemas.
 import copy
 import re
 
+import jsonschema
+
 
 class InvalidDocumentError(Exception):
     """Raised when the document is invalid"""
@@ -473,3 +475,19 @@ class SocorroDataReducer:
             raise InvalidDocumentError(
                 f"invalid: {path}: type {type(document_part)} not recognized"
             )
+
+
+def validate_instance(instance, schema):
+    """Validates an instance document against the specified socorro-data schema
+
+    :arg dict instance: the instance document
+    :arg dict schema: the schema which is valid socorro-data schema
+
+    :raises: validation errors
+
+    """
+    # NOTE(willkg): If we update the jsonschema used for socorro-data, we need to update
+    # this, too
+    jsonschema.validate(
+        instance=instance, schema=schema, cls=jsonschema.Draft7Validator
+    )

--- a/socorro/schemas/validate_processed_crash.py
+++ b/socorro/schemas/validate_processed_crash.py
@@ -19,6 +19,7 @@ from socorro.lib.libsocorrodataschema import (
     SocorroDataReducer,
     split_path,
     transform_schema,
+    validate_instance,
 )
 from socorro.schemas import PROCESSED_CRASH_SCHEMA
 
@@ -150,7 +151,7 @@ def validate_and_test(ctx, crashdir):
         reduced_processed_crash = schema_reducer.traverse(processed_crash)
         reduced_keys.log_keys(reduced_processed_crash)
 
-        jsonschema.validate(processed_crash, PROCESSED_CRASH_SCHEMA)
+        validate_instance(processed_crash, PROCESSED_CRASH_SCHEMA)
 
     click.echo("Done testing, all crash reports passed.")
 


### PR DESCRIPTION
bug 1788971: fix jsonschema deprecation warning
    
jsonschema was kicking up this deprecation warning:
    
```
DeprecationWarning: The metaschema specified by $schema was not found.
Using the latest draft to validate, but this will raise an error in the
future.
```
    
This fixes that by passing in the correct validator. Further, since I
think I want to be validating test data because a lot of it is wrong, I
created a function for it that we can use everywhere.