### PR TITLE
bug 1801122: update rust-minidump to v20221107.0

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20220830.0/socorro-stackwalker.2022-08-30.f9933c36.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20221117.0/socorro-stackwalker.2022-11-17.7faf03c5.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This updates rust-minidump to v20221107.0:

```
0aec5ef update indicatif now that a working version is published
dc8deb2 Improve printing of hexadecimal values
048c10a Improvements to Windows error codes printouts
c796d07 Added macOS ARM arithmetic exceptions
2d78f05 Fixed macOS ARM breakpoint and bad access exceptions and added missing ones
6aaf36a Added perma-links to Apple's sources holding the exceptions' declarations
cb7b25c Add instruction disassembly and access to JSON output
3ee32fc Properly report non-canonical addresses on Amd64 architecture
c06fd69 Remove MemoryListCursor and associated trait machinery
d64fb49 Add info about crashing instruction to output
134675e Refactor crash information into its own structure
dfcfac5 Implement op_analysis::SparseMemoryStream for memory lists
ab7fc08 Add instruction analysis for amd64
a6a486b post-release fixup
```

This fixes bug #1493342.