### PR TITLE
bug 1808595: stop caching RawCrash and ProcessedCrash data

### DIFF
--- a/bin/process_crashes.sh
+++ b/bin/process_crashes.sh
@@ -56,5 +56,5 @@ mkdir "${DATADIR}" || echo "${DATADIR} already exists."
 # Print urls to make it easier to look at them
 for crashid in "$@"
 do
-    echo "Check webapp: http://localhost:8000/report/index/${crashid}?refresh=cache"
+    echo "Check webapp: http://localhost:8000/report/index/${crashid}"
 done

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1326,7 +1326,7 @@
                   processed crash uploaded.
                 </p>
                 <p>
-                  <a href="?refresh=cache">Reload this page without cache</a>
+                  <a href="{{ request.get_full_path() }}">Reload this page</a>
                 </p>
               </div>
               <div class="reprocessing-error hidden">

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -616,6 +616,9 @@ def get_processed_crash_permissions_reducer(permissions_tuple):
 
 
 class ProcessedCrash(SocorroMiddleware):
+    # Prevent caching processed crash data from storage
+    cache_seconds = 0
+
     # FIXME(willkg): change this to BotoS3CrashStorage
     implementation = SimplifiedCrashData
     implementation_config_namespace = "crashdata"
@@ -696,6 +699,9 @@ class RawCrash(SocorroMiddleware):
     To access any of the raw dumps (e.g. format=raw) you need an API
     token that carries the "View Raw Dumps" permission.
     """
+
+    # Prevent caching raw crash data from storage
+    cache_seconds = 0
 
     implementation = SimplifiedCrashData
     implementation_config_namespace = "crashdata"

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -103,12 +103,10 @@ def report_index(request, crash_id, default_context=None):
     context = default_context or {}
     context["crash_id"] = crash_id
 
-    refresh_cache = request.GET.get("refresh") == "cache"
-
     raw_api = models.RawCrash()
     raw_api.api_user = request.user
     try:
-        context["raw"] = raw_api.get(crash_id=crash_id, refresh_cache=refresh_cache)
+        context["raw"] = raw_api.get(crash_id=crash_id)
     except CrashIDNotFound:
         # If the raw crash can't be found, we can't do much.
         return render(
@@ -119,7 +117,7 @@ def report_index(request, crash_id, default_context=None):
     api = models.ProcessedCrash()
     api.api_user = request.user
     try:
-        context["report"] = api.get(crash_id=crash_id, refresh_cache=refresh_cache)
+        context["report"] = api.get(crash_id=crash_id)
     except CrashIDNotFound:
         # ...if we haven't already done so.
         cache_key = f"priority_job:{crash_id}"


### PR DESCRIPTION
This changes the RawCrash and ProcessedCrash models to stop caching results. This updates the report view and drops the "refresh=cache" bits, too.

All caching is doing here is reducing the number of times we fetch data from S3. For the report view, HTTP GET requests are sub-1s, don't happen often, and don't tend to repeat. If we need to cache things, we should cache the output of rendering the report view template which would save us two S3 fetches and the work to render the template. We can look into that if we encounter a need to make this faster.