### PR TITLE
bug-1799125: switch from urllib.parse's urlparse to urlsplit

### DIFF
--- a/bin/service-status.py
+++ b/bin/service-status.py
@@ -24,7 +24,7 @@ import argparse
 import json
 import os
 import sys
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import requests
 
@@ -212,7 +212,7 @@ def main():
         commit = resp["commit"]
         tag = resp.get("version") or "(none)"
 
-        parsed = urlparse(resp["source"])
+        parsed = urlsplit(resp["source"])
         _, user, repo = parsed.path.split("/")
         service_name = repo
         out.row(service_name, "version", commit, tag)

--- a/bin/waitfor.py
+++ b/bin/waitfor.py
@@ -15,7 +15,7 @@ import argparse
 import socket
 import urllib.error
 import urllib.request
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlsplit
 import sys
 import time
 
@@ -41,12 +41,12 @@ def main(args):
     ok_codes = [int(code.strip()) for code in parsed.codes.split(",")]
 
     url = parsed.url
-    parsed_url = urlparse(url)
+    parsed_url = urlsplit(url)
     if "@" in parsed_url.netloc:
         netloc = parsed_url.netloc
         netloc = netloc[netloc.find("@") + 1 :]
         parsed_url = parsed_url._replace(netloc=netloc)
-        url = urlunparse(parsed_url)
+        url = parsed_url.geturl()
 
     if parsed.verbose:
         print(

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -9,7 +9,7 @@ import gzip
 import json
 import re
 from typing import Any
-from urllib.parse import unquote_plus, urlparse, urlunparse
+from urllib.parse import unquote_plus, urlsplit
 from zlib import error as ZlibError
 
 from glom import glom
@@ -1021,7 +1021,7 @@ class ModuleURLRewriteRule(Rule):
                 continue
 
             url = module["symbol_url"]
-            parsed = urlparse(url)
+            parsed = urlsplit(url)
 
             if "localhost" in parsed.netloc:
                 # If this is a localhost url, then remove it.
@@ -1033,7 +1033,7 @@ class ModuleURLRewriteRule(Rule):
             if "symbols.mozilla.org" in parsed.netloc:
                 # If this is a symbols.mozilla.org url, remove the querystring.
                 parsed = parsed._replace(query="")
-                module["symbol_url"] = urlunparse(parsed)
+                module["symbol_url"] = parsed.geturl()
 
 
 class DistributionIdRule(Rule):

--- a/socorro/schemas/validate_telemetry_socorro_crash.py
+++ b/socorro/schemas/validate_telemetry_socorro_crash.py
@@ -8,7 +8,7 @@
 
 import json
 import os
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import click
 import jsonschema
@@ -106,7 +106,7 @@ def validate_and_test(ctx, crashes_per_url, url):
             # To make it easy for people, if someone pastes the URL
             # of a regular SuperSearch page (and not the API URL), then
             # automatically convert it for them.
-            parsed = urlparse(url)
+            parsed = urlsplit(url)
             if parsed.path == "/search/":
                 parsed = parsed._replace(path="/api/SuperSearch/")
                 parsed = parsed._replace(fragment=None)

--- a/socorro/scripts/db.py
+++ b/socorro/scripts/db.py
@@ -7,7 +7,7 @@
 # Usage: ./bin/db.py CMD
 
 import os
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import click
 import psycopg2
@@ -34,7 +34,7 @@ def create_database(ctx):
     if not dsn:
         raise click.ClickException("DATABASE_URL is not defined in environment")
 
-    parsed = urlparse(dsn)
+    parsed = urlsplit(dsn)
     db_name = parsed.path[1:]
     adjusted_dsn = dsn[: -(len(db_name) + 1)]
 
@@ -56,7 +56,7 @@ def drop_database(ctx):
     if not dsn:
         raise click.ClickException("DATABASE_URL is not defined in environment")
 
-    parsed = urlparse(dsn)
+    parsed = urlsplit(dsn)
     db_name = parsed.path[1:]
     adjusted_dsn = dsn[: -(len(db_name) + 1)]
 

--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -5,7 +5,7 @@
 import argparse
 import datetime
 from functools import total_ordering
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlsplit, parse_qs
 
 from socorro.lib.libdatetime import utc_now
 from socorro.lib.librequests import session_with_retries
@@ -115,7 +115,7 @@ def fetch_crashids(host, params, num_results):
 
 def extract_params(url):
     """Parses out params from the query string and drops any that start with _"""
-    parsed = urlparse(url)
+    parsed = urlsplit(url)
     params = parse_qs(parsed.query)
 
     for key in list(params.keys()):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -6,7 +6,7 @@
 import contextlib
 import copy
 import re
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from glom import glom, assign
 
@@ -411,7 +411,7 @@ def parse_crashid(item):
         return item[3:]
 
     if item.startswith("http"):
-        parsed = urlparse(item)
+        parsed = urlsplit(item)
         path = parsed.path
         if path.startswith("/report/index"):
             crash_id = path.split("/")[-1]

--- a/webapp/crashstats/crashstats/decorators.py
+++ b/webapp/crashstats/crashstats/decorators.py
@@ -4,7 +4,7 @@
 
 import functools
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import markus
 from markus.utils import generate_tag
@@ -155,7 +155,7 @@ def track_view(view):
         if referer:
             # If the referer host is the same as the request host that implies that the
             # API was used as an AJAX request in our main webapp itself.
-            referer_host = urlparse(referer).netloc
+            referer_host = urlsplit(referer).netloc
             if referer_host == request.headers.get("Host"):
                 is_ajax = True
 

--- a/webapp/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -4,7 +4,7 @@
 
 import datetime
 import time
-from urllib.parse import quote_plus, parse_qs, urlparse
+from urllib.parse import quote_plus, parse_qs, urlsplit
 
 import pytest
 
@@ -139,7 +139,7 @@ class Test_generate_create_bug_url:
 
     @staticmethod
     def _extract_query_string(url):
-        return parse_qs(urlparse(url).query)
+        return parse_qs(urlsplit(url).query)
 
     @staticmethod
     def _create_frame(

--- a/webapp/crashstats/crashstats/tests/test_models.py
+++ b/webapp/crashstats/crashstats/tests/test_models.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import random
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlsplit, parse_qs
 from unittest import mock
 
 import pytest
@@ -296,7 +296,7 @@ class TestMiddlewareModels(DjangoTestCase):
 
         def mocked_get(url, **options):
             assert url.startswith(settings.BZAPI_BASE_URL)
-            parsed = urlparse(url)
+            parsed = urlsplit(url)
             query = parse_qs(parsed.query)
             assert query["include_fields"] == ["summary,status,id,resolution"]
             return Response(

--- a/webapp/crashstats/manage/admin.py
+++ b/webapp/crashstats/manage/admin.py
@@ -4,7 +4,7 @@
 
 import json
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import requests
 
@@ -31,7 +31,7 @@ def site_status(request):
     # Get version information for deployed parts
     version_info = {}
     for url in settings.OVERVIEW_VERSION_URLS.split(","):
-        hostname = urlparse(url).netloc
+        hostname = urlsplit(url).netloc
         url = url.strip()
         try:
             data = requests.get(url).json()

--- a/webapp/crashstats/sources/views.py
+++ b/webapp/crashstats/sources/views.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
@@ -53,7 +53,7 @@ def highlight_url(request):
     if not url:
         return HttpResponseBadRequest("No url specified.")
 
-    parsed = urlparse(url)
+    parsed = urlsplit(url)
 
     # We will only pull urls from allowed hosts
     if parsed.netloc not in ALLOWED_SOURCE_HOSTS:


### PR DESCRIPTION
and from `urllib.parse.urlunparse` to `urllib.parse.SplitResult.geturl` instead of `urllib.parse.urlunsplit` so that we consistently use `geturl` instead of a mix of both