### PR TITLE
bug 1850428: rework stackwalker execution and timeout

### DIFF
--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -286,8 +286,7 @@ STACKWALKER = {
         doc="Aboslute path to the stackwalker binary.",
     ),
     "command_line": (
-        "timeout --signal KILL {kill_timeout} "
-        + "{command_path} "
+        "{command_path} "
         + "--evil-json={raw_crash_path} "
         + "--symbols-cache={symbol_cache_path} "
         + "--symbols-tmp={symbol_tmp_path} "

--- a/socorro/tests/processor/rules/test_breakpad.py
+++ b/socorro/tests/processor/rules/test_breakpad.py
@@ -12,6 +12,7 @@ import pytest
 from socorro.lib.libsocorrodataschema import get_schema, validate_instance
 from socorro.processor.pipeline import Status
 from socorro.processor.rules.breakpad import (
+    execute_process,
     CrashingThreadInfoRule,
     MinidumpSha256HashRule,
     MinidumpStackwalkRule,
@@ -166,6 +167,20 @@ canonical_stackwalker_output = {
     # ...
 }
 canonical_stackwalker_output_str = json.dumps(canonical_stackwalker_output)
+
+
+def test_execute_process():
+    ret = execute_process("echo foo")
+    assert ret["stdout"] == b"foo\n"
+    assert ret["stderr"] == b""
+    assert ret["returncode"] == 0
+
+
+def test_execute_process_timeout():
+    ret = execute_process("sleep 10", timeout=1)
+    assert ret["stdout"] == b""
+    assert ret["stderr"] == b""
+    assert ret["returncode"] == -9
 
 
 class TestCrashingThreadInfoRule:


### PR DESCRIPTION
This reworks how we run the stackwalker. Previously, it was run using the timeout gnu coreutils command which would kill the stackwalker process after some timeout if it was still running.

processor -> timeout -> stackwalker

Now it runs the stackwalker using the timeout argument to subprocess.run() and subprocess.run() keeps track of time using threads. This removes an intermediary process and a possibility for the stackwalker process to get orphaned.

processor -> stackwalker