### PR TITLE
bug 1808594: change default cache expiration to 5 minutes

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -342,7 +342,7 @@ def model_wrapper(request, model_name, model):
             result["DEPRECATION_WARNING"] = model.deprecation_warning
         headers["DEPRECATION-WARNING"] = model.deprecation_warning.replace("\n", " ")
 
-    if model.cache_seconds:
+    if model.cache_seconds > 0:
         # We can set a Cache-Control header.
         # We say 'private' because the content can depend on the user
         # and we don't want the response to be collected in HTTP proxies


### PR DESCRIPTION
This changes the default cache expiration from 60 minutes to 5 minutes. This affects the following APIs:

* Bugs
* SignatureByBugs
* RawCrash
* ProcessedCrash
* SuperSearch

5 minutes protects against the thundering herd, but reduces the amount of stuff sitting around in cache.