### PR TITLE
bug 1529342: removing waiting_func

### DIFF
--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -124,12 +124,8 @@ class TaskManager(RequiredConfig):
                 self.logger.info("%s: %dsec of %dsec", wait_reason, x, seconds)
             time.sleep(1.0)
 
-    def blocking_start(self, waiting_func=None):
-        """this function starts the task manager running to do tasks.  The
-        waiting_func is normally used to do something while other threads
-        are running, but here we don't have other threads.  So the waiting
-        func will never get called.  I can see wanting this function to be
-        called at least once after the end of the task loop."""
+    def blocking_start(self):
+        """This function starts the task manager running to do tasks."""
         self.logger.debug("threadless start")
         try:
             # May never exhaust

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -179,10 +179,6 @@ class ProcessorApp(App):
         from_string_converter=class_converter,
     )
 
-    def __init__(self, config):
-        super().__init__(config)
-        self.waiting_func = None
-
     @classmethod
     def configure_sentry(cls, basedir, host_id, sentry_dsn):
         release = get_release_name(basedir)
@@ -367,10 +363,6 @@ class ProcessorApp(App):
         else:
             self.companion_process = None
 
-        # This function will be called by the MainThread periodically
-        # while the threaded_task_manager processes crashes.
-        self.waiting_func = None
-
         self.processor = self.config.processor.processor_class(
             config=self.config.processor, host_id=self.app_instance_name
         )
@@ -422,7 +414,7 @@ class ProcessorApp(App):
 
         self._setup_task_manager()
         self._setup_source_and_destination()
-        self.task_manager.blocking_start(waiting_func=self.waiting_func)
+        self.task_manager.blocking_start()
         self.close()
         self.logger.info("done.")
 

--- a/socorro/tests/lib/test_task_manager.py
+++ b/socorro/tests/lib/test_task_manager.py
@@ -58,12 +58,9 @@ class TestTaskManager:
 
         tm = MyTaskManager(config, task_func=mock.Mock())
 
-        waiting_func = mock.Mock()
-
-        tm.blocking_start(waiting_func=waiting_func)
+        tm.blocking_start()
 
         assert tm.task_func.call_count == 10
-        assert waiting_func.call_count == 0
 
     def test_blocking_start_with_quit_on_empty(self):
         config = DotDict()
@@ -72,9 +69,6 @@ class TestTaskManager:
 
         tm = TaskManager(config, task_func=mock.Mock())
 
-        waiting_func = mock.Mock()
-
-        tm.blocking_start(waiting_func=waiting_func)
+        tm.blocking_start()
 
         assert tm.task_func.call_count == 10
-        assert waiting_func.call_count == 0

--- a/socorro/tests/lib/test_threaded_task_manager.py
+++ b/socorro/tests/lib/test_threaded_task_manager.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import time
-from unittest import mock
 
 from configman.dotdict import DotDict
 
@@ -104,7 +103,5 @@ class TestThreadedTaskManager:
 
         tm = ThreadedTaskManager(config, task_func=task_func)
 
-        waiting_func = mock.Mock()
-
-        tm.blocking_start(waiting_func=waiting_func)
+        tm.blocking_start()
         assert len(calls) == 10


### PR DESCRIPTION
This removes the waiting_func argument that gets passed around the task management code because it's not used anywhere.