### PR TITLE
bug 1604845: remove entropy from raw_crash path

### DIFF
--- a/bin/remove_field.py
+++ b/bin/remove_field.py
@@ -12,6 +12,12 @@ Usage::
 
     python bin/remove_field.py CRASHIDSFILE FIELD [FIELD...]
 
+File should be a set of lines of the form:
+
+    {"crashid": CRASHID, "index": INDEX, ...}
+
+Lines prefixed with "#" are ignored.
+
 """
 
 import concurrent.futures
@@ -197,9 +203,12 @@ def cmd_remove_field(ctx, parallel, max_workers, crashidsfile, fields):
     """
     Remove a field from raw crash data on S3 and Elasticsearch.
 
-    The crashidsfile is a path to a file with crash ids in it--one per line.
-    Lines prefixed with # are treated as comments and are ignored.
+    The crashidsfile is a path to a file with crash ids in it. File should be a set of
+    lines of the form:
 
+        {"crashid": CRASHID, "index": INDEX, ...}
+
+    Lines prefixed with "#" are ignored.
 
     """
     if not os.path.exists(crashidsfile):

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -7,6 +7,7 @@ import json
 import os
 import os.path
 
+from socorro.external.boto.crashstorage import build_keys
 from socorro.lib.libdatetime import JsonDTEncoder
 from socorro.lib.librequests import session_with_retries
 from socorro.scripts import FallbackToPipeAction, FlagAction, WrappedTextHelpFormatter
@@ -82,9 +83,8 @@ def fetch_crash(
 
         # Save raw crash to file system
         raw_crash = resp.json()
-        fn = os.path.join(
-            outputdir, "v2", "raw_crash", crash_id[0:3], "20" + crash_id[-6:], crash_id
-        )
+        key = build_keys("raw_crash", crash_id)[0]
+        fn = os.path.join(outputdir, key)
         create_dir_if_needed(os.path.dirname(fn))
         with open(fn, "w") as fp:
             json.dump(raw_crash, fp, cls=JsonDTEncoder, indent=2, sort_keys=True)
@@ -117,7 +117,8 @@ def fetch_crash(
             dumps[dump_name] = resp.content
 
         # Save dump_names to file system
-        fn = os.path.join(outputdir, "v1", "dump_names", crash_id)
+        key = build_keys("dump_names", crash_id)[0]
+        fn = os.path.join(outputdir, key)
         create_dir_if_needed(os.path.dirname(fn))
         with open(fn, "w") as fp:
             json.dump(list(dumps.keys()), fp)
@@ -127,7 +128,8 @@ def fetch_crash(
             if dump_name == "upload_file_minidump":
                 dump_name = "dump"
 
-            fn = os.path.join(outputdir, "v1", dump_name, crash_id)
+            key = build_keys(dump_name, crash_id)[0]
+            fn = os.path.join(outputdir, key)
             create_dir_if_needed(os.path.dirname(fn))
             with open(fn, "wb") as fp:
                 fp.write(data)
@@ -152,7 +154,8 @@ def fetch_crash(
 
         # Save processed crash to file system
         processed_crash = resp.json()
-        fn = os.path.join(outputdir, "v1", "processed_crash", crash_id)
+        key = build_keys("processed_crash", crash_id)[0]
+        fn = os.path.join(outputdir, key)
         create_dir_if_needed(os.path.dirname(fn))
         with open(fn, "w") as fp:
             json.dump(processed_crash, fp, cls=JsonDTEncoder, indent=2, sort_keys=True)

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -10,11 +10,51 @@ import pytest
 
 from socorro.external.boto.crashstorage import (
     BotoS3CrashStorage,
-    TelemetryBotoS3CrashStorage,
+    build_keys,
     dict_to_str,
+    TelemetryBotoS3CrashStorage,
 )
 from socorro.external.crashstorage_base import CrashIDNotFound, MemoryDumpsMapping
 from socorro.unittest.external.boto import get_config
+
+
+@pytest.mark.parametrize(
+    "kind, crashid, expected",
+    [
+        (
+            "raw_crash",
+            "0bba929f-8721-460c-dead-a43c20071027",
+            [
+                "v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
+                "v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            ],
+        ),
+        (
+            "dump_names",
+            "0bba929f-8721-460c-dead-a43c20071027",
+            [
+                "v1/dump_names/0bba929f-8721-460c-dead-a43c20071027",
+            ],
+        ),
+        (
+            "processed_crash",
+            "0bba929f-8721-460c-dead-a43c20071027",
+            [
+                "v1/processed_crash/0bba929f-8721-460c-dead-a43c20071027",
+            ],
+        ),
+        # For telemetry
+        (
+            "crash_report",
+            "0bba929f-8721-460c-dead-a43c20071027",
+            [
+                "v1/crash_report/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            ],
+        ),
+    ],
+)
+def test_build_keys(kind, crashid, expected):
+    assert build_keys(kind, crashid) == expected
 
 
 class TestBotoS3CrashStorage:
@@ -41,7 +81,7 @@ class TestBotoS3CrashStorage:
         # contents
         raw_crash = boto_helper.download_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            key="v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
         )
 
         assert json.loads(raw_crash) == {
@@ -73,7 +113,7 @@ class TestBotoS3CrashStorage:
         # Verify the raw_crash made it to the right place and has the right contents
         raw_crash = boto_helper.download_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            key="v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
         )
 
         assert json.loads(raw_crash) == {
@@ -139,7 +179,7 @@ class TestBotoS3CrashStorage:
 
         boto_helper.upload_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/936/20120408/936ce666-ff3b-4c7a-9674-367fe2120408",
+            key="v2/raw_crash/20120408/936ce666-ff3b-4c7a-9674-367fe2120408",
             data=dict_to_str(raw_crash).encode("utf-8"),
         )
 

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -633,7 +633,7 @@ class TestCrashVerify:
         crash_data = {"submitted_timestamp": "2018-03-14-09T22:21:18.646733+00:00"}
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
-        raw_crash_key = "v2/raw_crash/%s/20%s/%s" % (uuid[0:3], uuid[-6:], uuid)
+        raw_crash_key = "v2/raw_crash/20%s/%s" % (uuid[-6:], uuid)
         boto_helper.upload_fileobj(
             bucket_name=bucket,
             key=raw_crash_key,

--- a/webapp-django/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp-django/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -16,8 +16,12 @@ TODAY = utc_now().strftime("%Y%m%d")
 BUCKET_NAME = os.environ.get("resource.boto.bucket_name")
 
 
-def get_small_entropy(self):
-    """Returns small entropy so we're not spending ages cycling through things."""
+def get_threechars_subset(self):
+    """Returns subset of threechars combinations
+
+    This reduces the time it takes to run the tests.
+
+    """
     yield from ["000", "111", "222"]
 
 
@@ -58,9 +62,9 @@ class TestVerifyProcessed:
             conn.index(index=index_name, doc_type=doctype, body=document, id=crash_id)
         es_conn.refresh()
 
-    def test_get_entropy(self):
+    def test_get_threechars(self):
         cmd = Command()
-        entropy = list(sorted(cmd.get_entropy()))
+        entropy = list(sorted(cmd.get_threechars()))
 
         # We don't want to assert the contents of the whole list, so let's
         # just assert some basic facts and it's probably fine
@@ -70,7 +74,7 @@ class TestVerifyProcessed:
 
     def test_no_crashes(self, boto_helper, monkeypatch):
         """Verify no crashes in bucket result in no missing crashes."""
-        monkeypatch.setattr(Command, "get_entropy", get_small_entropy)
+        monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
         boto_helper.create_bucket(bucket)
@@ -81,7 +85,7 @@ class TestVerifyProcessed:
 
     def test_no_missing_crashes(self, boto_helper, es_conn, monkeypatch):
         """Verify raw crashes with processed crashes result in no missing crashes."""
-        monkeypatch.setattr(Command, "get_entropy", get_small_entropy)
+        monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
         boto_helper.create_bucket(bucket)
@@ -105,7 +109,7 @@ class TestVerifyProcessed:
 
     def test_missing_crashes(self, boto_helper, es_conn, monkeypatch):
         """Verify it finds a missing crash."""
-        monkeypatch.setattr(Command, "get_entropy", get_small_entropy)
+        monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
         boto_helper.create_bucket(bucket)
@@ -126,7 +130,7 @@ class TestVerifyProcessed:
 
     def test_missing_crashes_es(self, boto_helper, es_conn, monkeypatch):
         """Verify it finds a processed crash missing in ES."""
-        monkeypatch.setattr(Command, "get_entropy", get_small_entropy)
+        monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
         boto_helper.create_bucket(bucket)


### PR DESCRIPTION
This removes the "entropy" section from the raw crash path in AWS S3. This makes it easier to work with raw crash data and also sets us up for moving to GCP where we're not planning to have an "entropy" section at all.

This also fixes the instructions in `bin/remove_field.py` to make it easier to test next time without reading through the code and the PR that created that file.

I went through and tested the following:

* loading raw crashes works with old and new key formats
* verifyprocessed works
* permadelete_crash_data works
* remove_field works
* fetch_crash_data puts crash data in new key location

In relevant places, I added notes about when the deprecated code can be removed.