### PR TITLE
bug 1797295: fix create-a-bug links

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -3,20 +3,20 @@
    This renders to text--not html!! Whitespace is a complete nightmare. #}
 Crash report: {{ full_url(request, "crashstats:report_index", crash_id=uuid ) }}
 
-{% if java_stack_trace -%}
+{% if java_stack_trace %}
 Java stack trace:
 ```
 {{ java_stack_trace|safe }}
 ```
-{% elif frames -%}
-{%- if moz_crash_reason -%}
+{% elif frames %}
+{% if moz_crash_reason %}
 MOZ_CRASH Reason: ```{{ moz_crash_reason|safe }}```
-{%- elif reason -%}
+{% elif reason %}
 Reason: ```{{ reason|safe }}```
-{%- endif -%}
-{%- if crashing_thread is none %}
+{% endif %}
+{% if crashing_thread is none %}
 No crashing thread identified; using thread 0.
-{% endif -%}
+{% endif %}
 Top {{ frames|length }} frames of crashing thread:
 ```
 {% for frame in frames -%}

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -153,6 +153,9 @@ def show_bug_link(bug_id):
     return markupsafe.Markup(tmpl) % data
 
 
+EXTRA_NEWLINES_RE = re.compile(r"\n\n\n+")
+
+
 @library.global_function
 def generate_create_bug_url(
     request, template, raw_crash, report, parsed_dump, crashing_thread
@@ -196,6 +199,10 @@ def generate_create_bug_url(
             "crashing_thread": crashing_thread,
         },
     )
+
+    # Whitespace is a nightmare when using Jinja2 templates to render text that's not
+    # destined for HTML. So we do a pass on removing extra line endings.
+    comment = EXTRA_NEWLINES_RE.sub("\n\n", comment)
 
     kwargs = {
         "bug_type": "defect",


### PR DESCRIPTION
The create-a-bug links are generated with a Jinja2 function which uses a Jinja2 template to generate the comment. Jinja2 templates are great for HTML where consecutive whitespace is no big thing, but they're awful for text output especially complex templates with if/then/else and for loops.

Over the years, we've spent a lot of time trying to get the `bug_comment.txt` template to work for the variations it needs to support.

This adds a "look, squash all cases of 2 or more line endings to just 2" `re.sub()` which makes editing the template a lot less nightmarish.