### PR TITLE
bug 1687987: support raw crash version 2

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -13,6 +13,7 @@ from socorro.external.crashstorage_base import (
     CrashStorageBase,
     CrashIDNotFound,
     MemoryDumpsMapping,
+    migrate_raw_crash,
 )
 from socorro.lib.libjsonschema import JsonSchemaReducer
 from socorro.lib.libsocorrodataschema import (
@@ -201,7 +202,8 @@ class BotoS3CrashStorage(CrashStorageBase):
         for path in build_keys("raw_crash", crash_id):
             try:
                 raw_crash_as_string = self.conn.load_file(path)
-                return json.loads(raw_crash_as_string)
+                data = json.loads(raw_crash_as_string)
+                return migrate_raw_crash(data)
             except self.conn.KeyNotFound:
                 continue
 

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -125,13 +125,15 @@ def migrate_raw_crash(data):
             "payload_compressed",
         ]
         metadata = data.get("metadata", {})
-        metadata.update({
-            "collector_notes": data.get("collector_notes", []),
-            "dump_checksums": data.get("dump_checksums", {}),
-            "payload_compressed": data.get("payload_compressed", "0"),
-            "payload": data.get("payload", "unknown"),
-            "migrated_from_version_1": True,
-        })
+        metadata.update(
+            {
+                "collector_notes": data.get("collector_notes", []),
+                "dump_checksums": data.get("dump_checksums", {}),
+                "payload_compressed": data.get("payload_compressed", "0"),
+                "payload": data.get("payload", "unknown"),
+                "migrated_from_version_1": True,
+            }
+        )
         data["metadata"] = metadata
         for key in old_keys:
             if key in data:

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -15,6 +15,7 @@ from socorro.external.crashstorage_base import (
     CrashIDNotFound,
     FileDumpsMapping,
     MemoryDumpsMapping,
+    migrate_raw_crash,
 )
 from socorro.lib.libdatetime import utc_now, JsonDTEncoder
 from socorro.lib.libooid import date_from_ooid, depth_from_ooid
@@ -199,10 +200,13 @@ class FSPermanentStorage(CrashStorageBase):
         parent_dir = self._get_radixed_parent_directory(crash_id)
         if not os.path.exists(parent_dir):
             raise CrashIDNotFound
-        with open(
-            os.sep.join([parent_dir, crash_id + self.config.json_file_suffix])
-        ) as f:
-            return json.load(f)
+        path = os.sep.join([parent_dir, crash_id + self.config.json_file_suffix])
+
+        with open(path) as f:
+            data = json.load(f)
+
+        data = migrate_raw_crash(data)
+        return data
 
     def get_raw_dump(self, crash_id, name=None):
         parent_dir = self._get_radixed_parent_directory(crash_id)

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -20,7 +20,7 @@ import sentry_sdk
 from socorro.lib.libdatetime import date_to_string, utc_now
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
-    MinidumpSha256Rule,
+    MinidumpSha256HashRule,
     MinidumpStackwalkRule,
 )
 from socorro.processor.rules.general import (
@@ -188,7 +188,7 @@ class ProcessorPipeline(RequiredConfig):
                 CopyFromRawCrashRule(schema=PROCESSED_CRASH_SCHEMA),
                 SubmittedFromRule(),
                 IdentifierRule(),
-                MinidumpSha256Rule(),
+                MinidumpSha256HashRule(),
                 MinidumpStackwalkRule(
                     dump_field=config.minidumpstackwalk.dump_field,
                     symbols_urls=config.minidumpstackwalk.symbols_urls,

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -65,7 +65,9 @@ class MinidumpSha256HashRule(Rule):
 
     def action(self, raw_crash, dumps, processed_crash, status):
         checksums = raw_crash.get("metadata", {}).get("dump_checksums", {})
-        processed_crash["minidump_sha256_hash"] = checksums.get("upload_file_minidump", "")
+        processed_crash["minidump_sha256_hash"] = checksums.get(
+            "upload_file_minidump", ""
+        )
 
 
 @contextmanager

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -54,14 +54,18 @@ class CrashingThreadInfoRule(Rule):
         )
 
 
-class MinidumpSha256Rule(Rule):
-    """Copy over MinidumpSha256Hash value if there is one"""
+class MinidumpSha256HashRule(Rule):
+    """Copy sha256 hash of upload_file_minidump value if there is one
 
-    def predicate(self, raw_crash, dumps, processed_crash, status):
-        return "MinidumpSha256Hash" in raw_crash
+    Fills in:
+
+    * minidump_sha256_hash (str): hash of upload_file_minidump
+
+    """
 
     def action(self, raw_crash, dumps, processed_crash, status):
-        processed_crash["minidump_sha256_hash"] = raw_crash["MinidumpSha256Hash"]
+        checksums = raw_crash.get("metadata", {}).get("dump_checksums", {})
+        processed_crash["minidump_sha256_hash"] = checksums.get("upload_file_minidump", "")
 
 
 @contextmanager

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -543,7 +543,7 @@ class MozCrashReasonRule(Rule):
 
 
 class OutOfMemoryBinaryRule(Rule):
-    # Number of bytes, max, that we accept memory info payloads as JSON.
+    # Number of bytes, max, that we accept memory_report value as JSON.
     MAX_SIZE_UNCOMPRESSED = 20 * 1024 * 1024  # ~20Mb
 
     def predicate(self, raw_crash, dumps, processed_crash, status):

--- a/socorro/scripts/fetch_crash_data.py
+++ b/socorro/scripts/fetch_crash_data.py
@@ -92,7 +92,15 @@ def fetch_crash(
     if fetchdumps:
         # Fetch dumps
         dumps = {}
-        dump_names = raw_crash.get("dump_checksums", {}).keys()
+
+        # The dump_checksums is in a different place depending on the raw_crash
+        # structure version
+        raw_crash_version = raw_crash.get("version", 1)
+        if raw_crash_version == 1:
+            dump_names = raw_crash.get("dump_checksums", {}).keys()
+        elif raw_crash_version == 2:
+            dump_names = raw_crash.get("metadata", {}).get("dump_checksums", {}).keys()
+
         for dump_name in dump_names:
             print("Fetching dump %s/%s" % (crash_id, dump_name))
 

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -183,7 +183,18 @@ class TestBotoS3CrashStorage:
         )
 
         result = boto_s3_store.get_raw_crash("936ce666-ff3b-4c7a-9674-367fe2120408")
-        assert result == raw_crash
+        expected = {
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "migrated_from_version_1": True,
+                "payload": "unknown",
+                "payload_compressed": "0",
+            },
+            "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00",
+            "version": 2,
+        }
+        assert result == expected
 
     def test_get_raw_crash_not_found(self, boto_helper):
         boto_s3_store = self.get_s3_store()

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -35,7 +35,7 @@ class Test_migrate_raw_crash:
                         "payload": "unknown",
                     },
                     "version": 2,
-                }
+                },
             ),
             # If it's version 2 already, nothing happens
             (
@@ -55,7 +55,7 @@ class Test_migrate_raw_crash:
                         "payload_compressed": "0",
                         "payload": "json",
                     },
-                    "version": 2
+                    "version": 2,
                 },
             ),
             # Migrate version 1 to latest
@@ -87,7 +87,7 @@ class Test_migrate_raw_crash:
                     "version": 2,
                 },
             ),
-        ]
+        ],
     )
     def test_migration(self, data, expected):
         assert migrate_raw_crash(data) == expected

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -15,7 +15,82 @@ from socorro.external.crashstorage_base import (
     MemoryDumpsMapping,
     MetricsCounter,
     MetricsBenchmarkingWrapper,
+    migrate_raw_crash,
 )
+
+
+class Test_migrate_raw_crash:
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            # Empty dict turns into defaults
+            (
+                {},
+                {
+                    "metadata": {
+                        "collector_notes": [],
+                        "dump_checksums": {},
+                        "migrated_from_version_1": True,
+                        "payload_compressed": "0",
+                        "payload": "unknown",
+                    },
+                    "version": 2,
+                }
+            ),
+            # If it's version 2 already, nothing happens
+            (
+                {
+                    "metadata": {
+                        "collector_notes": [],
+                        "dump_checksums": {},
+                        "payload_compressed": "0",
+                        "payload": "json",
+                    },
+                    "version": 2,
+                },
+                {
+                    "metadata": {
+                        "collector_notes": [],
+                        "dump_checksums": {},
+                        "payload_compressed": "0",
+                        "payload": "json",
+                    },
+                    "version": 2
+                },
+            ),
+            # Migrate version 1 to latest
+            (
+                {
+                    "BuildID": "20220902183841",
+                    "CrashTime": "1662147837",
+                    "ProductName": "Firefox",
+                    "collector_notes": ["note1"],
+                    "dump_checksums": {"upload_file_minidump": "hash"},
+                    "payload": "json",
+                    "payload_compressed": "0",
+                    "submitted_timestamp": "2022-09-02T19:44:32.762212+00:00",
+                    "uuid": "20aec939-4154-4520-ba3c-024930220902",
+                },
+                {
+                    "BuildID": "20220902183841",
+                    "CrashTime": "1662147837",
+                    "ProductName": "Firefox",
+                    "metadata": {
+                        "collector_notes": ["note1"],
+                        "dump_checksums": {"upload_file_minidump": "hash"},
+                        "migrated_from_version_1": True,
+                        "payload_compressed": "0",
+                        "payload": "json",
+                    },
+                    "submitted_timestamp": "2022-09-02T19:44:32.762212+00:00",
+                    "uuid": "20aec939-4154-4520-ba3c-024930220902",
+                    "version": 2,
+                },
+            ),
+        ]
+    )
+    def test_migration(self, data, expected):
+        assert migrate_raw_crash(data) == expected
 
 
 class A(CrashStorageBase):

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -12,7 +12,7 @@ from socorro.lib.libsocorrodataschema import validate_instance
 from socorro.processor.processor_pipeline import ProcessorPipeline, Status
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
-    MinidumpSha256Rule,
+    MinidumpSha256HashRule,
     MinidumpStackwalkRule,
 )
 from socorro.schemas import PROCESSED_CRASH_SCHEMA
@@ -221,24 +221,23 @@ class TestCrashingThreadInfoRule:
 
 
 class TestMinidumpSha256HashRule:
-    def test_hash_not_in_raw_crash(self):
+    def test_no_dump_checksum(self):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
-        rule = MinidumpSha256Rule()
-        assert rule.predicate(raw_crash, dumps, processed_crash, status) is False
+        rule = MinidumpSha256HashRule()
+        rule.act(raw_crash, dumps, processed_crash, status)
+        assert processed_crash["minidump_sha256_hash"] == ""
 
-    def test_hash_in_raw_crash(self):
-        raw_crash = {"MinidumpSha256Hash": "hash"}
+    def test_copy_over(self):
+        raw_crash = {"metadata": {"dump_checksums": {"upload_file_minidump": "hash"}}}
         dumps = {}
         processed_crash = {}
         status = Status()
 
-        rule = MinidumpSha256Rule()
-        assert rule.predicate(raw_crash, dumps, processed_crash, status) is True
-
+        rule = MinidumpSha256HashRule()
         rule.act(raw_crash, dumps, processed_crash, status)
         assert processed_crash["minidump_sha256_hash"] == "hash"
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1125,11 +1125,11 @@
               <table class="record data-table hardwrapped">
                 <tbody>
                   <tr>
-                    <th class="w-2/12" scope="row">UUID</th>
+                    <th class="w-2/12" scope="row">uuid</th>
                     <td>{{ raw.uuid }}</td>
                   </tr>
                   <tr>
-                    <th scope="row">Collected timestamp</th>
+                    <th scope="row">submitted_timestamp</th>
                     <td>{{ raw.submitted_timestamp | human_readable_iso_date }} UTC</td>
                   </tr>
                   <tr>
@@ -1144,38 +1144,32 @@
                     <th scope="row">SubmittedFromInfobar</th>
                     <td>{{ raw.SubmittedFromInfobar|default("--") }}</td>
                   </tr>
-                  <tr>
-                    <th scope="row">Payload</th>
-                    <td>{{ raw.payload }}</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Payload compressed</th>
-                    <td>{{ raw.payload_compressed }}</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Dump checksums</th>
-                    <td>
-                      {% if raw.dump_checksums %}
-                        <table class="data-table">
-                          {% for name, sha in raw.dump_checksums.items() %}
-                            <tr>
-                              <th class="w-2/12">{{ name }}:</th>
-                              <td>
-                                <code>{{ sha }}</code>
-                                {% if sha == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" %}
-                                  <span class="humanized">(empty minidump)</span>
-                                {% endif %}
-                              </td>
-                            </tr>
-                          {% endfor %}
-                        </table>
-                      {% endif %}
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Collector notes</th>
-                    <td><pre>{{ raw.collector_notes|join("\n") }}</pre></td>
-                  </tr>
+                  {% for key, val in raw.metadata | dictsort %}
+                    <tr>
+                      <th scope="row">{{ key }}</th>
+                      <td>
+                        {% if key == "collector_notes" %}
+                          <pre>{{ val | join("\n") }}</pre>
+                        {% elif key == "dump_checksums" %}
+                          <table class="data-table">
+                            {% for name, sha in val | dictsort %}
+                              <tr>
+                                <th class="w-2/12">{{ name }}:</th>
+                                <td>
+                                  <code>{{ sha }}</code>
+                                  {% if sha == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" %}
+                                    <span class="humanized">(empty minidump)</span>
+                                  {% endif %}
+                                </td>
+                              </tr>
+                            {% endfor %}
+                          </table>
+                        {% else %}
+                          {{ val }}
+                        {% endif %}
+                      </td>
+                    </tr>
+                  {% endfor %}
                 </tbody>
               </table>
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -761,7 +761,6 @@ class RawCrash(SocorroMiddleware):
     API_ALLOWLIST = (
         # Crash annotations:
         # https://searchfox.org/mozilla-central/source/toolkit/crashreporter/CrashAnnotations.yaml
-        "additional_minidumps",
         "Accessibility",
         "AdapterDeviceID",
         "AdapterDriverVersion",
@@ -799,7 +798,6 @@ class RawCrash(SocorroMiddleware):
         "MacMemoryPressureNormalTime",
         "MacMemoryPressureSysctl",
         "MacMemoryPressureWarningTime",
-        "MinidumpSha256Hash",
         "Notes",
         "NumberOfProcessors",
         "OOMAllocationSize",
@@ -815,7 +813,6 @@ class RawCrash(SocorroMiddleware):
         "ShutdownProgress",
         "SubmittedFrom",
         "StartupTime",
-        "submitted_timestamp",
         "SystemMemoryUsePercentage",
         "TotalVirtualMemory",
         "useragent_locale",
@@ -825,7 +822,7 @@ class RawCrash(SocorroMiddleware):
         "Winsock_LSP",
         "XPCOMSpinEventLoopStack",
         # Fields added by the collector
-        "additional_minidumps",
+        "submitted_timestamp",
         "uuid",
     )
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -633,10 +633,12 @@ class TestViews(BaseTestViews):
                     "Version": "5.0a1",
                     "Vendor": "Mozilla",
                     "URL": "farmville.com",
-                    "dump_checksums": {
-                        "upload_file_minidump": "xxx",
-                        "upload_file_minidump_foo": "xxx",
-                        "upload_file_minidump_bar": "xxx",
+                    "metadata": {
+                        "dump_checksums": {
+                            "upload_file_minidump": "xxx",
+                            "upload_file_minidump_foo": "xxx",
+                            "upload_file_minidump_bar": "xxx",
+                        },
                     },
                 }
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from urllib.parse import quote
 
+import glom
+
 from django import http
 from django.conf import settings
 from django.core.cache import cache
@@ -216,7 +218,9 @@ def report_index(request, crash_id, default_context=None):
     dump_urls = []
     if request.user.has_perm("crashstats.view_rawdump"):
         # Add link for minidumps and memory report
-        dumps = sorted(context["raw"].get("dump_checksums", {}).keys())
+        dumps = sorted(
+            glom.glom(context, "raw.metadata.dump_checksums", default={}).keys()
+        )
         for dump_name in dumps:
             dump_urls.append(
                 (


### PR DESCRIPTION
This adds some code to migrate raw crash data from version 1 to version 2. It updates all the places in Socorro to use the new raw crash version 2 locations for things.

It also changes how `minidump_sha256_hash` gets populated in the processed crash. We're going to drop the `MinidumpSha256Hash` fake annotation in the raw crash that the collector adds. The information is in `dump_checksums`, so there's no need to have it in two places and the fake annotation suggests things that are confusing unless you know where it comes from.