### PR TITLE
bug 1529342: switch to datadogmetrics backend

### DIFF
--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -70,7 +70,7 @@ LOGGING_LEVEL = _config(
 # Markus configuration for metrics
 MARKUS_BACKENDS = [
     {
-        "class": "markus.backends.statsd.StatsdMetrics",
+        "class": "markus.backends.datadog.DatadogMetrics",
         "options": {
             "statsd_host": _config(
                 "STATSD_HOST",


### PR DESCRIPTION
This switches to the DatadogMetrics backend which supports tags.