### PR TITLE
bug 1787931: fix super search fields to pull permissions from processed crash schema

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import copy
 import datetime
 import json
 import logging
@@ -28,9 +27,6 @@ from socorro.schemas import TELEMETRY_SOCORRO_CRASH_SCHEMA
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 def wait_time_generator():
@@ -301,9 +297,13 @@ class TelemetryBotoS3CrashStorage(BotoS3CrashStorage):
         self.build_reducers()
 
     def build_reducers(self):
-        only_public = permissions_transform_function(permissions_have=["public"])
+        processed_crash_schema = get_schema("processed_crash.schema.yaml")
+        only_public = permissions_transform_function(
+            permissions_have=["public"],
+            default_permissions=processed_crash_schema["default_permissions"],
+        )
         public_processed_crash_schema = transform_schema(
-            schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA),
+            schema=processed_crash_schema,
             transform_function=only_public,
         )
         self.processed_crash_reducer = SocorroDataReducer(

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -18,15 +18,19 @@ from socorro.external.crashstorage_base import (
 )
 from socorro.lib.libjsonschema import JsonSchemaReducer
 from socorro.lib.libsocorrodataschema import (
+    get_schema,
     permissions_transform_function,
     SocorroDataReducer,
     transform_schema,
 )
 from socorro.lib.libooid import date_from_ooid
-from socorro.schemas import PROCESSED_CRASH_SCHEMA, TELEMETRY_SOCORRO_CRASH_SCHEMA
+from socorro.schemas import TELEMETRY_SOCORRO_CRASH_SCHEMA
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 def wait_time_generator():

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2,13 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from dataclasses import dataclass
-import datetime
 import logging
-
-from configman import class_converter, Namespace, RequiredConfig
-import elasticsearch
-from elasticsearch_dsl import Search
 
 
 logger = logging.getLogger(__name__)
@@ -242,120 +236,6 @@ def add_doc_values(value):
     if value.get("properties"):
         for field in value["properties"].values():
             add_doc_values(field)
-
-
-class SuperSearchFieldsData:
-    """Data class for super search fields.
-
-    This just holds the FIELDS and some accessors to get them.
-
-    """
-
-    def get_fields(self):
-        """Return all the fields from our super_search_fields.json file."""
-        return FIELDS
-
-    # Alias ``get`` as ``get_fields`` so this can be used in the API well and
-    # can be conveniently subclassed by ``SuperSearchFields``.
-    get = get_fields
-
-
-@dataclass
-class IndexDataItem:
-    name: str
-    start_date: datetime.datetime
-    count: int
-
-
-class SuperSearchFields(SuperSearchFieldsData):
-    def __init__(self, context):
-        self.context = context
-
-    def get_connection(self):
-        with self.context() as conn:
-            return conn
-
-    def get_supersearch_status(self):
-        """Return list of indices, latest index, and mapping.
-
-        :returns: list of IndexDataItem instances
-
-        """
-        conn = self.get_connection()
-        index_client = elasticsearch.client.IndicesClient(conn)
-        indices = sorted(self.context.get_indices())
-        latest_index = indices[-1]
-
-        doctype = self.context.get_doctype()
-        index_template = self.context.get_index_template()
-        if index_template.endswith("%Y%W"):
-            # Doing strptime on a template that has %W but doesn't have a day-of-week,
-            # will ignore the %W part; so we anchor it with 1 (Monday)
-            add_day_of_week = True
-            index_template = f"{index_template}%w"
-        else:
-            add_day_of_week = False
-
-        index_data = []
-        for index_name in indices:
-            count = Search(using=conn, index=index_name, doc_type=doctype).count()
-
-            if add_day_of_week:
-                # %W starts on Mondays, so we set the day-of-week to 1 which is
-                # Monday
-                adjusted_index_name = f"{index_name}1"
-            else:
-                adjusted_index_name = index_name
-            start_date = datetime.datetime.strptime(adjusted_index_name, index_template)
-            start_date = start_date.date()
-
-            index_data.append(
-                IndexDataItem(
-                    name=index_name,
-                    start_date=start_date,
-                    count=count,
-                )
-            )
-
-        mapping = index_client.get_mapping(index=latest_index)
-        mapping_properties = mapping[latest_index]["mappings"][doctype]["properties"]
-
-        return {
-            "indices": index_data,
-            "latest_index": latest_index,
-            "mapping": mapping_properties,
-        }
-
-
-class SuperSearchFieldsModel(RequiredConfig, SuperSearchFields):
-    """Model for accessing super search fields."""
-
-    # Defining some filters that need to be considered as lists.
-    filters = [
-        ("form_field_choices", None, ["list", "str"]),
-        ("permissions_needed", None, ["list", "str"]),
-    ]
-
-    required_config = Namespace()
-    required_config.add_option(
-        "elasticsearch_class",
-        doc="a class that implements the ES connection object",
-        default="socorro.external.es.connection_context.ConnectionContext",
-        from_string_converter=class_converter,
-    )
-
-    def __init__(self, config):
-        # NOTE(willkg): This doesn't call the super().__init__ but instead
-        # sets everything up itself.
-        self.config = config
-        self.context = self.config.elasticsearch_class(self.config)
-
-
-class SuperSearchStatusModel(SuperSearchFieldsModel):
-    """Model that returns list of indices and latest mapping."""
-
-    def get(self):
-        return super().get_supersearch_status()
 
 
 # Cache of hashed_args -> list of fields values

--- a/socorro/lib/libsocorrodataschema.py
+++ b/socorro/lib/libsocorrodataschema.py
@@ -11,6 +11,8 @@ import re
 
 import jsonschema
 
+from socorro.schemas import get_file_content
+
 
 class InvalidDocumentError(Exception):
     """Raised when the document is invalid"""
@@ -492,3 +494,19 @@ def validate_instance(instance, schema):
     jsonschema.validate(
         instance=instance, schema=schema, cls=jsonschema.Draft7Validator
     )
+
+
+def get_schema(schema_filename, resolve_refs=True):
+    """Returns a schema with references resolved
+
+    :arg schema_filename: the filename of the socorro data schema in the schemas/
+        directory
+    :arg resolve_refs: whether or not to resolve references
+
+    :returns: schema structure as a Python dict
+
+    """
+    schema = get_file_content(schema_filename)
+    if resolve_refs:
+        schema = resolve_references(schema)
+    return schema

--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -7,7 +7,6 @@ crash.  In this latest version, all transformations have been reimplemented
 as sets of loadable rules.  The rules are applied one at a time, each doing
 some small part of the transformation process."""
 
-import copy
 import logging
 import os
 import tempfile
@@ -19,6 +18,7 @@ from configman.converters import str_to_list
 import sentry_sdk
 
 from socorro.lib.libdatetime import date_to_string, utc_now
+from socorro.lib.libsocorrodataschema import get_schema
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
     MinidumpSha256HashRule,
@@ -62,7 +62,6 @@ from socorro.processor.rules.mozilla import (
     ThemePrettyNameRule,
     TopMostFilesRule,
 )
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
 
 
 @define
@@ -186,7 +185,7 @@ class ProcessorPipeline(RequiredConfig):
                 PluginContentURL(),
                 PluginUserComment(),
                 # rules to transform a raw crash into a processed crash
-                CopyFromRawCrashRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA)),
+                CopyFromRawCrashRule(schema=get_schema("processed_crash.schema.yaml")),
                 SubmittedFromRule(),
                 IdentifierRule(),
                 MinidumpSha256HashRule(),
@@ -210,7 +209,7 @@ class ProcessorPipeline(RequiredConfig):
                 DatesAndTimesRule(),
                 OutOfMemoryBinaryRule(),
                 PHCRule(),
-                BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA)),
+                BreadcrumbsRule(schema=get_schema("processed_crash.schema.yaml")),
                 JavaProcessRule(),
                 MacCrashInfoRule(),
                 MozCrashReasonRule(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -434,7 +434,7 @@ class BreadcrumbsRule(Rule):
 
         # NOTE(willkg): if the "breadcrumbs" section ever gets moved in the processed
         # crash schema, we'll need to update this
-        self.BREADCRUMBS_SCHEMA = schema["definitions"]["breadcrumbs"]
+        self.breadcrumbs_schema = schema["properties"]["breadcrumbs"]
 
     def predicate(self, raw_crash, dumps, processed_crash, status):
         return bool(raw_crash.get("Breadcrumbs", None))
@@ -451,7 +451,7 @@ class BreadcrumbsRule(Rule):
             if isinstance(breadcrumbs_data, dict) and "values" in breadcrumbs_data:
                 breadcrumbs_data = breadcrumbs_data["values"]
 
-            validate_instance(breadcrumbs_data, self.BREADCRUMBS_SCHEMA)
+            validate_instance(breadcrumbs_data, self.breadcrumbs_schema)
             processed_crash["breadcrumbs"] = breadcrumbs_data
         except json.JSONDecodeError:
             status.add_note("Breadcrumbs: malformed: not valid json")

--- a/socorro/schemas/__init__.py
+++ b/socorro/schemas/__init__.py
@@ -19,6 +19,4 @@ def get_file_content(filename):
     return schema
 
 
-PROCESSED_CRASH_SCHEMA = get_file_content("processed_crash.schema.yaml")
-
 TELEMETRY_SOCORRO_CRASH_SCHEMA = get_file_content("telemetry_socorro_crash.json")

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -9,6 +9,8 @@
 $schema: moz://mozilla.org/schemas/socorro/socorro-data/1-0-0
 type: object
 
+default_permissions: ["public", "protected"]
+
 definitions:
   breadcrumbs:
     description: >
@@ -536,6 +538,7 @@ definitions:
               type: ["integer", "null"]
               permissions: ["public"]
           type: ["object", "null"]
+          permissions: ["public"]
         type: ["array", "null"]
         permissions: ["public"]
       line:

--- a/socorro/schemas/socorro-data-1-0-0.schema.yaml
+++ b/socorro/schemas/socorro-data-1-0-0.schema.yaml
@@ -10,6 +10,12 @@ description: >
   Schema for defining Socorro-related data schemas.
 
 definitions:
+  simple_permissions:
+    enum:
+      - "public"
+      - "protected"
+    type: string
+
   simple_types:
     enum:
       - "array"
@@ -19,6 +25,7 @@ definitions:
       - "number"
       - "object"
       - "string"
+    type: string
 
   medium_id:
     allOf:
@@ -99,8 +106,7 @@ definitions:
         description: >
           The permissions required to view this field.
         items:
-          enum: ["public", "protected"]
-          type: string
+          $ref: "#/definitions/simple_permissions"
 
         type: array
         uniqueItems: true
@@ -134,6 +140,16 @@ properties:
   $schema:
     type: string
     format: url
+
+  default_permissions:
+    description: >
+      The default permission set required for items not defined by the schema
+      and items defined by the schema that don't have a permission set.
+
+    items:
+      $ref: "#/definitions/simple_permissions"
+    type: array
+    uniqueItems: true
 
   definitions:
     type: object

--- a/socorro/schemas/validate_processed_crash.py
+++ b/socorro/schemas/validate_processed_crash.py
@@ -22,6 +22,7 @@ from socorro.lib.libsocorrodataschema import (
     transform_schema,
     validate_instance,
 )
+from socorro.schemas import get_file_content
 
 
 HERE = os.path.dirname(__file__)
@@ -116,8 +117,12 @@ def match_key(schema_key, document_key):
 @click.argument("crashdir")
 @click.pass_context
 def validate_and_test(ctx, crashdir):
-    jsonschema.Draft4Validator.check_schema(PROCESSED_CRASH_SCHEMA)
-    click.echo("processed crash schema is a valid JSON schema.")
+    socorro_data_schema = get_file_content("socorro-data-1-0-0.schema.yaml")
+    jsonschema.Draft7Validator.check_schema(socorro_data_schema)
+    click.echo("socorro-data-1-0-0.schema.yaml is a valid jsonschema.")
+
+    jsonschema.validate(instance=PROCESSED_CRASH_SCHEMA, schema=socorro_data_schema)
+    click.echo("processed crash schema is a valid socorro data schema.")
 
     # Fetch crash report data from a Super Search URL
     datapath = pathlib.Path(crashdir).resolve()

--- a/socorro/schemas/validate_processed_crash.py
+++ b/socorro/schemas/validate_processed_crash.py
@@ -16,15 +16,18 @@ import jsonschema
 
 from socorro.lib.libsocorrodataschema import (
     compile_pattern_re,
+    get_schema,
     SocorroDataReducer,
     split_path,
     transform_schema,
     validate_instance,
 )
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
 
 
 HERE = os.path.dirname(__file__)
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 class InvalidSchemaError(Exception):

--- a/socorro/unittest/external/boto/test_upload_telemetry_schema.py
+++ b/socorro/unittest/external/boto/test_upload_telemetry_schema.py
@@ -7,7 +7,11 @@ from socorro.unittest.external.boto import get_config
 
 
 class TestUploadTelemetrySchema:
-    def test_upload_worked(self, boto_helper, caplogpp):
+    def test_upload_worked(self, boto_helper, caplogpp, monkeypatch):
+        # NOTE(willkg): configman apps look at sys.argv for command line arguments, so
+        # we monkey patch sys.argv so it doesn't pick up pytest arguments and errors
+        # out
+        monkeypatch.setattr("sys.argv", ["upload_telemetry_schema.py"])
         caplogpp.set_level("DEBUG")
         config = get_config(UploadTelemetrySchema)
         app = UploadTelemetrySchema(config)

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -13,7 +13,6 @@ from socorro.external.es.super_search_fields import (
     FIELDS,
     is_doc_values_friendly,
     get_fields_by_item,
-    SuperSearchFieldsModel,
 )
 from socorro.unittest.external.es.base import ElasticsearchTestCase
 
@@ -23,6 +22,10 @@ from socorro.unittest.external.es.base import ElasticsearchTestCase
 # import logging
 # logging.getLogger('elasticsearch').setLevel(logging.ERROR)
 # logging.getLogger('requests').setLevel(logging.ERROR)
+
+
+def get_fields():
+    return copy.deepcopy(FIELDS)
 
 
 class Test_get_fields_by_item:
@@ -94,16 +97,9 @@ class Test_get_fields_by_item:
 class Test_build_mapping(ElasticsearchTestCase):
     """Test build_mapping with an elasticsearch database containing fake data"""
 
-    def setup_method(self):
-        super().setup_method()
-
-        config = self.get_base_config(cls=SuperSearchFieldsModel)
-        self.api = SuperSearchFieldsModel(config=config)
-        self.api.get_fields = lambda: copy.deepcopy(FIELDS)
-
     def test_get_mapping(self):
         doctype = self.es_context.get_doctype()
-        mapping = build_mapping(doctype=doctype, fields=self.api.get_fields())
+        mapping = build_mapping(doctype=doctype, fields=get_fields())
 
         assert doctype in mapping
         properties = mapping[doctype]["properties"]

--- a/socorro/unittest/lib/test_libsocorrodataschema.py
+++ b/socorro/unittest/lib/test_libsocorrodataschema.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import copy
 import jsonschema
 import pytest
 
@@ -155,7 +156,11 @@ from socorro.schemas import get_file_content
     ],
 )
 def test_resolve_references(schema, expected):
+    original_schema = copy.deepcopy(schema)
     assert resolve_references(schema) == expected
+
+    # resolve_references should never modify the original schema argument
+    assert original_schema == schema
 
 
 class TestSocorroDataReducer:

--- a/socorro/unittest/lib/test_libsocorrodataschema.py
+++ b/socorro/unittest/lib/test_libsocorrodataschema.py
@@ -673,7 +673,10 @@ def test_permissions_transform_function():
     jsonschema.validate(instance=schema, schema=socorro_data_schema)
 
     # Create a public-only transform
-    public_only = permissions_transform_function(permissions_have=["public"])
+    public_only = permissions_transform_function(
+        permissions_have=["public"],
+        default_permissions=["public", "protected"],
+    )
 
     # Transform the schema using the public-only transform
     public_schema = transform_schema(schema=schema, transform_function=public_only)
@@ -709,7 +712,8 @@ def test_permissions_transform_function():
 
     # Create a public/protected transform
     all_permissions = permissions_transform_function(
-        permissions_have=["public", "protected"]
+        permissions_have=["public", "protected"],
+        default_permissions=["public", "protected"],
     )
 
     # Transform the schema using the public-only transform

--- a/socorro/unittest/processor/rules/test_breakpad.py
+++ b/socorro/unittest/processor/rules/test_breakpad.py
@@ -8,14 +8,16 @@ from unittest import mock
 
 from markus.testing import MetricsMock
 
-from socorro.lib.libsocorrodataschema import validate_instance
+from socorro.lib.libsocorrodataschema import get_schema, validate_instance
 from socorro.processor.processor_pipeline import ProcessorPipeline, Status
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
     MinidumpSha256HashRule,
     MinidumpStackwalkRule,
 )
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 example_uuid = "00000000-0000-0000-0000-000002140504"

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -11,6 +11,7 @@ from unittest import mock
 import requests_mock
 import pytest
 
+from socorro.lib.libsocorrodataschema import get_schema
 from socorro.processor.rules.mozilla import (
     AccessibilityRule,
     AddonsRule,
@@ -41,8 +42,10 @@ from socorro.processor.rules.mozilla import (
     TopMostFilesRule,
 )
 from socorro.processor.processor_pipeline import Status
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
 from socorro.signature.generator import SignatureGenerator
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 canonical_standard_raw_crash = {
@@ -905,7 +908,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
+        rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
@@ -920,7 +923,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
+        rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
@@ -931,7 +934,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
+        rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
         rule.act(raw_crash, dumps, processed_crash, status)
         assert processed_crash == {}
 
@@ -941,7 +944,7 @@ class TestBreadcrumbRule:
         processed_crash = {}
         status = Status()
 
-        rule = BreadcrumbsRule(schema=copy.deepcopy(PROCESSED_CRASH_SCHEMA))
+        rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
         rule.act(raw_crash, dumps, processed_crash, status)
 
         assert processed_crash == {}

--- a/socorro/unittest/schemas/test_socorro_data_schemas.py
+++ b/socorro/unittest/schemas/test_socorro_data_schemas.py
@@ -421,7 +421,10 @@ def test_processed_crash_schema():
     jsonschema.validate(instance=processed_crash_schema, schema=schema)
 
     # Reduce to the public-only parts of the schema
-    public_only = permissions_transform_function(permissions_have=["public"])
+    public_only = permissions_transform_function(
+        permissions_have=["public"],
+        default_permissions=processed_crash_schema["default_permissions"],
+    )
     public_schema = transform_schema(
         schema=processed_crash_schema,
         transform_function=public_only,

--- a/webapp-django/crashstats/crashstats/management/commands/updatesignatures.py
+++ b/webapp-django/crashstats/crashstats/management/commands/updatesignatures.py
@@ -14,7 +14,7 @@ from django.utils.dateparse import parse_datetime
 
 from crashstats.crashstats.models import Signature
 from crashstats.supersearch.models import SuperSearch
-from socorro.external.es.super_search_fields import SuperSearchFieldsData
+from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
 from socorro.lib.libdatetime import string_to_datetime
 
 
@@ -87,7 +87,7 @@ class Command(BaseCommand):
 
         # Do a super search and get the signature, buildid, and date processed for
         # every crash in the range
-        all_fields = SuperSearchFieldsData().get()
+        all_fields = SUPERSEARCH_FIELDS
         api = SuperSearch()
         self.stdout.write("Looking at %s to %s" % (start_datetime, end_datetime))
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -656,7 +656,10 @@ def get_processed_crash_permissions_reducer(permissions_tuple):
     permissioned_schema = transform_schema(
         schema=PROCESSED_CRASH_SCHEMA,
         transform_function=(
-            permissions_transform_function(permissions_have=permissions_tuple)
+            permissions_transform_function(
+                permissions_have=permissions_tuple,
+                default_permissions=PROCESSED_CRASH_SCHEMA["default_permissions"],
+            )
         ),
     )
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -29,11 +29,11 @@ from socorro.lib import BadArgumentError
 from socorro.lib.libooid import is_crash_id_valid
 from socorro.lib.librequests import session_with_retries
 from socorro.lib.libsocorrodataschema import (
+    get_schema,
+    permissions_transform_function,
     SocorroDataReducer,
     transform_schema,
-    permissions_transform_function,
 )
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
 
 from crashstats.crashstats.configman_utils import config_from_configman
 
@@ -42,6 +42,9 @@ logger = logging.getLogger("crashstats.models")
 
 
 metrics = markus.get_metrics("webapp.crashstats.models")
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 # Django models first

--- a/webapp-django/crashstats/crashstats/tests/conftest.py
+++ b/webapp-django/crashstats/crashstats/tests/conftest.py
@@ -14,7 +14,7 @@ from django.core.cache import cache
 from crashstats import productlib
 from crashstats.crashstats.signals import PERMISSIONS
 from crashstats.crashstats.tests.testbase import DjangoTestCase
-from socorro.external.es.super_search_fields import FIELDS
+from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
 
 
 class Response:
@@ -116,7 +116,7 @@ class SuperSearchFieldsMock:
         super().setUp()
 
         def mocked_supersearchfields(**params):
-            results = copy.deepcopy(FIELDS)
+            results = copy.deepcopy(SUPERSEARCH_FIELDS)
             # to be realistic we want to introduce some dupes that have a
             # different key but its `in_database_name` is one that is already
             # in the hardcoded list (the baseline)

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -21,8 +21,10 @@ from django.test.utils import override_settings
 from crashstats.crashstats import models
 from crashstats.crashstats.tests.conftest import BaseTestViews, Response
 from socorro.external.crashstorage_base import CrashIDNotFound
-from socorro.lib.libsocorrodataschema import validate_instance
-from socorro.schemas import PROCESSED_CRASH_SCHEMA
+from socorro.lib.libsocorrodataschema import get_schema, validate_instance
+
+
+PROCESSED_CRASH_SCHEMA = get_schema("processed_crash.schema.yaml")
 
 
 _SAMPLE_META = {

--- a/webapp-django/crashstats/supersearch/libsupersearch.py
+++ b/webapp-django/crashstats/supersearch/libsupersearch.py
@@ -1,0 +1,98 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from dataclasses import dataclass
+import datetime
+
+from configman import class_converter, Namespace, RequiredConfig
+import elasticsearch
+from elasticsearch_dsl import Search
+
+from socorro.external.es.super_search_fields import FIELDS
+
+
+SUPERSEARCH_FIELDS = FIELDS
+
+
+@dataclass
+class IndexDataItem:
+    name: str
+    start_date: datetime.datetime
+    count: int
+
+
+class SuperSearchStatusModel(RequiredConfig):
+    """Model that returns list of indices and latest mapping."""
+
+    filters = []
+
+    required_config = Namespace()
+    required_config.add_option(
+        "elasticsearch_class",
+        doc="a class that implements the ES connection object",
+        default="socorro.external.es.connection_context.ConnectionContext",
+        from_string_converter=class_converter,
+    )
+
+    def __init__(self, config):
+        self.config = config
+        self.context = self.config.elasticsearch_class(self.config)
+
+    def get_connection(self):
+        with self.context() as conn:
+            return conn
+
+    def get(self):
+        return self.get_supersearch_status()
+
+    def get_supersearch_status(self):
+        """Return list of indices, latest index, and mapping.
+
+        :returns: list of IndexDataItem instances
+
+        """
+        conn = self.get_connection()
+        index_client = elasticsearch.client.IndicesClient(conn)
+        indices = sorted(self.context.get_indices())
+        latest_index = indices[-1]
+
+        doctype = self.context.get_doctype()
+        index_template = self.context.get_index_template()
+        if index_template.endswith("%Y%W"):
+            # Doing strptime on a template that has %W but doesn't have a day-of-week,
+            # will ignore the %W part; so we anchor it with 1 (Monday)
+            add_day_of_week = True
+            index_template = f"{index_template}%w"
+        else:
+            add_day_of_week = False
+
+        index_data = []
+        for index_name in indices:
+            count = Search(using=conn, index=index_name, doc_type=doctype).count()
+
+            if add_day_of_week:
+                # %W starts on Mondays, so we set the day-of-week to 1 which is
+                # Monday
+                adjusted_index_name = f"{index_name}1"
+            else:
+                adjusted_index_name = index_name
+            start_date = datetime.datetime.strptime(adjusted_index_name, index_template)
+            start_date = start_date.date()
+
+            index_data.append(
+                IndexDataItem(
+                    name=index_name,
+                    start_date=start_date,
+                    count=count,
+                )
+            )
+
+        mapping = index_client.get_mapping(index=latest_index)
+        mapping_properties = mapping[latest_index]["mappings"][doctype]["properties"]
+
+        return {
+            "indices": index_data,
+            "latest_index": latest_index,
+            "mapping": mapping_properties,
+        }

--- a/webapp-django/crashstats/supersearch/libsupersearch.py
+++ b/webapp-django/crashstats/supersearch/libsupersearch.py
@@ -12,7 +12,38 @@ from elasticsearch_dsl import Search
 from socorro.external.es.super_search_fields import FIELDS
 
 
-SUPERSEARCH_FIELDS = FIELDS
+# Map of processed crash schema permissions to webapp permissions
+PROCESSED_CRASH_TO_WEBAPP_PERMISSIONS = {
+    "public": "",
+    "protected": "crashstats.view_pii",
+}
+
+
+def convert_permissions(fields):
+    """Converts processed crash schema / super search permissions to webapp permissions
+
+    :arg fields: super search fields structure to convert permissions of
+
+    :returns: fields with permissions converted
+
+    """
+
+    def _convert(permissions):
+        if not permissions:
+            return permissions
+
+        new_permissions = [
+            PROCESSED_CRASH_TO_WEBAPP_PERMISSIONS[perm] for perm in permissions
+        ]
+        return [perm for perm in new_permissions if perm]
+
+    for key, val in fields.items():
+        val["permissions_needed"] = _convert(val["permissions_needed"])
+
+    return fields
+
+
+SUPERSEARCH_FIELDS = convert_permissions(FIELDS)
 
 
 @dataclass

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -9,9 +9,12 @@ from django.core.cache import cache
 
 from crashstats import productlib
 from crashstats.crashstats import models
+from crashstats.supersearch.libsupersearch import (
+    SUPERSEARCH_FIELDS,
+    SuperSearchStatusModel,
+)
 from socorro.external.es import query
 from socorro.external.es import supersearch
-from socorro.external.es import super_search_fields
 from socorro.lib import BadArgumentError
 
 
@@ -43,7 +46,7 @@ def get_api_allowlist(include_all_fields=False):
         cache_key = "api_supersearch_fields"
         fields = cache.get(cache_key)
         if fields is None:
-            all_fields = SuperSearchFields().get()
+            all_fields = SUPERSEARCH_FIELDS
             fields = []
             for meta in all_fields.values():
                 if (
@@ -103,7 +106,7 @@ class SuperSearch(ESSocorroMiddleware):
     API_ALLOWLIST = get_api_allowlist()
 
     def __init__(self):
-        self.all_fields = SuperSearchFields().get()
+        self.all_fields = SUPERSEARCH_FIELDS
 
         # These fields contain lists of other fields. Later on, we want to
         # make sure that none of those listed fields are restricted.
@@ -197,8 +200,8 @@ class SuperSearchUnredacted(SuperSearch):
     IS_PUBLIC = True
 
     HELP_TEXT = """
-    API for searching and faceting on crash reports. Requires
-    permissions depending on which fields are being queried.
+    API for searching and faceting on crash reports. Requires permissions depending on
+    which fields are being queried.
     """
 
     API_ALLOWLIST = get_api_allowlist(include_all_fields=True)
@@ -206,7 +209,7 @@ class SuperSearchUnredacted(SuperSearch):
     implementation = supersearch.SuperSearch
 
     def __init__(self):
-        self.all_fields = SuperSearchFields().get()
+        self.all_fields = SUPERSEARCH_FIELDS
 
         histogram_fields = self._get_extended_params()
 
@@ -239,10 +242,7 @@ class SuperSearchUnredacted(SuperSearch):
 
 
 class SuperSearchFields(ESSocorroMiddleware):
-    # Read it in once as a class attribute since it'll never change unless the
-    # Python code changes and if that happens you will have reloaded the
-    # Python process.
-    _fields = super_search_fields.SuperSearchFieldsData().get()
+    _fields = SUPERSEARCH_FIELDS
 
     IS_PUBLIC = True
 
@@ -257,7 +257,7 @@ class SuperSearchFields(ESSocorroMiddleware):
 
 
 class SuperSearchStatus(ESSocorroMiddleware):
-    implementation = super_search_fields.SuperSearchStatusModel
+    implementation = SuperSearchStatusModel
 
     cache_seconds = 0
 

--- a/webapp-django/crashstats/supersearch/tests/test_forms.py
+++ b/webapp-django/crashstats/supersearch/tests/test_forms.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from crashstats.supersearch import forms
-from socorro.external.es.super_search_fields import FIELDS
+from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
 
 
 class TestForms:
@@ -11,7 +11,7 @@ class TestForms:
         self.products = ["WaterWolf", "NightTrain", "SeaMonkey", "Tinkerbell"]
         self.product_versions = ["20.0", "21.0a1", "20.0", "9.5"]
         self.platforms = ["Windows", "Mac OS X", "Linux"]
-        self.all_fields = FIELDS
+        self.all_fields = SUPERSEARCH_FIELDS
 
     def test_search_form(self):
         def get_new_form(data):

--- a/webapp-django/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp-django/crashstats/supersearch/tests/test_libsupersearch.py
@@ -3,4 +3,35 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-# FIXME(willkg): test SuperSearchStatusModel
+from crashstats.supersearch.libsupersearch import convert_permissions
+
+
+def test_convert_permissions():
+    fields = {
+        "build": {
+            "permissions_needed": [],
+        },
+        "product": {
+            "permissions_needed": ["public"],
+        },
+        "version": {
+            "permissions_needed": ["public", "protected"],
+        },
+    }
+
+    expected = {
+        "build": {
+            # No permission -> no required permissions
+            "permissions_needed": [],
+        },
+        "product": {
+            # "public" -> no required permissions
+            "permissions_needed": [],
+        },
+        "version": {
+            # "protected" -> "crashstats.view_pii"
+            "permissions_needed": ["crashstats.view_pii"],
+        },
+    }
+
+    assert convert_permissions(fields) == expected

--- a/webapp-django/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp-django/crashstats/supersearch/tests/test_libsupersearch.py
@@ -1,0 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+# FIXME(willkg): test SuperSearchStatusModel


### PR DESCRIPTION
This is a series of commits that move things around to eventually fix super search fields to pull permissions from the processed crash schema.

First, this removes `test_mapping` because it's dead code that's not used anymore. This fixes the `BreadcrumbsRule` and other things that used `get_schema()` and fixes `resolve_references` to return a new version of the data and not mutate the input. This fixes schema validation in `validate_processed_crash` so that it can be used for validating that the schemas themselves are valid in addition to testing them against processed crash data. This also moves some webapp-centric code from `socorro/external/es/super_search_fields.py` to `webapp-django/crashstats/supersearch/libsupersearch.py`. This also fixes the `upload_telemetry_schema` test because it prevented me from running tests using flags. :(

With all that cleanup done, then we add `default_permissions` to the schema so we're not defining defaults across the app.

Finally, we remove permissions from fields in super search fields and add some code to get the permissions from `processed_crash.schema.yaml`. We also add some code to the webapp to convert from schema permissions ("public", "protected", etc) to webapp permissions ("crashstats.view_pii"). This last bit of code is awkward feeling, but I didn't have a good way to generalize it and the webapp permissions are everywhere already.

To test this, I did this before the changes:

```
from socorro.external.es.super_search_fields import FIELDS


for key, val in FIELDS.items():
    print(f"{key}: {val['permissions_needed']}")
```

and this after:

```
from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS as FIELDS           

for key, val in FIELDS.items():                                                          
    print(f"{key}: {val['permissions_needed']}")    
```

And here's the differences:

```
> diff field_permissions_orig.txt field_permissions_new.txt 
39c39
< collector_notes: []
---
> collector_notes: ['crashstats.view_pii']
115c115
< remote_type: []
---
> remote_type: ['crashstats.view_pii']
119d118
< skunk_classification: []
124d122
< support_classification: []
```

The `*_classification` fields were removed because they don't refer to anything in the processed crash. The `remote_type` field had a typo in the `in_database_name` and fixing that fixes its permissions. `collector_notes` were marked protected in the `processed_crash.schema.yaml`, but not in `super_search_fields.py` which is a mistake.

I used `gmp_library_path` to verify that fields that are protected don't show up for people who don't have access to them.

I verified that *all fields* show up in the Super Search API reference.