### PR TITLE
bug 1749770: fix API endpoints to be more resilient

### DIFF
--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -64,6 +64,10 @@ def get_api_allowlist(include_all_fields=False):
 class ESSocorroMiddleware(models.SocorroMiddleware):
     implementation_config_namespace = "elasticsearch"
 
+    post = None
+    put = None
+    delete = None
+
 
 def validate_products(product_value):
     """Validates product values against supported products.
@@ -248,7 +252,7 @@ class SuperSearchFields(ESSocorroMiddleware):
 
     API_ALLOWLIST = None
 
-    def get(self):
+    def get(self, **kwargs):
         return copy.deepcopy(self._fields)
 
 


### PR DESCRIPTION
This fixes the API endpoints that derive from SocorroMiddleware to be more resilient to fuzzing.

To test, do things like this:

```
curl 'http://locahost:8000/api/SuperSearchFields/' --data ""
```

That does a POST to SuperSearchFields endpoint. In prod, that kicks up an HTTP 500 because it's using the default post function. This fixes it so now it'll return a `Method not allowed`.