### PR TITLE
bug 1745732: improve signatures for crash reports with thread index issues

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -362,13 +362,16 @@ class CSignatureTool:
             if crashed_thread is None:
                 notes.append("CSignatureTool: no crashing thread identified")
                 signature = "EMPTY: no crashing thread identified"
+
             else:
                 notes.append(
                     f"CSignatureTool: no frame data for crashing thread ({crashed_thread})"
                 )
-                try:
+                if source_list:
+                    # The frames were probably all irrelevant, so pick the first one.
                     signature = source_list[0]
-                except IndexError:
+                else:
+                    # There wasn't any frame data to look at.
                     signature = "EMPTY: no frame data available"
 
         return signature, notes, debug_notes
@@ -577,7 +580,7 @@ class SignatureGenerationRule(Rule):
 
         signature, notes, debug_notes = self.c_signature_tool.generate(
             signature_list,
-            crash_data.get("crashing_thread"),
+            crashing_thread,
         )
 
         if signature_list:

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1175,11 +1175,11 @@ class TestSignatureGenerationRule:
         # the call to be tested
         assert sgr.action(crash_data, result) is True
 
-        assert result.signature == "EMPTY: no crashing thread identified"
+        assert result.signature == "EMPTY: no frame data available"
         assert "proto_signature" not in result.extra
         assert "normalized_frames" not in result.extra
         assert result.notes == [
-            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
+            "SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)"
         ]
 
     def test_lower_case_modules(self):

--- a/socorro/signature/tests/test_signature_generator.py
+++ b/socorro/signature/tests/test_signature_generator.py
@@ -21,9 +21,9 @@ class TestSignatureGenerator:
         # NOTE(willkg): This is what the current pipeline yields. If any of those parts change, this
         # might change, too. The point of this test is that we can pass in empty dicts and the
         # SignatureGenerator and the rules in the default pipeline don't fall over.
-        assert ret.signature == "EMPTY: no crashing thread identified"
+        assert ret.signature == "EMPTY: no frame data available"
         assert ret.notes == [
-            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
+            "SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)"
         ]
 
     def test_failing_rule(self):

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -2011,10 +2011,10 @@ class TestSignatureGeneratorRule:
         # those parts change, this might change, too. The point of this test is
         # that we can pass in empty dicts and the SignatureGeneratorRule and
         # the generation rules in the default pipeline don't fall over.
-        assert processed_crash["signature"] == "EMPTY: no crashing thread identified"
+        assert processed_crash["signature"] == "EMPTY: no frame data available"
         assert "proto_signature" not in processed_crash
         assert status.notes == [
-            "SignatureGenerationRule: CSignatureTool: no crashing thread identified"
+            "SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)"
         ]
 
     def test_rule_fail_and_capture_error(self, sentry_helper):


### PR DESCRIPTION
For crash reports where the crashing thread index either doesn't point to a thread for which we have data or it's null, this defaults the crashing thread to 0.

```
Crash id: cf56f4aa-00a4-47ab-86fe-026d60220908
Original: EMPTY: no crashing thread identified; MissingThreadList
New:      EMPTY: no frame data available; MissingThreadList
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: ab1ed46b-eea9-49a0-abe6-acdad0220908
Original: OOM | large | EMPTY: no crashing thread identified; EmptyMinidump
New:      OOM | large | EMPTY: no frame data available; EmptyMinidump
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: 938bd64d-cd72-4431-addc-a64f50220908
Original: OOM | large | EMPTY: no crashing thread identified; EmptyMinidump
New:      OOM | large | EMPTY: no frame data available; EmptyMinidump
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: 2cd08bb2-fbbb-4a7f-99b3-8dfb40220908
Original: EMPTY: no crashing thread identified; MissingThreadList
New:      EMPTY: no frame data available; MissingThreadList
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: 2122ea3e-d9c9-4354-971e-75c4e0220908
Original: OOM | large | EMPTY: no crashing thread identified; EmptyMinidump
New:      OOM | large | EMPTY: no frame data available; EmptyMinidump
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: 7b18389e-f980-47e8-be98-947660220908
Original: EMPTY: no crashing thread identified; OK
New:      KiFastSystemCallRet
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)

Crash id: 4704fa5e-1824-4743-8c6c-e24270220908
Original: EMPTY: no crashing thread identified; OK
New:      EMPTY: no frame data available; OK
Same?:    False
Notes:    (1)
          SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)
```