### PR TITLE
bug 1789705: fix table column widths across the site

### DIFF
--- a/webapp-django/crashstats/api/static/api/css/documentation.less
+++ b/webapp-django/crashstats/api/static/api/css/documentation.less
@@ -4,15 +4,7 @@ p.url {
     margin: 15px;
     font-size: 1.6em;
     code {
-
         padding-left: 25px;
-    }
-}
-
-th,
-td {
-    &.fixed {
-        width: 15%;
     }
 }
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -662,11 +662,11 @@
                   <table class="data-table">
                     <thead>
                       <tr>
-                        <th scope="col">Frame</th>
-                        <th scope="col">Module</th>
-                        <th scope="col">Function</th>
-                        <th scope="col">Source</th>
-                        <th scope="col">In app?</th>
+                        <th class="w-1/12" scope="col">Frame</th>
+                        <th class="w-2/12" scope="col">Module</th>
+                        <th class="w-5/12" scope="col">Function</th>
+                        <th class="w-3/12" scope="col">Source</th>
+                        <th class="w-1/12" scope="col">In app?</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -693,9 +693,9 @@
                     <thead>
                       <tr>
                         <th class="w-1/12" scope="col">Frame</th>
-                        <th class="w-1/12" scope="col">Module</th>
+                        <th class="w-2/12" scope="col">Module</th>
                         <th class="w-5/12" class="signature-column" scope="col">Signature</th>
-                        <th class="w-4/12" scope="col">Source</th>
+                        <th class="w-3/12" scope="col">Source</th>
                         <th class="w-1/12" scope="col">Trust</th>
                       </tr>
                     </thead>
@@ -756,9 +756,9 @@
                         <thead>
                           <tr>
                             <th class="w-1/12" scope="col">Frame</th>
-                            <th class="w-1/12" scope="col">Module</th>
+                            <th class="w-2/12" scope="col">Module</th>
                             <th class="w-5/12" class="signature-column" scope="col">Signature</th>
-                            <th class="w-4/12" scope="col">Source</th>
+                            <th class="w-3/12" scope="col">Source</th>
                             <th class="w-1/12" scope="col">Trust</th>
                           </tr>
                         </thead>
@@ -827,11 +827,11 @@
                 <table class="data-table breadcrumbs-table">
                   <thead>
                     <tr>
-                      <th class="small-col" scope="col">Level</th>
-                      <th class="small-col" scope="col">Type</th>
-                      <th class="small-col" scope="col">Category</th>
-                      <th scope="col">Data</th>
-                      <th class="small-col" scope="col">Timestamp</th>
+                      <th class="w-1/12" scope="col">Level</th>
+                      <th class="w-1/12" scope="col">Type</th>
+                      <th class="w-2/12" scope="col">Category</th>
+                      <th scope="w-6/12">Data</th>
+                      <th class="w-2/12" scope="col">Timestamp</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -949,10 +949,10 @@
               <table class="tablesorter data-table" id="modules-list">
                 <thead>
                   <tr>
-                    <th scope="col">Filename</th>
-                    <th scope="col">Version</th>
-                    <th scope="col">Debug Identifier</th>
-                    <th scope="col">Debug Filename</th>
+                    <th class="w-3/12" scope="col">Filename</th>
+                    <th class="w-2/12" scope="col">Version</th>
+                    <th class="w-3/12" scope="col">Debug Identifier</th>
+                    <th class="w-2/12" scope="col">Debug Filename</th>
                     {% if parsed_dump.modules_contains_cert_info %}<th scope="col">Signed By</th>{% endif %}
                   </tr>
                 </thead>
@@ -1059,11 +1059,11 @@
               <table class="data-table">
                 <thead>
                   <tr>
-                    <th scope="col">Extension Id</th>
-                    <th scope="col">Name</th>
-                    <th scope="col">Version</th>
-                    <th scope="col">System?</th>
-                    <th scope="col">Signed state</th>
+                    <th class="w-3/12" scope="col">Extension Id</th>
+                    <th class="w-5/12" scope="col">Name</th>
+                    <th class="w-1/12" scope="col">Version</th>
+                    <th class="w-1/12" scope="col">System?</th>
+                    <th class="w-2/12" scope="col">Signed state</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/tables.less
@@ -1,10 +1,11 @@
-
 table {
     thead,
     tbody {
         tr {
             z-index: 50;
-            th,
+            th {
+                border: 1px solid @black;
+            }
             td {
                 border: solid 1px @grey;
             }
@@ -68,7 +69,6 @@ table {
             overflow-wrap: anywhere;
         }
     }
-
 }
 
 .tablesorter {

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/table_sorter.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/table_sorter.less
@@ -2,7 +2,8 @@
 
 table.tablesorter {
     th {
-        background-color: @light-grey;
+        background-color: @dark-tan;
+        border: solid 1px @grey;
     }
     tbody {
         tr.odd {
@@ -12,11 +13,7 @@ table.tablesorter {
             padding: 7px .5em 8px .5em;
             background-color: transparent;
         }
-    }
-}
 
-table.tablesorter {
-    tbody {
         tr {
             td.in1 {
                 padding-left: 15px;

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/pages/report_index.less
@@ -9,13 +9,6 @@
 }
 
 #breadcrumbs {
-    thead {
-        tr {
-            th.small-col {
-                width: 1%;
-            }
-        }
-    }
     th, td {
         vertical-align: top;
     }

--- a/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
+++ b/webapp-django/crashstats/documentation/jinja2/documentation/supersearch/home.html
@@ -138,8 +138,8 @@
     <table>
       <thead>
         <tr>
-          <th>Data type</th>
-          <th>Operators</th>
+          <th class="w-2/12">Data type</th>
+          <th class="w-3/12">Operators</th>
           <th>Description</th>
         </tr>
       </thead>
@@ -217,9 +217,9 @@
     <table>
       <thead>
         <tr>
-          <th>Operator</th>
-          <th>Code</th>
-          <th>Data types</th>
+          <th class="w-2/12">Operator</th>
+          <th class="w-2/12">Code</th>
+          <th class="w-2/12">Data types</th>
           <th>Description</th>
         </tr>
       </thead>

--- a/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
+++ b/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
@@ -40,12 +40,10 @@
         }
         thead > tr > th {
             vertical-align: bottom;
-            border-bottom: 2px solid @light-grey;
         }
         td, th {
             padding: 8px;
             vertical-align: top;
-            border: 1px solid @light-grey;
         }
     }
 

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_aggregation.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_aggregation.html
@@ -2,10 +2,10 @@
   <table class="tablesorter data-table">
     <thead>
       <tr>
-        <th scope="col">Rank</th>
-        <th data-field-name="{{ aggregation }}" scope="col">{{ aggregation | replace('_', ' ') | capitalize }}</th>
-        <th scope="col">Count</th>
-        <th scope="col">%</th>
+        <th class="w-2/12" scope="col">Rank</th>
+        <th class="w-6/12" data-field-name="{{ aggregation }}" scope="col">{{ aggregation | replace('_', ' ') | capitalize }}</th>
+        <th class="w-2/12" scope="col">Count</th>
+        <th class="w-2/12" scope="col">%</th>
       </tr>
     </thead>
     <tbody>

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -49,9 +49,9 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Operating System</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-8/12">Operating System</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -76,10 +76,10 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Product</th>
-          <th class="header">Version</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-4/12">Product</th>
+          <th class="header w-2/12">Version</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
           <th class="header">Installations (approx)</th>
         </tr>
       </thead>
@@ -109,9 +109,9 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Process Type</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-8/12">Process Type</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -136,16 +136,16 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Manufacturer</th>
-          <th class="header">Model</th>
-          <th class="header">
+          <th class="header w-2/12">Manufacturer</th>
+          <th class="header w-2/12">Model</th>
+          <th class="header w-2/12">
             <a href="https://en.wikipedia.org/wiki/Android_%28operating_system%29#Platform_usage">
               API Level
             </a>
           </th>
-          <th class="header">CPU ABI</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-2/12">CPU ABI</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -173,9 +173,9 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Uptime Range</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-8/12">Uptime Range</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -200,9 +200,9 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Architecture</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-8/12">Architecture</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -227,9 +227,9 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th class="header">Flash&trade; Version</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th class="header w-8/12">Flash&trade; Version</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>
@@ -254,10 +254,10 @@
     <table class="tablesorter data-table">
       <thead>
         <tr>
-          <th data-field-name="adapter_vendor" class="header">Vendor</th>
-          <th data-field-name="adapter_device" class="header">Adapter</th>
-          <th class="header">Count</th>
-          <th class="header">Percentage</th>
+          <th data-field-name="adapter_vendor" class="header w-4/12">Vendor</th>
+          <th data-field-name="adapter_device" class="header w-4/12">Adapter</th>
+          <th class="header w-2/12">Count</th>
+          <th class="header w-2/12">Percentage</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
I threw together some width classes in an earlier commit. This tweaks the widths of the stacks table to fit the data better. This also improves a bunch of other tables to make them more stable layout-wise and remove pixel widths.

I also adjusted borders for table headers. There was a bunch of css code in random places for that. I reduced that some.