### PR TITLE
bug 1759065: stop building stackwalker every build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,36 +1,4 @@
 # =========================================================================
-# Dokcer image with https://github.com/rust-minidump/rust-minidump
-# =========================================================================
-
-# https://hub.docker.com/_/rust/
-FROM rust:1.63.0-buster@sha256:13d2a0af50f0d86c7e107de4acb13b21829c28751f441f796b640659cb4442c5 as rustminidump
-
-ARG groupid=10001
-ARG userid=10001
-
-WORKDIR /app/
-
-RUN update-ca-certificates && \
-    groupadd --gid $groupid app && \
-    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \
-    chown app:app /app/
-
-USER app
-
-# From: https://github.com/rust-minidump/rust-minidump
-# This is 0.14.0
-ARG MINIDUMPREV=f9933c36c5f48bf806a428b06399242e1b170020
-ARG MINIDUMPREVDATE=2022-08-30
-
-RUN cargo install --locked --root=/app/ \
-    --git https://github.com/rust-minidump/rust-minidump.git \
-    --rev $MINIDUMPREV \
-    minidump-stackwalk
-RUN echo "{\"sha\":\"$MINIDUMPREV\",\"date\":\"$MINIDUMPREVDATE\"}" > /app/bin/minidump-stackwalk.version.json
-RUN ls -al /app/bin/
-
-
-# =========================================================================
 # Building app image
 # =========================================================================
 
@@ -51,9 +19,10 @@ RUN groupadd --gid $groupid app && \
     DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh && \
     rm /tmp/set_up_ubuntu.sh
 
-# Copy stackwalk bits from rust-minidump minidump-stackwalker; this picks
-# up minidump-stackwalk.sha as well
-COPY --from=rustminidump /app/bin/* /stackwalk-rust/
+# Install stackwalker
+COPY docker/set_up_stackwalker.sh /tmp/set_up_stackwalker.sh
+RUN /tmp/set_up_stackwalker.sh && \
+    rm /tmp/set_up_stackwalker.sh
 
 # Install frontend JS deps
 COPY ./webapp-django/package*.json /webapp-frontend-deps/

--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: docker/set_up_stackwalker.sh
+#
+# Installs the stackwalker.
+
+set -euo pipefail
+
+# This should be a url to a .tar.gz file from the release page:
+# https://github.com/rust-minidump/rust-minidump/releases
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20220830.0/socorro-stackwalker.2022-08-30.f9933c36.tar.gz"
+
+TARFILE="stackwalker.tar.gz"
+TARGETDIR="/stackwalk-rust"
+TMPDIR="/tmp/stackwalkerinstall"
+
+mkdir -p "${TMPDIR}"
+pushd "${TMPDIR}"
+
+# Download tar file
+curl -sL -o "${TARFILE}" "${URL}"
+pwd
+ls -l "${TARFILE}"
+
+# Untar tarfile and put contents in the right place
+tar -xzvf "${TARFILE}"
+mkdir -p "${TARGETDIR}" || true
+cp build/bin/minidump-stackwalk "${TARGETDIR}"
+cp build/stackwalk.version.json "${TARGETDIR}/minidump-stackwalk.version.json"
+ls -l "${TARGETDIR}"
+
+# Clean up
+popd
+rm -rf "${TMPDIR}"


### PR DESCRIPTION
We've moved building the stackwalker to a separate repository that does "releases" which include a .tar.gz file. The file is like 5mb.

Then we changed the Socorro build so that it downloads the file rather than building stackwalker _again_. This will improve build times when the docker image cache isn't available or doesn't have anything useful.