### PR TITLE
bug 1733904: add "bad hardware" to signature for STATUS_DEVICE_DATA_ERROR

### DIFF
--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -7,23 +7,25 @@ import sys
 from typing import Any, Dict, List
 
 from .rules import (
-    SignatureGenerationRule,
-    StackwalkerErrorSignatureRule,
-    OOMSignature,
     AbortSignature,
-    SignatureShutdownTimeout,
-    SignatureRunWatchDog,
+    BadHardware,
+    OOMSignature,
+    SigFixWhitespace,
+    SignatureGenerationRule,
     SignatureIPCChannelError,
     SignatureIPCMessageName,
-    SigFixWhitespace,
-    SigTruncate,
     SignatureParentIDNotEqualsChildID,
+    SignatureRunWatchDog,
+    SignatureShutdownTimeout,
+    SigTruncate,
+    StackwalkerErrorSignatureRule,
 )
 
 
 DEFAULT_PIPELINE = [
     SignatureGenerationRule(),
     StackwalkerErrorSignatureRule(),
+    BadHardware(),
     OOMSignature(),
     AbortSignature(),
     SignatureShutdownTimeout(),

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -628,6 +628,35 @@ class OOMSignature(Rule):
         return True
 
 
+class BadHardware(Rule):
+    """Prepends ``bad hardware`` to signatures that are from bad hardware.
+
+    See bug #1733904.
+
+    """
+
+    # These reason values indicate an OOM
+    bad_hardware_reason = [
+        "STATUS_DEVICE_DATA_ERROR",
+    ]
+
+    def predicate(self, crash_data, result):
+        # Check the reason to see if it's one of a few values that indicate an OOM
+        reason = crash_data.get("reason", None)
+        if not reason:
+            return False
+
+        for possibility in self.bad_hardware_reason:
+            if possibility in reason:
+                return True
+
+        return False
+
+    def action(self, crash_data, result):
+        result.set_signature(self.name, f"bad hardware | {result.signature}")
+        return True
+
+
 class AbortSignature(Rule):
     """Prepends abort message to signature.
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1230,6 +1230,35 @@ class TestOOMSignature:
         assert result.signature == "OOM | large | hello"
 
 
+class TestBadHardware:
+    @pytest.mark.parametrize(
+        "reason, expected",
+        [
+            ("FOO", False),
+            ("EXCEPTION_IN_PAGE_ERROR_READ / STATUS_DEVICE_DATA_ERROR", True),
+            ("EXCEPTION_IN_PAGE_ERROR_EXEC / STATUS_DEVICE_DATA_ERROR", True),
+            ("EXCEPTION_IN_PAGE_ERROR_WRITE / STATUS_DEVICE_DATA_ERROR", True),
+        ],
+    )
+    def test_predicate_reason(self, reason, expected):
+        crash_data = {"reason": reason}
+        result = generator.Result()
+        result.signature = "Text"
+        rule = rules.BadHardware()
+        assert rule.predicate(crash_data, result) is expected
+
+    def test_action(self):
+        crash_data = {
+            "reason": "EXCEPTION_IN_PAGE_ERROR_READ / STATUS_DEVICE_DATA_ERROR",
+        }
+        result = generator.Result()
+        result.signature = "Text"
+        rule = rules.BadHardware()
+        action_result = rule.action(crash_data, result)
+        assert action_result is True
+        assert result.signature == "bad hardware | Text"
+
+
 class TestAbortSignature:
     def test_predicate(self):
         rule = rules.AbortSignature()


### PR DESCRIPTION
This prepends "bad hardware" to the signature if the reason has "STATUS_DEVICE_DATA_ERROR" in it. This reduces the likelihood we spend time looking into crash reports that we can't do anything about.