### PR TITLE
Add core::slice::index::slice_end_index_len_fail to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -34,6 +34,7 @@ core::ptr::drop_in_place
 core::ptr::real_drop_in_place
 core::result::unwrap_failed
 core::slice::index::slice_end_index_len_fail
+core::slice::index::slice_end_index_len_fail_rt
 core::slice::slice_index_order_fail
 core::str::slice_error_fail
 CreateFileMappingA

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -33,6 +33,7 @@ core::option::expect_none_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place
 core::result::unwrap_failed
+core::slice::index::slice_end_index_len_fail
 core::slice::slice_index_order_fail
 core::str::slice_error_fail
 CreateFileMappingA


### PR DESCRIPTION
This should help attribute the crashes tracked in https://bugzilla.mozilla.org/show_bug.cgi?id=1765793