### PR TITLE
bug 1802715: add new[] to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -137,6 +137,7 @@ moz_xrealloc
 MOZ_CrashPrintf
 msvcr120\.dll@0x
 \<name omitted\>
+new\[\]
 NP_Shutdown
 (NS_)?(Lossy)?(Copy|Append|Convert).*UTF
 NS_CycleCollectorSuspect3


### PR DESCRIPTION
```
app$ socorro-cmd signature 52df7903-2585-4bd2-8b9d-c56090221124
Crash id: 52df7903-2585-4bd2-8b9d-c56090221124
Original: OOM | large | mozalloc_abort | moz_xmalloc | new[]
New:      OOM | large | mozalloc_abort | moz_xmalloc | new[] | mozilla::SPSCRingBufferBase<T>::SPSCRingBufferBase
Same?:    False
```