### PR TITLE
bug 1811242: update face to 22.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -267,9 +267,9 @@ exceptiongroup==1.1.0 \
     --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \
     --hash=sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23
     # via pytest
-face==20.1.1 \
-    --hash=sha256:3790311a7329e4b0d90baee346eecad54b337629576edf3a246683a5f0d24446 \
-    --hash=sha256:7d59ca5ba341316e58cf72c6aff85cca2541cf5056c4af45cb63af9a814bed3e
+face==22.0.0 \
+    --hash=sha256:344fe31562d0f6f444a45982418f3793d4b14f9abb98ccca1509d22e0a3e7e35 \
+    --hash=sha256:d5d692f90bc8f5987b636e47e36384b9bbda499aaf0a77aa0b0bbe834c76923d
     # via glom
 fillmore==1.0.0 \
     --hash=sha256:6829367ad75f10711a9b97144cb3f9a925d0c06af9c460ea28ab51f8a6d5cd80 \


### PR DESCRIPTION
This updates face to 22.0.0 which makes the hash mismatch issue moot. We could have added the hash for the new py3 wheel, but might as well upgrade.