### PR TITLE
bug 1746630: support unloaded modules in signature generation and report view

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -198,6 +198,7 @@ class CSignatureTool:
         line=None,
         module_offset=None,
         offset=None,
+        unloaded_modules=None,
     ):
         """Normalizes a single frame
 
@@ -226,8 +227,22 @@ class CSignatureTool:
             return f"{file}#{line}"
 
         # If there's an offset and no module/module_offset, use that
-        if not module and not module_offset and offset:
-            return f"@{strip_leading_zeros(offset)}"
+        if not module and not module_offset:
+            if unloaded_modules:
+                # Use the first unloaded module and the offset or "0"
+                unloaded_module = unloaded_modules[0]
+                unloaded_module_module = unloaded_module.get("module")
+                unloaded_module_offsets = unloaded_module.get("offsets")
+                if unloaded_module_module and unloaded_module_offsets:
+                    return "(unloaded {}@{})".format(
+                        unloaded_module_module,
+                        strip_leading_zeros(unloaded_module_offsets[0]),
+                    )
+                elif unloaded_module_module:
+                    return "(unloaded {})".format(unloaded_module_module)
+
+            if offset:
+                return f"@{strip_leading_zeros(offset)}"
 
         # Return module/module_offset
         return "{}@{}".format(module or "", strip_leading_zeros(module_offset))
@@ -262,6 +277,8 @@ class CSignatureTool:
                 "line": frame.get("line"),
                 "module_offset": frame.get("module_offset"),
                 "offset": frame.get("offset"),
+                # NOTE(gsvelto): unloaded modules can only appear in non-inlined frames
+                "unloaded_modules": frame.get("unloaded_modules"),
             }
 
     def create_frame_list(self, thread_data, make_modules_lower_case=False):
@@ -338,7 +355,10 @@ class CSignatureTool:
                 continue
 
             # If the frame signature is a dll, remove the @xxxxx part.
-            if ".dll" in a_signature.lower():
+            if (
+                not a_signature.startswith("(unloaded")
+                and ".dll" in a_signature.lower()
+            ):
                 a_signature = a_signature.split("@")[0]
 
                 # If this trimmed DLL signature is the same as the previous frame's, skip it.

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -13,14 +13,14 @@ Java stack trace:
 MOZ_CRASH Reason: ```{{ moz_crash_reason|safe }}```
 {%- elif reason -%}
 Reason: ```{{ reason|safe }}```
-{%- endif %}
-{% if crashing_thread is none %}
+{%- endif -%}
+{%- if crashing_thread is none %}
 No crashing thread identified; using thread 0.
-{% endif %}
+{% endif -%}
 Top {{ frames|length }} frames of crashing thread:
 ```
 {% for frame in frames -%}
-{{ frame.frame|safe}} {{ frame.module|safe }} {{ frame.signature|safe }} {{ frame.source|safe }}
+{{ frame.frame|safe}}  {{ frame.module|safe }}  {{ frame.signature|safe }}  {{ frame.source|safe }}
 {% endfor -%}
 ```
 {% endif %}

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -251,13 +251,16 @@ def bugzilla_thread_frames(thread):
         if frame.get("line"):
             source += ":{}".format(frame["line"])
 
+        signature = frame.get("signature") or ""
+
         # Remove function arguments
-        signature = re.sub(r"\(.*\)", "", frame.get("signature", ""))
+        if not signature.startswith("(unloaded"):
+            signature = re.sub(r"\(.*\)", "", signature)
 
         frames.append(
             {
                 "frame": frame.get("frame", "?"),
-                "module": frame.get("module", ""),
+                "module": frame.get("module") or "?",
                 "signature": signature,
                 "source": source,
             }

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -28,6 +28,7 @@ from crashstats import productlib
 from crashstats.crashstats import models
 import crashstats.supersearch.models as supersearch_models
 from socorro.lib.libversion import generate_semver, VersionParseError
+from socorro.signature.utils import strip_leading_zeros
 
 
 logger = logging.getLogger(__name__)
@@ -253,25 +254,6 @@ def _json_clean(value):
     # http://stackoverflow.com/questions/1580647/json-why-are-forward-slashe\
     # s-escaped
     return value.replace("</", "<\\/")
-
-
-def strip_leading_zeros(text):
-    """Strips leading zeros from a hex string.
-
-    Example:
-
-    >>> strip_leading_zeros("0x0000000000032ec0")
-    "0x32ec0"
-
-    :param text: the text to strip leading zeros from
-
-    :returns: hex string with leading zeros stripped
-
-    """
-    try:
-        return hex(int(text, base=16))
-    except (ValueError, TypeError):
-        return text
 
 
 def enhance_frame(frame, vcs_mappings):


### PR DESCRIPTION
This updates signature generation to take unloaded modules into account. This uses gankra's notation where it denotes which parts are from unloaded modules from the first commit in PR #6021 . Examples:

```
app@socorro:/app$ socorro-cmd signature edcb4dbc-5516-4b15-9464-26adc0221001 1e8a0180-dd82-4051-b1ac-1006c0221001 9cc1cb90-c92a-4a31-b69c-cebfc0221001
Crash id: edcb4dbc-5516-4b15-9464-26adc0221001
Original: QueryDnsForFamily
New:      (unloaded PrxDrvPE64.dll@0x5387) | QueryDnsForFamily
Same?:    False

Crash id: 1e8a0180-dd82-4051-b1ac-1006c0221001
Original: UserCallWinProcCheckWow
New:      (unloaded RTSUltraMonHook.dll@0xbff8) | UserCallWinProcCheckWow
Same?:    False

Crash id: 9cc1cb90-c92a-4a31-b69c-cebfc0221001
Original: CFGControl::SetFirstVW
New:      (unloaded obs-virtualcam-module64.dll@0xe4df) | CFGControl::SetFirstVW
Same?:    False
```

This also adds support for unloaded modules in the report view in the webapp.

While implementing the relevant tests, I switched them to be pytest parametrized tests because that's a lot cleaner and more maintainable.

Also, while this doesn't implement the functionality in the third commit of PR #6021, this does replace that PR.