### PR TITLE
bug 1851884: generalize to catch all psutil errors

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -314,7 +314,9 @@ class ProcessorApp:
                     open_files_count = len(proc.open_files())
                     proc_status = proc.status()
 
-                except psutil.AccessDenied:
+                except psutil.Error:
+                    # For any psutil error, we want to track that we saw a process, but
+                    # the details don't matter
                     proc_type = "unknown"
                     proc_status = "unknown"
                     open_files_count = 0


### PR DESCRIPTION
This generalizes the exception handling to catch all psutil errors. There are a lot of race conditions that can happen during the course of the loop so for now we want to keep track of processes generally, but not sweat the details when a race condition happens.