### PR TITLE
bug 1529342: fix symbol cache manager race

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -364,19 +364,19 @@ class ProcessorApp(App):
             namespace=self.app_name,
         )
 
-        if self.config.companion_process.companion_class:
-            self.companion_process = self.config.companion_process.companion_class(
-                self.config.companion_process
-            )
-        else:
-            self.companion_process = None
-
         self.processor = self.config.processor.processor_class(
             config=self.config.processor, host_id=self.app_instance_name
         )
 
         self.temporary_path = self.config.processor.temporary_path
         os.makedirs(self.temporary_path, exist_ok=True)
+
+        if self.config.companion_process.companion_class:
+            self.companion_process = self.config.companion_process.companion_class(
+                self.config.companion_process
+            )
+        else:
+            self.companion_process = None
 
     def _setup_task_manager(self):
         """instantiate the threaded task manager to run the producer/consumer

--- a/socorro/processor/symbol_cache_manager.py
+++ b/socorro/processor/symbol_cache_manager.py
@@ -168,6 +168,9 @@ class SymbolLRUCacheManager(RequiredConfig):
         # Load existing files into the cache.
         self._get_existing_files(self.directory)
         self._notifier.start()
+        self.logger.warning(
+            "symbol_cache_manager started with cache: %s", self.directory
+        )
 
     @property
     def num_files(self):


### PR DESCRIPTION
If the symbol cache directory hasn't been created before the symbol cache manager starts up, then it fails. This fixes the race problem by making sure the processor is built before the symbol cache manager is started.