### PR TITLE
bug 1767566: fix clickability of tabs in report view

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -151,4 +151,14 @@ $(document).ready(function () {
 
   // Enhance bug links.
   BugLinks.enhance();
+
+  // Fix accessibility for the tab links so that the tabs respond to click
+  // events and not just the a tags. bug #1767566
+  $('.ui-tab').each(function (i, tab) {
+    tab.addEventListener('click', function (evt) {
+      if (evt.target == tab) {
+        tab.firstElementChild.click();
+      }
+    });
+  });
 });


### PR DESCRIPTION
The tabs are implemented with jquery ui tab component and it's structured such that the "tab" is a li with an a child that responds to click events. But since the tab has aria-labeledby that tells screen readers to ignore the content, the a isn't clickable.

This adds James' suggested fix which adds a listener for click to the tab which then clicks the a tag.