### PR TITLE
bug 1815235: stringify cond names in SignatureShutdownTimeout rule

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -943,7 +943,7 @@ class SignatureShutdownTimeout(Rule):
                 # be a string that looks like a "name" or a dict with a "name" in it.
                 #
                 # This handles both variations.
-                c["name"] if isinstance(c, dict) else c
+                str(c["name"] if isinstance(c, dict) else c)
                 for c in shutdown_data.get("conditions") or []
             ]
             if conditions:


### PR DESCRIPTION
We hit a case where the condition name was a float. That should never happen and we should catch that in processing in a validation/normalization rule so that signature generation doesn't have to deal with weird data.

However, in the interests of getting a fix out there now, I'm just going to stringify the condition names.