### PR TITLE
bug 1790136: don't display line "None"

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -3,6 +3,14 @@
   Protected data: <a href="{{ url('documentation:protected_data_access') }}">Protected data policy.</a>
 {%- endmacro %}
 
+{% macro source_link(link, file, line) -%}
+{% if link %}
+  <a href="{{ link }}">{{ file }}{% if line is not none %}:{{ line }}{% endif %}</a>
+{% elif file %}
+  {{ file }}{% if line is not none %}:{{line }}{% endif %}
+{% endif %}
+{%- endmacro %}
+
 {% extends "crashstats_base.html" %}
 
 {% block summary_page_tags %}
@@ -715,13 +723,7 @@
                                 </td>
                                 <td>{{ frame.module }}</td>
                                 <td title="{{ inline.function }}">{{ inline.function }}</td>
-                                <td>
-                                  {% if inline.source_link %}
-                                    <a href="{{ inline.source_link }}">{{ inline.file }}:{{ inline.line }}</a>
-                                  {% else %}
-                                    {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
-                                  {% endif %}
-                                </td>
+                                <td>{{ source_link(inline.source_link, inline.file, inline.line) }}</td>
                                 <td>inlined</td>
                               </tr>
                             {% endfor %}
@@ -735,13 +737,7 @@
                             </td>
                             <td>{{ frame.module }}</td>
                             <td title="{{ frame.signature }}">{{ frame.signature }}</td>
-                            <td>
-                              {% if frame.source_link %}
-                                <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
-                              {% else %}
-                                {% if frame.file %}{{ frame.file }}:{{ frame.line }}{% endif %}
-                              {% endif %}
-                            </td>
+                            <td>{{ source_link(frame.source_link, frame.file, frame.line) }}</td>
                             <td>{{ frame.trust }}</td>
                           </tr>
                         {% endif %}
@@ -783,13 +779,7 @@
                                     </td>
                                     <td>{{ frame.module }}</td>
                                     <td title="{{ inline.function }}">{{ inline.function }}</td>
-                                    <td>
-                                      {% if inline.source_link %}
-                                        <a href="{{ inline.source_link }}">{{ inline.file }}:{{ inline.line }}</a>
-                                      {% else %}
-                                        {% if inline.file %}{{ inline.file }}:{{ inline.line }}{% endif %}
-                                      {% endif %}
-                                    </td>
+                                    <td>{{ source_link(inline.source_link, inline.file, inline.line) }}</td>
                                     <td>inlined</td>
                                   </tr>
                                 {% endfor %}
@@ -803,13 +793,7 @@
                                 </td>
                                 <td>{{ frame.module }}</td>
                                 <td title="{{ frame.signature }}">{{ frame.signature }}</td>
-                                <td>
-                                  {% if frame.source_link %}
-                                    <a href="{{ frame.source_link }}">{{ frame.file }}:{{ frame.line }}</a>
-                                  {% else %}
-                                    {{ frame.file }}{% if frame.line %}:{{ frame.line }}{% endif %}
-                                  {% endif %}
-                                </td>
+                                <td>{{ source_link(frame.source_link, frame.file, frame.line) }}</td>
                                 <td>{{ frame.trust }}</td>
                               </tr>
                             {% endif %}


### PR DESCRIPTION
If line data is None, then don't display it at all.

Test with https://crash-stats.mozilla.org/report/index/c8e640f4-6d6d-46aa-a015-9db2c0220909 . After this patch, the first inlined frame should have no line number.