### PR TITLE
bug 1819181: use tini to start services

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,4 +54,4 @@ RUN cd /app/webapp/ && SECRET_KEY=fakekey python manage.py collectstatic --noinp
 
 # Set entrypoint for this image. The entrypoint script takes a service
 # to run as the first argument. See the script for available arguments.
-ENTRYPOINT ["/app/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/bin/entrypoint.sh"]

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -27,6 +27,9 @@ PACKAGES_TO_INSTALL=(
     # For scripts
     git
 
+    # For running services
+    tini
+
     # For nodejs and npm
     curl
 )


### PR DESCRIPTION
This switches the socorro_app image to use tini in the ENTRYPOINT so that interrupts stop the docker container immediately without requiring 10s of waiting and then a sigkill.