### PR TITLE
bug 1788103: redo display of inline functions in report view

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -704,29 +704,16 @@
                         {% if frame.truncated %}
                           <tr><td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td></tr>
                         {% else %}
-                          <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                            <td rowspan="{{ rowspan_for_inlines(frame) }}">
-                              {% if frame.missing_symbols %}
-                                <span class="row-notice" title="missing symbol">&Oslash;</span>
-                              {% endif %}
-                              {{ frame.frame }}
-                            </td>
-                            <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.module }}</td>
-                            <td title="{{ frame.signature }}">{{ frame.signature }}</td>
-                            <td>
-                              {% if frame.source_link %}
-                                <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
-                              {% else %}
-                                {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
-                              {% endif %}
-                            </td>
-                            <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.trust }}</td>
-                          </tr>
                           {% if frame.inlines %}
                             {% for inline in frame.inlines %}
                               <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                                {# frame index #}
-                                {# module #}
+                                <td>
+                                  {% if frame.missing_symbols %}
+                                    <span class="row-notice" title="missing symbol">&Oslash;</span>
+                                  {% endif %}
+                                  {{ frame.frame }}
+                                </td>
+                                <td>{{ frame.module }}</td>
                                 <td title="{{ inline.function }}">{{ inline.function }}</td>
                                 <td>
                                   {% if inline.source_link %}
@@ -735,10 +722,28 @@
                                     {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
                                   {% endif %}
                                 </td>
-                                {# trust #}
+                                <td>inlined</td>
                               </tr>
                             {% endfor %}
                           {% endif %}
+                          <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                            <td>
+                              {% if frame.missing_symbols %}
+                                <span class="row-notice" title="missing symbol">&Oslash;</span>
+                              {% endif %}
+                              {{ frame.frame }}
+                            </td>
+                            <td>{{ frame.module }}</td>
+                            <td title="{{ frame.signature }}">{{ frame.signature }}</td>
+                            <td>
+                              {% if frame.source_link %}
+                                <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
+                              {% else %}
+                                {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
+                              {% endif %}
+                            </td>
+                            <td>{{ frame.trust }}</td>
+                          </tr>
                         {% endif %}
                       {% endfor %}
                     </tbody>
@@ -767,29 +772,16 @@
                             {% if frame.truncated %}
                               <tr><td colspan="5">truncated {{ frame.truncated|digitgroupseparator }} frames...</td></tr>
                             {% else %}
-                              <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                                <td rowspan="{{ rowspan_for_inlines(frame) }}">
-                                  {% if frame.missing_symbols %}
-                                    <span class="row-notice" title="missing symbol">&Oslash;</span>
-                                  {% endif %}
-                                  {{ frame.frame }}
-                                </td>
-                                <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.module }}</td>
-                                <td title="{{ frame.signature }}">{{ frame.signature }}</td>
-                                <td>
-                                  {% if frame.source_link %}
-                                    <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
-                                  {% else %}
-                                    {{ frame.file }}{% if frame.line %}:{{ frame.line }}{% endif %}
-                                  {% endif %}
-                                </td>
-                                <td rowspan="{{ rowspan_for_inlines(frame) }}">{{ frame.trust }}</td>
-                              </tr>
                               {% if frame.inlines %}
                                 {% for inline in frame.inlines %}
                                   <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
-                                    {# frame index #}
-                                    {# module #}
+                                    <td>
+                                      {% if frame.missing_symbols %}
+                                        <span class="row-notice" title="missing symbol">&Oslash;</span>
+                                      {% endif %}
+                                      {{ frame.frame }}
+                                    </td>
+                                    <td>{{ frame.module }}</td>
                                     <td title="{{ inline.function }}">{{ inline.function }}</td>
                                     <td>
                                       {% if inline.source_link %}
@@ -798,10 +790,28 @@
                                         {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
                                       {% endif %}
                                     </td>
-                                    {# trust #}
+                                    <td>inlined</td>
                                   </tr>
                                 {% endfor %}
                               {% endif %}
+                              <tr class="{% if frame.missing_symbols %}missingsymbols{% endif %}">
+                                <td>
+                                  {% if frame.missing_symbols %}
+                                    <span class="row-notice" title="missing symbol">&Oslash;</span>
+                                  {% endif %}
+                                  {{ frame.frame }}
+                                </td>
+                                <td>{{ frame.module }}</td>
+                                <td title="{{ frame.signature }}">{{ frame.signature }}</td>
+                                <td>
+                                  {% if frame.source_link %}
+                                    <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
+                                  {% else %}
+                                    {{ frame.file }}{% if frame.line %}:{{ frame.line }}{% endif %}
+                                  {% endif %}
+                                </td>
+                                <td>{{ frame.trust }}</td>
+                              </tr>
                             {% endif %}
                           {% endfor %}
                         </tbody>

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -509,8 +509,3 @@ def filter_featured_versions(product_versions):
 @library.global_function
 def filter_not_featured_versions(product_versions):
     return [pv for pv in product_versions if not pv["is_featured"]]
-
-
-@library.global_function
-def rowspan_for_inlines(frame):
-    return 1 + len(frame.get("inlines") or [])


### PR DESCRIPTION
This fixes the display of inline functions in the report view in two fundamental ways:

1. it switches to displaying functions as depicted in the other mockup
2. it fixes the ordering of frame function vs. the inline functions so it makes sense now