### PR TITLE
Add std::alloc::_::__rg_oom to irrelevant_signature_re.txt

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -202,6 +202,7 @@ SkyLight
 SleepConditionVariableSRW
 __stack_chk_fail
 std::__
+std::alloc::_::__rg_oom
 std::alloc::rust_oom
 std::all_of
 std::io::stdio::_eprint


### PR DESCRIPTION
This should improve crashes like: https://crash-stats.mozilla.org/report/index/75873ba4-f5c4-45ef-ba71-6047b0230323