### PR TITLE
bug 1809451: improve symbolssupplier

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ __pycache__
 .cache
 webapp-django/node_modules
 webapp-django/static
+symbols/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 webapp-django/.env
 .pytest_cache
 .python-version
+symbols/
 
 # docker things
 .docker-build*

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ my.env:
 build: my.env  ## | Build docker images.
 	${DC} build ${DOCKER_BUILD_OPTS} --build-arg userid=${SOCORRO_UID} --build-arg groupid=${SOCORRO_GID} --progress plain app
 	${DC} build --progress plain oidcprovider fakesentry
-	${DC} build --progress plain statsd postgresql memcached localstack elasticsearch
+	${DC} build --progress plain statsd postgresql memcached localstack elasticsearch symbolsserver
 	touch .docker-build
 
 .PHONY: setup
@@ -60,12 +60,12 @@ updatedata: my.env  ## | Add/update necessary database data.
 	${DC} run --rm app shell /app/bin/update_data.sh
 
 .PHONY: run
-run: my.env  ## | Run processor, webapp, fakesentry, and all required services.
-	${DC} up processor webapp fakesentry
+run: my.env  ## | Run processor, webapp, fakesentry, symbolsserver, and all required services.
+	${DC} up processor webapp fakesentry symbolsserver
 
 .PHONY: runservices
 runservices: my.env  ## | Run service containers (Postgres, SQS, etc)
-	${DC} up -d statsd postgresql memcached localstack elasticsearch
+	${DC} up -d statsd postgresql memcached localstack elasticsearch symbolsserver
 
 .PHONY: stop
 stop: my.env  ## | Stop all service containers.
@@ -79,6 +79,7 @@ shell: my.env .docker-build  ## | Open a shell in the app container.
 clean:  ## | Remove all build, test, coverage, and Python artifacts.
 	-rm .docker-build*
 	-rm -rf .cache
+	@echo "Skipping deletion of symbols/ in case you have data in there."
 
 .PHONY: docs
 docs: my.env .docker-build  ## | Generate Sphinx HTML documetation.

--- a/bin/run_symbolsserver.sh
+++ b/bin/run_symbolsserver.sh
@@ -16,5 +16,10 @@ set -euxo pipefail
 SYMBOLS_PATH=/app/symbols
 PORT=8070
 
+if [ ! -d "${SYMBOLS_PATH}" ]
+then
+    mkdir -p "${SYMBOLS_PATH}"
+fi
+
 echo "Running local symbols server at ${SYMBOLS_PATH} ..."
 python -m http.server --directory "${SYMBOLS_PATH}" --bind 0.0.0.0 "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - statsd
       - localstack
       - elasticsearch
+      - symbolsserver
     command: ["processor"]
     volumes:
       - .:/app

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -79,7 +79,7 @@ processor.minidumpstackwalk.kill_timeout=30
 
 # Set symbols_urls to two symbol servers so we make sure we can specify multiple
 # --symbols-url values in minidump-stackwalk
-processor.minidumpstackwalk.symbols_urls=https://symbols.mozilla.org/try,https://symbols.stage.mozaws.net/try
+processor.minidumpstackwalk.symbols_urls=https://symbols.mozilla.org/try,http://symbolsserver:8070
 
 # Set the telemetry bucket name explicitly
 destination.telemetry.bucket_name=telemetry-bucket


### PR DESCRIPTION
This adjusts the run script to create the symbols directory first. This adds the symbols directory to .gitignore (don't want to check in contents) and .dockerignore (don't want contents to be part of docker image). This  adds symbolsserver to the services that run with `make run`. This adds it as the second item in the symbols_url for the processor.

This gives us a few things:

1. we can test `symbols_url` with multiple suppliers; it was using tecken prod and stage before, but now it uses tecken prod and localhost
2. we can see log output from the local symbols supplier, the HTTP request it got, and what it returned
3. we can add symbols files that mimic various scenarios when debugging issues like malformed sym files