### PR TITLE
bug-1812771: fix os_name, os_version, and os_pretty_version for Android

### DIFF
--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -4,7 +4,10 @@
 
 from socorro import settings
 from socorro.lib.libsocorrodataschema import get_schema
-from socorro.processor.rules.android import AndroidCPUInfoRule
+from socorro.processor.rules.android import (
+    AndroidCPUInfoRule,
+    AndroidOSInfoRule,
+)
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
     MinidumpSha256HashRule,
@@ -103,6 +106,7 @@ DEFAULT_RULESET = [
     AndroidCPUInfoRule(),
     DistributionIdRule(),
     OSInfoRule(),
+    AndroidOSInfoRule(),
     BetaVersionRule(
         version_string_api=settings.BETAVERSIONRULE_VERSION_STRING_API,
     ),

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2848,12 +2848,16 @@ properties:
       For Linux, this is derived from `lsb_release.description` in the
       stackwalker output from the minidump and degrades to the `os_name` if
       that information isn't available.
+
+      For Android, this is "Android" plus the sdk version.
     type: string
     permissions: ["public"]
   os_version:
-    description: >
+    description: |
       Version of the operating system. This comes from `system_info.os_ver`
       from the stackwalker output of the minidump.
+
+      For Android, this is the sdk version.
     type: string
     permissions: ["public"]
   phc_alloc_stack:

--- a/socorro/tests/processor/rules/test_android.py
+++ b/socorro/tests/processor/rules/test_android.py
@@ -5,7 +5,10 @@
 import pytest
 
 from socorro.processor.pipeline import Status
-from socorro.processor.rules.android import AndroidCPUInfoRule
+from socorro.processor.rules.android import (
+    AndroidCPUInfoRule,
+    AndroidOSInfoRule,
+)
 
 
 class TestAndroidCPUInfoRule:
@@ -27,3 +30,52 @@ class TestAndroidCPUInfoRule:
         rule = AndroidCPUInfoRule()
         rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["cpu_arch"] == expected
+
+
+class TestAndroidOSInfoRule:
+    @pytest.mark.parametrize(
+        "os_name, android_version, expected",
+        [
+            ("Windows", None, False),
+            ("Unknown", None, False),
+            ("Unknown", "23 (REL)", True),
+            ("Android", "23 (REL)", True),
+        ],
+    )
+    def test_predicate(self, tmp_path, os_name, android_version, expected):
+        raw_crash = {}
+        if android_version is not None:
+            raw_crash["Android_Version"] = android_version
+        processed_crash = {"os_name": os_name}
+        dumps = {}
+        status = Status()
+
+        rule = AndroidOSInfoRule()
+        result = rule.predicate(
+            raw_crash, dumps, processed_crash, str(tmp_path), status
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "os_name, android_version, expected_name, expected_version",
+        [
+            ("Unknown", "23 (REL)", "Android", "23"),
+            ("Android", "23 (REL)", "Android", "23"),
+            ("Android", "23 (KittyCatUpsideDownSundae)", "Android", "23"),
+            ("Unknown", "23", "Android", "23"),
+            ("Unknown", "xx", "Android", ""),
+        ],
+    )
+    def test_act(
+        self, tmp_path, os_name, android_version, expected_name, expected_version
+    ):
+        raw_crash = {}
+        raw_crash["Android_Version"] = android_version
+        processed_crash = {"os_name": os_name}
+        dumps = {}
+        status = Status()
+
+        rule = AndroidOSInfoRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+        assert processed_crash["os_name"] == expected_name
+        assert processed_crash.get("os_version", "") == expected_version

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -1822,6 +1822,9 @@ class TestOsPrettyName:
             ("Linux", "5.17-0.1 #2 SMP PREEMPT", "Linux"),
             # Linux with - in version
             ("Linux", "3.14-2-686-pae #1 SMP Debian 3.14.15-2", "Linux"),
+            # Android versions
+            ("Android", None, "Android"),
+            ("Android", "23", "Android 23"),
         ],
     )
     def test_everything_we_hoped_for(self, tmp_path, os_name, os_version, expected):
@@ -1875,16 +1878,6 @@ class TestOsPrettyName:
         rule = OSPrettyVersionRule()
         rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
         assert processed_crash["os_pretty_version"] == expected
-
-    def test_dotdict(self, tmp_path):
-        raw_crash = copy.deepcopy(canonical_standard_raw_crash)
-        dumps = {}
-        processed_crash = {"os_name": "Windows NT", "os_version": "10.0.11.7600"}
-        status = Status()
-
-        rule = OSPrettyVersionRule()
-        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
-        assert processed_crash["os_pretty_version"] == "Windows 10"
 
     def test_none(self, tmp_path):
         raw_crash = copy.deepcopy(canonical_standard_raw_crash)


### PR DESCRIPTION
We want to pull the version for Android from the `Android_Version` annotation which holds the sdk version and the release name. Then we use that to build an os_pretty_version that works for C++/Rust crash reports as well as Java crash reports and is much more useful than what we've got now.

I did this implementation so that it only changes the `os_name`, `os_version`, and `os_pretty_version` for crashes on Android platforms.

What we've got now:

![image](https://github.com/mozilla-services/socorro/assets/820826/d1aa9e0c-e7be-48e9-9ced-d558ce71ac00)

*Figure 1: Bunch of "Unknown" and the version is set to the Linux kernel. Unhelpful.*

What the changes in this PR do:

![image](https://github.com/mozilla-services/socorro/assets/820826/4ab7f9a8-deb1-4f6b-926d-f3822832965a)

*Figure 2: Android crashes are marked "Android" and the version is always the sdk version.*