### PR TITLE
bug 1815535: remove raw crash v2 path support

### DIFF
--- a/docs/crashstorage.rst
+++ b/docs/crashstorage.rst
@@ -282,6 +282,6 @@ All of this is done in a single S3 bucket.
 
 The "directory" hierarchy of that bucket looks like this:
 
-* ``{prefix}/v2/{name_of_thing}/{entropy}/{date}/{id}``: Raw crash data.
+* ``{prefix}/v1/{name_of_thing}/{date}/{id}``: Raw crash data.
 * ``{prefix}/v1/{name_of_thing}/{id}``: Processed crash data, dumps, dump_names,
   and other things.

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -71,16 +71,8 @@ def build_keys(name_of_thing, crashid):
 
     """
     if name_of_thing == "raw_crash":
-        # Insert the first 3 chars of the crashid providing some entropy
-        # earlier in the key so that consecutive s3 requests get
-        # distributed across multiple s3 partitions
-        entropy = crashid[:3]
         date = get_datestamp(crashid).strftime("%Y%m%d")
-        return [
-            f"v1/{name_of_thing}/{date}/{crashid}",
-            # NOTE(willkg): This format is deprecated and will be removed in April 2023
-            f"v2/{name_of_thing}/{entropy}/{date}/{crashid}",
-        ]
+        return [f"v1/{name_of_thing}/{date}/{crashid}"]
 
     elif name_of_thing == "crash_report":
         # Crash data from the TelemetryBotoS3CrashStorage

--- a/socorro/tests/external/boto/test_crashstorage.py
+++ b/socorro/tests/external/boto/test_crashstorage.py
@@ -47,7 +47,6 @@ TELEMETRY_SETTINGS = {
             "0bba929f-8721-460c-dead-a43c20071027",
             [
                 "v1/raw_crash/20071027/0bba929f-8721-460c-dead-a43c20071027",
-                "v2/raw_crash/0bb/20071027/0bba929f-8721-460c-dead-a43c20071027",
             ],
         ),
         (


### PR DESCRIPTION
We no longer store anything with the v2 path, so this removes the last bit of support for it.