### PR TITLE
bug 1803385: update to rust-minidump 0.15.0

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20221117.0/socorro-stackwalker.2022-11-17.7faf03c5.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20221130.0/socorro-stackwalker.2022-11-30.v0.15.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -742,7 +742,6 @@ class BetaVersionRule(Rule):
             product = "DevEdition"
 
         key = "%s:%s:%s" % (product, channel, build_id)
-        print(key)
         if key in self.cache:
             self.metrics.incr("cache", tags=["result:hit"])
             return self.cache[key]


### PR DESCRIPTION
```
2df6521 (HEAD -> main, tag: v0.15.0, official/main) chore: Release
cd2a736 Update configuration for cargo release 0.22+ and add release notes
a5196a5 Appease clippy
8d7f96e Updated the dependencies
1a456a1 Merge pull request #744 from ePirat/epirat-fix-markdown-help-instructions
f04ecf5 Merge pull request #745 from ePirat/epirat-fix-cargo-release
3e3db7f Merge pull request #742 from ePirat/epirat-fix-parsing-empty-lines-symfile
00292ab Fix cargo-release replacements
66975e6 fix documentation how to generated markdown help
f5f0696 Add empty line in symbol file test
efe2fa0 Add support for empty lines to symbol file parser
```