### PR TITLE
bug 1795898: update docs and overhaul crash annotation docs

### DIFF
--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -4,103 +4,64 @@
 Crash Annotations
 =================
 
-A crash report contains a set of *crash annotations* and zero or more
-minidumps. For example, a crash report may contain the following annotations:
+A crash report contains a set of *crash annotations*. For example, a crash
+report may contain the following annotations:
 
-* **ProductName**: Firefox
-* **Version**: 77.0a1
-* **ReleaseChannel**: nightly
+==================  =======
+name                value
+==================  =======
+``ProductName``     Firefox
+``Version``         77.0a1
+``ReleaseChannel``  nightly
+==================  =======
 
-Annotations are documented in `CrashAnnotations.yaml`_.
-
+Crash annotations for all Mozilla products are documented in
+`CrashAnnotations.yaml`_.
 
 .. _CrashAnnotations.yaml: https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml
 
 
-Adding new crash annotations to a crash report
-==============================================
+Adding new crash annotations
+============================
 
-1. First, check
-   `CrashAnnotations.yaml`_
+.. Note::
+
+   If you need any help with this, please ask on `#crashreporting on Matrix
+   <https://chat.mozilla.org/#/room/#crashreporting:mozilla.org>`__.
+
+
+Follow these steps for adding new crash annotations to a crash report:
+
+1. Check `CrashAnnotations.yaml`_.
 
    Verify that the annotation you want to add doesn't already exist with a
    different name and that there isn't an annotation with that name already.
 
-   You can't change the meaning or type of an existing annotation.
+   **You can't change the meaning or type of an existing annotation.**
 
-2. New annotations need to undergo data collection review:
-   https://wiki.mozilla.org/Firefox/Data_Collection
+2. Get a data collection review.
 
-   If you're creating a new annotation or adjusting an existing annotation, you
-   should use:
-   `<https://github.com/mozilla/data-review/blob/main/request.md>`_.
+   Whenever you add a new crash annotation, it must pass a data review first.
 
-   Here are some things to keep in mind when filling out the review request:
+   See :ref:`annotations-chapter-data-review`.
 
-   1. If the field will be available in crash reports AND crash pings, make
-      sure that's mentioned in the data collection review request. It's
-      easiest if it's noted at the top.
+3. Once the data review for the new crash annotation is approved, the
+   annotation needs to be documented in the `CrashAnnotations.yaml`_ file.
 
-      ::
+   Example of a crash annotation that will be in crash reports::
 
-          This data review covers a crash annotation to be sent in both crash
-          reports and crash pings.
-
-   2. Link to the documentation can be a link to `CrashAnnotations.yaml`_.
-
-      ::
-
-          6. Please provide a link to the documentation for this data
-             collection which describes the ultimate data set in a
-             public, complete, and accurate way.
-
-          Documentation is in
-          https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml
-
-   3. Crash annotation data is collected forever.
-
-      ::
-
-          7. How long will this data be collected? Choose one of the following:
-
-          I want to permanently monitor this data. (put someone's name here)
-
-      Make sure to specify someone.
-
-   4. Crash annotation data sent in crash reports is *opt-in by default*, but
-      crash pings are *opt-out by default*.
-
-      If you want the annotation ONLY in crash reports, answer this way::
-
-          9. If this data collection is default on, what is the opt-out
-             mechanism for users?
-
-          No mechanism is required for crash report data.
-
-      If you want the annotation showing up in crash reports AND in crash pings,
-      answer this way::
-
-          9. If this data collection is default on, what is the opt-out
-             mechanism for users?
-
-          This data is opt-out via the normal telemetry opt-out mechanism for
-          crash ping data.
+      AsyncShutdownTimeout:
+        description: >
+          This annotation is present if a shutdown blocker was not released in time
+          and the browser was crashed instead of waiting for shutdown to finish. The
+          condition that caused the hang is contained in the annotation.
+        type: string
 
 
-   .. Note::
+   If you want the crash annotation to also be available in crash pings sent to
+   Telemetry, you need to add ``ping: true`` to `CrashAnnotations.yaml`_
 
-      If you need any help with this step, ask on #crashreporting on Matrix.
-
-      Any data steward can review a data review request, but feel free to tag
-      ``:willkg`` with the data review requests for crash annotations.
-
-3. Once the data review for the new annotation is approved, details about the
-   annotation need to be added to the `CrashAnnotations.yaml`_ file.
-
-   If the field also needs to be available in crash pings sent to Telemetry,
-   you need to add ``ping: true`` to ``CrashAnnotations.yaml``
-
-   For example::
+   Example of a crash annotation that will be in crash reports AND crash pings::
 
       AsyncShutdownTimeout:
         description: >
@@ -114,58 +75,202 @@ Adding new crash annotations to a crash report
 4. Add the code to put the annotation in the crash report.
 
    As soon as that code is merged and new builds are created and crash reports
-   start adding the annotation, the annotation data will be available in Crash
-   Stats and require protected data access.
+   start adding the crash annotation, the crash annotation data will be
+   available in Crash Stats and require protected data access.
 
-5. (Optional) If you want the field to show up in crash pings sent to Telemetry,
-   we have to update the crash ping schema.
 
-   `File a bug in Data Platform and Tools :: Datasets: General <https://bugzilla.mozilla.org/enter_bug.cgi?comment=Please%20add%20the%20following%20crash%20annotations%20to%20the%20crash%20ping%20schema%3A%0D%0A%0D%0A%2A%20%0D%0A%0D%0AThe%20data%20review%20for%20these%20annotations%20is%20bug%20%23XYZ.&component=Datasets%3A%20General&bug_type=task&product=Data%20Platform%20and%20Tools&rep_platform=Unspecified&short_desc=add%20crash%20annotation%20XYZ%20to%20crash%20ping%20schema>`_
-   to add the annotation to the crash ping schema.
+Supporting crash annotations
+============================
 
-   You can either wait for someone to update the schema or make the changes
-   yourself following these steps:
+Once the crash annotation is being sent by the crash reporter, you want to be
+able to analyze it. There are several things you can do.
 
-   1. From a mozilla-pipeline-schemas (https://github.com/mozilla-services/mozilla-pipeline-schemas/)
-      checkout, run::
 
-         scripts/extract_crash_annotation_fields /path/to/mozilla-unified/toolkit/crashreporter/CrashAnnotations.yaml
+Support on Crash Stats (publicly viewable, searchable, etc)
+-----------------------------------------------------------
 
-      If any exist, you will get a list of crash annotations that are contained
-      in the ping but are not yet in the schema.
+Crash Stats is the site we use for accessing and analyzing crash report data
+processed by the crash ingestion pipeline.
 
-   2. Add the annotation to ``templates/telemetry/crash/crash.4.schema.json`` under
-      the ``payload/metadata`` section.
+`File a "support new annotation" bug
+<https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&comment=I%20would%20like%20to%20add%20support%20for%20crash%20annotation%20XYZ%20to%20Crash%20Stats.%0D%0A%0D%0AI%20would%20like%20to%20%28pick%20the%20ones%20that%20apply%29%3A%0D%0A%0D%0A%2A%20make%20this%20annotation%20public%0D%0A%2A%20make%20this%20annotation%20searchable%20in%20Super%20Search%0D%0A%2A%20make%20this%20annotation%20aggregatable%20in%20Super%20Search%0D%0A%2A%20add%20additional%20processing%20for%20this%20annotation%0D%0A%0D%0AThe%20data%20review%20for%20this%20field%20is%20in%20bug%20%23XYZ.&component=General&contenttypemethod=list&contenttypeselection=text%2Fplain&defined_groups=1&filed_via=standard_form&form_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=support%20crash%20annotation%20XYZ>`__
+to request support for your crash annotation in Crash Stats for any of the
+following:
 
-   3. Follow `<https://github.com/mozilla-services/mozilla-pipeline-schemas#cmake-build-instructions>`_ to
-      build the schema files.
+* make it public
+* make it searchable in Super Search
+* make it aggregatable in Super Search
+* add any additional processing in Socorro for the field
 
-   4. Create a pull request against the main branch in mozilla-pipeline-schemas
-      referencing that bug.
 
-      Example: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/711
+Sent in the crash ping data and available in telemetry.crash
+------------------------------------------------------------
 
-   .. Note::
+The crash reporter sends crash report data to the crash ingestion pipeline. It
+also sends a subset of this data in crash pings directly to Telemetry.
 
-      If you need any help with this step, ask on #telemetry on Matrix. or
-      #data-help on Slack, or needinfo :willkg in a bug.
+If you want the crash annotation data sent in the crash ping, make sure you marked
+``ping: true`` in `CrashAnnotations.yaml`_.
 
-6. (Optional) `File a "support new annotation" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=support%20XXX%20field>`_
-   to request support for your crash annotation in Crash Stats to:
+`File a bug in Data Platform and Tools :: Datasets: General
+<https://bugzilla.mozilla.org/enter_bug.cgi?comment=Please%20add%20the%20following%20crash%20annotations%20to%20the%20crash%20ping%20schema%3A%0D%0A%0D%0A%2A%20%0D%0A%0D%0AThe%20data%20review%20for%20these%20annotations%20is%20bug%20%23XYZ.&component=Datasets%3A%20General&bug_type=task&product=Data%20Platform%20and%20Tools&rep_platform=Unspecified&short_desc=add%20crash%20annotation%20XYZ%20to%20crash%20ping%20schema>`__
+to request the crash ping schema be updated so that the crash annotation shows
+up in the crash ping data.
 
-   * make it public
-   * make it searchable in Super Search
-   * make it aggregatable in Super Search
-   * add any additional processing in Socorro for the field
+Feel free to needinfo ``Will Kahn-Greene [:willkg]``.
 
-   .. Note::
 
-      If you need any help with this step, ask on #crashreporting on Matrix.
+Support in telemetry.socorro_crash
+----------------------------------
 
-7. (Optional) `File a "send field to telemetry" bug <https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=Generalform_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=send%20XXX%20field%20to%20telemetry>`_
-   to make it available in ``telemetry.socorro_crash`` (BigQuery table for
-   crash report data exported from Socorro) and correlations on Crash Stats.
+Socorro processes incoming crash reports and stores them for analysis using
+Crash Stats.
 
-   .. Note::
+Socorro also sends a subset of crash report data to Telemetry. This data is
+imported and stored in the ``telemetry.socorro_crash`` BigQuery table.
 
-      If you need any help with this step, ask on #crashreporting on Matrix.
+See :ref:`telemetry-chapter` for details on how to use this data.
+
+`File a "send field to telemetry" bug
+<https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&comment=I%20would%20like%20to%20have%20crash%20annotation%20XYZ%20sent%20to%20Telemetry%20and%20included%20in%20the%20%60telemetry.socorro_crash%60%20table.%0D%0A%0D%0AThe%20data%20review%20for%20this%20field%20is%20in%20bug%20%23XYZ.&component=General&contenttypemethod=list&contenttypeselection=text%2Fplain&defined_groups=1&filed_via=standard_form&form_name=enter_bug&op_sys=All&product=Socorro&rep_platform=All&short_desc=send%20crash%20annotation%20XYZ%20to%20telemetry.socorro_crash>`_,
+if you want the crash annotation data available in the
+``telemetry.socorro_crash`` BigQuery table.
+
+
+.. _annotations-chapter-data-review:
+
+Getting a data review for crash annotations
+===========================================
+
+This crash annotation data review template is based on `the data review request
+template <https://github.com/mozilla/data-review/blob/main/request.md>`_.
+
+Follow these steps:
+
+1. Take this template and fill it out completely as a text file.
+
+2. Attach the completed data review request as a text file to:
+
+   * the bug for adding the collection code for this annotation, OR
+   * a new bug in your own component for adding this annotation
+
+3. Notify a data steward to review the request.
+
+   Flag the attached, completed request form for ``data-review`` by setting the
+   ``data-review`` flag to ``?`` and choosing a data steward.
+
+   Data stewards are listed on the `Data Collection
+   <https://wiki.mozilla.org/Data_Collection>`__ wiki page.
+
+   Any data steward can review a data review request, but feel free to tag
+   ``Will Kahn-Greene [:willkg]`` with the data review requests for crash
+   annotations.
+
+If you need any help with filing a data review request, ask on `#crashreporting
+on Matrix <https://chat.mozilla.org/#/room/#crashreporting:mozilla.org>`__.
+
+Template::
+
+    Request for data collection review form
+    =======================================
+
+    All questions are mandatory. You must receive review from a data steward
+    peer on your responses to these questions before shipping new data
+    collection.
+
+    (If you want this crash annotation data to be in BOTH crash reports AND
+    crash pings, include this line. Otherwise remove it.)
+
+    This data review covers a crash annotation to be sent in both crash reports
+    and crash pings.
+
+
+    1) What questions will you answer with this data?
+
+
+    2) Why does Mozilla need to answer these questions?  Are there benefits for
+    users? Do we need this information to address product or business
+    requirements?
+
+    Some example responses:
+
+    * Establish baselines or measure changes in product or platform quality or
+      performance.
+
+    * Provide information essential for advancing a business objective such as
+      supporting OKRs.
+
+    * Determine whether a product or platform change has an effect on user or
+      browser behavior.
+
+
+    3) What alternative methods did you consider to answer these questions? Why
+    were they not sufficient?
+
+
+    4) Can current instrumentation answer these questions?
+
+
+    5) List all proposed annotations and indicate the category of data
+    collection for each measurement, using the "Firefox data collection
+    categories" (https://wiki.mozilla.org/Data_Collection) found on the Mozilla
+    wiki. Note that the data steward reviewing your request will characterize
+    your data collection based on the highest (and most sensitive) category.
+
+    (Use this template for each proposed annotation.)
+
+    * Annotation description:
+    * Data collection category:
+    * Tracking bug #:
+
+
+    6) Please provide a link to the documentation for this data collection
+    which describes the ultimate data set in a public, complete, and accurate
+    way. Often the Privacy Notice for your product will link to where the
+    documentation is expected to be.
+
+    Documentation for crash annotations is in
+    https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml
+
+
+    7) How long will this data be collected?
+
+    * I want to permanently monitor this data. (Put name of who owns this data
+      here.)
+
+
+    8) What populations will you measure?
+
+    * Which release channels?
+
+    * Which countries?
+
+    * Which locales?
+
+    * Any other filters?  Please describe in detail below.
+
+
+    9) If this data collection is default on, what is the opt-out mechanism for
+    users?
+
+    Crash annotation data sent by crash report is opt-out by default.
+
+    (If this data review request also covers sending the crash annotation data
+    in the crash ping, include this line. Otherwise remove it.)
+
+    Crash annotation data sent by crash ping is opt-out via the normal
+    telemetry opt-out mechanism for crash ping data.
+
+
+    10) Please provide a general description of how you will analyze this data.
+
+
+    11) Where do you intend to share the results of your analysis?
+
+    Crash annotation data is available on the Crash Stats website.
+
+
+    12) Is there a third-party tool (i.e. not Glean or Telemetry) that you are
+    proposing to use for this data collection? If so:
+
+    * Are you using that on the Mozilla backend? Or going directly to the third-party?

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Socorro'
-copyright = '2013-2021 Mozilla Foundation'
+copyright = '2013-2022 Mozilla Foundation'
 author = 'Socorro team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -104,59 +104,3 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ["_static"]
 
 html_css_files = ["css/custom.css"]
-
-# -- Options for HTMLHelp output ------------------------------------------
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'Socorrodoc'
-
-
-# -- Options for LaTeX output ---------------------------------------------
-
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'Socorro.tex', 'Socorro Documentation',
-     'Socorro team', 'manual'),
-]
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'socorro', 'Socorro Documentation',
-     [author], 1)
-]
-
-
-# -- Options for Texinfo output -------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'Socorro', 'Socorro Documentation',
-     author, 'Socorro', 'One line description of project.',
-     'Miscellaneous'),
-]

--- a/docs/crashpings.rst
+++ b/docs/crashpings.rst
@@ -1,0 +1,85 @@
+Crash pings
+===========
+
+crash report vs. crash ping
+---------------------------
+
+We have two different methods of collecting crash data.
+
+**crash report**
+    The crash reporter assembles a crash report with crash annotations and
+    minidumps and some other things. It prompts the user for permission to
+    submit the crash report. If the user says "yes", then the crash reporter
+    submits it to the crash ingestion pipeline where it's collected, processed,
+    and available in `Crash Stats <https://crash-stats.mozilla.org/>`__.
+
+    Crash report data is opt-out by default.
+
+    Crash report data contains protected data which includes sensitive data,
+    PII, etc.
+
+    Not all crashes result in a crash report sent to the crash ingestion
+    pipeline for various technical reasons.
+
+    Not all users say "yes" to submit the crash report.
+
+    The crash ingestion pipeline throttles crash reports. For example, it only
+    accepts 10% of incoming Firefox desktop release channel crash reports and
+    rejects the rest.
+
+    .. Seealso::
+
+       Collector throttle rules:
+           https://github.com/mozilla-services/antenna/blob/main/antenna/throttler.py
+
+
+**crash ping**
+    The crash reporter walks the stack and assembles a crash ping which a
+    subset of crash annotation data. It sends this using Telemetry clients to
+    the Telemetry data ingestion pipeline. It is available in the
+    ``telemetry.crash`` BigQuery table.
+
+
+    Crash ping data is opt-in by default.
+
+    Crash ping data does not contain protected data.
+
+    As of 2022-10-18, we only support crash ping data with Firefox.
+
+    .. Seealso::
+
+       Crash ping documentation:
+           https://docs.telemetry.mozilla.org/datasets/pings.html#crash-ping
+
+
+.. Seealso::
+
+   Older blog post on crash reports vs. crash pings (2019):
+       https://bluesock.org/~willkg/blog/mozilla/crash_pings_crash_reports.html
+
+
+Updating crash ping schema
+--------------------------
+
+After someone has added a new field to `CrashAnnotations.yaml
+<https://hg.mozilla.org/mozilla-central/file/tip/toolkit/crashreporter/CrashAnnotations.yaml>`__
+which has ``ping: true`` in it, we do the following:
+
+1. From a mozilla-pipeline-schemas (https://github.com/mozilla-services/mozilla-pipeline-schemas/)
+   checkout, run::
+
+      scripts/extract_crash_annotation_fields /path/to/mozilla-unified/toolkit/crashreporter/CrashAnnotations.yaml
+
+   If any exist, you will get a list of crash annotations that are contained
+   in the ping but are not yet in the schema.
+
+2. Add the annotation to ``templates/telemetry/crash/crash.4.schema.json`` under
+   the ``payload/metadata`` section.
+
+3. Follow `<https://github.com/mozilla-services/mozilla-pipeline-schemas#cmake-build-instructions>`_ to
+   build the schema files.
+
+4. Create a pull request against the main branch in mozilla-pipeline-schemas
+   referencing that bug.
+
+   Example: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/711

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ and Super Search is located at `<https://crash-stats.mozilla.org/documentation/>
    contributing
    service/index
    flows/index
+   crashpings
    stackwalk
    crashstorage
    crashqueue

--- a/docs/stackwalk.rst
+++ b/docs/stackwalk.rst
@@ -2,10 +2,24 @@ minidump-stackwalk
 ==================
 
 Socorro uses ``stackwalker`` from
-`<https://github.com/rust-minidump/rust-minidump>`_.
-`<https://github.com/mozilla-services/minidump-stackwalk>`_.
+`<https://github.com/rust-minidump/rust-minidump>`__.
 
-There's a ``bin/run_mdsw.sh`` script for running ``stackwalker`` on
-minidumps to test it out.
 
-See the minidump-stackwalk repo for more details.
+releases
+--------
+
+We have a repository with scripts for maintaining the version we use in
+Socorro. We also tag, compile, and release binaries for Socorro builds.
+`<https://github.com/mozilla-services/socorro-stackwalk>`__.
+
+There are instructions in the ``README.md`` for maintaining it.
+
+
+debugging
+---------
+
+In the ``socorro`` repository, there's a ``bin/run_mdsw.sh`` script for running
+``stackwalker`` on minidumps like the processor does.
+
+There are also scripts in ``socorro-stackwalk`` repository for debugging
+stackwalk issues.


### PR DESCRIPTION
This simplifies the process for adding new crash annotations. Before it was hard to follow and hard to link to specific parts of.
    
This:
    
1. moves the crash ping schema update docs to a different place
2. breaks up "add a new annotation" from the various things you should/could do to support the new annotation for anlaysis
3. uses better terminology for things that should be clearer
4. improves the "create a bug" links to have a comment outlining the request so the reader doesn't have to guess at it
5. includes a complete template for the data review rather than requiring the reader to copy-and-paste it from somewhere else and then modify it to conform to crash annotations

This creates a new crash ping chapter that talks about crash reports and crash pings. It also outlines the process for updating the crash ping schema.

This update stackwalk docs which were out of date.

This updates the copyright data and truncates a bunch of configuration we don't need in `docs/conf.py`.