### PR TITLE
bug 1853662: downgrade to python:3.9.18-slim-bullseye

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # =========================================================================
 
 # https://hub.docker.com/_/python
-FROM python:3.9.18-slim-bookworm@sha256:08a6a1666ddebe94becbec1986235cb8c321d2f7a7fd00f614befba5c1f23e67
+FROM python:3.9.18-slim-bullseye@sha256:d09e0452f6fe44e662af689b379991cb3b21af72476a4e8b5fe54e07b6af4535
 
 # Set up user and group
 ARG groupid=10001

--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230927.0/socorro-stackwalker.2023-09-18.v0.18.0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230928.0/socorro-stackwalker.2023-09-18.v0.18.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This downgrades the base image from bookworm to bullseye. It pulls in a
stackwalker built with bullseye so we don't have a glibc version
problem.
