### PR TITLE
bug 1803808: fix wrapping for field examples

### DIFF
--- a/webapp-django/crashstats/documentation/jinja2/docs/datadictionary/field_doc.html
+++ b/webapp-django/crashstats/documentation/jinja2/docs/datadictionary/field_doc.html
@@ -38,17 +38,19 @@
                 <th scope="row">example data from last 7 days</th>
                 <td>
                   {% if example_data %}
-                    <ul>
-                      {% for item in example_data %}
-                        <li><code>{{ item }}</code></li>
-                      {% endfor %}
-                    </ul>
+                    {% for item in example_data %}
+                      <div class="field-example"><code>{{ item|string|truncate(100, killwords=True, end="...") }}</code></div>
+                    {% endfor %}
                   {% else %}
-                    <i>
-                      No examples available. Either this field is new and has
-                      no data, is rarely emitted and has no data this week, or
-                      this field isn't public.
-                    </i>
+                    {% if "protected" in permissions %}
+                      <i>This field is not public. No examples will be shown.</i>
+                    {% else %}
+                      <i>
+                        No examples available. Either this field is new and has
+                        no data or this field is rarely emitted and has no data
+                        this week.
+                      </i>
+                    {% endif %}
                   {% endif %}
                 </td>
               </tr>

--- a/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
+++ b/webapp-django/crashstats/documentation/static/documentation/css/documentation.less
@@ -60,6 +60,21 @@
         }
     }
 
+    div.field-example {
+        background-color: @off-white;
+        border: 1px solid @light-grey;
+        border-radius: 3px;
+        margin: 0.5em;
+        word-break: break-all;
+
+        code {
+            // Undo the css values for general <code>
+            margin: 0;
+            padding: 0;
+            border: 0;
+        }
+    }
+
     ul {
         margin-top: 0;
         margin-bottom: 10px;
@@ -74,6 +89,7 @@
                 margin-left: 15px;
                 margin-bottom: 0;
             }
+
         }
     }
 
@@ -85,6 +101,7 @@
         padding: 1px 5px;
         white-space: nowrap;
     }
+
     pre {
         display: block;
         padding: 9.5px;


### PR DESCRIPTION
This fixes word wrapping for field example data. It also tweaks the text that gets shown when example data isn't available.