### PR TITLE
bug 1763154: truncate frames from huge stacks

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -702,22 +702,26 @@
                     <tbody>
                       {% for frame in parsed_dump.threads[crashing_thread].frames %}
                         <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                          <td>
-                            {% if frame.missing_symbols %}
-                              <span class="row-notice" title="missing symbol">&Oslash;</span>
-                            {% endif %}
-                            {{ frame.frame }}
-                          </td>
-                          <td>{{ frame.module }}</td>
-                          <td title="{{ frame.signature }}">{{ frame.signature }}</td>
-                          <td>
-                            {% if frame.source_link %}
-                              <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
-                            {% else %}
-                              {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
-                            {% endif %}
-                          </td>
-                          <td>{{ frame.trust }}</td>
+                          {% if frame.truncated %}
+                            <td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td>
+                          {% else %}
+                            <td>
+                              {% if frame.missing_symbols %}
+                                <span class="row-notice" title="missing symbol">&Oslash;</span>
+                              {% endif %}
+                              {{ frame.frame }}
+                            </td>
+                            <td>{{ frame.module }}</td>
+                            <td title="{{ frame.signature }}">{{ frame.signature }}</td>
+                            <td>
+                              {% if frame.source_link %}
+                                <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
+                              {% else %}
+                                {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
+                              {% endif %}
+                            </td>
+                            <td>{{ frame.trust }}</td>
+                          {% endif %}
                         </tr>
                       {% endfor %}
                     </tbody>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -125,13 +125,11 @@ def report_index(request, crash_id, default_context=None):
     # For C++/Rust crashes
     if "json_dump" in context["report"]:
         json_dump = context["report"]["json_dump"]
-        if "sensitive" in json_dump and not request.user.has_perm(
-            "crashstats.view_pii"
-        ):
-            del json_dump["sensitive"]
+        # This is for the "Raw data and minidumps" tab
         context["raw_stackwalker_output"] = json.dumps(
             json_dump, sort_keys=True, indent=4, separators=(",", ": ")
         )
+        # This is for displaying on the "Details" tab
         utils.enhance_json_dump(json_dump, settings.VCS_MAPPINGS)
         parsed_dump = json_dump
     else:


### PR DESCRIPTION
When a stack has more than 100 frames, this truncates the middle in the report view so it shows the first 50, a "truncated" line, and then the last 50. This should significantly reduce the HTML involved in stack overflow bugs and make the page load _much_ faster.

Example crash report: 25e8e40f-42a1-4248-b24d-43d2e0220403

I picked 100 because it seemed like a good number and ran it by some others who agreed. However, it's kind of arbitrary. If we decide there are better numbers to truncate on, we can change it in a new bug.