### PR TITLE
bug 1837413: fix .length call on null value

### DIFF
--- a/webapp/crashstats/crashstats/static/crashstats/js/socorro/report.js
+++ b/webapp/crashstats/crashstats/static/crashstats/js/socorro/report.js
@@ -120,7 +120,7 @@ $(document).ready(function () {
     // This avoids adding multiple calls to addExpand which will add multiple links to the
     // same header.
     cells.each(function () {
-      if ($(this).attr('title').length !== $(this).text().length && !isExpandAdded) {
+      if ($(this).attr('title') && $(this).attr('title').length !== $(this).text().length && !isExpandAdded) {
         addExpand($(this).parents('tbody').find('th.signature-column'));
         isExpandAdded = true;
       }


### PR DESCRIPTION
If the table cell doesn't have a title, then `attr('title')` returned null and then `.length` failed and the rest of the js wouldn't run. This fixes that case so the rest runs now.