### PR TITLE
bug 1806119: add nsQueryObject<T>::operator to irrelevant list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -120,6 +120,7 @@ mozilla::ThreadEventQueue
 mozilla::ThreadSafeAutoRefCnt
 mozilla::UniquePtr
 mozilla::widget::WlCrashHandler
+nsQueryObject<T>::operator
 nsThread::GetEvent
 mozilla::PrioritizedEventQueue<T>::GetEvent
 nsThread::ProcessNextEvent


### PR DESCRIPTION
```
app@socorro:/app$ socorro-cmd signature 6ecb01f7-aad6-402c-bc10-8fb810221211
Crash id: 6ecb01f7-aad6-402c-bc10-8fb810221211
Original: nsQueryObject<T>::operator()
New:      nsThread::GetPerformanceCounterBase
Same?:    False
```