### PR TITLE
bug-1830954: add support for has_guard_page_access

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1206,6 +1206,7 @@ FIELDS = {
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },
+    "has_guard_page_access": boolean_field(name="has_guard_page_access"),
     "has_mac_boot_args": boolean_field(name="has_mac_boot_args"),
     "install_age": {
         "data_validation_type": "int",

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -10,6 +10,7 @@ from socorro.processor.rules.android import (
 )
 from socorro.processor.rules.breakpad import (
     CrashingThreadInfoRule,
+    HasGuardPageAccessRule,
     MinidumpSha256HashRule,
     MinidumpStackwalkRule,
     PossibleBitFlipsRule,
@@ -87,6 +88,7 @@ DEFAULT_RULESET = [
     CrashingThreadInfoRule(),
     TruncateStacksRule(),
     PossibleBitFlipsRule(),
+    HasGuardPageAccessRule(),
     MajorVersionRule(),
     PluginRule(),
     AccessibilityRule(),

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -124,6 +124,34 @@ class PossibleBitFlipsRule(Rule):
         )
 
 
+class HasGuardPageAccessRule(Rule):
+    """Compute has_guard_page_access value
+
+    Fills in:
+
+    * has_guard_page_access (bool): whether there are "is_likely_guard_page=True"
+      in json_dump.crash_info.memory_accesses structures
+
+    """
+
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        accesses = glom.glom(
+            processed_crash, "json_dump.crash_info.memory_accesses", default=None
+        )
+        if accesses is None:
+            return
+
+        # is_likely_guard_page is True iff at least one of the memory_accesses values is
+        # true
+        has_guard_page_access = any(
+            data.get("is_likely_guard_page", False) for data in accesses
+        )
+
+        # Only set the property if it's True
+        if has_guard_page_access:
+            processed_crash["has_guard_page_access"] = True
+
+
 class TruncateStacksRule(Rule):
     """Truncate stacks that are too large
 

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -199,6 +199,13 @@ definitions:
                     Size of memory access.
                   type: ["integer", "null"]
                   permissions: ["public"]
+                is_likely_guard_page:
+                  description: >
+                    Whether the address falls in a likely guard page (typically
+                    indicating buffer overflow). This field may only be present
+                    when the value is `true`.
+                  type: ["boolean", "null"]
+                  permissions: ["protected"]
               type: ["object"]
               permissions: ["public"]
             permissions: ["public"]
@@ -2631,6 +2638,13 @@ properties:
     type: boolean
     permissions: ["public"]
     source_annotation: IsGarbageCollecting
+  has_guard_page_access:
+    description: >
+      Set to `true` if and only if at least one of the memory accesses fell in
+      a likely guard page per the stackwalker output. Otherwise, this is
+      omitted.
+    type: ["boolean", "null"]
+    permissions: ["protected"]
   java_exception:
     $ref: "#/definitions/java_exception"
     description: >

--- a/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -329,6 +329,15 @@
                   </tr>
                 {% endif %}
 
+                {% if report.has_guard_page_access %}
+                  <tr title="{{ fields_desc['processed_crash.has_guard_page_access'] }}">
+                    <th scope="row">Has guard page access</th>
+                    <td>
+                      <pre>{{ report.has_guard_page_access }}</pre>
+                    </td>
+                  </tr>
+                {% endif %}
+
                 {% if report.possible_bit_flips_max_confidence %}
                   <tr title="{{ fields_desc['processed_crash.possible_bit_flips_max_confidence'] }}">
                     <th scope="row">Possible bit flips max confidence</th>


### PR DESCRIPTION
This adds is_likely_guard_page to the stackwalker output part of the processed crash schema.

It also adds a new top-level has_guard_page_access protected field. This is true iff there's at least one memory access where is_likely_guard_page is true.

These fields are marked protected because there are security concerns with this data.

Example crash reports:

* 8dd52551-692d-45ff-82d0-9ab000240228
* a5875ef2-5cc1-4fdd-bbab-0b1400240229
* 7c66167c-de29-4b8f-85c3-1c7db0240228
* 456b3a73-1607-4487-9814-929700240228
* c52e0b31-5a34-4937-a922-b97c30240228

To test:

1. rebuild local dev environment
2. process crash reports
3. open browser in webapp (not logged in)
   1. view crash report
      1. verify you can't see "Has guard page access: true" in "Details" tab
      2. verify you can't see `is_likely_guard_page` in report view "Raw data and minidumps" tab
      3. verify you can't see `has_guard_page_access` in processed crash
   2. view super search
      1. verify you can't search using `has_guard_page_access` field
4. log into webapp
   1. view crash report
      1. verify you can't see "Has guard page access: true" in "Details" tab
      2. verify you CAN see `is_likely_guard_page` in report view "Raw data and minidumps" tab
      3. verify you CAN see `has_guard_page_access` in processed crash
   2. view super search
      1. verify you CAN search using `has_guard_page_access` field