### PR TITLE
bug 1796389: add "stackoverflow" to signature

### DIFF
--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -18,6 +18,7 @@ from .rules import (
     SignatureRunWatchDog,
     SignatureShutdownTimeout,
     SigTruncate,
+    StackOverflowSignature,
     StackwalkerErrorSignatureRule,
 )
 
@@ -33,6 +34,7 @@ DEFAULT_PIPELINE = [
     SignatureIPCChannelError(),
     SignatureIPCMessageName(),
     SignatureParentIDNotEqualsChildID(),
+    StackOverflowSignature(),
     # NOTE(willkg): These should always come last and in this order
     SigFixWhitespace(),
     SigTruncate(),

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -619,6 +619,32 @@ class SignatureGenerationRule(Rule):
         return True
 
 
+class StackOverflowSignature(Rule):
+    """Prepends ``stackoverflow``
+
+    See bug #1796389.
+
+    """
+
+    # These reason values indicate a stackoverflow
+    stackoverflow_reason = [
+        "EXCEPTION_STACK_OVERFLOW",
+    ]
+
+    def predicate(self, crash_data, result):
+        # Check the reason to see if it's one of a few values that indicate a
+        # stackoverflow
+        reason = crash_data.get("reason", None)
+        if reason in self.stackoverflow_reason:
+            return True
+
+        return False
+
+    def action(self, crash_data, result):
+        result.set_signature(self.name, f"stackoverflow | {result.signature}")
+        return True
+
+
 class OOMSignature(Rule):
     """Prepends ``OOM | <size>`` to signatures for OOM crashes.
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -1249,6 +1249,38 @@ class TestSignatureGenerationRule:
         assert result.notes == []
 
 
+class TestStackOverflowSignature:
+    def test_predicate_no_match(self):
+        result = generator.Result()
+        result.signature = "hello"
+        rule = rules.StackOverflowSignature()
+        assert rule.predicate({}, result) is False
+
+    @pytest.mark.parametrize(
+        "reason, expected",
+        [
+            ("FOO", False),
+            ("EXCEPTION_STACK_OVERFLOW", True),
+        ],
+    )
+    def test_predicate_reason(self, reason, expected):
+        crash_data = {"reason": reason}
+        result = generator.Result()
+        result.signature = "Text"
+        rule = rules.StackOverflowSignature()
+        assert rule.predicate(crash_data, result) is expected
+
+    def test_action_success(self):
+        crash_data = {"reason": "EXCEPTION_STACK_OVERFLOW"}
+        result = generator.Result()
+        result.signature = "hello"
+        rule = rules.StackOverflowSignature()
+        action_result = rule.action(crash_data, result)
+
+        assert action_result is True
+        assert result.signature == "stackoverflow | hello"
+
+
 class TestOOMSignature:
     def test_predicate_no_match(self):
         result = generator.Result()


### PR DESCRIPTION
This adds a new tag "stackoverflow" to crash signatures when the reason (json_dump.crash_info.type) is "EXCEPTION_STACK_OVERFLOW". Because this is only one of a myriad of indicators and we want to expand support over time, I structured the rule like the OOMSignature rule which also has multiple indicators.

```
app@socorro:/app$ socorro-cmd signature 389b5d5b-5140-429e-b216-bfd270220802 
Crash id: 389b5d5b-5140-429e-b216-bfd270220802
Original: _chkstk | nsTextFrame::ReflowText
New:      stackoverflow | nsTextFrame::ReflowText
Same?:    False
```

(Ignore the `_chkstk` difference--that's because of another signature generation change in the last couple of months.)

```
app@socorro:/app$ socorro-cmd signature e0d562aa-1ee3-43ee-a266-61b5b0221019    
Crash id: e0d562aa-1ee3-43ee-a266-61b5b0221019
Original: OOM | large | RtlFindActivationContextSectionString | sxsisol_SearchActCtxForDllName
New:      stackoverflow | OOM | large | RtlFindActivationContextSectionString | sxsisol_SearchActCtxForDllName
Same?:    False
```