### PR TITLE
bug 1791742: fix cpu_microcode_version handling to fix values

### DIFF
--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -129,11 +129,15 @@ class CPUInfoRule(Rule):
         cpu_microcode_version = glom(
             processed_crash, "json_dump.system_info.cpu_microcode_version", default=None
         )
-        if not cpu_microcode_version:
+        if cpu_microcode_version is not None:
+            # This is a u32, so we convert it to a hex string
+            processed_crash["cpu_microcode_version"] = hex(cpu_microcode_version)
+        else:
+            # This is a hex string
             cpu_microcode_version = raw_crash.get("CPUMicrocodeVersion")
 
-        if cpu_microcode_version:
-            processed_crash["cpu_microcode_version"] = cpu_microcode_version
+            if cpu_microcode_version:
+                processed_crash["cpu_microcode_version"] = cpu_microcode_version
 
 
 class OSInfoRule(Rule):

--- a/socorro/unittest/processor/rules/test_general.py
+++ b/socorro/unittest/processor/rules/test_general.py
@@ -279,9 +279,7 @@ class TestCPUInfoRule:
 
     def test_cpu_microcode_version_from_stackwalker(self):
         raw_crash = {"CPUMicrocodeVersion": "ignored value"}
-        processed_crash = {
-            "json_dump": {"system_info": {"cpu_microcode_version": "0x42"}}
-        }
+        processed_crash = {"json_dump": {"system_info": {"cpu_microcode_version": 66}}}
         dumps = {}
         status = Status()
 


### PR DESCRIPTION
The stackwalker outputs a u32, but the crash annotation has a hex string. This fixes the processor rule to convert the stackwalker value to a hex string if there's a stackwalker value.