### PR TITLE
bug 1822648: handle race condition in CREATE event

### DIFF
--- a/socorro/processor/cache_manager.py
+++ b/socorro/processor/cache_manager.py
@@ -250,7 +250,13 @@ class DiskCacheManager:
                             # Handle file events which update our LRU cache
                             if flags.CREATE in event_flags:
                                 if path not in self.lru:
-                                    size = os.stat(path).st_size
+                                    try:
+                                        size = os.stat(path).st_size
+                                    except FileNotFoundError:
+                                        # The file was created and deleted in rapid
+                                        # succession, so we can ignore it
+                                        continue
+
                                     self.make_room(size)
                                     self.lru[path] = size
                                     self.total_size += size


### PR DESCRIPTION
If a file was created and deleted rapidly, we should ignore the CREATE event.