### PR TITLE
bug 1529342: fix temporary path value

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -165,7 +165,15 @@ class ProcessorApp(App):
             "a local filesystem path that can be used as a workspace for processing "
             + "rules"
         ),
-        default=os.path.join(tempfile.gettempdir(), "workspace"),
+        default=os.path.join(
+            (
+                # FIXME(willkg): this is for backwards compatability with existing
+                # configuration
+                os.environ.get("resource.boto.temporary_file_system_storage_path", "")
+                or tempfile.gettempdir()
+            ),
+            "workspace",
+        ),
     )
 
     # The companion_process runs alongside the processor and cleans up


### PR DESCRIPTION
The existing infrastructure configuration uses the old resource.boto.temporary_file_system_storage_path variable that we dropped (code-wise) in 1eb8a195. This adds some code to make the code backwards-compatible with the old configuration.