### PR TITLE
bug-1876623: Treat `<.plt ELF section...>` as prefix signature

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -173,6 +173,7 @@ o_strcat_s
 <.*>::operator()
 pages_commit
 PL_
+<\.plt ELF section in .*>
 port_
 PORT_
 _PR_


### PR DESCRIPTION
Treat frames like `<.plt ELF section in libxul.so>` as prefix signatures.

For example, this bug is not a useful aggregation: https://bugzilla.mozilla.org/show_bug.cgi?id=1870546

That includes the crash:
https://crash-stats.mozilla.org/report/index/82af7f36-4ed2-4826-bdd6-6397c0240118

whose stack begins:

```
<.plt ELF section in libxul.so>
js::wasm::Instance::callExport(JSContext*, unsigned int, JS::CallArgs, js::wasm::CoercionLevel)
```

That second frame would be a much more interesting thing to file the crash under.