### PR TITLE
bug 1834536: add mozilla::dom::syncedcontext::Transaction<T>::Commit to prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -100,6 +100,7 @@ mozilla::detail::InvalidArrayIndex_CRASH
 mozilla::detail::nsTStringRepr<T>::
 mozilla::dom::AutoJSAPI::Init
 mozilla::dom::Promise::
+mozilla::dom::syncedcontext::Transaction<T>::Commit
 mozilla::dom::ToJSValue
 mozilla::DOMEventTargetHelper::AddRef
 mozilla::Maybe<T>


### PR DESCRIPTION
```
app@socorro:/app$ ./socorro-cmd signature 521a8bc3-d9ff-45f3-9c29-100130230615 6ee01b21-eb71-4863-aecd-e48e90230614 ed1435c3-ed21-4ea5-be93-b6c170230614 
Crash id: 521a8bc3-d9ff-45f3-9c29-100130230615
Original: mozilla::dom::syncedcontext::Transaction<T>::Commit
New:      mozilla::dom::syncedcontext::Transaction<T>::Commit | mozilla::dom::BrowsingContext::SetOpenerPolicy
Same?:    False

Crash id: 6ee01b21-eb71-4863-aecd-e48e90230614
Original: mozilla::dom::syncedcontext::Transaction<T>::Commit
New:      mozilla::dom::syncedcontext::Transaction<T>::Commit | mozilla::dom::BrowsingContext::SetCurrentInnerWindowId
Same?:    False

Crash id: ed1435c3-ed21-4ea5-be93-b6c170230614
Original: mozilla::dom::syncedcontext::Transaction<T>::Commit
New:      mozilla::dom::syncedcontext::Transaction<T>::Commit | mozilla::dom::Document::SetHeaderData
Same?:    False
```