### PR TITLE
Disambiguate crashes that happen in mozilla::TimeStampValue::operator-

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -111,6 +111,9 @@ mozilla::net::ShutdownEvent::PostAndWait
 mozilla::OffTheBooksMutex::Lock
 SleepConditionVariable(CS|SRW)
 mozilla::TimeStamp::Now
+mozilla::TimeStamp::operator
+mozilla::TimeStampValue::operator-
+mozilla::TimeStampValue::operator!=
 mozilla::detail::MutexImpl::
 mozilla::detail::SupportCheckedUnsafePtrImpl<T>::~SupportCheckedUnsafePtrImpl
 mozilla::ipc::LogicError


### PR DESCRIPTION
Here's an example crash: https://crash-stats.mozilla.org/report/index/a1270472-4d4b-4e22-8d02-25ecc0221027