### PR TITLE
Bug 1529342: everett and honcho

### DIFF
--- a/bin/run_processor.sh
+++ b/bin/run_processor.sh
@@ -18,5 +18,6 @@ PROCESSOR_WORKERS=${PROCESSOR_WORKERS:-"1"}
 honcho \
     --procfile /app/processor/Procfile \
     --app-root /app \
+    --no-prefix \
     start \
     --concurrency "processor=${PROCESSOR_WORKERS}"

--- a/bin/run_processor_cache_manager.sh
+++ b/bin/run_processor_cache_manager.sh
@@ -12,5 +12,7 @@
 
 set -euo pipefail
 
+export PROCESS_NAME=cache_manager
+
 # Run the processor
 python socorro/processor/cache_manager.py

--- a/bin/run_processor_process.sh
+++ b/bin/run_processor_process.sh
@@ -12,5 +12,7 @@
 
 set -euo pipefail
 
+export PROCESS_NAME=processor
+
 # Run the processor
 python socorro/processor/processor_app.py

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -62,6 +62,7 @@ STACKWALKER_KILL_TIMEOUT=120
 # probably want to store that in a volume. These vars are all affected.
 SYMBOLS_CACHE_PATH=/tmp/symbols/cache
 SYMBOLS_TMP_PATH=/tmp/symbols/tmp
+SYMBOLS_CACHE_MAX_SIZE=4gb
 
 # Set symbols_urls to two symbol servers so we make sure we can specify multiple
 # --symbols-url values in minidump-stackwalk

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-session-csrf==0.7.1
 dj-database-url==1.2.0
 dockerflow==2022.8.0
 enforce-typing==1.0.0.post1
-everett==3.1.0
+everett==3.2.0
 fillmore==1.0.0
 freezegun==1.2.2
 glom==23.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,9 +269,9 @@ enforce-typing==1.0.0.post1 \
     --hash=sha256:90347a61d08e7f7578d9714b4f0fd8abd9b6bc48c8ac8d46d7f290d413afabb7 \
     --hash=sha256:d3184dfdbfd7f9520c884986561751a6106c57cdd65d730470645d2d40c47e18
     # via -r requirements.in
-everett==3.1.0 \
-    --hash=sha256:46175da5bcb06c193aa129e59714bca981344ff067c3a8bc2e625bc0b3dc01f6 \
-    --hash=sha256:db13891b849e45e54faea93ee79881d12458c5378f5b9b7f806eeff03ce1de3c
+everett==3.2.0 \
+    --hash=sha256:80517946d9746734ff8e6bda56d629f0092083389730c72157745f8d5d43d196 \
+    --hash=sha256:cdca5fc8815f402df650444eb1a2fa24c05ef524ff3ebbae3310d17edb11ea6a
     # via -r requirements.in
 exceptiongroup==1.1.0 \
     --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \

--- a/socorro/tests/processor/test_cache_manager.py
+++ b/socorro/tests/processor/test_cache_manager.py
@@ -308,6 +308,7 @@ BROKEN_EVENT = {
     },
     "extra": {
         "asctime": ANY,
+        "processname": "main",
         "sys.argv": ANY,
     },
     "level": "error",

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -224,7 +224,9 @@ LOGGING = {
         },
     },
     "formatters": {
-        "socorroapp": {"format": "%(asctime)s %(levelname)s - %(name)s - %(message)s"},
+        "socorroapp": {
+            "format": "%(asctime)s %(levelname)s - webapp - %(name)s - %(message)s"
+        },
         "mozlog": {
             "()": "dockerflow.logging.JsonLogFormatter",
             "logger_name": "socorro",


### PR DESCRIPTION
This updates Everett to 3.2.0 which has `parse_data_size` and `parse_time_period`.
    
This changes the `STACKWALKER_KILL_TIMEOUT` to use `parse_time_period` and changes the value to "2m" which is more readable than "120".
    
This changes the `SYMBOLS_CACHE_MAX_SIZE` to "40gb" which is more readable than "40000000000".

Honcho manages multiple processes and by default it prefixes stdout with the process name. This removes that prefix and puts the process name in the logging metadata.