### PR TITLE
bug 1667997: report_type field, processor rule, and adjustment to Top Crasher report

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1894,6 +1894,7 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"analyzer": "keyword", "type": "string"},
     },
+    "report_type": keyword_field(name="report_type"),
     "safe_mode": {
         "data_validation_type": "bool",
         "form_field_choices": [],

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -41,6 +41,7 @@ from socorro.processor.rules.mozilla import (
     OutOfMemoryBinaryRule,
     PHCRule,
     PluginRule,
+    ReportTypeRule,
     SignatureGeneratorRule,
     SubmittedFromRule,
     ThemePrettyNameRule,
@@ -90,6 +91,7 @@ DEFAULT_RULESET = [
     MacCrashInfoRule(),
     MozCrashReasonRule(),
     UtilityActorsNameRule(),
+    ReportTypeRule(),
     # post processing of the processed crash
     CPUInfoRule(),
     DistributionIdRule(),

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1097,3 +1097,29 @@ class UtilityActorsNameRule(Rule):
             item.strip() for item in utility_actors_name.split(",") if item.strip()
         ]
         processed_crash["utility_actors_name"] = names
+
+
+class ReportTypeRule(Rule):
+    """Determines the category for the report.
+
+    We get crash reports for different sorts of things. Some are from crashes. Others
+    are from browser hangs, content process hangs, shutdown hangs, etc. This determines
+    the type of the report and fills in the ``report_type`` field.
+
+    Bug #1667997
+
+    """
+
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        # "crash" is the default type
+        report_type = "crash"
+
+        # NOTE(willkg): This comes from the ipc_channel_error crash annotation
+        if "ipc_channel_error" in processed_crash:
+            report_type = "hang"
+
+        # NOTE(willkg): This comes from the AsyncShutdownTimeout crash annotation
+        if "async_shutdown_timeout" in processed_crash:
+            report_type = "hang"
+
+        processed_crash["report_type"] = report_type

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2866,8 +2866,8 @@ properties:
     source_annotation: RemoteType
   report_type:
     description: >
-      Type of the crash report. Can be set to `crash` (the default for reports),
-      `hang`, etc.
+      Type of the crash report. Can be set to `crash` (the default for reports)
+      and `hang`.
     type: string
     permissions: ["public"]
   safe_mode:

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2864,6 +2864,12 @@ properties:
     type: string
     permissions: ["protected"]
     source_annotation: RemoteType
+  report_type:
+    description: >
+      Type of the crash report. Can be set to `crash` (the default for reports),
+      `hang`, etc.
+    type: string
+    permissions: ["public"]
   safe_mode:
     description:
       Whether the browser was running in Safe mode.

--- a/socorro/tests/schemas/test_socorro_data_schemas.py
+++ b/socorro/tests/schemas/test_socorro_data_schemas.py
@@ -528,6 +528,7 @@ PUBLIC_PROCESSED_CRASH_FIELDS = {
     "quota_manager_shutdown_timeout",
     "reason",
     "release_channel",
+    "report_type",
     "safe_mode",
     "shutdown_progress",
     "shutdown_reason",

--- a/webapp/crashstats/topcrashers/forms.py
+++ b/webapp/crashstats/topcrashers/forms.py
@@ -16,3 +16,4 @@ class TopCrashersForm(BaseForm):
     _facets_size = forms.IntegerField(required=False)
     _tcbs_mode = forms.CharField(required=False)
     _range_type = forms.CharField(required=False)
+    _report_type = forms.CharField(required=False)

--- a/webapp/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -51,6 +51,24 @@
 
         <div class="tc-filters-block">
           <ul class="tc-filter">
+            <li class="tc-selector-heading">Report Type:</li>
+            <li>
+              <a href="{{ change_query_string(_report_type='any') }}"
+                 {% if query.report_type == 'any' %} class="selected"{% endif %}
+              >Any</a>
+            </li>
+            <li>
+              <a href="{{ change_query_string(_report_type=None) }}"
+                 {% if query.report_type == 'crash' %} class="selected"{% endif %}
+              >Crash</a>
+            </li>
+            <li>
+              <a href="{{ change_query_string(_report_type='hang') }}"
+                 {% if query.report_type == 'hang' %} class="selected"{% endif %}
+              >Hang</a>
+            </li>
+          </ul>
+          <ul class="tc-filter">
             <li class="tc-selector-heading">Report Date:</li>
             <li>
               <a href="{{ change_query_string(_tcbs_mode=None) }}"

--- a/webapp/crashstats/topcrashers/views.py
+++ b/webapp/crashstats/topcrashers/views.py
@@ -42,6 +42,7 @@ def get_topcrashers_stats(**kwargs):
         "is_garbage_collecting",
         "dom_fission_enabled",
         "process_type",
+        "report_type",
         "startup_crash",
         "_histogram.uptime",
         "_cardinality.install_time",
@@ -53,6 +54,9 @@ def get_topcrashers_stats(**kwargs):
 
     if params.get("process_type") in ("any", "all"):
         params["process_type"] = None
+
+    if params.get("report_type") in ("any", "all"):
+        params["report_type"] = None
 
     if range_type == "build":
         params["build_id"] = [
@@ -118,8 +122,10 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     result_count = form.cleaned_data["_facets_size"]
     tcbs_mode = form.cleaned_data["_tcbs_mode"]
     range_type = form.cleaned_data["_range_type"]
+    report_type = form.cleaned_data["_report_type"]
 
     range_type = "build" if range_type == "build" else "report"
+    report_type = report_type or "crash"
 
     if not tcbs_mode or tcbs_mode not in ("realtime", "byday"):
         tcbs_mode = "realtime"
@@ -196,6 +202,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         "result_count": str(result_count),
         "mode": tcbs_mode,
         "range_type": range_type,
+        "report_type": report_type,
         "end_date": end_date,
         "start_date": end_date - datetime.timedelta(days=days),
     }
@@ -205,6 +212,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         version=versions,
         platform=os_name,
         process_type=crash_type,
+        report_type=report_type,
         date=[
             "<" + end_date.isoformat(),
             ">=" + context["query"]["start_date"].isoformat(),


### PR DESCRIPTION
This adds a `report_type` field with values "crash" (the default) and "hang". It implements a processor rule to populate this field using heuristics we've been using for signature generation for a while. It also adjusts the Top Crasher report to allow users to filter on "report type" with values "any", "crash" (the default), and "hang".

This eases triage work by splitting the hang type crash reports from the crash type crash reports which are more actionable.