### PR TITLE
bug 1797742: show unloaded modules in modules tab

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -939,6 +939,7 @@
           <!-- /bugzilla -->
 
           <div id="modules" class="ui-tabs-hide">
+            <h2>Modules</h2>
             {% if parsed_dump.modules %}
               <table class="tablesorter data-table" id="modules-list">
                 <thead>
@@ -971,6 +972,32 @@
                   {% endfor %}
                 </tbody>
               </table>
+            {% else %}
+              No modules.
+            {% endif %}
+
+            <h2>Unloaded modules</h2>
+            {% if parsed_dump.unloaded_modules %}
+              <table class="tablesorter data-table" id="unloaded-modules-list">
+                <thead>
+                  <tr>
+                    <th class="w-3/12" scope="col">Filename</th>
+                    <th class="w-7/12" scope="col">Code id</th>
+                    <th class="w-3/12" scope="col">Signed By</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for module in parsed_dump.unloaded_modules %}
+                    <tr>
+                      <td>{{ module.filename }}</td>
+                      <td>{{ module.code_id}}</td>
+                      <td>{% if module.cert_subject %}{{ module.cert_subject }}{% endif %}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            {% else %}
+              No unloaded modules.
             {% endif %}
           </div>
           <!-- /modules -->


### PR DESCRIPTION
This adds the unloaded modules to the modules tab in the report view.

One thing to note is that unloaded modules show up multiple times in the list, but have different base/end addresses. Since we're not displaying the base/end addresses in the list, it seems like there's a bug causing them to be repeated. We could not repeat them, but it seems interesting to know that a module shows up three times. We could show the base/end addresses, but I was on the fence about that. We can think about that another day.