### PR TITLE
bug-1881630: update circleci remote docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       - checkout
 
       - setup_remote_docker:
-          version: 20.10.18
           docker_layer_caching: true
 
       - run:


### PR DESCRIPTION
Previously, we specified an image that's now deprecated. This removes the version specification which will cause it to use the default which is currently docker 24. default will change over time, but we'll know if CI fails pretty quick and we're switching to GCP soon with a completely different deploy pipeline anyhow.

CI spit out this output for the "setup remote docker" step:

```
Created container accessible with:
  DOCKER_HOST=unix:///var/run/docker.sock
  DOCKER_MACHINE_NAME=localhost

Server Engine Details:
  Version:          24.0.9
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.20.13
  Git commit:       fca702d
  Built:            2024-02-01T00:48:39.000000000+00:00
  OS/Arch:          linux/amd64
  Experimental:     false
```

That's using Docker 24, so I think we're good.