### PR TITLE
bug-1862204: add missing_symbols field

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1617,6 +1617,18 @@ FIELDS = {
         "query_type": "string",
         "storage_mapping": {"type": "string"},
     },
+    "missing_symbols": {
+        "data_validation_type": "str",
+        "form_field_choices": [],
+        "has_full_version": False,
+        "in_database_name": "missing_symbols",
+        "is_exposed": True,
+        "is_returned": True,
+        "name": "missing_symbols",
+        "namespace": "processed_crash",
+        "query_type": "string",
+        "storage_mapping": {"analyzer": "semicolon_keywords", "type": "string"},
+    },
     "modules_in_stack": {
         "data_validation_type": "str",
         "form_field_choices": [],

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -34,6 +34,7 @@ from socorro.processor.rules.mozilla import (
     FenixVersionRewriteRule,
     JavaProcessRule,
     MajorVersionRule,
+    MissingSymbolsRule,
     ModulesInStackRule,
     ModuleURLRewriteRule,
     MacCrashInfoRule,
@@ -104,6 +105,7 @@ DEFAULT_RULESET = [
     OSPrettyVersionRule(),
     TopMostFilesRule(),
     ModulesInStackRule(),
+    MissingSymbolsRule(),
     ThemePrettyNameRule(),
     MemoryReportExtraction(),
     # generate signature now that we've done all the processing it depends on

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -654,13 +654,10 @@ class MissingSymbolsRule(Rule):
         return f"{filename}/{version}/{debugid}"
 
     def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
-        return "json_dump" in processed_crash
+        return bool(glom(processed_crash, "json_dump.modules", default=[]))
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
-        modules = processed_crash["json_dump"].get("modules")
-
-        if not modules:
-            return
+        modules = processed_crash["json_dump"]["modules"]
 
         missing_symbols = [
             self.format_module(module)

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2759,6 +2759,12 @@ properties:
       hash for an empty 0-bytes minidump.
     type: ["string", "null"]
     permissions: ["public"]
+  missing_symbols:
+    description: >
+      Set of `;` delimited `module/version/debugid` strings of modules that the
+      stackwalker couldn't find symbols for.
+    type: string
+    permissions: ["public"]
   modules_in_stack:
     description: >
       Set of `;` delimited `module/debugid` strings of modules that are in the

--- a/socorro/tests/conftest.py
+++ b/socorro/tests/conftest.py
@@ -11,6 +11,7 @@ import io
 import logging
 import os
 import pathlib
+import uuid
 import sys
 
 import boto3
@@ -77,6 +78,19 @@ def caplogpp(caplog):
 
     for logger in changed_loggers:
         logger.propagate = False
+
+
+class DebugIdHelper:
+    """Breakpad debug id helper class."""
+
+    def generate(self):
+        """Returns 33-character uppercase hex string"""
+        return uuid.uuid4().hex.upper() + "A"
+
+
+@pytest.fixture
+def debug_id_helper():
+    yield DebugIdHelper()
 
 
 class S3Helper:

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -26,6 +26,7 @@ from socorro.processor.rules.mozilla import (
     JavaProcessRule,
     MacCrashInfoRule,
     MajorVersionRule,
+    MissingSymbolsRule,
     ModulesInStackRule,
     ModuleURLRewriteRule,
     MozCrashReasonRule,
@@ -1437,6 +1438,107 @@ class TestTopMostFilesRule:
         rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
 
         assert "topmost_filenames" not in processed_crash
+
+
+def generate_debug_id():
+    """Generates a valid debug id."""
+
+
+class TestMissingSymbolsRule:
+    def test_basic(self, tmp_path, debug_id_helper):
+        raw_crash = {}
+        dumps = {}
+        debug_id_1 = debug_id_helper.generate()
+        debug_id_2 = debug_id_helper.generate()
+        debug_id_3 = debug_id_helper.generate()
+        debug_id_4 = debug_id_helper.generate()
+        processed_crash = {
+            "json_dump": {
+                "modules": [
+                    {
+                        "filename": "libxul.dll",
+                        "version": None,
+                        "debug_id": debug_id_1,
+                        "missing_symbols": True,
+                    },
+                    {
+                        "filename": "libnss3.dll",
+                        "version": "1.0",
+                        "debug_id": debug_id_2,
+                        "missing_symbols": True,
+                    },
+                    {
+                        "filename": "mozglue.dll",
+                        "debug_id": debug_id_3,
+                        "missing_symbols": None,
+                    },
+                    {
+                        "filename": "somethingmozglue.dll",
+                        "debug_id": debug_id_4,
+                        "missing_symbols": False,
+                    },
+                ],
+            },
+        }
+        status = Status()
+
+        rule = MissingSymbolsRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert (
+            processed_crash["missing_symbols"]
+            == f"libnss3.dll/1.0/{debug_id_2};libxul.dll/None/{debug_id_1}"
+        )
+
+    @pytest.mark.parametrize(
+        "processed_crash",
+        [
+            {},
+            {"modules": None},
+            {"modules": []},
+            {"modules": [{}]},
+            {"modules": [{"missing_symbols": True}]},
+            {"modules": [{"filename": "libxul.dll"}]},
+            {"modules": [{"filename": "libxul.dll", "version": "1.0"}]},
+        ],
+    )
+    def test_missing_things(self, tmp_path, processed_crash):
+        status = Status()
+        rule = MissingSymbolsRule()
+
+        rule.act({}, {}, processed_crash, str(tmp_path), status)
+        assert "missing_symbols" not in processed_crash
+
+    @pytest.mark.parametrize(
+        "item, expected",
+        [
+            (
+                {"filename": "libxul.so", "missing_symbols": True},
+                "libxul.so/None/" + MissingSymbolsRule.NULL_DEBUG_ID,
+            ),
+            (
+                {
+                    "filename": "libxul_2.dll",
+                    "version": "1.0",
+                    "debug_id": "51C36FAFFD214DB4A0D91D93B38336CEA",
+                    "missing_symbols": True,
+                },
+                "libxul_2.dll/1.0/51C36FAFFD214DB4A0D91D93B38336CEA",
+            ),
+            (
+                {
+                    "filename": " l\nib (foo)",
+                    "version": "1.0/5",
+                    "debug_id": "this is bad",
+                    "missing_symbols": True,
+                },
+                "libfoo/1.0\\/5/bad",
+            ),
+        ],
+    )
+    def test_format_module(self, item, expected):
+        rule = MissingSymbolsRule()
+        assert rule.format_module(item) == expected
 
 
 class TestModulesInStackRule:

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -1440,10 +1440,6 @@ class TestTopMostFilesRule:
         assert "topmost_filenames" not in processed_crash
 
 
-def generate_debug_id():
-    """Generates a valid debug id."""
-
-
 class TestMissingSymbolsRule:
     def test_basic(self, tmp_path, debug_id_helper):
         raw_crash = {}

--- a/socorro/tests/schemas/test_socorro_data_schemas.py
+++ b/socorro/tests/schemas/test_socorro_data_schemas.py
@@ -524,6 +524,7 @@ PUBLIC_PROCESSED_CRASH_FIELDS = {
     "memory_measures.vsize",
     "memory_measures.vsize_max_contiguous",
     "minidump_sha256_hash",
+    "missing_symbols",
     "modules_in_stack",
     "moz_crash_reason",
     "oom_allocation_size",


### PR DESCRIPTION
This adds a missing_symbols field to the processed crash and the search index.

This field is a `;` delimited list of "filename/version/debugid" tuples.

This is generated from the json_dump.modules list of modules that have a "filename" and "missing_symbols=True". "missing_symbols=True" indicates that the stackwalker was unable to find a symbols file at the time it was processing the minidump.

Because I'm working with debug ids, I decided to add a debug_id_helper pytest fixture for creating valid debug ids.

To test:

1. download some crash reports and process them
2. go to supersearch and do a facet on "missing symbols"

Unless you're really lucky, there should be one or two missing symbols.

![image](https://github.com/mozilla-services/socorro/assets/820826/efb6dc9d-b792-42cc-93e8-108af3d3ef0c)
