### PR TITLE
bug 1837409: fix create-a-bug links for Fenix Java crashes

### DIFF
--- a/webapp/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
+++ b/webapp/crashstats/crashstats/jinja2/crashstats/bug_comment.txt
@@ -6,7 +6,7 @@ Crash report: {{ full_url(request, "crashstats:report_index", crash_id=uuid ) }}
 {% if java_stack_trace %}
 Java stack trace:
 ```
-{{ java_stack_trace|safe }}
+{{ java_stack_trace|truncate(5000, True)|safe }}
 ```
 {% elif frames %}
 {% if moz_crash_reason %}

--- a/webapp/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -155,6 +155,8 @@ def show_bug_link(bug_id):
 
 EXTRA_NEWLINES_RE = re.compile(r"\n\n\n+")
 
+MAX_TITLE_LENGTH = 255
+
 
 @library.global_function
 def generate_create_bug_url(
@@ -214,8 +216,8 @@ def generate_create_bug_url(
     }
 
     # Truncate the title
-    if len(kwargs["title"]) > 255:
-        kwargs["title"] = kwargs["title"][: 255 - 3] + "..."
+    if len(kwargs["title"]) > MAX_TITLE_LENGTH:
+        kwargs["title"] = kwargs["title"][: MAX_TITLE_LENGTH - 3] + "..."
 
     # urlencode the values so they work in the url template correctly
     kwargs = {key: quote_plus(value) for key, value in kwargs.items()}


### PR DESCRIPTION
The JavaStackTrace annotation is a long vaguely structured string. The create-a-bug code uses that to build the bug description. If that value is too long, it exceeds the max url length and then gets clipped causing the create-a-bug links to not work.

This truncates the JavaStackTrace value.

At some point, we should look at switching to JavaException which is structured when it's available and fall back to JavaStackTrace if necessary.