### PR TITLE
bug 1604845: switch raw crash key version to v1

### DIFF
--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -44,11 +44,11 @@ do
     fi
 
     # Find the raw crash file
-    RAWCRASHFILE=$(find ${DATADIR}/v2/raw_crash/ -name $CRASHID -type f)
+    RAWCRASHFILE=$(find ${DATADIR}/v1/raw_crash/ -name $CRASHID -type f)
 
     timeout -s KILL 600 "${STACKWALKER}" \
         --raw-json $RAWCRASHFILE \
-        --symbols-url "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1" \
+        --symbols-url "https://symbols.mozilla.org/" \
         --symbols-cache /tmp/symbols/cache \
         --symbols-tmp /tmp/symbols/tmp \
         ${DATADIR}/v1/dump/$CRASHID

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -79,7 +79,7 @@ def build_keys(name_of_thing, crashid):
         entropy = crashid[:3]
         date = get_datestamp(crashid).strftime("%Y%m%d")
         return [
-            "v2/%(nameofthing)s/%(date)s/%(crashid)s"
+            "v1/%(nameofthing)s/%(date)s/%(crashid)s"
             % {
                 "nameofthing": name_of_thing,
                 "date": date,

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -25,7 +25,7 @@ from socorro.unittest.external.boto import get_config
             "raw_crash",
             "0bba929f-8721-460c-dead-a43c20071027",
             [
-                "v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
+                "v1/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
                 "v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027",
             ],
         ),
@@ -81,7 +81,7 @@ class TestBotoS3CrashStorage:
         # contents
         raw_crash = boto_helper.download_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            key="v1/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
         )
 
         assert json.loads(raw_crash) == {
@@ -113,7 +113,7 @@ class TestBotoS3CrashStorage:
         # Verify the raw_crash made it to the right place and has the right contents
         raw_crash = boto_helper.download_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
+            key="v1/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
         )
 
         assert json.loads(raw_crash) == {
@@ -179,7 +179,7 @@ class TestBotoS3CrashStorage:
 
         boto_helper.upload_fileobj(
             bucket_name=bucket,
-            key="v2/raw_crash/20120408/936ce666-ff3b-4c7a-9674-367fe2120408",
+            key="v1/raw_crash/20120408/936ce666-ff3b-4c7a-9674-367fe2120408",
             data=dict_to_str(raw_crash).encode("utf-8"),
         )
 

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -633,7 +633,7 @@ class TestCrashVerify:
         crash_data = {"submitted_timestamp": "2018-03-14-09T22:21:18.646733+00:00"}
 
         bucket = settings.SOCORRO_CONFIG["resource"]["boto"]["bucket_name"]
-        raw_crash_key = "v2/raw_crash/20%s/%s" % (uuid[-6:], uuid)
+        raw_crash_key = "v1/raw_crash/20%s/%s" % (uuid[-6:], uuid)
         boto_helper.upload_fileobj(
             bucket_name=bucket,
             key=raw_crash_key,

--- a/webapp-django/crashstats/crashstats/management/commands/verifyprocessed.py
+++ b/webapp-django/crashstats/crashstats/management/commands/verifyprocessed.py
@@ -28,7 +28,7 @@ from socorro.lib.libooid import date_from_ooid
 
 
 RAW_CRASH_ENTROPY_PREFIX_TEMPLATE = "v2/raw_crash/%s/%s/"
-RAW_CRASH_PREFIX_TEMPLATE = "v2/raw_crash/%s/%s"
+RAW_CRASH_PREFIX_TEMPLATE = "v1/raw_crash/%s/%s"
 PROCESSED_CRASH_TEMPLATE = "v1/processed_crash/%s"
 
 # Number of seconds until we decide a worker has stalled
@@ -151,7 +151,7 @@ def check_crashids_for_date(firstchars_chunk, date):
 
         for page in page_iterator:
             # NOTE(willkg): Keys here look like /v2/raw_crash/ENTROPY/DATE/CRASHID or
-            # /v2/raw_crash/DATE/CRASHID
+            # /v1/raw_crash/DATE/CRASHID
             crash_ids = [
                 item["Key"].split("/")[-1] for item in page.get("Contents", [])
             ]

--- a/webapp-django/crashstats/crashstats/tests/test_updatemissing.py
+++ b/webapp-django/crashstats/crashstats/tests/test_updatemissing.py
@@ -18,7 +18,7 @@ class TestUpdateMissing:
     def create_raw_crash_in_s3(self, boto_helper, crash_id):
         boto_helper.upload_fileobj(
             bucket_name=BUCKET_NAME,
-            key="v2/raw_crash/%s/%s/%s" % (crash_id[0:3], TODAY, crash_id),
+            key="v1/raw_crash/%s/%s" % (TODAY, crash_id),
             data=b"test",
         )
 

--- a/webapp-django/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp-django/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -34,7 +34,7 @@ class TestVerifyProcessed:
     def create_raw_crash_in_s3(self, boto_helper, crash_id):
         boto_helper.upload_fileobj(
             bucket_name=BUCKET_NAME,
-            key="v2/raw_crash/%s/%s/%s" % (crash_id[0:3], TODAY, crash_id),
+            key="v1/raw_crash/%s/%s" % (TODAY, crash_id),
             data=b"test",
         )
 


### PR DESCRIPTION
We're effectively returning to the original v1 from ages ago. Version changing shenanigans are irritating, but in this specific case, I don't think anything else relies on the pathing except antenna and socorro. Given that I control both and I'm changing it anyhow, it seems easier in general to return to v1 which matches the other paths than to keep v2 or go to v3.