### PR TITLE
bug 1788103: show inline functions in details tab of report view

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -701,17 +701,17 @@
                     </thead>
                     <tbody>
                       {% for frame in parsed_dump.threads[crashing_thread].frames %}
-                        <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                          {% if frame.truncated %}
-                            <td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td>
-                          {% else %}
-                            <td>
+                        {% if frame.truncated %}
+                          <tr><td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td></tr>
+                        {% else %}
+                          <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                            <td rowspan="{{ rowspan_for_inlines(frame) }}">
                               {% if frame.missing_symbols %}
                                 <span class="row-notice" title="missing symbol">&Oslash;</span>
                               {% endif %}
                               {{ frame.frame }}
                             </td>
-                            <td>{{ frame.module }}</td>
+                            <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.module }}</td>
                             <td title="{{ frame.signature }}">{{ frame.signature }}</td>
                             <td>
                               {% if frame.source_link %}
@@ -720,9 +720,26 @@
                                 {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
                               {% endif %}
                             </td>
-                            <td>{{ frame.trust }}</td>
+                            <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.trust }}</td>
+                          </tr>
+                          {% if frame.inlines %}
+                            {% for inline in frame.inlines %}
+                              <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                                {# frame index #}
+                                {# module #}
+                                <td title="{{ inline.function }}">{{ inline.function }}</td>
+                                <td>
+                                  {% if inline.source_link %}
+                                    <a href="{{ inline.source_link }}">{{ inline.file }}:{{ inline.line }}</a>
+                                  {% else %}
+                                    {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
+                                  {% endif %}
+                                </td>
+                                {# trust #}
+                              </tr>
+                            {% endfor %}
                           {% endif %}
-                        </tr>
+                        {% endif %}
                       {% endfor %}
                     </tbody>
                   </table>
@@ -747,17 +764,17 @@
                         </thead>
                         <tbody>
                           {% for frame in thread.frames %}
-                            <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                              {% if frame.truncated %}
-                                <td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td>
-                              {% else %}
-                                <td>
+                            {% if frame.truncated %}
+                              <tr><td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td></tr>
+                            {% else %}
+                              <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                                <td rowspan="{{ rowspan_for_inlines(frame) }}">
                                   {% if frame.missing_symbols %}
                                     <span class="row-notice" title="missing symbol">&Oslash;</span>
                                   {% endif %}
                                   {{ frame.frame }}
                                 </td>
-                                <td>{{ frame.module }}</td>
+                                <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.module }}</td>
                                 <td title="{{ frame.signature }}">{{ frame.signature }}</td>
                                 <td>
                                   {% if frame.source_link %}
@@ -766,9 +783,26 @@
                                     {{ frame.file }}{% if frame.line %}:{{ frame.line }}{% endif %}
                                   {% endif %}
                                 </td>
-                                <td>{{ frame.trust }}</td>
+                                <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.trust }}</td>
+                              </tr>
+                              {% if frame.inlines %}
+                                {% for inline in frame.inlines %}
+                                  <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                                    {# frame index #}
+                                    {# module #}
+                                    <td title="{{ inline.function }}">{{ inline.function }}</td>
+                                    <td>
+                                      {% if inline.source_link %}
+                                        <a href="{{ inline.source_link }}">{{ inline.file }}:{{ inline.line }}</a>
+                                      {% else %}
+                                        {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
+                                      {% endif %}
+                                    </td>
+                                    {# trust #}
+                                  </tr>
+                                {% endfor %}
                               {% endif %}
-                            </tr>
+                            {% endif %}
                           {% endfor %}
                         </tbody>
                       </table>

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -509,3 +509,8 @@ def filter_featured_versions(product_versions):
 @library.global_function
 def filter_not_featured_versions(product_versions):
     return [pv for pv in product_versions if not pv["is_featured"]]
+
+
+@library.global_function
+def rowspan_for_inlines(frame):
+    return 1 + len(frame.get("inlines") or [])

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -256,9 +256,10 @@ def _json_clean(value):
 
 
 def enhance_frame(frame, vcs_mappings):
-    """
-    Add some additional info to a stack frame--signature
-    and source links from vcs_mappings.
+    """Add additional info to a stack frame
+
+    This adds signature and source links from vcs_mappings.
+
     """
     if frame.get("truncated", None) is not None:
         return
@@ -348,6 +349,8 @@ def enhance_json_dump(dump, vcs_mappings):
 
         for frame in frames:
             enhance_frame(frame, vcs_mappings)
+            for inline in frame.get("inlines") or []:
+                enhance_frame(inline, vcs_mappings)
 
         thread["frames"] = frames
     return dump


### PR DESCRIPTION
This adds display of inline functions to the details tab of the report
view. This shows them for the crashing thread and all other threads.