### PR TITLE
bug 1847429: implement signature generation for JavaException

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -391,12 +391,10 @@ class DatesAndTimesRule(Rule):
 
 
 class JavaProcessRule(Rule):
-    """Move Java-crash-related bits over."""
+    """Process JavaStackTrace."""
 
     def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
-        return bool(raw_crash.get("JavaStackTrace", None)) or bool(
-            raw_crash.get("JavaException", None)
-        )
+        return bool(raw_crash.get("JavaStackTrace", None))
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         if "JavaStackTrace" in raw_crash:

--- a/socorro/schemas/raw_crash.schema.yaml
+++ b/socorro/schemas/raw_crash.schema.yaml
@@ -609,13 +609,14 @@ properties:
 
   JavaException:
     data_reviews:
-      - unknown
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1671654#c1
     description: |
       JSON structured Java stack trace, only present on Firefox for Android if
       we encounter an uncaught Java exception.
 
       Parts of the JSON structure can contain sensitive data.
     bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1671654
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1675560
     type: string
     permissions: ["protected"]

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -547,9 +547,9 @@ class JavaExceptionSignatureTool:
         else:
             exc_class = exc_type
 
-        frames = stacktrace.get("frames", [])
-        normalized_frames = [self.normalize_frame(frame) for frame in frames]
+        frames = stacktrace.get("frames") or []
         if frames:
+            normalized_frames = [self.normalize_frame(frame) for frame in frames]
             signature = f"{exc_class}: at {normalized_frames[0]}"
         else:
             signature = f"{exc_class}"

--- a/socorro/signature/schema.rst
+++ b/socorro/signature/schema.rst
@@ -1,0 +1,177 @@
+Signature generation crash data schema
+======================================
+
+This is the schema for the signature generation crash data structure::
+
+  {
+    platform: <string>,                // Optional, the platform for the crash. Currently one of
+                                       // "c" or "java". Defaults to "c".
+                                       //
+                                       // These match Sentry platform values.
+
+    crashing_thread: <int or null>,    // Optional, The index of the crashing thread in threads.
+                                       // This defaults to None which indicates there was no
+                                       // crashing thread identified in the crash report.
+                                       //
+                                       // Platform: c
+
+    reason: <string>,                  // Optional, The crash_info type value. This can indicate
+                                       // the crash was a OOM.
+                                       //
+                                       // Platform: c
+
+    os: <string>,                      // Optional, The name of the operating system. This
+                                       // doesn't affect anything unless the name is "Windows
+                                       // NT" in which case it will lowercase module names when
+                                       // iterating through frames to build the signature.
+                                       //
+                                       // Platform: c
+
+    threads: <threads_structure>,      // Optional, list of stack traces for c/c++/rust code.
+                                       //
+                                       // Platform: c
+
+    java_stack_trace: <string>,        // Optional, If the crash is a Java crash, then this will
+                                       // be the Java traceback as a single string. Signature
+                                       // generation will split this string into lines and then
+                                       // extract frame information from it to generate the
+                                       // signature.
+                                       //
+                                       // Platform: java
+
+                                       // FIXME(willkg): Write up better description of this.
+
+    java_exception: <java_exception_structure>,
+                                       // Optional, the exception structure.
+                                       //
+                                       // For Java crashes with a JavaException annotation, this
+                                       // will be the value.
+
+    oom_allocation_size: <int>,        // Optional, The allocation size that triggered an
+                                       // out-of-memory error. This will get added to the
+                                       // signature if one of the indicator functions appears in
+                                       // the stack of the crashing thread.
+
+    abort_message: <string>,           // Optional, The abort message for the crash, if there is
+                                       // one. This is added to the beginning of the signature.
+
+    hang_type: <int>,                  // Optional.
+                                       // 1 here indicates this is a chrome hang and we look at
+                                       // thread 0 for generation.
+                                       // -1 indicates another kind of hang.
+
+    async_shutdown_timeout: <text>,    // Optional, This is a text field encoded in JSON with
+                                       // "phase" and "conditions" keys.
+                                       // FIXME(willkg): Document this structure better.
+
+    jit_category: <string>,            // Optional, If there's a JIT classification in the
+                                       // crash, then that will override the signature
+
+    ipc_channel_error: <string>,       // Optional, If there is an IPC channel error, it
+                                       // replaces the signature.
+
+    ipc_message_name: <string>,        // Optional, This gets added to the signature if there
+                                       // was an IPC message name in the crash.
+
+    additional_minidumps: <string>,    // Optional, A crash report can contain multiple minidumps.
+                                       // This is a comma-delimited list of minidumps other than
+                                       // the main one that the crash had.
+
+                                       // Example: "browser,flash1,flash2,content"
+
+    mdsw_status_string: <string>,      // Optional, Socorro-generated
+                                       // This is the minidump-stackwalk status string. This
+                                       // gets generated when the Socorro processor runs the
+                                       // minidump through minidump-stackwalk. If you're not
+                                       // using minidump-stackwalk, you can ignore this.
+
+    moz_crash_reason: <string>,        // Optional, This is the MOZ_CRASH_REASON value. This
+                                       // doesn't affect anything unless the value is
+                                       // "MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)".
+  }
+
+
+Thread structure (c platform only)::
+
+  [
+    {
+      frames: [                        // List of one or more frames.
+        {
+          function: <string>,          // Optional, the name of the function.
+                                       // If this is ``None`` or not in the frame, then signature
+                                       // generation will calculate something using other data in
+                                       // the frame.
+
+          module: <string>,            // Optional, name of the module
+          file: <string>,              // Optional, name of the file
+          line: <int>,                 // Optional, line in the file
+          module_offset: <string>,     // Optional, offset in hex in the module for this frame
+          offset: <string>             // Optional, offset in hex for this frame
+
+                                       // Signature parts are computed using frame data in this
+                                       // order:
+
+                                       // 1. if there's a function (and optionally line)--use
+                                       //    that
+                                       // 2. if there's a file and a line--use that
+                                       // 3. if there's an offset and no module/module_offset--use
+                                       //    that
+                                       // 4. use module/module_offset
+        }
+        // ... additional frames
+      ],
+
+      thread_name: <string>,           // Optional, The name of the thread.
+                                       // This isn't used, yet, but might be in the future for
+                                       // debugging purposes.
+
+      frame_count: <int>               // Optional, This is the total number of frames. This
+                                       // isn't used.
+    }
+    // ... additional threads
+  ],
+
+
+Java exception structure::
+
+  {
+    exception: {                       // Exception
+
+      values: [                        // Exception value--there will be multiple values in a
+                                       // cascading exception in order of oldest to newest where
+                                       // the start of the cascade if first.
+
+        stacktrace: {                  // A stacktrace.
+
+          frames: [                    // A list of frames in the stack trace sorted newest
+                                       // to oldest so that the first frame is then one that
+                                       // had the exception.
+            {
+              module: <string>,        // Optional, name of the module
+
+              function: <string>,      // Optional, the name of the function
+
+              in_app: <boolean>,       // Optional, whether this frame is relevant to the
+                                       // execution of the relevant code in the app.
+
+              lineno: <int>,           // Optional, line in the file
+
+              filename: <string>,      // Optional, name of the file
+            },
+            // ... additional frames
+          ],
+
+          type: <string>,              // Optional, exception type
+
+          module: <string>,            // Optional, module the exception lives in
+
+          value: <string>              // Optional, exception value
+        },
+        // ... additional stacktraces
+      ]
+    }
+  }
+
+
+Missing keys in the structure are treated as ``None``, so you can pass in a
+minimal structure with just the parts you define.

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -68,18 +68,6 @@ def convert_to_crash_data(processed_crash):
 
     """
     crash_data = {
-        # JavaStackTrace or None
-        "java_stack_trace": glom(processed_crash, "java_stack_trace", default=None),
-        # int or None
-        "crashing_thread": glom(
-            processed_crash, "json_dump.crash_info.crashing_thread", default=None
-        ),
-        # string or None
-        "reason": glom(processed_crash, "json_dump.crash_info.type", default=None),
-        # list of CStackTrace or None
-        "threads": glom(processed_crash, "json_dump.threads", default=None),
-        # text or None
-        "os": glom(processed_crash, "json_dump.system_info.os", default=None),
         # text or None
         "hang": glom(processed_crash, "hang", default=None),
         # int or None
@@ -114,6 +102,33 @@ def convert_to_crash_data(processed_crash):
         # pull out the original signature if there was one
         "original_signature": glom(processed_crash, "signature", default=""),
     }
+
+    # Add platform-specific data for stacks
+
+    if "json_dump" in processed_crash:
+        # int or None
+        crash_data["crashing_thread"] = glom(
+            processed_crash, "json_dump.crash_info.crashing_thread", default=None
+        )
+        # string or None
+        crash_data["reason"] = glom(
+            processed_crash, "json_dump.crash_info.type", default=None
+        )
+        # list of CStackTrace or None
+        crash_data["threads"] = glom(processed_crash, "json_dump.threads", default=None)
+        # text or None
+        crash_data["os"] = glom(
+            processed_crash, "json_dump.system_info.os", default=None
+        )
+
+    if "java_exception" in processed_crash:
+        # java_exception structure or {}
+        crash_data["java_exception"] = glom(processed_crash, "java_exception")
+
+    if "java_stack_trace" in processed_crash:
+        # java_stack_trace string or None
+        crash_data["java_stack_trace"] = glom(processed_crash, "java_stack_trace")
+
     return crash_data
 
 


### PR DESCRIPTION
When there's no `JavaStackTrace` annotation, but there is a `JavaException` annotation, this will kick in and generate a signature that matches what it would look like if it came from the `JavaStackTrace` annotation.

The code is a little over-engineered, but gets us a step closer to changing the format for Java signatures to be more like the C signatures and to allow us to iterate over more than the first frame and include/ignore them like we do with C signatures.

This also moves the schema for the signature generation crash data structure to the socorro repository.