### PR TITLE
Bug 1791509 - Improve handling inlined library functions

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -104,7 +104,6 @@ objc_msgLookupSuper2
 objc_terminate
 org\.mozilla\.f.*\.apk@0x
 panic_abort::
-_platform
 PR_WaitCondVar
 __psynch_cvwait
 __pthread_
@@ -171,3 +170,14 @@ RtlFailFast2
 RtlpExecuteHandlerForException
 RtlpHandleInvalidUserCallTarget
 seh_filter_exe
+
+# macOS X libc internals
+_platform
+std::__1
+
+# Windows atomics
+std::atomic
+std::_Atomic
+std::_Fetch
+std::_Load
+std::_Store

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -84,8 +84,8 @@ libart\.so@0x
 libobjc.A.dylib@0x
 (libxul\.so|xul\.dll|XUL)@0x
 LL_
-lstrcatA
-lstrlenA
+lstrcat(A|W)
+lstrlen(A|W)
 malloc
 _MD_
 memcmp
@@ -208,30 +208,16 @@ send
 servo_arc::Arc<T>::drop_slow
 SetEvent
 setjmp
-SocketAccept
-SocketAcceptRead
-SocketAvailable
-SocketAvailable64
-SocketBind
-SocketClose
-SocketConnect
-SocketGetName
-SocketGetPeerName
-SocketListen
-SocketPoll
-SocketRead
-SocketRecv
-SocketSend
-SocketShutdown
-SocketSync
-SocketTransmitFile
-SocketWrite
-SocketWritev
+Socket
 ssl_
 SSL_
 std::alloc::rust_oom
 std::_Allocate
-std::_Func_impl_no_alloc<T>::_Do_call
+std::_Func_class<T>::
+std::_Func_impl_no_alloc<T>::
+std::_Func_impl<T>::
+std::_Function_base::_Base_manager<T>::
+std::_Function_handler<T>::
 std::_Hash<T>::
 std::list<.*>::
 std::collections::hash::map::
@@ -275,18 +261,10 @@ mozilla::UniquePtr<T>::reset
 .*\.dll
 
 # platform-specific memset implementations
-avx::memset16
-avx::memset32
-neon::memset32
-portable::memset32
-SK_OPTS_NS::memset32
-sse2::memset32
-sse2::memsetT<T>
+avx::memset
+neon::memset
+portable::memset
 
 # platform-specific strcmp implementations
-g_strcmp0
-lstrcmpA
-lstrcmpW
-lstrcmpiA
-lstrcmpiW
-wstrcmp
+lstrcmp(A|W)
+lstrcmpi(A|W)


### PR DESCRIPTION
This covers several areas:
* It makes Windows atomics irrelevant
* It adds several C++ Windows helper functions to the prefix list
* It makes macOS atomics and other libcs functions irrelevant
* It reorganizes some functions in the prefix list to shorten it
* It removes some functions which do not appear in crashes anymore