### PR TITLE
bug 1529342: handle empty string not being a valid int

### DIFF
--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -49,6 +49,15 @@ class ThreadedTaskManager(TaskManager):
         :arg task_func: a function that will accept the args and kwargs yielded
             by the job_source_iterator
         """
+
+        # If number of threads is None, set it to default
+        if number_of_threads is None:
+            number_of_threads = 4
+
+        # If maximum queue size is None, set it to default
+        if maximum_queue_size is None:
+            maximum_queue_size = 8
+
         super().__init__(
             idle_delay=idle_delay,
             quit_on_empty_queue=quit_on_empty_queue,

--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -16,6 +16,13 @@ from everett.manager import ConfigManager, ListOf
 _config = ConfigManager.basic_config()
 
 
+def int_or_none(val):
+    """If the value is an empty string, then return None"""
+    if val.strip() == "":
+        return None
+    return int(val)
+
+
 TOOL_ENV = _config(
     "TOOL_ENV",
     default="False",
@@ -92,13 +99,13 @@ PROCESSOR = {
             "number_of_threads": _config(
                 "PROCESSOR_NUMBER_OF_THREADS",
                 default="4",
-                parser=int,
+                parser=int_or_none,
                 doc="Number of worker threads for the processor.",
             ),
             "maximum_queue_size": _config(
                 "PROCESSOR_MAXIMUM_QUEUE_SIZE",
                 default="8",
-                parser=int,
+                parser=int_or_none,
                 doc="Number of items to queue up from the processing queues.",
             ),
         },
@@ -256,7 +263,7 @@ SYMBOLS_CACHE_PATH = _config(
 SYMBOLS_CACHE_MAX_SIZE = _config(
     "SYMBOLS_CACHE_MAX_SIZE",
     default=str(1024 * 1024 * 1024),
-    parser=int,
+    parser=int_or_none,
     doc=(
         "Max size (bytes) of symbols cache. You can use _ to group digits for "
         "legibility."
@@ -287,7 +294,7 @@ STACKWALKER = {
     "kill_timeout": _config(
         "STACKWALKER_KILL_TIMEOUT",
         default="120",
-        parser=int,
+        parser=int_or_none,
         doc="Timeout in seconds before the stackwalker is killed.",
     ),
     "symbols_urls": _config(

--- a/socorro/processor/cache_manager.py
+++ b/socorro/processor/cache_manager.py
@@ -81,6 +81,8 @@ class DiskCacheManager:
 
         self.cachepath = pathlib.Path(settings.SYMBOLS_CACHE_PATH).resolve()
         self.max_size = settings.SYMBOLS_CACHE_MAX_SIZE
+        if self.max_size is None:
+            raise ValueError("SYMBOLS_CACHE_MAX_SIZE must have non-None value")
 
         # Set up attributes for cache monitoring; these get created in the generator
         self.lru = LastUpdatedOrderedDict()

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -216,6 +216,11 @@ class MinidumpStackwalkRule(Rule):
         symbol_cache_path="/tmp/symbols",
     ):
         super().__init__()
+
+        # If kill_timeout is None, set it to 600--the default
+        if kill_timeout is None:
+            kill_timeout = 600
+
         self.dump_field = dump_field
         self.symbols_urls = symbols_urls or []
         self.command_path = command_path


### PR DESCRIPTION
The webapp imports mozilla_settings and when it does that, it doesn't have settings for the processor-related configuration, so those things get set to the empty string which isn't a valid int.

This accounts for that by handling the empty string case and making it a None. Then it adds some code to the relevant parts of the codebase that use those settings to handle the None value.