### PR TITLE
bug 1810789: support null as a valid type for ReleaseChannel

### DIFF
--- a/socorro/schemas/raw_crash.schema.yaml
+++ b/socorro/schemas/raw_crash.schema.yaml
@@ -872,7 +872,7 @@ properties:
       The update channel that the product is on. Typically `nightly`, `aurora`,
       `beta`, `release`, or `esr`. This may also be other values like
       `release-cck-partner`.
-    type: string
+    type: ["string", "null"]
     examples:
       - "nightly"
       - "aurora"


### PR DESCRIPTION
Crash reports can contain crash annotations in a JSON blob. When this happens, some values can be null and thus have a null type. This fixes the schema to support null type for `ReleaseChannel`.