### PR TITLE
Update Fenix's and Focus's "Create a bug" links

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -8,19 +8,15 @@
   "bug_links": [
     [
       "Fenix",
-      "https://github.com/mozilla-mobile/fenix/issues/new?title=%(title)s&body=%(description)s"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix&component=General&bug_type=%(bug_type)s&keywords=crash&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ],
     [
       "GeckoView",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&component=General&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ],
     [
       "Core",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "Android-Components",
-      "https://github.com/mozilla-mobile/android-components/issues/new?title=%(title)s&body=%(description)s"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ],
     [
       "Application-Services",

--- a/product_details/Focus.json
+++ b/product_details/Focus.json
@@ -7,23 +7,15 @@
   "bug_links": [
     [
       "Focus",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Focus&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "Core",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "External Software Affecting Firefox",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=External+Software+Affecting+Firefox&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
-    ],
-    [
-      "Toolkit",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Toolkit&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Focus&component=General&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ],
     [
       "GeckoView",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&op_sys=%(op_sys)s&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=GeckoView&component=General&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+    ],
+    [
+      "Core",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=%(bug_type)s&keywords=crash&product=Core&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ]
   ],
   "product_home_links": []


### PR DESCRIPTION
1. Fenix, Focus, and Android-Components bug tracking is moving to Bugzilla. We won't have a separate Bugzilla product for Android Components: we'll file Android-Components bugs in the Fenix product.

2. Fenix only runs on Android, so set Fenix's default `op_sys=Android`.

3. All Focus crashes in Socorro are from Android because Focus iOS doesn't submit crash reports to Socorro, so set Focus's default `op_sys=Android`.

4. Set a default component ("General") for convenience. If the person filing the crash bug from Socorro knows a more appropriate Fenix or Focus component, they can select the other component in Bugzilla before submitting the new bug.

5. Remove the "External Software Affecting Firefox" and "Toolkit" links because they aren't relevant for Focus crashes.