### PR TITLE
Updates 20230201

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ enforce-typing==1.0.0.post1
 fillmore==1.0.0
 flake8==6.0.0
 freezegun==1.2.2
-glom==22.1.0
+glom==23.1.1
 gunicorn==20.1.0
 humanfriendly==10.0
 isodate==0.6.1

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 attrs==22.2.0
-awscli==1.27.41
-black==22.12.0
-boto3==1.26.41
+awscli==1.27.61
+black==23.1.0
+boto3==1.26.61
 click==8.1.3
 configman==1.3.0
 contextlib2==21.6.0
@@ -10,7 +10,7 @@ django-cors-headers==3.13.0
 django_csp==3.7
 django-jinja==2.10.2
 django-npm==1.0.0
-django-pipeline==2.0.8
+django-pipeline==2.0.9
 django-ratelimit==4.0.0
 djangorestframework==3.14.0
 django-session-csrf==0.7.1
@@ -18,7 +18,6 @@ dj-database-url==1.2.0
 dockerflow==2022.8.0
 enforce-typing==1.0.0.post1
 fillmore==1.0.0
-flake8==6.0.0
 freezegun==1.2.2
 glom==23.1.1
 gunicorn==20.1.0
@@ -33,26 +32,29 @@ markdown-it-py==2.1.0
 more-itertools==9.0.0
 mozilla-django-oidc==3.0.0
 oauth2client==4.1.3
-pip-tools==6.12.1
+pip-tools==6.12.2
 psycopg2-binary==2.9.5
 pygments==2.14.0
 pyinotify==0.9.6
 pymemcache==4.0.0
 pyquery==2.0.0
-pytest==7.2.0
+pytest==7.2.1
 pytest-django==4.5.2
 pytest-env==0.8.1
 python-decouple==3.7
-requests==2.28.1
+requests==2.28.2
 requests-mock==1.10.0
 semver==2.13.0
-sentry-sdk==1.12.1
-sphinx==4.4.0
-sphinx_rtd_theme==1.0.0
+sentry-sdk==1.14.0
 statsd==4.0.1
 urlwait==1.0
 werkzeug==2.2.2
 whitenoise==6.3.0
+
+# NOTE(willkg): Wait to upgrade these until after we split out flake8.
+flake8==6.0.0
+sphinx==4.4.0
+sphinx_rtd_theme==1.0.0
 
 # NOTE(willkg): We need this until we update to Python 3.10.
 importlib-metadata==6.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ pyquery==2.0.0
 pytest==7.2.0
 pytest-django==4.5.2
 pytest-env==0.8.1
-python-decouple==3.6
+python-decouple==3.7
 requests==2.28.1
 requests-mock==1.10.0
 semver==2.13.0

--- a/requirements.in
+++ b/requirements.in
@@ -68,7 +68,7 @@ importlib_resources==5.10.0
 django-waffle==2.3.0
 
 # NOTE(willkg): We stick with LTS releases and the next one is 4.2 (2023).
-django==3.2.16
+django==3.2.17
 
 # NOTE(willkg): Need to keep elasticsearch and elasticsearch-dsl at these versions
 # because they work with the cluster we're using

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,9 +191,9 @@ dj-database-url==1.2.0 \
     --hash=sha256:5c2993b91801c0f78a8b19e642b497b90831124cbade0c265900d4c1037b4730 \
     --hash=sha256:b23b15046cb38180e0c95207bcc90fe5e9dbde8eef16065907dd85cf4ca7036c
     # via -r requirements.in
-django==3.2.16 \
-    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
-    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
+django==3.2.17 \
+    --hash=sha256:59c39fc342b242fb42b6b040ad8b1b4c15df438706c1d970d416d63cdd73e7fd \
+    --hash=sha256:644288341f06ebe4938eec6801b6bd59a6534a78e4aedde2a153075d11143894
     # via
     #   -r requirements.in
     #   dj-database-url
@@ -263,10 +263,6 @@ enforce-typing==1.0.0.post1 \
     --hash=sha256:90347a61d08e7f7578d9714b4f0fd8abd9b6bc48c8ac8d46d7f290d413afabb7 \
     --hash=sha256:d3184dfdbfd7f9520c884986561751a6106c57cdd65d730470645d2d40c47e18
     # via -r requirements.in
-exceptiongroup==1.1.0 \
-    --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \
-    --hash=sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23
-    # via pytest
 face==22.0.0 \
     --hash=sha256:344fe31562d0f6f444a45982418f3793d4b14f9abb98ccca1509d22e0a3e7e35 \
     --hash=sha256:d5d692f90bc8f5987b636e47e36384b9bbda499aaf0a77aa0b0bbe834c76923d
@@ -310,9 +306,7 @@ imagesize==1.3.0 \
 importlib-metadata==6.0.0 \
     --hash=sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad \
     --hash=sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d
-    # via
-    #   -r requirements.in
-    #   sphinx
+    # via -r requirements.in
 importlib-resources==5.10.0 \
     --hash=sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668 \
     --hash=sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437
@@ -839,17 +833,11 @@ statsd==4.0.1 \
 tomli==1.2.3 \
     --hash=sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f \
     --hash=sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c
-    # via
-    #   black
-    #   build
-    #   pep517
-    #   pytest
+    # via pep517
 typing-extensions==4.3.0 \
     --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
     --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
-    # via
-    #   -r requirements.in
-    #   black
+    # via -r requirements.in
 urllib3==1.26.13 \
     --hash=sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc \
     --hash=sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8
@@ -880,7 +868,6 @@ zipp==3.11.0 \
     # via
     #   -r requirements.in
     #   importlib-metadata
-    #   importlib-resources
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/requirements.txt
+++ b/requirements.txt
@@ -696,9 +696,9 @@ python-dateutil==2.8.2 \
     #   botocore
     #   elasticsearch-dsl
     #   freezegun
-python-decouple==3.6 \
-    --hash=sha256:2838cdf77a5cf127d7e8b339ce14c25bceb3af3e674e039d4901ba16359968c7 \
-    --hash=sha256:6cf502dc963a5c642ea5ead069847df3d916a6420cad5599185de6bab11d8c2e
+python-decouple==3.7 \
+    --hash=sha256:1596dad2670cca5b1f87d087d9adb6a1958c590df346b85d4b19a9d6f0d52cef \
+    --hash=sha256:e88a8d6bdf3b07d471a854099e455e20a6fa7a4d6ecf8631b250e3db654336e6
     # via -r requirements.in
 pytz==2022.1 \
     --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -267,9 +267,10 @@ exceptiongroup==1.1.0 \
     --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \
     --hash=sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23
     # via pytest
-face==22.0.0 \
-    --hash=sha256:344fe31562d0f6f444a45982418f3793d4b14f9abb98ccca1509d22e0a3e7e35 \
-    --hash=sha256:d5d692f90bc8f5987b636e47e36384b9bbda499aaf0a77aa0b0bbe834c76923d
+face==20.1.1 \
+    --hash=sha256:3790311a7329e4b0d90baee346eecad54b337629576edf3a246683a5f0d24446 \
+    --hash=sha256:7d59ca5ba341316e58cf72c6aff85cca2541cf5056c4af45cb63af9a814bed3e \
+    --hash=sha256:ca3a1d8b8b6aa8e61d62a300e9ee24e09c062aceda549e9a640128e4fa0f4559
     # via glom
 fillmore==1.0.0 \
     --hash=sha256:6829367ad75f10711a9b97144cb3f9a925d0c06af9c460ea28ab51f8a6d5cd80 \
@@ -310,7 +311,9 @@ imagesize==1.3.0 \
 importlib-metadata==6.0.0 \
     --hash=sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad \
     --hash=sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sphinx
 importlib-resources==5.10.0 \
     --hash=sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668 \
     --hash=sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437
@@ -837,11 +840,17 @@ statsd==4.0.1 \
 tomli==1.2.3 \
     --hash=sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f \
     --hash=sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c
-    # via pep517
+    # via
+    #   black
+    #   build
+    #   pep517
+    #   pytest
 typing-extensions==4.3.0 \
     --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
     --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   black
 urllib3==1.26.13 \
     --hash=sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc \
     --hash=sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8
@@ -872,6 +881,7 @@ zipp==3.11.0 \
     # via
     #   -r requirements.in
     #   importlib-metadata
+    #   importlib-resources
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,27 +21,40 @@ attrs==22.2.0 \
     #   glom
     #   jsonschema
     #   pytest
-awscli==1.27.41 \
-    --hash=sha256:11c015c6ae03ca10068bbd9392cd491478b616d0c5e14f77a1c23dfbb0ef758b \
-    --hash=sha256:e94d3f04a5f3fc7cc91c8004ba00e71c7aabd9685c092bd7b2f99a51c55ec0b9
+awscli==1.27.61 \
+    --hash=sha256:3dc5f45ceef44093cb7802c3ebb47af8873967ea393024c3faf8c9124c449f59 \
+    --hash=sha256:5a5fa41b5e250acab34e6e6f0a4bc1f3ffc4531056a2e798fa41d87a4c1ea390
     # via -r requirements.in
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
     # via sphinx
-black==22.12.0 \
-    --hash=sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320 \
-    --hash=sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351 \
-    --hash=sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350 \
-    --hash=sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f \
-    --hash=sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf \
-    --hash=sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148 \
-    --hash=sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4 \
-    --hash=sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d \
-    --hash=sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc \
-    --hash=sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d \
-    --hash=sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2 \
-    --hash=sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
+black==23.1.0 \
+    --hash=sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd \
+    --hash=sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555 \
+    --hash=sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481 \
+    --hash=sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468 \
+    --hash=sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9 \
+    --hash=sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a \
+    --hash=sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958 \
+    --hash=sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580 \
+    --hash=sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26 \
+    --hash=sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32 \
+    --hash=sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8 \
+    --hash=sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753 \
+    --hash=sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b \
+    --hash=sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074 \
+    --hash=sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651 \
+    --hash=sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24 \
+    --hash=sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6 \
+    --hash=sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad \
+    --hash=sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac \
+    --hash=sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221 \
+    --hash=sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06 \
+    --hash=sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27 \
+    --hash=sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648 \
+    --hash=sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739 \
+    --hash=sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104
     # via -r requirements.in
 boltons==21.0.0 \
     --hash=sha256:65e70a79a731a7fe6e98592ecfb5ccf2115873d01dbc576079874629e5c90f13 \
@@ -49,13 +62,13 @@ boltons==21.0.0 \
     # via
     #   face
     #   glom
-boto3==1.26.41 \
-    --hash=sha256:05a5ce3af2d7419e39d93498c7f56fd5c2cc17870c92c4abc75659553b0b16de \
-    --hash=sha256:8cbea352f28ec6b241f348356bcb8f331fc433bec3ad76ebf6194227f1a7f613
+boto3==1.26.61 \
+    --hash=sha256:5194c16e1f2371c25ee038e8291faf99117b4f2d272d70f48851ba47bcea44b4 \
+    --hash=sha256:78d75f6a08c33618d9ce37acca78e4f80e316a8ce3ac040c562f8054afe6451e
     # via -r requirements.in
-botocore==1.29.41 \
-    --hash=sha256:78761227d986d393956b6d08fdadcfe142748828e0e9db33f2f4c42a482dcd35 \
-    --hash=sha256:b670b7f8958a2908167081efb6ea39794bf61d618be729984629a63d85cf8bfe
+botocore==1.29.61 \
+    --hash=sha256:22ead51f900e3465d0e4e670d02d091e613c88be8b333c47bfda727f8988eef3 \
+    --hash=sha256:c7a7133d02c5e9a8fcc9e5a238bf15bde2d5369366553520332a88bc05b7358a
     # via
     #   awscli
     #   boto3
@@ -217,9 +230,9 @@ django-jinja==2.10.2 \
 django-npm==1.0.0 \
     --hash=sha256:2e6bba65e728fa18b9db3c8dc0d4490b70cb7f43bacf60eb3654d7dcb6424272
     # via -r requirements.in
-django-pipeline==2.0.8 \
-    --hash=sha256:26f1d344a7bf39bc92c9dc520093471d912de53abd7d22ac715e77d779a831c8 \
-    --hash=sha256:56c299cec0e644e77d5f928f4cebfff804b919cc10ff5c0bfaa070ff57e8da44
+django-pipeline==2.0.9 \
+    --hash=sha256:b0f2748d43e4e773033f563ac0e8c3b2d47b88320abf726eb83e35a7172bf83a \
+    --hash=sha256:deb278d151c6cc8de3d3eec5e70d8a21527000dd58b616215deba2fa9a51c7e2
     # via -r requirements.in
 django-ratelimit==4.0.0 \
     --hash=sha256:19cba9e8101277f28c7a974c54c997067341ab30175431d3739e8ffb63cdd2b2 \
@@ -508,10 +521,11 @@ oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
     # via -r requirements.in
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+packaging==23.0 \
+    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
+    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
     # via
+    #   black
     #   build
     #   pytest
     #   sphinx
@@ -523,9 +537,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via build
-pip-tools==6.12.1 \
-    --hash=sha256:88efb7b29a923ffeac0713e6f23ef8529cc6175527d42b93f73756cc94387293 \
-    --hash=sha256:f0c0c0ec57b58250afce458e2e6058b1f30a4263db895b7d72fd6311bf1dc6f7
+pip-tools==6.12.2 \
+    --hash=sha256:6a51f4fd67140d5e83703ebfa9610fb61398727151f56a1be02a972d062e4679 \
+    --hash=sha256:8b903696df4598b10d469026ef9995c5f9a874b416e88e7a214884ebe4a70245
     # via -r requirements.in
 platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
@@ -651,9 +665,7 @@ pyopenssl==23.0.0 \
 pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
-    # via
-    #   httplib2
-    #   packaging
+    # via httplib2
 pyquery==2.0.0 \
     --hash=sha256:8dfc9b4b7c5f877d619bbae74b1898d5743f6ca248cfd5d72b504dd614da312f \
     --hash=sha256:963e8d4e90262ff6d8dec072ea97285dc374a2f69cad7776f4082abcf6a1d8ae
@@ -681,9 +693,9 @@ pyrsistent==0.18.1 \
     --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
     --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
     # via jsonschema
-pytest==7.2.0 \
-    --hash=sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71 \
-    --hash=sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59
+pytest==7.2.1 \
+    --hash=sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5 \
+    --hash=sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42
     # via
     #   -r requirements.in
     #   pytest-django
@@ -745,9 +757,9 @@ pyyaml==5.4.1 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
     # via awscli
-requests==2.28.1 \
-    --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983 \
-    --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
+requests==2.28.2 \
+    --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
+    --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
     # via
     #   -r requirements.in
     #   datadog
@@ -774,9 +786,9 @@ semver==2.13.0 \
     --hash=sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4 \
     --hash=sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f
     # via -r requirements.in
-sentry-sdk==1.12.1 \
-    --hash=sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c \
-    --hash=sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6
+sentry-sdk==1.14.0 \
+    --hash=sha256:273fe05adf052b40fd19f6d4b9a5556316807246bd817e5e3482930730726bb0 \
+    --hash=sha256:72c00322217d813cf493fe76590b23a757e063ff62fec59299f4af7201dd4448
     # via
     #   -r requirements.in
     #   fillmore

--- a/requirements.txt
+++ b/requirements.txt
@@ -263,6 +263,10 @@ enforce-typing==1.0.0.post1 \
     --hash=sha256:90347a61d08e7f7578d9714b4f0fd8abd9b6bc48c8ac8d46d7f290d413afabb7 \
     --hash=sha256:d3184dfdbfd7f9520c884986561751a6106c57cdd65d730470645d2d40c47e18
     # via -r requirements.in
+exceptiongroup==1.1.0 \
+    --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \
+    --hash=sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23
+    # via pytest
 face==22.0.0 \
     --hash=sha256:344fe31562d0f6f444a45982418f3793d4b14f9abb98ccca1509d22e0a3e7e35 \
     --hash=sha256:d5d692f90bc8f5987b636e47e36384b9bbda499aaf0a77aa0b0bbe834c76923d
@@ -279,9 +283,9 @@ freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
     # via -r requirements.in
-glom==22.1.0 \
-    --hash=sha256:1510c6587a8f9c64a246641b70033cbc5ebde99f02ad245693678038e821aeb5 \
-    --hash=sha256:5339da206bf3532e01a83a35aca202960ea885156986d190574b779598e9e772
+glom==23.1.1 \
+    --hash=sha256:b6bef86c36dde4539b70fe096cf23dc4eb0b8b5df9e00df6d18dfe144d75f85e \
+    --hash=sha256:b7442309e013feb6feab206197abf8aec32835ec709d8a92a8514322f64c0eff
     # via -r requirements.in
 gunicorn==20.1.0 \
     --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \

--- a/webapp/crashstats/api/tests/test_views.py
+++ b/webapp/crashstats/api/tests/test_views.py
@@ -879,7 +879,6 @@ def test_api_model_names():
 
 @pytest.mark.parametrize("name", API_MODEL_NAMES)
 class TestAPIModels:
-
     MODEL = {}
 
     def setup_class(cls):

--- a/webapp/crashstats/authentication/migrations/0001_initial.py
+++ b/webapp/crashstats/authentication/migrations/0001_initial.py
@@ -11,7 +11,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]

--- a/webapp/crashstats/crashstats/migrations/0001_initial.py
+++ b/webapp/crashstats/crashstats/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = []

--- a/webapp/crashstats/crashstats/migrations/0002_1457747_graphics_devices.py
+++ b/webapp/crashstats/crashstats/migrations/0002_1457747_graphics_devices.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("crashstats", "0001_initial")]

--- a/webapp/crashstats/crashstats/migrations/0003_1457747_graphics_data_migration.py
+++ b/webapp/crashstats/crashstats/migrations/0003_1457747_graphics_data_migration.py
@@ -66,7 +66,6 @@ def noop(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0002_1457747_graphics_devices")]
 
     operations = [migrations.RunPython(copy_graphics_devices_data, noop)]

--- a/webapp/crashstats/crashstats/migrations/0004_1463121-signature.py
+++ b/webapp/crashstats/crashstats/migrations/0004_1463121-signature.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0003_1457747_graphics_data_migration")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0005_1463121-signature-data-migration.py
+++ b/webapp/crashstats/crashstats/migrations/0005_1463121-signature-data-migration.py
@@ -9,7 +9,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0004_1463121-signature")]
 
     operations = []

--- a/webapp/crashstats/crashstats/migrations/0006_1493768-bug-associations.py
+++ b/webapp/crashstats/crashstats/migrations/0006_1493768-bug-associations.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0005_1463121-signature-data-migration")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0007_1498441-platform.py
+++ b/webapp/crashstats/crashstats/migrations/0007_1498441-platform.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0006_1493768-bug-associations")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0008_1498441-name-unique.py
+++ b/webapp/crashstats/crashstats/migrations/0008_1498441-name-unique.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0007_1498441-platform")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0009_1506907_product.py
+++ b/webapp/crashstats/crashstats/migrations/0009_1506907_product.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0008_1498441-name-unique")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0011_1506907_productversion.py
+++ b/webapp/crashstats/crashstats/migrations/0011_1506907_productversion.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0010_1506907_product_migration")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0012_1507916_productversion_major_version.py
+++ b/webapp/crashstats/crashstats/migrations/0012_1507916_productversion_major_version.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0011_1506907_productversion")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0014_auto_20181214_1951.py
+++ b/webapp/crashstats/crashstats/migrations/0014_auto_20181214_1951.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0013_1507916_major_version_data_migration")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0015_1463514-remove-eventlog.py
+++ b/webapp/crashstats/crashstats/migrations/0015_1463514-remove-eventlog.py
@@ -19,7 +19,6 @@ def noop(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0014_auto_20181214_1951")]
 
     operations = [migrations.RunPython(remove_eventlog_tables, noop)]

--- a/webapp/crashstats/crashstats/migrations/0016_1523284_fenix.py
+++ b/webapp/crashstats/crashstats/migrations/0016_1523284_fenix.py
@@ -25,7 +25,6 @@ def delete_product(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0015_1463514-remove-eventlog")]
 
     operations = [migrations.RunPython(create_product, delete_product)]

--- a/webapp/crashstats/crashstats/migrations/0017_missingprocessedcrashes.py
+++ b/webapp/crashstats/crashstats/migrations/0017_missingprocessedcrashes.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0016_1523284_fenix")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0018_missingprocessedcrash.py
+++ b/webapp/crashstats/crashstats/migrations/0018_missingprocessedcrash.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0017_missingprocessedcrashes")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0020_auto_20190403_2208.py
+++ b/webapp/crashstats/crashstats/migrations/0020_auto_20190403_2208.py
@@ -8,7 +8,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("crashstats", "0019_missing-crashes-migration")]
 
     operations = [

--- a/webapp/crashstats/crashstats/migrations/0021_bug_1657668_product_support.py
+++ b/webapp/crashstats/crashstats/migrations/0021_bug_1657668_product_support.py
@@ -8,7 +8,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("crashstats", "0020_auto_20190403_2208"),
     ]

--- a/webapp/crashstats/crashstats/migrations/0022_auto_20210317_2220.py
+++ b/webapp/crashstats/crashstats/migrations/0022_auto_20210317_2220.py
@@ -20,7 +20,6 @@ def noop(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("crashstats", "0021_bug_1657668_product_support"),
     ]

--- a/webapp/crashstats/cron/migrations/0001_initial.py
+++ b/webapp/crashstats/cron/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = []

--- a/webapp/crashstats/cron/migrations/0002_job_log.py
+++ b/webapp/crashstats/cron/migrations/0002_job_log.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("cron", "0001_initial")]

--- a/webapp/crashstats/cron/migrations/0003_auto_20181116_1432.py
+++ b/webapp/crashstats/cron/migrations/0003_auto_20181116_1432.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cron", "0002_job_log")]
 
     operations = [

--- a/webapp/crashstats/cron/migrations/0004_auto_20181214_1951.py
+++ b/webapp/crashstats/cron/migrations/0004_auto_20181214_1951.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cron", "0003_auto_20181116_1432")]
 
     operations = [

--- a/webapp/crashstats/cron/migrations/0005_auto_20190430_1242.py
+++ b/webapp/crashstats/cron/migrations/0005_auto_20190430_1242.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cron", "0004_auto_20181214_1951")]
 
     operations = [

--- a/webapp/crashstats/status/migrations/0001_initial.py
+++ b/webapp/crashstats/status/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/webapp/crashstats/status/migrations/0002_auto_20180522_1545.py
+++ b/webapp/crashstats/status/migrations/0002_auto_20180522_1545.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("status", "0001_initial")]
 
     operations = [

--- a/webapp/crashstats/status/migrations/0003_auto_20181214_1951.py
+++ b/webapp/crashstats/status/migrations/0003_auto_20181214_1951.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("status", "0002_auto_20180522_1545")]
 
     operations = [

--- a/webapp/crashstats/status/migrations/0004_auto_20190118_1546.py
+++ b/webapp/crashstats/status/migrations/0004_auto_20190118_1546.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("status", "0003_auto_20181214_1951")]
 
     operations = [

--- a/webapp/crashstats/tokens/migrations/0001_initial.py
+++ b/webapp/crashstats/tokens/migrations/0001_initial.py
@@ -9,7 +9,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("auth", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/webapp/crashstats/tokens/tests/test_middleware.py
+++ b/webapp/crashstats/tokens/tests/test_middleware.py
@@ -26,7 +26,6 @@ def get_response(req):
 
 
 class TestMiddleware(DjangoTestCase):
-
     django_session_middleware = SessionMiddleware(get_response)
     django_auth_middleware = AuthenticationMiddleware(get_response)
     middleware = APIAuthenticationMiddleware(get_response)


### PR DESCRIPTION
Update dependencies. This covers:

* Update dependencies
  * awscli: 1.27.41 -> 1.27.61
  * black: 22.12.0 -> 23.1.0
  * boto3: 1.26.41 -> 1.26.61
  * django-pipeline: 2.0.8 -> 2.0.9
  * pip-tools: 6.12.1 -> 6.12.2
  * pytest: 7.2.0 -> 7.2.1
  * requests: 2.28.1 -> 2.28.2
  * sentry-sdk: 1.12.1 -> 1.14.0
* Recompile requirements.txt
* Bump glom from 22.1.0 to 23.1.1 (from PR #6335)
* Bump python-decouple from 3.6 to 3.7 (from PR #6334)
* Bump django from 3.2.16 to 3.2.17 (from PR #6332)
