### PR TITLE
bug 1767282: fix temp files in processor

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -52,7 +52,6 @@ resource.boto.s3_endpoint_url=http://localstack:4566/
 resource.boto.access_key=foo
 secrets.boto.secret_access_key=foo
 resource.boto.bucket_name=dev-bucket
-resource.boto.temporary_file_system_storage_path=/tmp
 resource.boto.region=us-west-2
 
 resource.boto.sqs_endpoint_url=http://localstack:4566/

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -63,9 +63,6 @@ resource.boto.reprocessing_queue=local-dev-reprocessing
 # processor
 # ---------
 
-# Use the rust-minidump minidump-stackwalk binary
-processor.minidump_stackwalker=rust
-
 # In the docker local dev environment, we store symbol cache and other things
 # in /tmp because there's only one processor node. For server environments, we
 # probably want to store that in a volume. These vars are all affected.
@@ -73,9 +70,9 @@ companion_process.symbol_cache_path=/tmp/symbols/cache
 processor.minidumpstackwalk.symbol_cache_path=/tmp/symbols/cache
 processor.minidumpstackwalk.symbol_tmp_path=/tmp/symbols/tmp
 
-# Drop kill_timeout to 30 because this is a dev environment and 5 minutes is
+# Drop kill_timeout to 60 because this is a dev environment and 5 minutes is
 # a long time
-processor.minidumpstackwalk.kill_timeout=30
+processor.minidumpstackwalk.kill_timeout=120
 
 # Set symbols_urls to two symbol servers so we make sure we can specify multiple
 # --symbols-url values in minidump-stackwalk

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -140,12 +140,6 @@ class BotoS3CrashStorage(CrashStorageBase):
         reference_value_from="resource.boto",
     )
     required_config.add_option(
-        "temporary_file_system_storage_path",
-        doc="a local filesystem path where dumps temporarily during processing",
-        default="/home/socorro/temp",
-        reference_value_from="resource.boto",
-    )
-    required_config.add_option(
         "dump_file_suffix",
         doc="the suffix used to identify a dump file (for use in temp files)",
         default=".dump",
@@ -250,7 +244,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         except self.conn.KeyNotFound as x:
             raise CrashIDNotFound("%s not found: %s" % (crash_id, x))
 
-    def get_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id, tmpdir):
         """Get the dump files for given crash id and save them to tmp.
 
         :returns: dict of dumpname -> file path
@@ -262,7 +256,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         # convert our native memory dump mapping into a file dump mapping.
         return in_memory_dumps.as_file_dumps_mapping(
             crash_id,
-            self.config.temporary_file_system_storage_path,
+            tmpdir,
             self.config.dump_file_suffix,
         )
 

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -223,10 +223,11 @@ class CrashStorageBase(RequiredConfig):
         """
         raise NotImplementedError("get_dumps is not implemented")
 
-    def get_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id, tmpdir):
         """Fetch all dumps for a crash report and save as files.
 
         :param crash_id: crash report id
+        :param tmpdir: the path to store the dump files in
 
         :returns: dict of dumpname -> file path
 
@@ -527,9 +528,9 @@ class BenchmarkingCrashStorage(CrashStorageBase):
         self.logger.debug("%s get_dumps %s", self.tag, end_time - start_time)
         return result
 
-    def get_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id, tmpdir):
         start_time = self.start_timer()
-        result = self.wrapped_crashstore.get_dumps_as_files(crash_id)
+        result = self.wrapped_crashstore.get_dumps_as_files(crash_id, tmpdir)
         end_time = self.end_timer()
         self.logger.debug("%s get_dumps_as_files %s", self.tag, end_time - start_time)
         return result

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -214,7 +214,9 @@ class FSPermanentStorage(CrashStorageBase):
         ) as f:
             return f.read()
 
-    def get_dumps_as_files(self, crash_id):
+    def get_dumps_as_files(self, crash_id, tmpdir):
+        # NOTE(willkg): We don't need to use tmpdir here because the files are already
+        # on the file system.
         parent_dir = self._get_radixed_parent_directory(crash_id)
         if not os.path.exists(parent_dir):
             raise CrashIDNotFound
@@ -232,7 +234,7 @@ class FSPermanentStorage(CrashStorageBase):
         )
 
     def get_dumps(self, crash_id):
-        file_dump_mapping = self.get_dumps_as_files(crash_id)
+        file_dump_mapping = self.get_dumps_as_files(crash_id, None)
         # ensure that we return a name/blob mapping
         return file_dump_mapping.as_memory_dumps_mapping()
 
@@ -258,7 +260,7 @@ class FSPermanentStorage(CrashStorageBase):
             raise CrashIDNotFound
 
         removal_candidates = [os.sep.join([parent_dir, crash_id + ".json"])] + list(
-            self.get_dumps_as_files(crash_id).values()
+            self.get_dumps_as_files(crash_id, None).values()
         )
 
         # Remove all the files related to the crash

--- a/socorro/processor/rules/base.py
+++ b/socorro/processor/rules/base.py
@@ -25,12 +25,13 @@ class Rule:
     def name(self):
         return self.__class__.__module__ + "." + self.__class__.__name__
 
-    def predicate(self, raw_crash, dumps, processed_crash, status):
+    def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
         """Determines whether to run the action for this crash
 
         :arg raw_crash: the raw crash data
         :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
+        :arg tmpdir: a temporary directory to use
         :arg status: any notes or bookkeeping we need to keep about
             processing as we process
 
@@ -39,24 +40,26 @@ class Rule:
         """
         return True
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         """Executes the rule transforming the crash data
 
         :arg raw_crash: the raw crash data
         :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
+        :arg tmpdir: a temporary directory to use
         :arg status: any notes or bookkeeping we need to keep about
             processing as we process
 
         """
         return
 
-    def act(self, raw_crash, dumps, processed_crash, status):
+    def act(self, raw_crash, dumps, processed_crash, tmpdir, status):
         """Runs predicate and action for a rule
 
         :arg raw_crash: the raw crash data
         :arg dumps: any minidumps associated with this crash
         :arg processed_crash: the processed crash
+        :arg tmpdir: a temporary directory to use
         :arg status: any notes or bookkeeping we need to keep about
             processing as we process
 
@@ -67,6 +70,7 @@ class Rule:
                 raw_crash=raw_crash,
                 dumps=dumps,
                 processed_crash=processed_crash,
+                tmpdir=tmpdir,
                 status=status,
             )
             if ret:
@@ -74,6 +78,7 @@ class Rule:
                     raw_crash=raw_crash,
                     dumps=dumps,
                     processed_crash=processed_crash,
+                    tmpdir=tmpdir,
                     status=status,
                 )
 

--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -39,7 +39,7 @@ class DeNullRule(Rule):
         # return it as is
         return s
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         had_nulls = False
 
         # Go through the raw crash and de-null keys and values
@@ -66,7 +66,7 @@ class DeNoneRule(Rule):
 
     """
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         had_nones = False
 
         # Remove keys that have None values
@@ -80,7 +80,7 @@ class DeNoneRule(Rule):
 
 
 class IdentifierRule(Rule):
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         if "uuid" in raw_crash:
             processed_crash["crash_id"] = raw_crash["uuid"]
             processed_crash["uuid"] = raw_crash["uuid"]
@@ -103,7 +103,7 @@ class CPUInfoRule(Rule):
         "x86_64": "amd64",
     }
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         # This is the CPU info of the machine the product was running on
         processed_crash["cpu_info"] = glom(
             processed_crash, "json_dump.system_info.cpu_info", default="unknown"
@@ -141,7 +141,7 @@ class CPUInfoRule(Rule):
 
 
 class OSInfoRule(Rule):
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         os_name = glom(
             processed_crash, "json_dump.system_info.os", default="Unknown"
         ).strip()
@@ -169,7 +169,7 @@ class CrashReportKeysRule(Rule):
 
         return key
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         all_keys = set(raw_crash.keys()) | set(dumps.keys())
 
         # Go through and remove obviously invalid keys
@@ -188,5 +188,5 @@ class CrashReportKeysRule(Rule):
 class CollectorMetadataRule(Rule):
     """Copies collector metadata to processed crash"""
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         processed_crash["collector_metadata"] = raw_crash.get("metadata", {})

--- a/socorro/processor/rules/memory_report_extraction.py
+++ b/socorro/processor/rules/memory_report_extraction.py
@@ -20,7 +20,7 @@ class MemoryReportExtraction(Rule):
 
     """
 
-    def predicate(self, raw_crash, dumps, processed_crash, status):
+    def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
         try:
             # Verify that...
             return (
@@ -36,7 +36,7 @@ class MemoryReportExtraction(Rule):
         except KeyError:
             return False
 
-    def action(self, raw_crash, dumps, processed_crash, status):
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         pid = processed_crash["json_dump"]["pid"]
         memory_report = processed_crash["memory_report"]
 

--- a/socorro/tests/external/test_crashstorage_base.py
+++ b/socorro/tests/external/test_crashstorage_base.py
@@ -279,7 +279,7 @@ class TestCrashStorageBase:
 
 
 class TestBench:
-    def test_benchmarking_crashstore(self, caplogpp):
+    def test_benchmarking_crashstore(self, tmp_path, caplogpp):
         caplogpp.set_level("DEBUG")
 
         required_config = Namespace()
@@ -334,9 +334,10 @@ class TestBench:
             assert "test get_dumps 1" in [rec.message for rec in caplogpp.records]
             caplogpp.clear()
 
-            crashstorage.get_dumps_as_files("uuid")
+            crashstorage.get_dumps_as_files("uuid", tmpdir=str(tmp_path))
             crashstorage.wrapped_crashstore.get_dumps_as_files.assert_called_with(
-                "uuid"
+                "uuid",
+                str(tmp_path),
             )
             assert "test get_dumps_as_files 1" in [
                 rec.message for rec in caplogpp.records

--- a/socorro/tests/processor/rules/test_memory_report_extraction.py
+++ b/socorro/tests/processor/rules/test_memory_report_extraction.py
@@ -5,6 +5,7 @@
 import os
 import json
 
+from socorro.processor.processor_pipeline import Status
 from socorro.processor.rules.memory_report_extraction import MemoryReportExtraction
 
 
@@ -18,7 +19,7 @@ def get_example_file_data(filename):
 
 
 class TestMemoryReportExtraction:
-    def test_predicate_success(self):
+    def test_predicate_success(self, tmp_path):
         rule = MemoryReportExtraction()
 
         processed_crash = {
@@ -30,26 +31,34 @@ class TestMemoryReportExtraction:
             "json_dump": {"pid": 42},
         }
 
-        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        predicate_result = rule.predicate(
+            {}, {}, processed_crash, str(tmp_path), Status()
+        )
         assert predicate_result
 
-    def test_predicate_no_match(self):
+    def test_predicate_no_match(self, tmp_path):
         rule = MemoryReportExtraction()
 
         processed_crash = {}
 
-        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        predicate_result = rule.predicate(
+            {}, {}, processed_crash, str(tmp_path), Status()
+        )
         assert not predicate_result
 
         processed_crash["memory_report"] = {}
-        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        predicate_result = rule.predicate(
+            {}, {}, processed_crash, str(tmp_path), Status()
+        )
         assert not predicate_result
 
         processed_crash["json_dump"] = {"pid": None}
-        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        predicate_result = rule.predicate(
+            {}, {}, processed_crash, str(tmp_path), Status()
+        )
         assert not predicate_result
 
-    def test_predicate_failure_bad_unrecognizable(self):
+    def test_predicate_failure_bad_unrecognizable(self, tmp_path):
         rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data("bad_unrecognizable.json")
@@ -59,10 +68,12 @@ class TestMemoryReportExtraction:
             "json_dump": {"pid": 11620},
         }
 
-        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        predicate_result = rule.predicate(
+            {}, {}, processed_crash, str(tmp_path), Status()
+        )
         assert not predicate_result
 
-    def test_action_success(self):
+    def test_action_success(self, tmp_path):
         rule = MemoryReportExtraction()
 
         memory_report = get_example_file_data("good.json")
@@ -71,7 +82,7 @@ class TestMemoryReportExtraction:
             "memory_report": memory_report,
             "json_dump": {"pid": 11620},
         }
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" in processed_crash
 
@@ -97,7 +108,7 @@ class TestMemoryReportExtraction:
 
         # Test with a different pid
         processed_crash["json_dump"]["pid"] = 11717
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" in processed_crash
 
@@ -121,7 +132,7 @@ class TestMemoryReportExtraction:
         }
         assert processed_crash["memory_measures"] == expected_res
 
-    def test_action_failure_bad_kind(self, caplogpp):
+    def test_action_failure_bad_kind(self, tmp_path, caplogpp):
         caplogpp.set_level("DEBUG")
 
         rule = MemoryReportExtraction()
@@ -132,7 +143,7 @@ class TestMemoryReportExtraction:
             "memory_report": memory_report,
             "json_dump": {"pid": 11620},
         }
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" not in processed_crash
 
@@ -142,7 +153,7 @@ class TestMemoryReportExtraction:
             "bad kind for an explicit/ report: explicit/foo, 2"
         )
 
-    def test_action_failure_bad_units(self, caplogpp):
+    def test_action_failure_bad_units(self, tmp_path, caplogpp):
         caplogpp.set_level("DEBUG")
 
         rule = MemoryReportExtraction()
@@ -153,7 +164,7 @@ class TestMemoryReportExtraction:
             "memory_report": memory_report,
             "json_dump": {"pid": 11620},
         }
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" not in processed_crash
 
@@ -163,7 +174,7 @@ class TestMemoryReportExtraction:
             "bad units for an explicit/ report: explicit/foo, 1"
         )
 
-    def test_action_failure_bad_pid(self, caplogpp):
+    def test_action_failure_bad_pid(self, tmp_path, caplogpp):
         caplogpp.set_level("DEBUG")
 
         rule = MemoryReportExtraction()
@@ -174,7 +185,7 @@ class TestMemoryReportExtraction:
             "memory_report": memory_report,
             "json_dump": {"pid": 12345},
         }
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" not in processed_crash
 
@@ -184,7 +195,7 @@ class TestMemoryReportExtraction:
             "no measurements found for pid 12345"
         )
 
-    def test_action_failure_key_error(self, caplogpp):
+    def test_action_failure_key_error(self, tmp_path, caplogpp):
         caplogpp.set_level("DEBUG")
 
         rule = MemoryReportExtraction()
@@ -195,7 +206,7 @@ class TestMemoryReportExtraction:
             "memory_report": memory_report,
             "json_dump": {"pid": 11620},
         }
-        rule.action({}, {}, processed_crash, {})
+        rule.action({}, {}, processed_crash, str(tmp_path), Status())
 
         assert "memory_measures" not in processed_crash
 

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -192,19 +192,19 @@ class TestCopyFromRawCrashRule:
 
         raise Exception(f"no CopyItem for {annotation}")
 
-    def test_empty(self):
+    def test_empty(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
 
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash == {}
         assert processed_crash == {}
         assert status.notes == []
 
-    def test_boolean(self):
+    def test_boolean(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "Accessibility")
 
@@ -213,7 +213,7 @@ class TestCopyFromRawCrashRule:
             dumps = {}
             processed_crash = {}
             status = Status()
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
             assert processed_crash == {copy_item.key: True}
             assert status.notes == []
@@ -223,12 +223,12 @@ class TestCopyFromRawCrashRule:
             dumps = {}
             processed_crash = {}
             status = Status()
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
             assert processed_crash == {copy_item.key: False}
             assert status.notes == []
 
-    def test_invalid_boolean(self):
+    def test_invalid_boolean(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "Accessibility")
 
@@ -236,12 +236,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {}
         assert status.notes == [f"{copy_item.annotation} has non-boolean value foo"]
 
-    def test_integer(self):
+    def test_integer(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "AvailablePageFile")
 
@@ -249,12 +249,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: 1}
         assert status.notes == []
 
-    def test_invalid_integer(self):
+    def test_invalid_integer(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "AvailablePageFile")
 
@@ -262,12 +262,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {}
         assert status.notes == [f"{copy_item.annotation} has a non-int value"]
 
-    def test_number(self):
+    def test_number(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "UptimeTS")
 
@@ -275,12 +275,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: 10.0}
         assert status.notes == []
 
-    def test_invalid_number(self):
+    def test_invalid_number(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "UptimeTS")
 
@@ -288,12 +288,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {}
         assert status.notes == [f"{copy_item.annotation} has a non-float value"]
 
-    def test_string(self):
+    def test_string(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "URL")
 
@@ -301,12 +301,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: "some string"}
         assert status.notes == []
 
-    def test_object(self):
+    def test_object(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "ComplexStructure")
 
@@ -322,12 +322,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: json_data}
         assert status.notes == []
 
-    def test_object_invalid_json(self):
+    def test_object_invalid_json(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "ComplexStructure")
 
@@ -335,12 +335,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert copy_item.key not in processed_crash
         assert status.notes == ["ComplexStructure value is malformed json"]
 
-    def test_object_invalid_value(self):
+    def test_object_invalid_value(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "ComplexStructure")
 
@@ -356,12 +356,12 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert copy_item.key not in processed_crash
         assert status.notes == ["ComplexStructure value is malformed complex_structure"]
 
-    def test_default(self):
+    def test_default(self, tmp_path):
         # Verify that the default is used if the annotation is missing
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_DEFAULT)
         copy_item = self.get_copy_item(rule, "ProcessType")
@@ -370,7 +370,7 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: "gpu"}
         assert status.notes == []
@@ -379,54 +379,54 @@ class TestCopyFromRawCrashRule:
         dumps = {}
         processed_crash = {}
         status = Status()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {copy_item.key: copy_item.default}
         assert status.notes == []
 
 
 class TestConvertModuleSignatureInfoRule:
-    def test_no_value(self):
+    def test_no_value(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash == {}
         assert processed_crash == {}
 
-    def test_string_value(self):
+    def test_string_value(self, tmp_path):
         raw_crash = {"ModuleSignatureInfo": "{}"}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash == {"ModuleSignatureInfo": "{}"}
         assert processed_crash == {}
 
-    def test_object_value(self):
+    def test_object_value(self, tmp_path):
         raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
         assert processed_crash == {}
 
-    def test_object_value_with_dict(self):
+    def test_object_value_with_dict(self, tmp_path):
         raw_crash = {"ModuleSignatureInfo": {"foo": "bar"}}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = ConvertModuleSignatureInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash == {"ModuleSignatureInfo": '{"foo": "bar"}'}
         assert processed_crash == {}
 
@@ -451,6 +451,7 @@ class TestSubmittedFromRule:
     )
     def test_action(
         self,
+        tmp_path,
         submitted_from,
         submitted_from_infobar,
         expected_submitted_from,
@@ -469,7 +470,7 @@ class TestSubmittedFromRule:
         processed_crash = {}
         status = Status()
         rule = SubmittedFromRule()
-        rule.action(raw_crash, dumps, processed_crash, status)
+        rule.action(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash == {
             "submitted_from": expected_submitted_from,
             "submitted_from_infobar": expected_submitted_from_infobar,
@@ -477,7 +478,7 @@ class TestSubmittedFromRule:
 
 
 class TestPluginRule:
-    def test_browser_hang(self):
+    def test_browser_hang(self, tmp_path):
         raw_crash = {
             "ProcessType": "parent",
         }
@@ -486,13 +487,13 @@ class TestPluginRule:
         status = Status()
 
         rule = PluginRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "plugin_filename" not in processed_crash
         assert "plugin_name" not in processed_crash
         assert "plugin_version" not in processed_crash
 
-    def test_plugin_bits(self):
+    def test_plugin_bits(self, tmp_path):
         raw_crash = {
             "ProcessType": "plugin",
             "PluginName": "name1",
@@ -504,7 +505,7 @@ class TestPluginRule:
         status = Status()
 
         rule = PluginRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         expected = {
             "plugin_name": "name1",
@@ -515,38 +516,38 @@ class TestPluginRule:
 
 
 class TestAccessibilityRule:
-    def test_not_there(self):
+    def test_not_there(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = AccessibilityRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["accessibility"] is False
 
-    def test_active(self):
+    def test_active(self, tmp_path):
         raw_crash = {"Accessibility": "Active"}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = AccessibilityRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["accessibility"] is True
 
 
 class TestAddonsRule:
-    def test_action_nothing_unexpected(self):
+    def test_action_nothing_unexpected(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {}
         status = Status()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, dumps, processed_crash, status)
+        addons_rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         # the raw crash & dumps should not have changed
         assert raw_crash == canonical_standard_raw_crash
@@ -568,7 +569,7 @@ class TestAddonsRule:
         assert processed_crash["addons"] == expected_addon_list
         assert processed_crash["addons_checked"] is True
 
-    def test_action_colon_in_addon_version(self):
+    def test_action_colon_in_addon_version(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Add-ons"] = "adblockpopups@jessehakanen.net:0:3:1"
         raw_crash["EMCheckCompatibility"] = "Nope"
@@ -577,13 +578,13 @@ class TestAddonsRule:
         status = Status()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, dumps, processed_crash, status)
+        addons_rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         expected_addon_list = ["adblockpopups@jessehakanen.net:0:3:1"]
         assert processed_crash["addons"] == expected_addon_list
         assert processed_crash["addons_checked"] is False
 
-    def test_action_addon_is_nonsense(self):
+    def test_action_addon_is_nonsense(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["Add-ons"] = "naoenut813teq;mz;<[`19ntaotannn8999anxse `"
         dumps = {}
@@ -591,7 +592,7 @@ class TestAddonsRule:
         status = Status()
 
         addons_rule = AddonsRule()
-        addons_rule.act(raw_crash, dumps, processed_crash, status)
+        addons_rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         expected_addon_list = ["naoenut813teq;mz;<[`19ntaotannn8999anxse `:NO_VERSION"]
         assert processed_crash["addons"] == expected_addon_list
@@ -639,7 +640,7 @@ class TestDatesAndTimesRule:
             "value: 17; %s" % type_error_value
         ]
 
-    def test_everything_we_hoped_for(self):
+    def test_everything_we_hoped_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {
@@ -648,7 +649,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["submitted_timestamp"] == raw_crash["submitted_timestamp"]
@@ -662,7 +663,7 @@ class TestDatesAndTimesRule:
         assert processed_crash["uptime"] == 20116
         assert processed_crash["last_crash"] == 86985
 
-    def test_no_crash_time(self):
+    def test_no_crash_time(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash["CrashTime"]
         dumps = {}
@@ -672,7 +673,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         expected = datetime.datetime.fromisoformat(raw_crash["submitted_timestamp"])
         expected_timestamp = int(expected.timestamp())
@@ -693,7 +694,7 @@ class TestDatesAndTimesRule:
             "client_crash_date is unknown",
         ]
 
-    def test_no_startup_time(self):
+    def test_no_startup_time(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         del raw_crash["StartupTime"]
         dumps = {}
@@ -701,7 +702,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["submitted_timestamp"] == raw_crash["submitted_timestamp"]
@@ -716,7 +717,7 @@ class TestDatesAndTimesRule:
         assert processed_crash["last_crash"] == 86985
         assert status.notes == []
 
-    def test_bad_install_time(self):
+    def test_bad_install_time(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["InstallTime"] = "feed the goats"
         dumps = {}
@@ -726,7 +727,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["submitted_timestamp"] == raw_crash["submitted_timestamp"]
@@ -741,7 +742,7 @@ class TestDatesAndTimesRule:
         assert processed_crash["last_crash"] == 86985
         assert status.notes == ['non-integer value of "InstallTime"']
 
-    def test_bad_seconds_since_last_crash(self):
+    def test_bad_seconds_since_last_crash(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["SecondsSinceLastCrash"] = "feed the goats"
         dumps = {}
@@ -749,7 +750,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["submitted_timestamp"] == raw_crash["submitted_timestamp"]
@@ -764,7 +765,7 @@ class TestDatesAndTimesRule:
         assert processed_crash["last_crash"] is None
         assert status.notes == ['non-integer value of "SecondsSinceLastCrash"']
 
-    def test_absent_seconds_since_last_crash(self):
+    def test_absent_seconds_since_last_crash(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash.pop("SecondsSinceLastCrash")
         dumps = {}
@@ -772,7 +773,7 @@ class TestDatesAndTimesRule:
         status = Status()
 
         rule = DatesAndTimesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["submitted_timestamp"] == raw_crash["submitted_timestamp"]
@@ -802,17 +803,17 @@ class TestMacCrashInfoRule:
             ({"json_dump": {"mac_crash_info": {"num_records": 1}}}, True),
         ],
     )
-    def test_mac_crash_info_variations(self, processed, expected):
+    def test_mac_crash_info_variations(self, tmp_path, processed, expected):
         raw_crash = {}
         dumps = {}
         status = Status()
         rule = MacCrashInfoRule()
 
-        rule.action(raw_crash, dumps, processed, status)
+        rule.action(raw_crash, dumps, processed, str(tmp_path), status)
 
         assert ("mac_crash_info" in processed) == expected
 
-    def test_mac_crash_info_action(self):
+    def test_mac_crash_info_action(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {
@@ -828,7 +829,7 @@ class TestMacCrashInfoRule:
         status = Status()
 
         rule = MacCrashInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["mac_crash_info"] == (
             '{"num_records": 1, "records": [{"thread": null}]}'
@@ -848,7 +849,7 @@ class TestMajorVersionRule:
             ("50.0b4", 50),
         ],
     )
-    def test_major_version(self, version, expected):
+    def test_major_version(self, tmp_path, version, expected):
         raw_crash = {}
         if version is not None:
             raw_crash["Version"] = version
@@ -857,24 +858,24 @@ class TestMajorVersionRule:
         status = Status()
 
         rule = MajorVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["major_version"] == expected
 
 
 class TestBreadcrumbRule:
-    def test_basic(self):
+    def test_basic(self, tmp_path):
         raw_crash = {"Breadcrumbs": json.dumps([{"timestamp": "2021-01-07T16:09:31"}])}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
 
-    def test_sentry_style(self):
+    def test_sentry_style(self, tmp_path):
         raw_crash = {
             "Breadcrumbs": json.dumps(
                 {"values": [{"timestamp": "2021-01-07T16:09:31"}]}
@@ -885,35 +886,35 @@ class TestBreadcrumbRule:
         status = Status()
 
         rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["breadcrumbs"] == [{"timestamp": "2021-01-07T16:09:31"}]
 
-    def test_missing(self):
+    def test_missing(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash == {}
 
-    def test_malformed(self):
+    def test_malformed(self, tmp_path):
         raw_crash = {"Breadcrumbs": "{}"}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = BreadcrumbsRule(schema=PROCESSED_CRASH_SCHEMA)
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash == {}
         assert status.notes == ["Breadcrumbs: malformed: {} is not of type 'array'"]
 
 
 class TestJavaProcessRule:
-    def test_javastacktrace(self):
+    def test_javastacktrace(self, tmp_path):
         raw_crash = {
             "JavaStackTrace": (
                 "Exception: some messge\n"
@@ -927,7 +928,7 @@ class TestJavaProcessRule:
         status = Status()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         # The entire JavaStackTrace blob
         assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
@@ -939,7 +940,7 @@ class TestJavaProcessRule:
             == "Exception\n\tat org.File.function(File.java:100)"
         )
 
-    def test_malformed_javastacktrace(self):
+    def test_malformed_javastacktrace(self, tmp_path):
         raw_crash = {"JavaStackTrace": "junk\n\tat org.File.function\njunk"}
 
         dumps = {}
@@ -947,7 +948,7 @@ class TestJavaProcessRule:
         status = Status()
 
         rule = JavaProcessRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         # The entire JavaStackTrace blob
         assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
@@ -972,13 +973,13 @@ class TestModuleURLRewriteRule:
             ({"json_dump": {"modules": [{}]}}, True),
         ],
     )
-    def test_predicate(self, processed, expected):
+    def test_predicate(self, tmp_path, processed, expected):
         status = Status()
 
         rule = ModuleURLRewriteRule()
-        assert rule.predicate({}, {}, processed, status) == expected
+        assert rule.predicate({}, {}, processed, str(tmp_path), status) == expected
 
-    def test_action_no_modules(self):
+    def test_action_no_modules(self, tmp_path):
         processed = {"json_dump": {"modules": []}}
         status = Status()
 
@@ -986,10 +987,10 @@ class TestModuleURLRewriteRule:
         expected = copy.deepcopy(processed)
 
         rule = ModuleURLRewriteRule()
-        rule.act({}, {}, processed, status)
+        rule.act({}, {}, processed, str(tmp_path), status)
         assert processed == expected
 
-    def test_rewrite_no_url(self):
+    def test_rewrite_no_url(self, tmp_path):
         processed = {
             "json_dump": {
                 "modules": [
@@ -1014,7 +1015,7 @@ class TestModuleURLRewriteRule:
         expected = copy.deepcopy(processed)
 
         rule = ModuleURLRewriteRule()
-        rule.act({}, {}, processed, status)
+        rule.act({}, {}, processed, str(tmp_path), status)
         assert processed == expected
 
     @pytest.mark.parametrize(
@@ -1041,7 +1042,7 @@ class TestModuleURLRewriteRule:
             ),
         ],
     )
-    def test_rewrite(self, url, expected):
+    def test_rewrite(self, tmp_path, url, expected):
         processed = {
             "json_dump": {
                 "modules": [
@@ -1064,29 +1065,29 @@ class TestModuleURLRewriteRule:
         status = Status()
 
         rule = ModuleURLRewriteRule()
-        rule.act({}, {}, processed, status)
+        rule.act({}, {}, processed, str(tmp_path), status)
         assert processed["json_dump"]["modules"][0]["symbol_url"] == expected
 
 
 class TestMozCrashReasonRule:
-    def test_no_mozcrashreason(self):
+    def test_no_mozcrashreason(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = MozCrashReasonRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash == {}
 
-    def test_good_mozcrashreason(self):
+    def test_good_mozcrashreason(self, tmp_path):
         raw_crash = {"MozCrashReason": "MOZ_CRASH(OOM)"}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = MozCrashReasonRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash == {
             "moz_crash_reason_raw": "MOZ_CRASH(OOM)",
             "moz_crash_reason": "MOZ_CRASH(OOM)",
@@ -1100,7 +1101,7 @@ class TestMozCrashReasonRule:
             "do not use eval with system privileges: jar:file...",
         ],
     )
-    def test_bad_mozcrashreason(self, bad_reason):
+    def test_bad_mozcrashreason(self, tmp_path, bad_reason):
         rule = MozCrashReasonRule()
 
         raw_crash = {"MozCrashReason": bad_reason}
@@ -1108,7 +1109,7 @@ class TestMozCrashReasonRule:
         processed_crash = {}
         status = Status()
 
-        rule.action(raw_crash, dumps, processed_crash, status)
+        rule.action(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash == {
             "moz_crash_reason_raw": bad_reason,
             "moz_crash_reason": "sanitized--see moz_crash_reason_raw",
@@ -1131,7 +1132,7 @@ class TestOutOfMemoryBinaryRule:
             mocked_gzip_open.assert_called_with("a_pathname", "rb")
             assert memory == {"mysterious": ["awesome", "memory"]}
 
-    def test_extract_memory_info_too_big(self):
+    def test_extract_memory_info_too_big(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
         dumps = {"memory_report": "a_pathname"}
@@ -1163,11 +1164,11 @@ class TestOutOfMemoryBinaryRule:
             assert status.notes == [expected_error_message]
             opened.close.assert_called_with()
 
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
             assert "memory_report" not in processed_crash
             assert processed_crash["memory_report_error"] == expected_error_message
 
-    def test_extract_memory_info_with_trouble(self):
+    def test_extract_memory_info_with_trouble(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
         dumps = {"memory_report": "a_pathname"}
@@ -1184,14 +1185,14 @@ class TestOutOfMemoryBinaryRule:
             assert memory["ERROR"] == "error in gzip for a_pathname: OSError()"
             assert status.notes == ["error in gzip for a_pathname: OSError()"]
 
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
             assert "memory_report" not in processed_crash
             assert (
                 processed_crash["memory_report_error"]
                 == "error in gzip for a_pathname: OSError()"
             )
 
-    def test_extract_memory_info_with_json_trouble(self):
+    def test_extract_memory_info_with_json_trouble(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
         dumps = {"memory_report": "a_pathname"}
@@ -1213,12 +1214,12 @@ class TestOutOfMemoryBinaryRule:
                 assert status.notes == ["error in json for a_pathname: ValueError()"]
                 mocked_gzip_open.return_value.close.assert_called_with()
 
-                rule.act(raw_crash, dumps, processed_crash, status)
+                rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
                 assert "memory_report" not in processed_crash
                 expected = "error in json for a_pathname: ValueError()"
                 assert processed_crash["memory_report_error"] == expected
 
-    def test_everything_we_hoped_for(self):
+    def test_everything_we_hoped_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
         dumps = {"memory_report": "a_pathname"}
@@ -1234,10 +1235,10 @@ class TestOutOfMemoryBinaryRule:
 
         with mock.patch("socorro.processor.rules.mozilla.temp_file_context"):
             rule = MyOutOfMemoryBinaryRule()
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
             assert processed_crash["memory_report"] == "mysterious-awesome-memory"
 
-    def test_this_is_not_the_crash_you_are_looking_for(self):
+    def test_this_is_not_the_crash_you_are_looking_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["JavaStackTrace"] = "this is a Java Stack trace"
         dumps = {}
@@ -1245,7 +1246,7 @@ class TestOutOfMemoryBinaryRule:
         status = Status()
 
         rule = OutOfMemoryBinaryRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "memory_report" not in processed_crash
 
@@ -1262,7 +1263,7 @@ class TestFenixVersionRewriteRule:
             ("Firefox", "Nightly 75.0", False),
         ],
     )
-    def test_predicate(self, product, version, expected):
+    def test_predicate(self, tmp_path, product, version, expected):
         raw_crash = {
             "ProductName": product,
             "Version": version,
@@ -1272,10 +1273,10 @@ class TestFenixVersionRewriteRule:
         status = Status()
 
         rule = FenixVersionRewriteRule()
-        ret = rule.predicate(raw_crash, dumps, processed_crash, status)
+        ret = rule.predicate(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert ret == expected
 
-    def test_act(self):
+    def test_act(self, tmp_path):
         raw_crash = {
             "ProductName": "Fenix",
             "Version": "Nightly 200315 05:05",
@@ -1285,13 +1286,13 @@ class TestFenixVersionRewriteRule:
         status = Status()
 
         rule = FenixVersionRewriteRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert raw_crash["Version"] == "0.0a1"
         assert status.notes == ["Changed version from 'Nightly 200315 05:05' to 0.0a1"]
 
 
 class TestESRVersionRewrite:
-    def test_everything_we_hoped_for(self):
+    def test_everything_we_hoped_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "esr"
         dumps = {}
@@ -1299,14 +1300,14 @@ class TestESRVersionRewrite:
         status = Status()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert raw_crash["Version"] == "12.0esr"
 
         # processed_crash should be unchanged
         assert processed_crash == {}
 
-    def test_this_is_not_the_crash_you_are_looking_for(self):
+    def test_this_is_not_the_crash_you_are_looking_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "not_esr"
         dumps = {}
@@ -1314,14 +1315,14 @@ class TestESRVersionRewrite:
         status = Status()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert raw_crash["Version"] == "12.0"
 
         # processed_crash should be unchanged
         assert processed_crash == {}
 
-    def test_this_is_really_broken(self):
+    def test_this_is_really_broken(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         raw_crash["ReleaseChannel"] = "esr"
         del raw_crash["Version"]
@@ -1330,7 +1331,7 @@ class TestESRVersionRewrite:
         status = Status()
 
         rule = ESRVersionRewrite()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "Version" not in raw_crash
         assert status.notes == ['"Version" missing from esr release raw_crash']
@@ -1340,7 +1341,7 @@ class TestESRVersionRewrite:
 
 
 class TestTopMostFilesRule:
-    def test_file_in_frame(self):
+    def test_file_in_frame(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {
@@ -1359,11 +1360,11 @@ class TestTopMostFilesRule:
         status = Status()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["topmost_filenames"] == "MozPromise.h"
 
-    def test_file_in_inlines(self):
+    def test_file_in_inlines(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {
@@ -1391,22 +1392,22 @@ class TestTopMostFilesRule:
         status = Status()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["topmost_filenames"] == "RTCRtpTransceiver.cpp"
 
-    def test_missing_json_dump(self):
+    def test_missing_json_dump(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {}
         status = Status()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "topmost_filenames" not in processed_crash
 
-    def test_missing_crashing_thread(self):
+    def test_missing_crashing_thread(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {
@@ -1431,13 +1432,13 @@ class TestTopMostFilesRule:
         status = Status()
 
         rule = TopMostFilesRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "topmost_filenames" not in processed_crash
 
 
 class TestModulesInStackRule:
-    def test_basic(self):
+    def test_basic(self, tmp_path):
         raw_crash = {}
         dumps = {}
         processed_crash = {
@@ -1457,7 +1458,7 @@ class TestModulesInStackRule:
         status = Status()
 
         rule = ModulesInStackRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert (
             processed_crash["modules_in_stack"]
@@ -1496,11 +1497,11 @@ class TestModulesInStackRule:
             },
         ],
     )
-    def test_missing_things(self, processed_crash):
+    def test_missing_things(self, tmp_path, processed_crash):
         status = Status()
         rule = ModulesInStackRule()
 
-        rule.act({}, {}, processed_crash, status)
+        rule.act({}, {}, processed_crash, str(tmp_path), status)
         assert "modules_in_stack" not in processed_crash
 
     @pytest.mark.parametrize(
@@ -1537,7 +1538,7 @@ class TestBetaVersionRule:
             ("Fenix", "beta", False),
         ],
     )
-    def test_predicate(self, product, channel, expected):
+    def test_predicate(self, tmp_path, product, channel, expected):
         raw_crash = {}
         dumps = {}
         processed_crash = {
@@ -1549,9 +1550,12 @@ class TestBetaVersionRule:
         status = Status()
 
         rule = self.build_rule()
-        assert rule.predicate(raw_crash, dumps, processed_crash, status) == expected
+        assert (
+            rule.predicate(raw_crash, dumps, processed_crash, str(tmp_path), status)
+            == expected
+        )
 
-    def test_beta_channel_known_version(self):
+    def test_beta_channel_known_version(self, tmp_path):
         # Beta channel with known version gets converted correctly
         raw_crash = {}
         dumps = {}
@@ -1569,11 +1573,11 @@ class TestBetaVersionRule:
                 self.API_URL + "?product=Firefox&channel=beta&build_id=20001001101010",
                 json={"hits": [{"version_string": "3.0b1"}], "total": 1},
             )
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["version"] == "3.0b1"
         assert status.notes == []
 
-    def test_release_channel(self):
+    def test_release_channel(self, tmp_path):
         """Release channel doesn't trigger rule"""
         raw_crash = {}
         dumps = {}
@@ -1587,12 +1591,12 @@ class TestBetaVersionRule:
 
         rule = self.build_rule()
         with requests_mock.Mocker():
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["version"] == "2.0"
         assert status.notes == []
 
-    def test_nightly_channel(self):
+    def test_nightly_channel(self, tmp_path):
         """Nightly channel doesn't trigger rule"""
         raw_crash = {}
         dumps = {}
@@ -1606,12 +1610,12 @@ class TestBetaVersionRule:
 
         rule = self.build_rule()
         with requests_mock.Mocker():
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["version"] == "5.0a1"
         assert status.notes == []
 
-    def test_bad_buildid(self):
+    def test_bad_buildid(self, tmp_path):
         """Invalid buildids don't cause errors"""
         raw_crash = {}
         dumps = {}
@@ -1631,7 +1635,7 @@ class TestBetaVersionRule:
                 self.API_URL + '?product=Firefox&channel=beta&build_id=2",381,,"',
                 json={"hits": [], "total": 0},
             )
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["version"] == "5.0b0"
         assert status.notes == [
@@ -1639,7 +1643,7 @@ class TestBetaVersionRule:
             'added "b0" suffix to version number'
         ]
 
-    def test_beta_channel_unknown_version(self):
+    def test_beta_channel_unknown_version(self, tmp_path):
         """Beta crash that Socorro doesn't know about gets b0"""
         raw_crash = {}
         dumps = {}
@@ -1657,7 +1661,7 @@ class TestBetaVersionRule:
                 self.API_URL + "?product=Firefox&channel=beta&build_id=220000101101011",
                 json={"hits": [], "total": 0},
             )
-            rule.action(raw_crash, dumps, processed_crash, status)
+            rule.action(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert processed_crash["version"] == "3.0.1b0"
         assert status.notes == [
@@ -1665,7 +1669,7 @@ class TestBetaVersionRule:
             'added "b0" suffix to version number'
         ]
 
-    def test_aurora_channel(self):
+    def test_aurora_channel(self, tmp_path):
         """Test aurora channel lookup"""
         raw_crash = {}
         dumps = {}
@@ -1684,7 +1688,7 @@ class TestBetaVersionRule:
                 + "?product=Firefox&channel=aurora&build_id=20001001101010",
                 json={"hits": [{"version_string": "3.0b1"}], "total": 0},
             )
-            rule.act(raw_crash, dumps, processed_crash, status)
+            rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["version"] == "3.0b1"
         assert status.notes == []
 
@@ -1714,17 +1718,17 @@ class TestOsPrettyName:
             ("Linux", "3.14-2-686-pae #1 SMP Debian 3.14.15-2", "Linux"),
         ],
     )
-    def test_everything_we_hoped_for(self, os_name, os_version, expected):
+    def test_everything_we_hoped_for(self, tmp_path, os_name, os_version, expected):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {"os_name": os_name, "os_version": os_version}
         status = Status()
 
         rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] == expected
 
-    def test_lsb_release(self):
+    def test_lsb_release(self, tmp_path):
         # If this is Linux and there's data in json_dump.lsb_release.description,
         # use that
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
@@ -1737,7 +1741,7 @@ class TestOsPrettyName:
         status = Status()
 
         rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] == "Ubuntu 18.04 LTS"
 
     @pytest.mark.parametrize(
@@ -1751,7 +1755,7 @@ class TestOsPrettyName:
             ("Linux", "5", "Linux"),
         ],
     )
-    def test_junk_data(self, os_name, os_version, expected):
+    def test_junk_data(self, tmp_path, os_name, os_version, expected):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         # Now try some bogus processed_crashes.
@@ -1763,32 +1767,32 @@ class TestOsPrettyName:
         status = Status()
 
         rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] == expected
 
-    def test_dotdict(self):
+    def test_dotdict(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {"os_name": "Windows NT", "os_version": "10.0.11.7600"}
         status = Status()
 
         rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] == "Windows 10"
 
-    def test_none(self):
+    def test_none(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {"os_name": None, "os_version": None}
         status = Status()
 
         rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] is None
 
 
 class TestThemePrettyNameRule:
-    def test_everything_we_hoped_for(self):
+    def test_everything_we_hoped_for(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         dumps = {}
         processed_crash = {}
@@ -1808,7 +1812,7 @@ class TestThemePrettyNameRule:
         status = Status()
 
         rule = ThemePrettyNameRule()
-        rule.act(raw_crash, dumps, processed_crash, status)
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         # the raw crash & dumps should not have changed
         assert raw_crash == canonical_standard_raw_crash
@@ -1829,19 +1833,19 @@ class TestThemePrettyNameRule:
         ]
         assert processed_crash["addons"] == expected_addon_list
 
-    def test_missing_key(self):
+    def test_missing_key(self, tmp_path):
         processed_crash = {}
         status = Status()
 
         rule = ThemePrettyNameRule()
 
         # Test with missing key.
-        res = rule.predicate({}, {}, processed_crash, status)
+        res = rule.predicate({}, {}, processed_crash, str(tmp_path), status)
         assert res is False
 
         # Test with empty list.
         processed_crash["addons"] = []
-        res = rule.predicate({}, {}, processed_crash, status)
+        res = rule.predicate({}, {}, processed_crash, str(tmp_path), status)
         assert res is False
 
         # Test with key missing from list.
@@ -1849,10 +1853,10 @@ class TestThemePrettyNameRule:
             "adblockpopups@jessehakanen.net:0.3",
             "dmpluginff@westbyte.com:1,4.8",
         ]
-        res = rule.predicate({}, {}, processed_crash, status)
+        res = rule.predicate({}, {}, processed_crash, str(tmp_path), status)
         assert res is False
 
-    def test_with_malformed_addons_field(self):
+    def test_with_malformed_addons_field(self, tmp_path):
         processed_crash = {}
         processed_crash["addons"] = [
             "addon_with_no_version",
@@ -1862,7 +1866,7 @@ class TestThemePrettyNameRule:
         status = Status()
 
         rule = ThemePrettyNameRule()
-        rule.act({}, {}, processed_crash, status)
+        rule.act({}, {}, processed_crash, str(tmp_path), status)
         expected_addon_list = [
             "addon_with_no_version",
             "{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme)",
@@ -1872,7 +1876,7 @@ class TestThemePrettyNameRule:
 
 
 class TestSignatureGeneratorRule:
-    def test_signature(self):
+    def test_signature(self, tmp_path):
         rule = SignatureGeneratorRule()
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)
         processed_crash = {
@@ -1899,7 +1903,7 @@ class TestSignatureGeneratorRule:
         }
         status = Status()
 
-        rule.action(raw_crash, {}, processed_crash, status)
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), status)
         assert processed_crash["signature"] == "Alpha<T>::Echo<T>"
         assert (
             processed_crash["proto_signature"]
@@ -1907,13 +1911,13 @@ class TestSignatureGeneratorRule:
         )
         assert status.notes == []
 
-    def test_empty_raw_and_processed_crashes(self):
+    def test_empty_raw_and_processed_crashes(self, tmp_path):
         rule = SignatureGeneratorRule()
         raw_crash = {}
         processed_crash = {}
         status = Status()
 
-        rule.action(raw_crash, {}, processed_crash, status)
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), status)
 
         # NOTE(willkg): This is what the current pipeline yields. If any of
         # those parts change, this might change, too. The point of this test is
@@ -1925,7 +1929,7 @@ class TestSignatureGeneratorRule:
             "SignatureGenerationRule: CSignatureTool: no frame data for crashing thread (0)"
         ]
 
-    def test_rule_fail_and_capture_error(self, sentry_helper):
+    def test_rule_fail_and_capture_error(self, tmp_path, sentry_helper):
         exc_value = Exception("Cough")
 
         class BadRule:
@@ -1948,7 +1952,7 @@ class TestSignatureGeneratorRule:
             processed_crash = {}
             status = Status()
 
-            rule.action(raw_crash, {}, processed_crash, status)
+            rule.action(raw_crash, {}, processed_crash, str(tmp_path), status)
 
             # NOTE(willkg): The signature is an empty string because there are no
             # working rules that add anything to it.
@@ -1965,22 +1969,22 @@ class TestSignatureGeneratorRule:
 
 
 class TestPHCRule:
-    def test_predicate(self):
+    def test_predicate(self, tmp_path):
         rule = PHCRule()
-        assert rule.predicate({}, {}, {}, {}) is False
+        assert rule.predicate({}, {}, {}, str(tmp_path), Status()) is False
 
     @pytest.mark.parametrize(
         "base_address, expected",
         [(None, None), ("", None), ("foo", None), ("10", "0xa"), ("100", "0x64")],
     )
-    def test_phc_base_address(self, base_address, expected):
+    def test_phc_base_address(self, tmp_path, base_address, expected):
         raw_crash = {"PHCKind": "FreedPage"}
         if base_address is not None:
             raw_crash["PHCBaseAddress"] = base_address
 
         rule = PHCRule()
         processed_crash = {}
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         if expected is None:
             assert "phc_base_address" not in processed_crash
         else:
@@ -1989,20 +1993,20 @@ class TestPHCRule:
     @pytest.mark.parametrize(
         "usable_size, expected", [(None, None), ("", None), ("foo", None), ("10", 10)]
     )
-    def test_phc_usable_size(self, usable_size, expected):
+    def test_phc_usable_size(self, tmp_path, usable_size, expected):
         raw_crash = {"PHCKind": "FreedPage"}
         if usable_size is not None:
             raw_crash["PHCUsableSize"] = usable_size
 
         rule = PHCRule()
         processed_crash = {}
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         if expected is None:
             assert "phc_usable_size" not in processed_crash
         else:
             assert processed_crash["phc_usable_size"] == expected
 
-    def test_copied_values(self):
+    def test_copied_values(self, tmp_path):
         raw_crash = {
             "PHCKind": "FreedPage",
             "PHCUsableSize": "8",
@@ -2012,7 +2016,7 @@ class TestPHCRule:
         }
         rule = PHCRule()
         processed_crash = {}
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash == {
             "phc_kind": "FreedPage",
             "phc_usable_size": 8,
@@ -2023,18 +2027,18 @@ class TestPHCRule:
 
 
 class TestDistributionIdRule:
-    def test_no_annotation_and_no_telemetry(self):
+    def test_no_annotation_and_no_telemetry(self, tmp_path):
         raw_crash = {}
         processed_crash = {}
         rule = DistributionIdRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash["distribution_id"] == "unknown"
 
-    def test_annotation(self):
+    def test_annotation(self, tmp_path):
         raw_crash = {"DistributionID": "mint"}
         processed_crash = {}
         rule = DistributionIdRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash["distribution_id"] == "mint"
 
     @pytest.mark.parametrize(
@@ -2048,38 +2052,38 @@ class TestDistributionIdRule:
             '{"partner": {}}',
         ],
     )
-    def test_telemetry_values_unknown(self, telemetry_value):
+    def test_telemetry_values_unknown(self, tmp_path, telemetry_value):
         raw_crash = {"TelemetryEnvironment": telemetry_value}
         processed_crash = {}
 
         rule = DistributionIdRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash["distribution_id"] == "unknown"
 
-    def test_telemetry_value_mozilla(self):
+    def test_telemetry_value_mozilla(self, tmp_path):
         raw_crash = {"TelemetryEnvironment": '{"partner": {"distributionId": null}}'}
         processed_crash = {}
 
         rule = DistributionIdRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash["distribution_id"] == "mozilla"
 
-    def test_telemetry_value_mint(self):
+    def test_telemetry_value_mint(self, tmp_path):
         raw_crash = {"TelemetryEnvironment": '{"partner": {"distributionId": "mint"}}'}
         processed_crash = {}
 
         rule = DistributionIdRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash["distribution_id"] == "mint"
 
 
 class TestUtilityActorsNameRule:
-    def test_no_data(self):
+    def test_no_data(self, tmp_path):
         raw_crash = {}
         processed_crash = {}
 
         rule = UtilityActorsNameRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         assert processed_crash == {}
 
     @pytest.mark.parametrize(
@@ -2092,13 +2096,13 @@ class TestUtilityActorsNameRule:
             ("  abc, def", ["abc", "def"]),
         ],
     )
-    def test_data(self, value, expected):
+    def test_data(self, tmp_path, value, expected):
         raw_crash = {
             "UtilityActorsName": value,
         }
         processed_crash = {}
 
         rule = UtilityActorsNameRule()
-        rule.action(raw_crash, {}, processed_crash, Status())
+        rule.action(raw_crash, {}, processed_crash, str(tmp_path), Status())
         print(processed_crash)
         assert processed_crash["utility_actors_name"] == expected

--- a/socorro/tests/processor/test_processor_pipeline.py
+++ b/socorro/tests/processor/test_processor_pipeline.py
@@ -141,7 +141,7 @@ class TestProcessorPipeline:
         config = cm.get_config()
         return config
 
-    def test_rule_error(self, sentry_helper):
+    def test_rule_error(self, tmp_path, sentry_helper):
         set_up_sentry()
 
         with sentry_helper.reuse() as sentry_client:
@@ -152,7 +152,7 @@ class TestProcessorPipeline:
             processed_crash = DotDict()
 
             processor = ProcessorPipeline(config, rules={"default": [BadRule()]})
-            processor.process_crash("default", raw_crash, {}, processed_crash)
+            processor.process_crash("default", raw_crash, {}, processed_crash, tmp_path)
 
             # Notes were added again
             notes = processed_crash["processor_notes"].split("\n")
@@ -171,7 +171,7 @@ class TestProcessorPipeline:
             # Assert that there are no frame-local variables
             assert event == RULE_ERROR_EVENT
 
-    def test_process_crash_existing_processed_crash(self):
+    def test_process_crash_existing_processed_crash(self, tmp_path):
         raw_crash = DotDict({"uuid": "1"})
         dumps = {}
         processed_crash = DotDict(
@@ -191,6 +191,7 @@ class TestProcessorPipeline:
                 raw_crash=raw_crash,
                 dumps=dumps,
                 processed_crash=processed_crash,
+                tmpdir=str(tmp_path),
             )
 
         assert processed_crash["success"] is True


### PR DESCRIPTION
The processor uses a temporary directory to save crash report data in order to process it. Previously there were multiple parts of the processor saving data in different places--some of which weren't safe from thread contention.
    
This fixes that by pulling ownership of the temporary directory (creation, deletion) into the processor app and then passing that
directory around to the pipeline and rules. The processor app now creates a new temporary directory in process_crash that's unique to that processing run. This should fix orphaned files and thread contention issues (and future possible process contention issues).