### PR TITLE
bug-1862730: update stackwalker to v0.20.0

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20231013.0/socorro-stackwalker.2023-10-13.1869d3a0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20240228.0/socorro-stackwalker.2024-01-31.v0.20.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This updates the stackwalker to v0.20.0 which picks up the following changes:

```
3581196 (tag: v0.20.0) chore: Release
852af14 Updated cargo-dist configuration
0b3aff9 Updated the release notes for the next version
8e2dae5 Updated ctor to version 0.2
7da12de Updated all the dependencies, this removes a few duplications and picks up some useful fixes
e6b5c2a fix: restore the idx field on thread spans
dd377d1 Remove the dependency on dump_syms
35651c5 Make MmapMinidump static
8d69037 Avoid requiring a dependency on memmap2 to use Minidump<'_, Mmap>
7f38b36 bug-1873529: fix debug id for modules found by code-info lookup
5f31ab7 Update scroll to 0.12
362a4a0 Update memmap2 to 0.9.3
a068902 fmt
05396af fix clippy lints from 1.75.0
99e0590 Use the procfs crate in minidump for parsing linux memory maps. (#812)
7a9ea0b Print the si_code of a Linux signal correctly when it contains a negative code (#911)
43e9781 Add support for additional macOS guard exception types and flavors (#901)
640de21 Interpret Windows error-code correctly even when they're sign-extended. (#894)
c3de84b (tag: v0.19.1) chore: Release
46a9833 Updated the release notes for the next version
f6de402 Remove the MSI installer
aae3c27 Updated all the dependencies to address several mild security issues in some crates
3a60101 (tag: v0.19.0) chore: Release
e92bcec Updated cargo-dist to version 0.4.2
ca0a97d Updated the release notes for the next version
8e7457c Bump the versions of the fuzzing crates
403e1c9 Update symbolic and memmap2, also get rid of crate versions that were yanked
2851131 Add support for the MINIDUMP_HANDLE_DATA_STREAM stream (#885)
9b8dd79 Merge pull request #881 from lissyx/fds
f696691 cargo doc
cc597b6 panic instead of assert as per clippy
de13372 remove debug
a3ff3d7 cargo fmt
8f15e96 cargo insta review pass 2
a18d69d cargo insta review pass 1
7a1533d Fix review comments
055e3d0 Add /proc/PID/limits to produced JSON
6c6edb5 Parsing /proc/PID/limits
b816e2a Remove MozLinuxFDs and add MozLinuxLimits to lib doc
2f99693 Add entries for /proc/self/fd/ and /proc/self/limits
```

I did regression testing when building the rust-minidump release binary in:

https://github.com/mozilla-services/socorro-stackwalk/pull/12