### PR TITLE
Remove timeout from bin/run_mdsw.sh

### DIFF
--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -18,6 +18,7 @@ STACKWALKER="/stackwalk-rust/minidump-stackwalk"
 
 # This will pull symbols from the symbols server
 SYMBOLS="--symbols-url=https://symbols.mozilla.org"
+# SYMBOLS="--symbols-url=https://symbols.stage.mozaws.net"
 
 # This will pull symbols from disk
 # SYMBOLS="--symbols-path=/app/symbols/
@@ -46,7 +47,7 @@ do
     # Find the raw crash file
     RAWCRASHFILE=$(find ${DATADIR}/v1/raw_crash/ -name $CRASHID -type f)
 
-    timeout -s KILL 600 "${STACKWALKER}" \
+    "${STACKWALKER}" \
         --evil-json=$RAWCRASHFILE \
         --symbols-cache=/tmp/symbols/cache \
         --symbols-tmp=/tmp/symbols/tmp \


### PR DESCRIPTION
We no longer use timeout when running the stackwalker. This removes it from the bin/run_mdsw.sh script we use for testing/development.