### PR TITLE
bug 1763710: prep work for looking at corrupt_symbols stuff

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -37,6 +37,9 @@ crontabber)  ## Run crontabber service
 webapp)  ## Run webapp service
     /app/bin/run_webapp.sh "$@"
     ;;
+symbolsserver)  ## Runs a local symbols server
+    /app/bin/run_symbolsserver.sh
+    ;;
 shell)  ## Open a shell or run something else
     if [ -z "$*" ]; then
         bash

--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -20,7 +20,13 @@ function getenv {
 }
 
 DATADIR=./crashdata_mdsw_tmp
-STACKWALKER="$(getenv 'processor.command_pathname')"
+STACKWALKER="/stackwalk-rust/minidump-stackwalk"
+
+# This will pull symbols from the symbols server
+SYMBOLS="--symbols-url=https://symbols.mozilla.org"
+
+# This will pull symbols from disk
+# SYMBOLS="--symbols-path=/app/symbols/
 
 if [[ $# -eq 0 ]]; then
     if [ -t 0 ]; then
@@ -47,9 +53,12 @@ do
     RAWCRASHFILE=$(find ${DATADIR}/v1/raw_crash/ -name $CRASHID -type f)
 
     timeout -s KILL 600 "${STACKWALKER}" \
-        --raw-json $RAWCRASHFILE \
-        --symbols-url "https://symbols.mozilla.org/" \
-        --symbols-cache /tmp/symbols/cache \
-        --symbols-tmp /tmp/symbols/tmp \
+        --evil-json=$RAWCRASHFILE \
+        --symbols-cache=/tmp/symbols/cache \
+        --symbols-tmp=/tmp/symbols/tmp \
+        --no-color \
+        ${SYMBOLS} \
+        --json \
+        --verbose=error \
         ${DATADIR}/v1/dump/$CRASHID
 done

--- a/bin/run_symbolsserver.sh
+++ b/bin/run_symbolsserver.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: bin/run_symbolsserver.sh
+#
+# Runs a local symbols server for the local dev environment.
+#
+# Note: This is not a production-ready server. It's intended only for
+# debugging.
+
+set -euxo pipefail
+
+SYMBOLS_PATH=/app/symbols
+PORT=8070
+
+echo "Running local symbols server at ${SYMBOLS_PATH} ..."
+python -m http.server --directory "${SYMBOLS_PATH}" --bind 0.0.0.0 "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,15 +157,6 @@ services:
       - "9200:9200"
       - "9300:9300"
 
-  # https://www.docker.elastic.co/
-  elasticsearch7:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.1.0
-    environment:
-      - discovery.type=single-node
-    ports:
-      - "9201:9200"
-      - "9301:9300"
-
   # https://hub.docker.com/_/postgres/
   postgresql:
     image: postgres:12.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,17 @@ services:
     volumes:
       - .:/socorro
 
+  symbolsserver:
+    image: local/socorro_app
+    env_file:
+      - docker/config/local_dev.env
+      - my.env
+    command: ["symbolsserver"]
+    ports:
+      - "8070:8070"
+    volumes:
+      - .:/app
+
   # https://hub.docker.com/r/hopsoft/graphite-statsd/
   statsd:
     image: hopsoft/graphite-statsd


### PR DESCRIPTION
This fixes `run_mdsw.sh` so it works again and adds a really basic local symbols server.