### PR TITLE
bug 1815535: remove raw crash path with entropy from verifyprocessed

### DIFF
--- a/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -64,13 +64,13 @@ class TestVerifyProcessed:
 
     def test_get_threechars(self):
         cmd = Command()
-        entropy = list(sorted(cmd.get_threechars()))
+        threechars = list(sorted(cmd.get_threechars()))
 
         # We don't want to assert the contents of the whole list, so let's
         # just assert some basic facts and it's probably fine
-        assert len(entropy) == 4096
-        assert entropy[0] == "000"
-        assert entropy[-1] == "fff"
+        assert len(threechars) == 4096
+        assert threechars[0] == "000"
+        assert threechars[-1] == "fff"
 
     def test_no_crashes(self, boto_helper, monkeypatch):
         """Verify no crashes in bucket result in no missing crashes."""


### PR DESCRIPTION
We phased out raw crash paths with entropy in September, so verifyprocessed doesn't need to check those anymore.

The remaining bits of entropy stuff are in the boto crash storage code. We need to keep that there until March 7th, 2023 when all the old data has expired out.