### PR TITLE
bug-1812771: clean up processor rules for java/android things

### DIFF
--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -20,6 +20,7 @@ from socorro.processor.rules.general import (
     IdentifierRule,
     OSInfoRule,
 )
+from socorro.processor.rules.java import JavaStackTraceRule
 from socorro.processor.rules.memory_report_extraction import MemoryReportExtraction
 from socorro.processor.rules.mozilla import (
     AccessibilityRule,
@@ -32,7 +33,6 @@ from socorro.processor.rules.mozilla import (
     DistributionIdRule,
     ESRVersionRewrite,
     FenixVersionRewriteRule,
-    JavaProcessRule,
     MajorVersionRule,
     MissingSymbolsRule,
     ModulesInStackRule,
@@ -91,7 +91,7 @@ DEFAULT_RULESET = [
     OutOfMemoryBinaryRule(),
     PHCRule(),
     BreadcrumbsRule(schema=get_schema("processed_crash.schema.yaml")),
-    JavaProcessRule(),
+    JavaStackTraceRule(),
     MacBootArgsRule(),
     MacCrashInfoRule(),
     MozCrashReasonRule(),

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -4,6 +4,7 @@
 
 from socorro import settings
 from socorro.lib.libsocorrodataschema import get_schema
+from socorro.processor.rules.android import AndroidCPUInfoRule
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
     MinidumpSha256HashRule,
@@ -99,6 +100,7 @@ DEFAULT_RULESET = [
     ReportTypeRule(),
     # post processing of the processed crash
     CPUInfoRule(),
+    AndroidCPUInfoRule(),
     DistributionIdRule(),
     OSInfoRule(),
     BetaVersionRule(

--- a/socorro/processor/rules/android.py
+++ b/socorro/processor/rules/android.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Processor rules that work on Android_* annotations"""
+
+from socorro.processor.rules.base import Rule
+
+
+class AndroidCPUInfoRule(Rule):
+    """Fill in cpu fields in processed crash using Android_CPU_ABI value
+
+    * cpu_arch
+    * cpu_info
+    * cpu_count
+    * cpu_microcode_version
+
+    """
+
+    # Map of Android_CPU_ABI values to cpu_arch values
+    ANDROID_CPU_ABI_MAP = {
+        "armeabi-v7a": "arm",
+        "arm64-v8a": "arm64",
+        "x86_64": "amd64",
+    }
+
+    def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        cpu_arch = processed_crash.get("cpu_arch", "unknown")
+        return cpu_arch == "unknown" and "Android_CPU_ABI" in raw_crash
+
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        android_cpu_abi = raw_crash["Android_CPU_ABI"]
+        cpu_arch = self.ANDROID_CPU_ABI_MAP.get(android_cpu_abi, android_cpu_abi)
+
+        processed_crash["cpu_arch"] = cpu_arch

--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -96,13 +96,6 @@ class CPUInfoRule(Rule):
 
     """
 
-    # Map of Android_CPU_ABI values to cpu_arch values
-    ANDROID_CPU_ABI_MAP = {
-        "armeabi-v7a": "arm",
-        "arm64-v8a": "arm64",
-        "x86_64": "amd64",
-    }
-
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         # This is the CPU info of the machine the product was running on
         processed_crash["cpu_info"] = glom(
@@ -118,10 +111,6 @@ class CPUInfoRule(Rule):
         cpu_arch = glom(
             processed_crash, "json_dump.system_info.cpu_arch", default="unknown"
         )
-        if cpu_arch == "unknown" and "Android_CPU_ABI" in raw_crash:
-            android_cpu_abi = raw_crash["Android_CPU_ABI"]
-            cpu_arch = self.ANDROID_CPU_ABI_MAP.get(android_cpu_abi, android_cpu_abi)
-
         processed_crash["cpu_arch"] = cpu_arch
 
         # The cpu_microcode_version is populated by minidump-stackwalk which gets it from

--- a/socorro/processor/rules/java.py
+++ b/socorro/processor/rules/java.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from socorro.processor.rules.base import Rule
+
+from socorro.lib import libjava
+
+
+class JavaStackTraceRule(Rule):
+    """Process and sanitize JavaStackTrace annotation."""
+
+    def predicate(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        return bool(raw_crash.get("JavaStackTrace", None))
+
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        java_stack_trace_raw = raw_crash["JavaStackTrace"]
+
+        # The java_stack_trace_raw version can contain PII in the exception message
+        # and should be treated as protected data
+        processed_crash["java_stack_trace_raw"] = java_stack_trace_raw
+
+        # Add java_stack_trace field to processed crash which is a sanitized
+        # version of java_stack_trace_raw
+        try:
+            parsed_java_stack_trace = libjava.parse_java_stack_trace(
+                java_stack_trace_raw
+            )
+            java_stack_trace = parsed_java_stack_trace.to_public_string()
+        except libjava.MalformedJavaStackTrace:
+            status.add_note("JavaStackTrace: malformed JavaStackTrace")
+            java_stack_trace = "malformed"
+
+        processed_crash["java_stack_trace"] = java_stack_trace

--- a/socorro/tests/processor/rules/test_android.py
+++ b/socorro/tests/processor/rules/test_android.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from socorro.processor.pipeline import Status
+from socorro.processor.rules.android import AndroidCPUInfoRule
+
+
+class TestAndroidCPUInfoRule:
+    @pytest.mark.parametrize(
+        "android_cpu_abi, expected",
+        [
+            ("x86", "x86"),
+            ("arm64-v8a", "arm64"),
+            ("x86_64", "amd64"),
+            ("value not in map", "value not in map"),
+        ],
+    )
+    def test_cpu_arch_from_android_cpu_abi(self, tmp_path, android_cpu_abi, expected):
+        raw_crash = {"Android_CPU_ABI": android_cpu_abi}
+        processed_crash = {}
+        dumps = {}
+        status = Status()
+
+        rule = AndroidCPUInfoRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+        assert processed_crash["cpu_arch"] == expected

--- a/socorro/tests/processor/rules/test_general.py
+++ b/socorro/tests/processor/rules/test_general.py
@@ -237,25 +237,6 @@ class TestCPUInfoRule:
         rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["cpu_arch"] == "x86"
 
-    @pytest.mark.parametrize(
-        "android_cpu_abi, expected",
-        [
-            ("x86", "x86"),
-            ("arm64-v8a", "arm64"),
-            ("x86_64", "amd64"),
-            ("value not in map", "value not in map"),
-        ],
-    )
-    def test_cpu_arch_from_android_cpu_abi(self, tmp_path, android_cpu_abi, expected):
-        raw_crash = {"Android_CPU_ABI": android_cpu_abi}
-        processed_crash = {}
-        dumps = {}
-        status = Status()
-
-        rule = CPUInfoRule()
-        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
-        assert processed_crash["cpu_arch"] == expected
-
     def test_no_cpu_microcode_version(self, tmp_path):
         raw_crash = {}
         processed_crash = {}

--- a/socorro/tests/processor/rules/test_java.py
+++ b/socorro/tests/processor/rules/test_java.py
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from socorro.processor.pipeline import Status
+from socorro.processor.rules.java import JavaStackTraceRule
+
+
+class TestJavaStackTraceRule:
+    def test_javastacktrace(self, tmp_path):
+        raw_crash = {
+            "JavaStackTrace": (
+                "Exception: some messge\n"
+                + "\tat org.File.function(File.java:100)\n"
+                + "\tCaused by: Exception: some other message\n"
+                + "\t\tat org.File.function(File.java:100)"
+            )
+        }
+        dumps = {}
+        processed_crash = {}
+        status = Status()
+
+        rule = JavaStackTraceRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        # The entire JavaStackTrace blob
+        assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
+
+        # Everything except the exception message and "Caused by" section
+        # which can contain PII
+        assert (
+            processed_crash["java_stack_trace"]
+            == "Exception\n\tat org.File.function(File.java:100)"
+        )
+
+    def test_malformed_javastacktrace(self, tmp_path):
+        raw_crash = {"JavaStackTrace": "junk\n\tat org.File.function\njunk"}
+
+        dumps = {}
+        processed_crash = {}
+        status = Status()
+
+        rule = JavaStackTraceRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        # The entire JavaStackTrace blob
+        assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
+
+        # The data is malformed, so this should just show "malformed"
+        assert processed_crash["java_stack_trace"] == "malformed"
+
+        # Make sure there's a note in the notes about it
+        assert "malformed JavaStackTrace" in status.notes[0]

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -23,7 +23,6 @@ from socorro.processor.rules.mozilla import (
     DistributionIdRule,
     ESRVersionRewrite,
     FenixVersionRewriteRule,
-    JavaProcessRule,
     MacBootArgsRule,
     MacCrashInfoRule,
     MajorVersionRule,
@@ -967,53 +966,6 @@ class TestBreadcrumbRule:
 
         assert processed_crash == {}
         assert status.notes == ["Breadcrumbs: malformed: {} is not of type 'array'"]
-
-
-class TestJavaProcessRule:
-    def test_javastacktrace(self, tmp_path):
-        raw_crash = {
-            "JavaStackTrace": (
-                "Exception: some messge\n"
-                + "\tat org.File.function(File.java:100)\n"
-                + "\tCaused by: Exception: some other message\n"
-                + "\t\tat org.File.function(File.java:100)"
-            )
-        }
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = JavaProcessRule()
-        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
-
-        # The entire JavaStackTrace blob
-        assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
-
-        # Everything except the exception message and "Caused by" section
-        # which can contain PII
-        assert (
-            processed_crash["java_stack_trace"]
-            == "Exception\n\tat org.File.function(File.java:100)"
-        )
-
-    def test_malformed_javastacktrace(self, tmp_path):
-        raw_crash = {"JavaStackTrace": "junk\n\tat org.File.function\njunk"}
-
-        dumps = {}
-        processed_crash = {}
-        status = Status()
-
-        rule = JavaProcessRule()
-        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
-
-        # The entire JavaStackTrace blob
-        assert processed_crash["java_stack_trace_raw"] == raw_crash["JavaStackTrace"]
-
-        # The data is malformed, so this should just show "malformed"
-        assert processed_crash["java_stack_trace"] == "malformed"
-
-        # Make sure there's a note in the notes about it
-        assert "malformed JavaStackTrace" in status.notes[0]
 
 
 class TestModuleURLRewriteRule:


### PR DESCRIPTION
This moves some java/android related processor rule code into separate modules. It makes it a little easier to find rules.