### PR TITLE
bug-1873658: fix params parsing date=>=2024-01-10 bug

### DIFF
--- a/webapp/crashstats/crashstats/static/crashstats/js/socorro/utils.js
+++ b/webapp/crashstats/crashstats/static/crashstats/js/socorro/utils.js
@@ -184,6 +184,7 @@
         var params = {};
         var queries;
         var temp;
+        var firstEquals;
         var i;
         var len;
 
@@ -197,7 +198,8 @@
 
         // Convert the array of strings into an object
         for (i = 0; i < len; i++) {
-          temp = queries[i].split('=');
+          firstEquals = queries[i].indexOf('=');
+          temp = [queries[i].slice(0, firstEquals), queries[i].slice(firstEquals + 1)];
           var key = temp[0];
           var value = decodeURIComponent(temp[1]);
 


### PR DESCRIPTION
This fixes a bug that occurs when breaking up the querystring into key=val parameters when the value has an = in it. Instead of dropping everything after the second = from the value, this takes more care to split on the first = and ensures everything after that is part of the value.

Before this fix, something like this kicks up a JS error in the console and prevents the page from fetching search results:

http://localhost:8000/search/?date=%3E=2024-01-09&date=%3C2024-01-10#crash-reports

After this fix, the params are parsed correctly, the from date is filled in, and search results show correctly.