### PR TITLE
bug 1792269: remove PluginContentURL and PluginUserComment code

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -53,9 +53,7 @@ from socorro.processor.rules.mozilla import (
     OSPrettyVersionRule,
     OutOfMemoryBinaryRule,
     PHCRule,
-    PluginContentURL,
     PluginRule,
-    PluginUserComment,
     ProductRule,
     SignatureGeneratorRule,
     SubmittedFromRule,
@@ -182,8 +180,6 @@ class ProcessorPipeline(RequiredConfig):
                 # rules to change the internals of the raw crash
                 FenixVersionRewriteRule(),
                 ESRVersionRewrite(),
-                PluginContentURL(),
-                PluginUserComment(),
                 # rules to transform a raw crash into a processed crash
                 CopyFromRawCrashRule(schema=get_schema("processed_crash.schema.yaml")),
                 SubmittedFromRule(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -602,28 +602,6 @@ class ESRVersionRewrite(Rule):
             status.add_note('"Version" missing from esr release raw_crash')
 
 
-class PluginContentURL(Rule):
-    def predicate(self, raw_crash, dumps, processed_crash, status):
-        try:
-            return bool(raw_crash["PluginContentURL"])
-        except KeyError:
-            return False
-
-    def action(self, raw_crash, dumps, processed_crash, status):
-        raw_crash["URL"] = raw_crash["PluginContentURL"]
-
-
-class PluginUserComment(Rule):
-    def predicate(self, raw_crash, dumps, processed_crash, status):
-        try:
-            return bool(raw_crash["PluginUserComment"])
-        except KeyError:
-            return False
-
-    def action(self, raw_crash, dumps, processed_crash, status):
-        raw_crash["Comments"] = raw_crash["PluginUserComment"]
-
-
 class TopMostFilesRule(Rule):
     """Origninating from Bug 519703, the topmost_filenames was specified as
     singular, there would be only one. The original programmer, in the

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -32,9 +32,7 @@ from socorro.processor.rules.mozilla import (
     OSPrettyVersionRule,
     OutOfMemoryBinaryRule,
     PHCRule,
-    PluginContentURL,
     PluginRule,
-    PluginUserComment,
     ProductRule,
     SignatureGeneratorRule,
     SubmittedFromRule,
@@ -1373,72 +1371,6 @@ class TestESRVersionRewrite:
 
         assert "Version" not in raw_crash
         assert status.notes == ['"Version" missing from esr release raw_crash']
-
-        # processed_crash should be unchanged
-        assert processed_crash == {}
-
-
-class TestPluginContentURL:
-    def test_everything_we_hoped_for(self):
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_crash["PluginContentURL"] = "http://mozilla.com"
-        raw_crash["URL"] = "http://google.com"
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = PluginContentURL()
-        rule.act(raw_crash, dumps, processed_crash, status)
-
-        assert raw_crash["URL"] == "http://mozilla.com"
-
-        # processed_crash should be unchanged
-        assert processed_crash == {}
-
-    def test_this_is_not_the_crash_you_are_looking_for(self):
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_crash["URL"] = "http://google.com"
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = PluginContentURL()
-        rule.act(raw_crash, dumps, processed_crash, status)
-
-        assert raw_crash["URL"] == "http://google.com"
-
-        # processed_crash should be unchanged
-        assert processed_crash == {}
-
-
-class TestPluginUserComment:
-    def test_everything_we_hoped_for(self):
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_crash["PluginUserComment"] = "I hate it when this happens"
-        raw_crash["Comments"] = "I wrote something here, too"
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = PluginUserComment()
-        rule.act(raw_crash, dumps, processed_crash, status)
-
-        assert raw_crash["Comments"] == "I hate it when this happens"
-
-        # processed_crash should be unchanged
-        assert processed_crash == {}
-
-    def test_this_is_not_the_crash_you_are_looking_for(self):
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        raw_crash["Comments"] = "I wrote something here"
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = PluginUserComment()
-        rule.act(raw_crash, dumps, processed_crash, status)
-
-        assert raw_crash["Comments"] == "I wrote something here"
 
         # processed_crash should be unchanged
         assert processed_crash == {}

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -809,7 +809,6 @@ class RawCrash(SocorroMiddleware):
         "OOMAllocationSize",
         "PluginFilename",
         "PluginName",
-        "PluginUserComment",
         "PluginVersion",
         "ProcessType",
         "ProductID",


### PR DESCRIPTION
These were from the days of flash and we no longer support that, so we can remove these.