### PR TITLE
bug 1791742: pull cpu_microcode_version from stackwalker output

### DIFF
--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -87,7 +87,14 @@ class IdentifierRule(Rule):
 
 
 class CPUInfoRule(Rule):
-    """Fill in cpu_arch, cpu_info, and cpu_count fields in processed crash"""
+    """Fill in cpu fields in processed crash
+
+    * cpu_arch
+    * cpu_info
+    * cpu_count
+    * cpu_microcode_version
+
+    """
 
     # Map of Android_CPU_ABI values to cpu_arch values
     ANDROID_CPU_ABI_MAP = {
@@ -116,6 +123,17 @@ class CPUInfoRule(Rule):
             cpu_arch = self.ANDROID_CPU_ABI_MAP.get(android_cpu_abi, android_cpu_abi)
 
         processed_crash["cpu_arch"] = cpu_arch
+
+        # The cpu_microcode_version is populated by stackwalker, but if it's not there,
+        # then degrade to the CPUMicrocodeVersion crash annotation value
+        cpu_microcode_version = glom(
+            processed_crash, "json_dump.system_info.cpu_microcode_version", default=None
+        )
+        if not cpu_microcode_version:
+            cpu_microcode_version = raw_crash.get("CPUMicrocodeVersion")
+
+        if cpu_microcode_version:
+            processed_crash["cpu_microcode_version"] = cpu_microcode_version
 
 
 class OSInfoRule(Rule):

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -1062,7 +1062,6 @@ properties:
     description: Microcode version of the CPU.
     type: string
     permissions: ["public"]
-    source_annotation: CPUMicrocodeVersion
   crash_id:
     description: Unique identifier of this crash report.
     type: string

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -267,6 +267,38 @@ class TestCPUInfoRule:
         rule.act(raw_crash, dumps, processed_crash, status)
         assert processed_crash["cpu_arch"] == expected
 
+    def test_no_cpu_microcode_version(self):
+        raw_crash = {}
+        processed_crash = {}
+        dumps = {}
+        status = Status()
+
+        rule = CPUInfoRule()
+        rule.act(raw_crash, dumps, processed_crash, status)
+        assert "cpu_microcode_version" not in processed_crash
+
+    def test_cpu_microcode_version_from_stackwalker(self):
+        raw_crash = {"CPUMicrocodeVersion": "ignored value"}
+        processed_crash = {
+            "json_dump": {"system_info": {"cpu_microcode_version": "0x42"}}
+        }
+        dumps = {}
+        status = Status()
+
+        rule = CPUInfoRule()
+        rule.act(raw_crash, dumps, processed_crash, status)
+        assert processed_crash["cpu_microcode_version"] == "0x42"
+
+    def test_cpu_microcode_version_from_annotation(self):
+        raw_crash = {"CPUMicrocodeVersion": "0x42"}
+        processed_crash = {}
+        dumps = {}
+        status = Status()
+
+        rule = CPUInfoRule()
+        rule.act(raw_crash, dumps, processed_crash, status)
+        assert processed_crash["cpu_microcode_version"] == "0x42"
+
 
 class TestOSInfoRule:
     def test_everything_we_hoped_for(self):


### PR DESCRIPTION
This changes the cpu_microcode_version field such that the processor now tries to populate it with the value generated by the stackwalker and degrades to the CPUMicrocodeVersion crash annotation value