### PR TITLE
bug 1858717: switch stackwalker to use output file

### DIFF
--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -291,6 +291,8 @@ STACKWALKER = {
         + "--symbols-cache={symbol_cache_path} "
         + "--symbols-tmp={symbol_tmp_path} "
         + "--no-color "
+        + "--output-file={output_path} "
+        + "--log-file={log_path} "
         + "{symbols_urls} "
         + "--json "
         + "--verbose=error "

--- a/socorro/tests/processor/rules/test_breakpad.py
+++ b/socorro/tests/processor/rules/test_breakpad.py
@@ -823,6 +823,13 @@ class TestMinidumpStackwalkRule:
                     stderr=b"",
                 )
 
+                # We mocked the subprocess, so we have to generate the output files we're
+                # expecting.
+                output_path = tmp_path / f"{example_uuid}.{rule.dump_field}.json"
+                output_path.write_text(MINIMAL_STACKWALKER_OUTPUT_STR)
+                log_path = tmp_path / f"{example_uuid}.{rule.dump_field}.log"
+                log_path.write_text("")
+
                 rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
             expected_output = copy.deepcopy(MINIMAL_STACKWALKER_OUTPUT)
@@ -899,6 +906,13 @@ class TestMinidumpStackwalkRule:
             mock_subprocess.run.return_value = ProcessCompletedMock(
                 returncode=-1, stdout=b"{ff", stderr=b"boo hiss"
             )
+
+            # We mocked the subprocess, so we have to generate the output files we're
+            # expecting.
+            output_path = tmp_path / f"{example_uuid}.{rule.dump_field}.json"
+            output_path.write_text("{ff")
+            log_path = tmp_path / f"{example_uuid}.{rule.dump_field}.log"
+            log_path.write_text("boo hiss")
 
             rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 


### PR DESCRIPTION
This switches the way Socorro runs the stackwalker to use an output file for output (previously used stdout) and a log file for error output (previously used stderr). This simplifies the code plus it makes it easier to differentiate between the output artifact and stackwalker logging.

This fixes the problem with bin/run_mdsw.sh where it didn't create the symbols cache directories before running the stackwalker. Now it does.

This also changes `bin/run_mdsw.sh` to use `--verbose=debug` since we're likely using it to debug stackwalker issues.