### PR TITLE
bug 1667997: change report_type default to "any"

### DIFF
--- a/webapp/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -58,7 +58,7 @@
               >Any</a>
             </li>
             <li>
-              <a href="{{ change_query_string(_report_type=None) }}"
+              <a href="{{ change_query_string(_report_type='crash') }}"
                  {% if query.report_type == 'crash' %} class="selected"{% endif %}
               >Crash</a>
             </li>

--- a/webapp/crashstats/topcrashers/tests/test_views.py
+++ b/webapp/crashstats/topcrashers/tests/test_views.py
@@ -289,12 +289,13 @@ class TestTopCrasherViews:
 
         url = reverse("topcrashers:topcrashers")
 
-        # Default yields report_type="crash"
+        # FIXME(willkg): default this to "crash" mid August 2023
+        # Default yields report_type="any"
         response = client.get(url, {"product": "Firefox", "version": "1.0"})
         assert response.status_code == 200
         print(response.content.decode("utf-8"))
         assert crashsignature in smart_str(response.content)
-        assert hangsignature not in smart_str(response.content)
+        assert hangsignature in smart_str(response.content)
 
         # Specify report_type="crash" does the same thing
         response = client.get(

--- a/webapp/crashstats/topcrashers/views.py
+++ b/webapp/crashstats/topcrashers/views.py
@@ -125,7 +125,8 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     report_type = form.cleaned_data["_report_type"]
 
     range_type = "build" if range_type == "build" else "report"
-    report_type = report_type or "crash"
+    # FIXME(willkg): default this to "crash" mid August 2023
+    report_type = report_type or "any"
 
     if not tcbs_mode or tcbs_mode not in ("realtime", "byday"):
         tcbs_mode = "realtime"


### PR DESCRIPTION
This changes the report_type default from "crash" which is what we eventually want to use to "any" which is less terrifying when there's no data in the search index with a report_type set.

Once we've accumulated several weeks of crash reports with report_type set, we can change the default back to "crash".