### PR TITLE
bug 1827416, 1827495: update stackwalker to v0.16.0; add support for adjusted_address

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20221130.0/socorro-stackwalker.2022-11-30.v0.15.0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230503.0/socorro-stackwalker.2023-04-27.v0.16.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"

--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -124,20 +124,14 @@ class CPUInfoRule(Rule):
 
         processed_crash["cpu_arch"] = cpu_arch
 
-        # The cpu_microcode_version is populated by stackwalker, but if it's not there,
-        # then degrade to the CPUMicrocodeVersion crash annotation value
+        # The cpu_microcode_version is populated by minidump-stackwalk which gets it from
+        # either the minidump or the CPUMicrocodeVersion crash annotation value; as
+        # of minidump-stackwalk v0.16.0, the value is always a hexstring.
         cpu_microcode_version = glom(
             processed_crash, "json_dump.system_info.cpu_microcode_version", default=None
         )
         if cpu_microcode_version is not None:
-            # This is a u32, so we convert it to a hex string
-            processed_crash["cpu_microcode_version"] = hex(cpu_microcode_version)
-        else:
-            # This is a hex string
-            cpu_microcode_version = raw_crash.get("CPUMicrocodeVersion")
-
-            if cpu_microcode_version:
-                processed_crash["cpu_microcode_version"] = cpu_microcode_version
+            processed_crash["cpu_microcode_version"] = cpu_microcode_version
 
 
 class OSInfoRule(Rule):

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -450,7 +450,9 @@ definitions:
           cpu_microcode_version:
             description: >
               The version number of the microcode running on the CPU.
-            type: ["integer", "null"]
+            # NOTE(willkg): We can change this to string/null in November 2023
+            # when the old data has expired.
+            type: ["integer", "string", "null"]
             permissions: ["public"]
           os:
             description: The flavor of operating system.

--- a/socorro/tests/processor/rules/test_general.py
+++ b/socorro/tests/processor/rules/test_general.py
@@ -268,17 +268,9 @@ class TestCPUInfoRule:
 
     def test_cpu_microcode_version_from_stackwalker(self, tmp_path):
         raw_crash = {"CPUMicrocodeVersion": "ignored value"}
-        processed_crash = {"json_dump": {"system_info": {"cpu_microcode_version": 66}}}
-        dumps = {}
-        status = Status()
-
-        rule = CPUInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
-        assert processed_crash["cpu_microcode_version"] == "0x42"
-
-    def test_cpu_microcode_version_from_annotation(self, tmp_path):
-        raw_crash = {"CPUMicrocodeVersion": "0x42"}
-        processed_crash = {}
+        processed_crash = {
+            "json_dump": {"system_info": {"cpu_microcode_version": "0x42"}}
+        }
         dumps = {}
         status = Status()
 


### PR DESCRIPTION
This updates the stackwalker from v0.15.0 to v0.16.0.

This fixes the handling for `cpu_microcode_version` since it changed from a u32 to a hexcode and the stackwalker now handles looking at the `CPUMicrocodeVersion` crash annotation if the minidump doesn't have the data.

This adds support for `crash_info.adjusted_address` and using that information to determine the final `address` in the processed crash.