### PR TITLE
bug 1853662: update stackwalker to 0.18.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # =========================================================================
 
 # https://hub.docker.com/_/python
-FROM python:3.9.16-slim@sha256:e23b65d2ed7cbb4f9975bcc46421470ca670e8e47744fe4b03eb94d39311ad24
+FROM python:3.9.18-slim@sha256:08a6a1666ddebe94becbec1986235cb8c321d2f7a7fd00f614befba5c1f23e67
 
 # Set up user and group
 ARG groupid=10001

--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230503.0/socorro-stackwalker.2023-04-27.v0.16.0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230927.0/socorro-stackwalker.2023-09-18.v0.18.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"
@@ -32,6 +32,9 @@ mkdir -p "${TARGETDIR}" || true
 cp build/bin/minidump-stackwalk "${TARGETDIR}"
 cp build/stackwalk.version.json "${TARGETDIR}/minidump-stackwalk.version.json"
 ls -l "${TARGETDIR}"
+
+# Make sure it runs and reports version
+${TARGETDIR}/minidump-stackwalk --version
 
 # Clean up
 popd

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -18,7 +18,6 @@ PACKAGES_TO_INSTALL=(
 
     # For building Python libraries
     build-essential
-    python-dev
     libpq-dev
     libxml2-dev libxslt1-dev
     libsasl2-dev


### PR DESCRIPTION
- bug 1853662: update stackwalker to 0.18.0 (v20230927.0)
- bug 1863662: update to python:3.9.18-slim base image
