### PR TITLE
bug 1746940: update stackwalker to v20231013.0 with codeinfo lookup

### DIFF
--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -18,7 +18,7 @@ STACKWALKER="/stackwalk-rust/minidump-stackwalk"
 SYMBOLSCACHE="/tmp/symbols"
 
 # This will pull symbols from the symbols server
-SYMBOLS="--symbols-url=https://symbols.mozilla.org"
+SYMBOLS="--symbols-url=https://symbols.mozilla.org/try"
 # SYMBOLS="--symbols-url=https://symbols.stage.mozaws.net"
 
 # This will pull symbols from disk
@@ -52,8 +52,8 @@ do
 
     "${STACKWALKER}" \
         --evil-json="${RAWCRASHFILE}" \
-        --symbols-cache=/tmp/symbols/cache \
-        --symbols-tmp=/tmp/symbols/tmp \
+        --symbols-cache="${SYMBOLSCACHE}/cache" \
+        --symbols-tmp="${SYMBOLSCACHE}/tmp/symbols/tmp" \
         --no-color \
         ${SYMBOLS} \
         --output-file="${CRASHID}.dump.json" \

--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20230928.0/socorro-stackwalker.2023-09-18.v0.18.0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20231013.0/socorro-stackwalker.2023-10-13.1869d3a0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This updates the stackwalker to v20231013.0 which is rust-minidump v0.18.0 plus:

* the codeinfo lookup fix (this bug)
* drop ThreadIdNameMapping fix
* pub-file-lookup fix