### PR TITLE
bug 1789705: fix breaks in report view stack table

### DIFF
--- a/webapp-django/crashstats/api/jinja2/api/documentation.html
+++ b/webapp-django/crashstats/api/jinja2/api/documentation.html
@@ -70,29 +70,29 @@
       <pre class="helptext">{{ endpoint.help_text }}</pre>
 
       {% if endpoint.parameters %}
-        <table class="data-table vertical">
+        <table class="data-table hardwrapped">
           <thead>
             <tr>
-              <th class="fixed" scope="col">Parameter key</th>
-              <th class="fixed" scope="col">Required?</th>
-              <th class="fixed" scope="col">Type</th>
-              <th class="fixed" scope="col">Default</th>
+              <th class="w-3/12" scope="col">Parameter key</th>
+              <th class="w-1/12" scope="col">Required?</th>
+              <th class="w-2/12" scope="col">Type</th>
+              <th class="w-2/12" scope="col">Default</th>
               <th>Test drive</th>
             </tr>
           </thead>
           <tbody>
             {% for parameter in endpoint.parameters %}
               <tr>
-                <td class="fixed">
+                <td>
                   <b>{{ parameter.name }}</b>
                 </td>
-                <td class="fixed">
+                <td>
                   {% if parameter.required %}Required {% else %}Optional {% endif %}
                 </td>
-                <td class="fixed">
+                <td>
                   {{ describe_friendly_type(parameter['type']) }}
                 </td>
-                <td class="fixed">
+                <td>
                   {% set default_val = endpoint['defaults'].get(parameter['name'], '') %}
                   {% if default_val %}
                     <code>{{ default_val }}</code>

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -107,14 +107,14 @@
           </ul>
 
           <div id="details" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
-            <table class="record data-table vertical hardwrapped">
+            <table class="record data-table hardwrapped">
               <tbody>
 
                 {# Crash Annotations #}
 
                 <tr title="{{ fields_desc['processed_crash.signature'] }}">
-                  <th scope="row">Signature</th>
-                  <td>
+                  <th class="w-2/12" scope="row">Signature</th>
+                  <td class="w-10/12">
                     {{ report.signature }}
                     <a href="{{ url('signature:signature_report') }}?{{ make_query_string(product=report.product, signature=report.signature) }}" class="sig-overview" title="View more reports of this type">More Reports</a>
                     <a href="{{ url('supersearch:search') }}?{{ make_query_string(product=report.product, signature='=' + report.signature) }}" class="sig-search" title="Search for more reports of this type">Search</a>
@@ -869,18 +869,18 @@
               These are the crash annotations from the submitted crash report
               that do not contain protected data.
             </div>
-            <table class="record data-table vertical hardwrapped">
+            <table class="record data-table hardwrapped">
               <tbody>
                 {% for key in public_raw_keys %}
                   <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
-                    <th scope="row">
+                    <th class="w-2/12" scope="row">
                       {% if key %}
                         {{ key }}
                       {% else %}
                         <i>empty key</i>
                       {% endif %}
                     </th>
-                    <td><pre>{{ raw[key] }}</pre></td>
+                    <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
                   </tr>
                 {% endfor %}
               </tbody>
@@ -896,18 +896,18 @@
               <div>
                 {{ protected_warning() }}
               </div>
-              <table class="record data-table vertical hardwrapped">
+              <table class="record data-table hardwrapped">
                 <tbody>
                   {% for key in protected_raw_keys %}
                     <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
-                      <th scope="row">
+                      <th class="w-2/12" scope="row">
                         {% if key %}
                           {{ key }}
                         {% else %}
                           <i>empty key</i>
                         {% endif %}
                       </th>
-                      <td><pre>{{ raw[key] }}</pre></td>
+                      <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
                     </tr>
                   {% endfor %}
                 </tbody>
@@ -1110,10 +1110,10 @@
               {{ protected_warning() }}
 
               <h4>Timeline</h4>
-              <table class="record data-table vertical hardwrapped">
+              <table class="record data-table hardwrapped">
                 <tbody>
                   <tr>
-                    <th scope="row">Collected</th>
+                    <th class="w-2/12" scope="row">Collected</th>
                     <td>{{ raw.submitted_timestamp | human_readable_iso_date }} UTC</td>
                   </tr>
                   <tr>
@@ -1128,10 +1128,10 @@
               </table>
 
               <h4>Collector</h4>
-              <table class="record data-table vertical hardwrapped">
+              <table class="record data-table hardwrapped">
                 <tbody>
                   <tr>
-                    <th scope="row">UUID</th>
+                    <th class="w-2/12" scope="row">UUID</th>
                     <td>{{ raw.uuid }}</td>
                   </tr>
                   <tr>
@@ -1165,7 +1165,7 @@
                         <table class="data-table">
                           {% for name, sha in raw.dump_checksums.items() %}
                             <tr>
-                              <th>{{ name }}:</th>
+                              <th class="w-2/12">{{ name }}:</th>
                               <td>
                                 <code>{{ sha }}</code>
                                 {% if sha == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" %}
@@ -1186,10 +1186,10 @@
               </table>
 
               <h4>Processor</h4>
-              <table class="record data-table vertical hardwrapped">
+              <table class="record data-table hardwrapped">
                 <tbody>
                   <tr>
-                    <th scope="row">Processing pipeline timestamps<br>(most recent)</th>
+                    <th class="w-2/12" scope="row">Processing pipeline timestamps<br>(most recent)</th>
                     <td>
                       start: {{ report.started_datetime | human_readable_iso_date }} UTC &#8594;
                       end: {{ report.completed_datetime | human_readable_iso_date }} UTC
@@ -1213,7 +1213,7 @@
                     <td>
                       <table class="data-table">
                         <tr>
-                          <th scope="row">version:</th>
+                          <th class="w-2/12" scope="row">version:</th>
                           <td>
                             {% if report and report.stackwalk_version %}
                               {{ report.stackwalk_version }}
@@ -1244,7 +1244,7 @@
                     <td>
                       <table class="data-table">
                         <tr>
-                          <th scope="row">signature:</th>
+                          <th class="w-2/12" scope="row">signature:</th>
                           <td>{{ report.signature }}</td>
                         </tr>
                         <tr>

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -689,14 +689,14 @@
               <div id="frames">
                 {% if crashing_thread is not none %}
                   <h2>Crashing Thread ({{ crashing_thread }}){% if parsed_dump.threads[crashing_thread].thread_name %}, Name: {{ parsed_dump.threads[crashing_thread].thread_name }}{% endif %}</h2>
-                  <table class="data-table">
+                  <table class="data-table hardwrapped">
                     <thead>
                       <tr>
-                        <th scope="col">Frame</th>
-                        <th scope="col">Module</th>
-                        <th class="signature-column" scope="col">Signature</th>
-                        <th scope="col">Source</th>
-                        <th scope="col">Trust</th>
+                        <th class="w-1/12" scope="col">Frame</th>
+                        <th class="w-1/12" scope="col">Module</th>
+                        <th class="w-5/12" class="signature-column" scope="col">Signature</th>
+                        <th class="w-4/12" scope="col">Source</th>
+                        <th class="w-1/12" scope="col">Trust</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -752,14 +752,14 @@
                   {% for thread in parsed_dump.threads %}
                     {% if thread.thread != crashing_thread %}
                       <h2>Thread {{ thread.thread }}{% if thread.thread_name %}, Name: {{ thread.thread_name }}{% endif %}</h2>
-                      <table class="data-table">
+                      <table class="data-table hardwrapped">
                         <thead>
                           <tr>
-                            <th scope="col">Frame</th>
-                            <th scope="col">Module</th>
-                            <th class="signature-column" scope="col">Signature</th>
-                            <th scope="col">Source</th>
-                            <th scope="col">Trust</th>
+                            <th class="w-1/12" scope="col">Frame</th>
+                            <th class="w-1/12" scope="col">Module</th>
+                            <th class="w-5/12" class="signature-column" scope="col">Signature</th>
+                            <th class="w-4/12" scope="col">Source</th>
+                            <th class="w-1/12" scope="col">Trust</th>
                           </tr>
                         </thead>
                         <tbody>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -72,6 +72,43 @@ time {
     display: inline-block;
 }
 
+.w-1\/12 {
+    width: 8.3333%;
+}
+.w-2\/12 {
+    width: 16.6667%;
+}
+.w-3\/12 {
+    width: 25%;
+}
+.w-4\/12 {
+    width: 33.3333%;
+}
+.w-5\/12 {
+    width: 41.6667%;
+}
+.w-6\/12 {
+    width: 50%;
+}
+.w-7\/12 {
+    width: 58.3333%;
+}
+.w-8\/12 {
+    width: 66.6667%;
+}
+.w-9\/12 {
+    width: 75%;
+}
+.w-10\/12 {
+    width: 83.3333%;
+}
+.w-11\/12 {
+    width: 91.666667%;
+}
+.w-full {
+    width: 100%;
+}
+
 #mainbody {
     position: relative;
     margin: 1em 2em;

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
@@ -63,14 +63,6 @@ table {
         }
     }
 
-    &.vertical {
-        th {
-            width: 150px;
-            border: 1px solid @black;
-            font-weight: bold;
-        }
-    }
-
     &.hardwrapped {
         td {
             overflow-wrap: anywhere;

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
@@ -3,8 +3,6 @@
 
 #details th,
 #metadata th {
-    width: 15%;
-    max-width: 250px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
This fixes the breaks in the report view stack table so that long sources and long function signatures don't make the table impossible to read.
    
It also applies widths to the columns to make table layout more stable across multiple stacks.

This gets rid of the "vertical" css class and fixes the affected tables by adding width classes making table layout more stable. The "vertical" class used a width in pixels which made it resize poorly. This switches to percentage widths for more of the layout.