### PR TITLE
bug 1795641: add nsObserverService to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -153,6 +153,7 @@ nsThread::GetEvent
 [-+]\[NSException raise(:format:(arguments:)?)?\]
 nsInterfaceHashtable<.*>::
 nsINode::Slots
+nsObserverService
 nsTSubstring<.*>::
 NS_QuickSort
 nsRefPtr


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature=nsObserverService | socorro-cmd signature
Crash id: e99b62e6-08aa-4241-8324-0187c0221016
Original: nsObserverService::RemoveObserver
New:      nsObserverService::RemoveObserver | nsBaseWidget::~nsBaseWidget
Same?:    False

Crash id: b02b13bc-fa05-422d-84cc-fe60a0221016
Original: shutdownhang | strlen | nsObserverService::NotifyObservers
New:      shutdownhang | strlen | nsObserverService::NotifyObservers | mozilla::DllServices::NotifyDllLoad
Same?:    False

Crash id: cd510bf8-019e-4d3f-bbfd-a73080221016
Original: shutdownhang | strcmp | nsTHashtable<T>::s_MatchEntry | PLDHashTable::Search | nsObserverService::NotifyObservers
New:      shutdownhang | strcmp | nsTHashtable<T>::s_MatchEntry | PLDHashTable::Search | nsObserverService::NotifyObservers | mozilla::AppShutdown::AdvanceShutdownPhase
Same?:    False
```