### PR TITLE
bug 1809728: implement processor_history

### DIFF
--- a/socorro/processor/processor_pipeline.py
+++ b/socorro/processor/processor_pipeline.py
@@ -297,19 +297,21 @@ class ProcessorPipeline(RequiredConfig):
                         f"{exc.__class__.__name__}"
                     )
 
-        # The crash made it through the processor rules with no exceptions
-        # raised, call it a success
+        # The crash made it through the processor rules with no exceptions raised, call
+        # it a success
         processed_crash["success"] = True
 
-        notes = status.notes
-
-        # Join notes into a single string
+        # Add previous notes to processor history
+        processor_history = processed_crash.get("processor_history", [])
         if processed_crash.get("processor_notes"):
             previous_notes = processed_crash["processor_notes"]
-            previous_notes = [line.strip() for line in previous_notes.split("\n")]
-            notes.extend(previous_notes)
+            processor_history.insert(0, previous_notes)
+        processed_crash["processor_history"] = processor_history
 
-        processed_crash["processor_notes"] = "\n".join(notes)
+        # Set notes to this processing pass' notes
+        processed_crash["processor_notes"] = "\n".join(status.notes)
+
+        # Set completed_datetime
         completed_datetime = utc_now()
         processed_crash["completed_datetime"] = date_to_string(completed_datetime)
 

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2773,12 +2773,21 @@ properties:
     type: string
     permissions: ["public"]
     source_annotation: ProcessType
-  processor_notes:
+  processor_history:
     description: |
-      Notes from all processing this crash report.
+      Notes from past processing.
 
-      Reprocessing crash reports will append processing notes to the previous
-      rounds.
+      Every time we reprocess a crash report, the `processor_notes` get added
+      to the `processor_history`.
+    items:
+      description: Notes for a single round of processing.
+      type: string
+      permissions: ["public"]
+    type: array
+    permissions: ["public"]
+  processor_notes:
+    description: >
+      Notes from the most recent round of processing for this crash report.
     type: string
     permissions: ["public"]
   product:

--- a/socorro/unittest/processor/test_processor_pipeline.py
+++ b/socorro/unittest/processor/test_processor_pipeline.py
@@ -196,6 +196,6 @@ class TestProcessorPipeline:
         assert processed_crash["success"] is True
         assert processed_crash["started_datetime"] == date_to_string(now)
         assert processed_crash["completed_datetime"] == date_to_string(now)
-        notes = processed_crash["processor_notes"].split("\n")
-        assert ">>> Start processing" in notes[0]
-        assert "previousnotes" in notes
+        assert "previousnotes" not in processed_crash["processor_notes"]
+        processor_history = "".join(processed_crash["processor_history"])
+        assert "previousnotes" in processor_history

--- a/socorro/unittest/schemas/test_socorro_data_schemas.py
+++ b/socorro/unittest/schemas/test_socorro_data_schemas.py
@@ -518,6 +518,7 @@ PUBLIC_PROCESSED_CRASH_FIELDS = {
     "plugin_name",
     "plugin_version",
     "process_type",
+    "processor_history.[]",
     "processor_notes",
     "product",
     "productid",

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1224,11 +1224,7 @@
                   <tr>
                     <th scope="row"># of times processed</th>
                     <td>
-                      {% if report.processor_notes %}
-                        {{ report.processor_notes.count(">>> ") }}
-                      {% else %}
-                        Unknown.
-                      {% endif %}
+                      {{ report.processor_history|length + 1 }}
                     </td>
                   </tr>
                   <tr>
@@ -1285,7 +1281,19 @@
                   </tr>
                   <tr>
                     <th scope="row">Processor notes</th>
-                    <td><pre>{{ report.processor_notes }}</pre></td>
+                    <td>
+                      <pre class="mx-4 my-2">{{ report.processor_notes }}</pre>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Processor history</th>
+                    <td>
+                      {% if report.processor_history %}
+                        {% for item in report.processor_history %}
+                          <pre class="mx-4 my-2">{{ item }}</pre>
+                        {% endfor %}
+                      {% endif %}
+                    </td>
                   </tr>
                 </tbody>
               </table>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/base.less
@@ -72,6 +72,15 @@ time {
     display: inline-block;
 }
 
+// tailwind-like utilities
+.mx-4 {
+    margin-left: 1.0rem;
+    margin-right: 1.0rem;
+}
+.my-2 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
 .w-1\/12 {
     width: 8.3333%;
 }


### PR DESCRIPTION
This changes the pipeline so that it stores the notes for the most recent processing pass in "processor_notes" and stores all previous notes in "processor_history".

This makes it easier to search for things that happened in processing without looking at all of the processing history.