### PR TITLE
bug 1795643: add nsINode::GetParentNode to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -149,6 +149,7 @@ NS_ABORT_OOM
 nsDataHashtable<.*>::
 NS_DebugBreak
 nsDebugImpl::Abort
+nsINode::GetParentNode
 nsThread::GetEvent
 [-+]\[NSException raise(:format:(arguments:)?)?\]
 nsInterfaceHashtable<.*>::


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd fetch_crashids --signature=nsINode::GetParentNode | socorro-cmd signature
Crash id: f2137a45-9edb-4fd9-9c7d-168c20221016
Original: nsINode::GetParentNode
New:      nsINode::GetParentNode | mozilla::dom::Node_Binding::get_parentNode
Same?:    False

Crash id: daef2d39-a33c-46cd-b89b-5f9af0221016
Original: nsINode::GetParentNode
New:      nsINode::GetParentNode | nsMutationReceiver::ContentAppended
Same?:    False
```