### PR TITLE
bug 1799539: support specifying signature lists

### DIFF
--- a/bin/update_siggen.py
+++ b/bin/update_siggen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/socorro/signature/README.rst
+++ b/socorro/signature/README.rst
@@ -17,22 +17,22 @@ signature and the newly generated one.
 This can be used for testing signature generation changes, regression testing,
 and astounding your friends at parties.
 
-You need to run this inside a Socorro environment. For example, you could
-run this in the processor Docker container. You can start a container
-like that like this::
+You need to run this inside a Socorro environment. For example, you could run
+this in the processor Docker container. You can start a container like that
+like this::
 
     $ make shell
 
 
-Once you're in your Socorro environment, you can run signature generation.
-You can pass it crash ids via the command line as arguments::
+Once you're in your Socorro environment, you can run signature generation. You
+can pass it crash ids via the command line as arguments::
 
     socorro-cmd signature CRASHID [CRASHID...]
 
 
 It can also take crash ids from stdin.
 
-Some examples:
+Examples:
 
 * getting crash ids from the file ``crashids.txt``::
 
@@ -41,6 +41,11 @@ Some examples:
 * getting crash ids from another command::
 
     $ socorro-cmd fetch_crashids --num=10 | socorro-cmd signature
+
+* getting crash ids for crash reports with a specific signature and then
+  checking to see if the signatures have changed::
+
+    $ socorro-cmd fetch_crashids --signature='js::NativeGetProperty' --num=5 | socorro-cmd signature
 
 * spitting output in CSV format to more easily analyze results for generating
   signatures for multiple crashes::
@@ -56,8 +61,7 @@ For more argument help, see::
 library
 -------
 
-This code is also available as library that's updated periodically by
-Will.
+This code is also available as library that's updated periodically by WillKG.
 
 If you're interested in using it, let us know.
 

--- a/socorro/signature/cmd_signature.py
+++ b/socorro/signature/cmd_signature.py
@@ -169,6 +169,14 @@ def main(argv=None):
         help="limit output to just the signatures that changed",
     )
     parser.add_argument(
+        "--signature-list-dir",
+        required=False,
+        help=(
+            "directory of signature list files to use; if not specified, uses the "
+            + "included signature list files"
+        ),
+    )
+    parser.add_argument(
         "crashids",
         metavar="crashid",
         nargs="*",
@@ -189,7 +197,13 @@ def main(argv=None):
 
     api_token = os.environ.get("SOCORRO_API_TOKEN", "")
 
-    generator = SignatureGenerator()
+    generator_kwargs = {}
+    if args.signature_list_dir:
+        generator_kwargs = {
+            "signature_list_dir": args.signature_list_dir,
+        }
+    generator = SignatureGenerator(**generator_kwargs)
+
     if args.crashids:
         crashids_iterable = args.crashids
     elif not sys.stdin.isatty():

--- a/socorro/signature/siglists_utils.py
+++ b/socorro/signature/siglists_utils.py
@@ -28,29 +28,29 @@ class BadRegularExpressionLineError(Exception):
     """Raised when a file contains an invalid regular expression."""
 
 
-class _PackageSource:
+class _IncludedSource:
     def __repr__(self):
-        return "PACKAGE"
+        return "INCLUDED"
 
     def __str__(self):
-        return "PACKAGE"
+        return "INCLUDED"
 
 
-PACKAGE = _PackageSource()
+INCLUDED = _IncludedSource()
 
 
-def get_filepath(name, source=PACKAGE):
+def get_filepath(name, source=INCLUDED):
     """Build a file path from the
 
     :param name: the signature list name
-    :param source: where to look for the specified signature list file: ``PACKAGE`` to
+    :param source: where to look for the specified signature list file: ``INCLUDED`` to
         look at included signature list files or the directory on the file system
         as a Path or string
 
     :returns: Path to file in package
 
     """
-    if source is PACKAGE:
+    if source is INCLUDED:
         package_name = ".".join(__name__.split(".")[0:-1])
         return importlib_resources.files(package_name).joinpath(f"siglists/{name}.txt")
 
@@ -58,13 +58,13 @@ def get_filepath(name, source=PACKAGE):
     return source / f"{name}.txt"
 
 
-def get_signature_list_content(name, source=PACKAGE):
+def get_signature_list_content(name, source=INCLUDED):
     """Return a tuple, each value being a line of the source file.
 
     Remove empty lines and comments (lines starting with a '#').
 
     :param name: the signature list name
-    :param source: where to look for the specified signature list file: ``PACKAGE`` to
+    :param source: where to look for the specified signature list file: ``INCLUDED`` to
         look at included signature list files or the directory on the file system
         as a Path or string
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -6,9 +6,9 @@ import copy
 import importlib
 import json
 import re
-from unittest import mock
 
 import pytest
+
 
 # NOTE(willkg): We do this so that we can extract signature generation into its
 # own namespace as an external library. This allows the tests to run if it's in
@@ -49,13 +49,12 @@ class TestCSignatureTool:
         td=[r"foo32\.dll.*"],
         ss=("sentinel", ("sentinel2", lambda x: "ff" in x)),
     ):
-        with mock.patch(BASE_MODULE + ".rules.siglists_utils") as mocked_siglists:
-            mocked_siglists.IRRELEVANT_SIGNATURE_RE = ig
-            mocked_siglists.PREFIX_SIGNATURE_RE = pr
-            mocked_siglists.SIGNATURES_WITH_LINE_NUMBERS_RE = si
-            mocked_siglists.TRIM_DLL_SIGNATURE_RE = td
-            mocked_siglists.SIGNATURE_SENTINELS = ss
-            return rules.CSignatureTool()
+        tool = rules.CSignatureTool()
+        tool.irrelevant_signature_re = tool.build_re(ig)
+        tool.prefix_signature_re = tool.build_re(pr)
+        tool.signatures_with_line_numbers_re = tool.build_re(si)
+        tool.signature_sentinels = ss
+        return tool
 
     def test_c_config_tool_init(self):
         """test_C_config_tool_init: constructor test"""

--- a/socorro/signature/tests/test_signature_generator.py
+++ b/socorro/signature/tests/test_signature_generator.py
@@ -30,7 +30,7 @@ class TestSignatureGenerator:
         class BadRule:
             pass
 
-        generator_obj = generator.SignatureGenerator(pipeline=[BadRule()])
+        generator_obj = generator.SignatureGenerator(ruleset=[BadRule])
         ret = generator_obj.generate({})
 
         assert ret.signature == ""
@@ -48,7 +48,7 @@ class TestSignatureGenerator:
         error_handler = mock.MagicMock()
 
         generator_obj = generator.SignatureGenerator(
-            pipeline=[BadRule()], error_handler=error_handler
+            ruleset=[BadRule], error_handler=error_handler
         )
         generator_obj.generate({"uuid": "ou812"})
 

--- a/socorro/unittest/processor/rules/test_mozilla.py
+++ b/socorro/unittest/processor/rules/test_mozilla.py
@@ -1943,7 +1943,7 @@ class TestSignatureGeneratorRule:
             # Override the regular SigntureGenerator with one with a BadRule
             # in the pipeline
             rule.generator = SignatureGenerator(
-                pipeline=[BadRule()], error_handler=rule._error_handler
+                ruleset=[BadRule], error_handler=rule._error_handler
             )
 
             raw_crash = {}


### PR DESCRIPTION
This adjusts signature generation to allow someone to build a SignatureGenerator and specify the directory containing signature lists. This functionality is extended to the `socorro-cmd signature` subcommand via a `--signature-list-dir` argument.