### PR TITLE
bug 1782258: add crashing_thread and crashing_thread_name fields

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1440,6 +1440,18 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"type": "string"},
     },
+    "crashing_thread": number_field(
+        "crashing_thread",
+        description="Index of the crashing thread.",
+        in_database_name="crashing_thread",
+        is_protected=False,
+    ),
+    "crashing_thread_name": keyword_field(
+        "crashing_thread_name",
+        description="Name of the crashing thread.",
+        in_database_name="crashing_thread_name",
+        is_protected=False,
+    ),
     "date": {
         "data_validation_type": "datetime",
         "description": "Date at which the crash report was received by Socorro.",

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -27,6 +27,7 @@ class CrashingThreadInfoRule(Rule):
     Fills in:
 
     * crashing_thread (int or None): index of the crashing thread
+    * crashing_thread_name (str or None): name of crashing thread
     * address (str or None): the address of the crash
     * type (str): the crash reason
 
@@ -44,6 +45,9 @@ class CrashingThreadInfoRule(Rule):
                 "mdsw did not identify the crashing thread"
             )
 
+        processed_crash["crashing_thread_name"] = glom.glom(
+            processed_crash, "json_dump.crashing_thread.thread_name", default=None
+        )
         processed_crash["address"] = glom.glom(
             processed_crash, "json_dump.crash_info.address", default=None
         )

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -1057,6 +1057,11 @@ properties:
       Index of the crashing thread.
     type: ["integer", "null"]
     permissions: ["public"]
+  crashing_thread_name:
+    description: >
+      Name of the crashing thread.
+    type: ["string", "null"]
+    permissions: ["public"]
   date_processed:
     description: |
       Date when the crash report was submitted to Socorro.

--- a/socorro/unittest/schemas/test_socorro_data_schemas.py
+++ b/socorro/unittest/schemas/test_socorro_data_schemas.py
@@ -106,6 +106,7 @@ KNOWN_PUBLIC_FIELDS = {
     "crash_report_keys.[]",
     "crash_time",
     "crashing_thread",
+    "crashing_thread_name",
     "date_processed",
     "distribution_id",
     "dom_fission_enabled",


### PR DESCRIPTION
This adds `crashing_thread` and `crashing_thread_name` fields to the processed crash and to super search.