### PR TITLE
bug 1787929: fix KeyError: "definitions" issue with BreadcrumbsRule

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import copy
 import datetime
 import json
 import logging
@@ -298,7 +299,7 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
     def build_reducers(self):
         only_public = permissions_transform_function(permissions_have=["public"])
         public_processed_crash_schema = transform_schema(
-            schema=PROCESSED_CRASH_SCHEMA,
+            schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA),
             transform_function=only_public,
         )
         self.processed_crash_reducer = SocorroDataReducer(

--- a/socorro/lib/libsocorrodataschema.py
+++ b/socorro/lib/libsocorrodataschema.py
@@ -362,6 +362,7 @@ class SocorroDataReducer:
         """
         :arg schema: the schema document specifying the structure to traverse
         """
+        schema = copy.deepcopy(schema)
         if "definitions" in schema:
             schema = resolve_references(schema)
 

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -7,6 +7,7 @@ crash.  In this latest version, all transformations have been reimplemented
 as sets of loadable rules.  The rules are applied one at a time, each doing
 some small part of the transformation process."""
 
+import copy
 import logging
 import os
 import tempfile
@@ -185,7 +186,7 @@ class ProcessorPipeline(RequiredConfig):
                 PluginContentURL(),
                 PluginUserComment(),
                 # rules to transform a raw crash into a processed crash
-                CopyFromRawCrashRule(schema=PROCESSED_CRASH_SCHEMA),
+                CopyFromRawCrashRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA)),
                 SubmittedFromRule(),
                 IdentifierRule(),
                 MinidumpSha256HashRule(),
@@ -209,7 +210,7 @@ class ProcessorPipeline(RequiredConfig):
                 DatesAndTimesRule(),
                 OutOfMemoryBinaryRule(),
                 PHCRule(),
-                BreadcrumbsRule(),
+                BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA)),
                 JavaProcessRule(),
                 MacCrashInfoRule(),
                 MozCrashReasonRule(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -27,7 +27,6 @@ from socorro.lib.libjsonschema import InvalidSchemaError, resolve_references
 from socorro.lib.librequests import session_with_retries
 from socorro.lib.libsocorrodataschema import SocorroDataReducer, validate_instance
 from socorro.processor.rules.base import Rule
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
 from socorro.signature.generator import SignatureGenerator
 from socorro.signature.utils import convert_to_crash_data
 
@@ -429,12 +428,13 @@ class JavaProcessRule(Rule):
 class BreadcrumbsRule(Rule):
     """Validate and move over breadcrumbs."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, schema):
+        super().__init__()
+        self.schema = schema
 
         # NOTE(willkg): if the "breadcrumbs" section ever gets moved in the processed
         # crash schema, we'll need to update this
-        self.BREADCRUMBS_SCHEMA = PROCESSED_CRASH_SCHEMA["definitions"]["breadcrumbs"]
+        self.BREADCRUMBS_SCHEMA = schema["definitions"]["breadcrumbs"]
 
     def predicate(self, raw_crash, dumps, processed_crash, status):
         return bool(raw_crash.get("Breadcrumbs", None))

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -41,6 +41,7 @@ from socorro.processor.rules.mozilla import (
     TopMostFilesRule,
 )
 from socorro.processor.processor_pipeline import Status
+from socorro.schemas import PROCESSED_CRASH_SCHEMA
 from socorro.signature.generator import SignatureGenerator
 
 
@@ -904,7 +905,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule()
+        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
@@ -919,7 +920,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule()
+        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
@@ -930,7 +931,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule()
+        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
         rule.act(raw_crash, dumps, processed_crash, status)
         assert processed_crash == {}
 
@@ -940,7 +941,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule()
+        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash == {}


### PR DESCRIPTION
Something is calling resolve_references on the PROCESSED_CRASH_SCHEMA without copying it first before BreadcrumbsRule initializes which means that "definitions" isn't there. This fixes that.