### PR TITLE
Update Django to 3.2.23

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -75,7 +75,7 @@ importlib_resources==6.1.0
 django-waffle==2.3.0
 
 # NOTE(willkg): We stick with LTS releases and the next one is 4.2 (2023).
-django==3.2.22
+django==3.2.23
 
 # NOTE(willkg): Need to keep elasticsearch and elasticsearch-dsl at these versions
 # because they work with the cluster we're using

--- a/requirements.txt
+++ b/requirements.txt
@@ -193,9 +193,9 @@ dj-database-url==2.0.0 \
     --hash=sha256:9c9e5f7224f62635a787e9cc3c6762c9be2b19541a21e3c08fa573bd01609b4b \
     --hash=sha256:a35a9f0f43775ca6f90d819dc456233ef7bcc76b47377d5d908b75c7eb320624
     # via -r requirements.in
-django==3.2.22 \
-    --hash=sha256:83b6d66b06e484807d778263fdc7f9186d4dc1862fcfa6507830446ac6b060ba \
-    --hash=sha256:c5e7b668025a6e06cad9ba6d4de1fd1a21212acebb51ea34abb400c6e4d33430
+django==3.2.23 \
+    --hash=sha256:82968f3640e29ef4a773af2c28448f5f7a08d001c6ac05b32d02aeee6509508b \
+    --hash=sha256:d48608d5f62f2c1e260986835db089fa3b79d6f58510881d316b8d88345ae6e1
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
This updates Django to 3.2.23 to pick up a security fix.

https://www.djangoproject.com/weblog/2023/nov/01/security-releases/