### PR TITLE
bug 1795762: show current signature if signature generation has changed

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -50,6 +50,12 @@
   >
     <div class="page-heading">
       <h2>{{ report.product }} {{ report.version }} Crash Report [@ {{ report.signature }} ]</h2>
+      <nav>
+        <ul class="options">
+          <li><a class="button" href="https://support.mozilla.org/search?{{ make_query_string(q=report.signature) }}" title="Find more answers at support.mozilla.org!">Search Mozilla Support for this signature</a></li>
+          <li><a class="button" href="https://developer.mozilla.org/en-US/docs/Understanding_crash_reports" title="MDN documentation about crash reports">How to read this crash report</a></li>
+        </ul>
+      </nav>
     </div>
 
     <div class="protected-info">
@@ -67,13 +73,15 @@
       <div class="body">
         {# Header #}
 
-        <div id="sumo-link">
-          <a href="https://support.mozilla.org/search?{{ make_query_string(q=report.signature) }}" title="Find more answers at support.mozilla.org!">Search Mozilla Support for this signature</a>
-          <a href="https://developer.mozilla.org/en-US/docs/Understanding_crash_reports" title="MDN documentation about crash reports">How to read this crash report</a>
-        </div>
         <div id="report-header-details">
-          ID: <code>{{ report.uuid }}</code><br/>
-          Signature: <code>{{ report.signature }}</code>
+          <div>Crash ID: <code>{{ report.uuid }}</code></div>
+          <div>Signature: <code>[@ {{ report.signature }} ]</code></div>
+          {% if report.signature != report.current_signature %}
+            <div class="tip-note">
+              Signature generation has changed since this was processed. New signature would be:
+              <code>[@ {{ report.current_signature }} ]</code>
+            </div>
+          {% endif %}
         </div>
 
         {# Report-index #}

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -306,4 +306,3 @@ div.each-sparkline {
 .ui-tabs-panel {
     border: 1px solid @off-white;
 }
-

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base/layout.less
@@ -20,8 +20,13 @@ html {
             align-items: center;
 
             h2 {
-                flex-grow: 1;
+                flex: auto;
+                font-size: 1.6em;
                 margin: 0;
+            }
+            nav {
+                flex: initial;
+                flex-shrink: 0;
             }
         }
         .panel {
@@ -158,16 +163,6 @@ body {
                 }
             }
         }
-    }
-}
-
-.page-heading {
-    h2 {
-        display: inline;
-        font-size: 21px;
-    }
-    p.old-new-report-link {
-        float: right;
     }
 }
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/nav.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/nav.less
@@ -6,25 +6,25 @@ nav {
     .options {
         display: inline;
         margin-left: 1em;
-        font-size: 14px;
+        font-size: 1.1em;
         vertical-align: 4px;
         li {
             display: inline;
             list-style: none;
-        }
-        a {
-            color: @primary-dark;
-            padding: .3em .7em;
-            text-decoration: none;
-            white-space: nowrap;
-            .rounded-corners(.4em);
+            a {
+                color: @primary-dark;
+                padding: 0.3em 0.7em;
+                text-decoration: none;
+                white-space: nowrap;
+                .rounded-corners(.3em);
 
-            &:hover {
-                background-color: @off-white;
-            }
-            &.selected {
-                background-color: @primary;
-                color: @white;
+                &:hover {
+                    background-color: @off-white;
+                }
+                &.selected, &.button {
+                    background-color: @primary;
+                    color: @white;
+                }
             }
         }
     }

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/components/tip.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/components/tip.less
@@ -5,8 +5,22 @@
     font-size: 1.1em;
     background-color: @grey-20;
     color: @grey-90;
+
+    &::before {
+        content: "Tip! ";
+        font-weight: bold;
+    }
 }
-.tip::before {
-    content: "Tip! ";
-    font-weight: bold;
+
+.tip-note {
+    padding: 0.5em 0.8em;
+    margin: 0.5em 0;
+    font-size: 1.1em;
+    background-color: @grey-20;
+    color: @grey-90;
+
+    &::before {
+        content: "Note! ";
+        font-weight: bold;
+    }
 }


### PR DESCRIPTION
If signature generation has changed since when a crash report was last processed, then the report view will now show a note with the new signature.

In order to do this, I needed to move some things around, so I took some time to make the top of the report view more consistent with other parts of the site and reduce some of the complexity in design.