### PR TITLE
bug 1837423: support __null__ for number fields in supersearch

### DIFF
--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -182,16 +182,17 @@ class SearchBase:
                                 break
 
                     # ensure the right data type
-                    try:
-                        value = convert_to_type(value, param.data_type)
-                    except ValueError as exc:
-                        raise BadArgumentError(
-                            param.name,
-                            msg=(
-                                "Bad value for parameter %s: not a valid %s"
-                                % (param.name, param.data_type)
-                            ),
-                        ) from exc
+                    if operator != "__null__":
+                        try:
+                            value = convert_to_type(value, param.data_type)
+                        except ValueError as exc:
+                            raise BadArgumentError(
+                                param.name,
+                                msg=(
+                                    "Bad value for parameter %s: not a valid %s"
+                                    % (param.name, param.data_type)
+                                ),
+                            ) from exc
 
                     if param.name not in parameters:
                         parameters[param.name] = []

--- a/webapp/crashstats/documentation/jinja2/docs/supersearch/home.html
+++ b/webapp/crashstats/documentation/jinja2/docs/supersearch/home.html
@@ -156,7 +156,7 @@
         </tr>
         <tr>
           <td>number</td>
-          <td><code></code>, <code>&gt;</code>, <code>&gt;=</code>, <code>&lt;</code>, <code>&lt;=</code></td>
+          <td><code></code>, <code>&gt;</code>, <code>&gt;=</code>, <code>&lt;</code>, <code>&lt;=</code>, <code>__null__</code></td>
           <td>Type for all numbers, underlying data can be float, int, long&hellip; </td>
         </tr>
         <tr>
@@ -166,13 +166,8 @@
         </tr>
         <tr>
           <td>boolean</td>
-          <td><code>__true__</code></td>
+          <td><code>__true__</code>, <code>__null__</code></td>
           <td>Type for fields that can be true or false.</td>
-        </tr>
-        <tr>
-          <td>flag</td>
-          <td><code>__null__</code></td>
-          <td>Type for fields that either have a value (generally <code>1</code>) or are missing.</td>
         </tr>
       </tbody>
     </table>
@@ -279,13 +274,13 @@
         <tr>
           <td>does not exist</td>
           <td><code>__null__</code></td>
-          <td>string, flag</td>
+          <td>string, boolean, number</td>
           <td>
             <p>
               The field is missing or has a null value.
             </p>
             <p>
-              Note: This doesn't work for empty string values.
+              Note: This will not match empty string values.
             </p>
           </td>
         </tr>

--- a/webapp/crashstats/supersearch/form_fields.py
+++ b/webapp/crashstats/supersearch/form_fields.py
@@ -153,7 +153,7 @@ class MultiplePrefixedValueField(PrefixedField):
                     )
 
 
-class IntegerField(MultiplePrefixedValueField, forms.IntegerField):
+class NumberField(MultiplePrefixedValueField, forms.IntegerField):
     pass
 
 
@@ -181,8 +181,6 @@ class StringField(MultipleValueField):
     on that field ("contains", "starts with"... ).
 
     """
-
-    pass
 
 
 class BooleanField(forms.CharField):

--- a/webapp/crashstats/supersearch/forms.py
+++ b/webapp/crashstats/supersearch/forms.py
@@ -12,9 +12,8 @@ from crashstats.supersearch import form_fields
 TYPE_TO_FIELD_MAPPING = {
     "enum": form_fields.MultipleValueField,
     "string": form_fields.StringField,
-    "number": form_fields.IntegerField,
+    "number": form_fields.NumberField,
     "bool": form_fields.BooleanField,
-    "flag": form_fields.StringField,
     "date": form_fields.DateTimeField,
 }
 

--- a/webapp/crashstats/supersearch/tests/test_form_fields.py
+++ b/webapp/crashstats/supersearch/tests/test_form_fields.py
@@ -12,19 +12,37 @@ from django.forms import ValidationError
 from crashstats.supersearch import form_fields
 
 
-class TestFormFields:
-    def test_integer_field(self):
-        field = form_fields.IntegerField()
+class TestNumberField:
+    def test_gt(self):
+        field = form_fields.NumberField()
         cleaned_value = field.clean([">13"])
         assert cleaned_value == [13]
         assert field.prefixed_value == [">13"]
 
-        # With a ! prefix.
+    def test_not(self):
+        field = form_fields.NumberField()
         cleaned_value = field.clean(["!13"])
         assert cleaned_value == [13]
         assert field.prefixed_value == ["!13"]
 
-    def test_datetime_field(self):
+    def test_invalid_combinations(self):
+        field = form_fields.NumberField()
+
+        # Test non-overlapping ranges
+        with pytest.raises(ValidationError, match="Operator combination failed"):
+            field.clean([">10", "<10"])
+        with pytest.raises(ValidationError, match="Operator combination failed"):
+            field.clean(["<10", ">10"])
+        with pytest.raises(ValidationError, match="Operator combination failed"):
+            field.clean(["<10", ">=10"])
+        with pytest.raises(ValidationError, match="Operator combination failed"):
+            field.clean(["<=10", ">10"])
+        with pytest.raises(ValidationError, match="Operator combination failed"):
+            field.clean(["<10", "<10"])
+
+
+class TestDateTimeField:
+    def test_gt_datetime(self):
         field = form_fields.DateTimeField()
         cleaned_value = field.clean([">12/31/2012 10:20:30"])
         dt = datetime.datetime(2012, 12, 31, 10, 20, 30)
@@ -32,6 +50,7 @@ class TestFormFields:
         assert cleaned_value == [dt]
         assert field.prefixed_value == [">2012-12-31T10:20:30+00:00"]
 
+    def test_gte_date(self):
         field = form_fields.DateTimeField()
         cleaned_value = field.clean([">=2012-12-31"])
         dt = datetime.datetime(2012, 12, 31)
@@ -39,6 +58,7 @@ class TestFormFields:
         assert cleaned_value == [dt]
         assert field.prefixed_value == [">=2012-12-31T00:00:00+00:00"]
 
+    def test_gte_datetime(self):
         field = form_fields.DateTimeField()
         cleaned_value = field.clean([">=2012-12-31T01:02:03+00:00"])
         dt = datetime.datetime(2012, 12, 31, 1, 2, 3)
@@ -46,40 +66,7 @@ class TestFormFields:
         assert cleaned_value == [dt]
         assert field.prefixed_value == [">=2012-12-31T01:02:03+00:00"]
 
-    def test_several_fields(self):
-        field1 = form_fields.DateTimeField()
-        cleaned_value1 = field1.clean([">12/31/2012 10:20:30"])
-
-        field2 = form_fields.DateTimeField()
-        cleaned_value2 = field2.clean(["<12/31/2012 10:20:40"])
-
-        dt = datetime.datetime(2012, 12, 31, 10, 20, 30)
-        dt = dt.replace(tzinfo=utc)
-        assert cleaned_value1 == [dt]
-        assert field1.prefixed_value == [">2012-12-31T10:20:30+00:00"]
-
-        dt = datetime.datetime(2012, 12, 31, 10, 20, 40)
-        dt = dt.replace(tzinfo=utc)
-        assert cleaned_value2 == [dt]
-        assert field2.prefixed_value == ["<2012-12-31T10:20:40+00:00"]
-
-        assert field1.operator == ">"
-        assert field2.operator == "<"
-
-    def test_several_fields_illogically_integerfield(self):
-        field = form_fields.IntegerField()
-        with pytest.raises(ValidationError):
-            field.clean([">10", "<10"])
-        with pytest.raises(ValidationError):
-            field.clean(["<10", ">10"])
-        with pytest.raises(ValidationError):
-            field.clean(["<10", ">=10"])
-        with pytest.raises(ValidationError):
-            field.clean(["<=10", ">10"])
-        with pytest.raises(ValidationError):
-            field.clean(["<10", "<10"])
-
-    def test_several_fields_illogically_datetimefield(self):
+    def test_invalid_combinations(self):
         field = form_fields.DateTimeField()
         with pytest.raises(ValidationError):
             field.clean([">2016-08-10", "<2016-08-10"])
@@ -111,12 +98,16 @@ class TestFormFields:
         with pytest.raises(ValidationError):
             field.clean(["<2016-08-01", "<2016-08-02", "<2016-08-03"])
 
-    def test_boolean_field(self):
+
+class TestBooleanField:
+    def test_none(self):
         field = form_fields.BooleanField(required=False)
         # If the input is None, leave it as None
         cleaned_value = field.clean(None)
         assert cleaned_value is None
 
+    def test_truthy(self):
+        field = form_fields.BooleanField(required=False)
         # The list of known truthy strings
         for value in form_fields.BooleanField.truthy_strings:
             cleaned_value = field.clean(value)
@@ -126,6 +117,8 @@ class TestFormFields:
             cleaned_value = field.clean(value.upper())  # note
             assert cleaned_value == "__true__"
 
+    def test_not_truthy(self):
+        field = form_fields.BooleanField(required=False)
         # Any other string that is NOT in form_fields.BooleanField.truthy_strings
         # should return `!__true__`
         cleaned_value = field.clean("FALSE")
@@ -135,3 +128,13 @@ class TestFormFields:
         # But not choke on non-ascii strings
         cleaned_value = field.clean("Nöö")
         assert cleaned_value == "!__true__"
+
+    def test_null(self):
+        field = form_fields.BooleanField()
+        cleaned_value = field.clean("__null__")
+        assert cleaned_value == "__null__"
+
+    def test_not_null(self):
+        field = form_fields.BooleanField()
+        cleaned_value = field.clean("!__null__")
+        assert cleaned_value == "!__null__"


### PR DESCRIPTION
This fixes `__null__` and `!__null__` for number fields. Support was partially implemented a couple of years ago in the search library code, but the Django form fields which parse and validate the request query string were never adjusted to support `__null__` and `!__null__`, so it never worked.
    
This adds support for `__null__` and `!__null__` and also adds appropriate validation for combinations of these values and other filters for a number field. This adds appropriate tests as well.