### PR TITLE
bug 1791208: Quote regex in test.env

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -23,7 +23,7 @@ resource.boto.reprocessing_queue=test-reprocessing
 
 # Elasticsearch configuration
 resource.elasticsearch.elasticsearch_index=testsocorro%Y%W
-resource.elasticsearch.elasticsearch_index_regex=^testsocorro[0-9]{6}$
+resource.elasticsearch.elasticsearch_index_regex='^testsocorro[0-9]{6}$'
 
 # Postgres configuration
 DATABASE_URL=postgres://postgres:aPassword@postgresql:5432/socorro_test


### PR DESCRIPTION
This was required to run `make build` with docker-compose v2.10.2.