### PR TITLE
bug 1809238: drop nip.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,8 +84,6 @@ services:
       - elasticsearch
       - memcached
       - oidcprovider
-    links:
-      - "oidcprovider:oidcprovider.127.0.0.1.nip.io"
     command: ["webapp", "--dev"]
     ports:
       - "8000:8000"

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -124,9 +124,11 @@ SENTRY_PORT=8090
 # ------------
 OIDC_RP_CLIENT_ID=1
 OIDC_RP_CLIENT_SECRET=bd01adf93cfb
-OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/authorize
-OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/token
-OIDC_OP_USER_ENDPOINT=http://oidcprovider.127.0.0.1.nip.io:8080/openid/userinfo
+# Redirect for the browser which is running on the docker host
+OIDC_OP_AUTHORIZATION_ENDPOINT=http://localhost:8080/openid/authorize
+# Requests between the webapp container and the oidcprovider container
+OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider:8080/openid/token
+OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
 
 # antenna
 # -------


### PR DESCRIPTION
We're using nip.io to help the webapp redirect the user's browser to the oidcprovider container. However, I was fiddling with that today and I think we don't need it because the webapp container can redirect the user's browser to localhost and that'll work fine.

I'm nixing it now. It feels weird to require nip.io service in order to do local development.                           