### PR TITLE
bug 1883055: stop using django-session-csrf

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,6 @@ django-npm==1.0.0
 django-pipeline==3.0.0
 django-ratelimit==4.1.0
 djangorestframework==3.14.0
-django-session-csrf==0.7.1
 dj-database-url==2.1.0
 dockerflow==2024.2.0
 enforce-typing==1.0.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -295,10 +295,6 @@ django-ratelimit==4.1.0 \
     --hash=sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b \
     --hash=sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92
     # via -r requirements.in
-django-session-csrf==0.7.1 \
-    --hash=sha256:e17177e6e2e6518ec7ce6693ad10a5c747f8571d09f4cfa9082599334421605d \
-    --hash=sha256:ff8c10e30d312c77fc6a6db7710e22b9383e28c03b7fe958876ca96f39aa6cf2
-    # via -r requirements.in
 django-waffle==2.3.0 \
     --hash=sha256:8f457523859f39f77b785dfeb18d57d8c80d97ba05698aed7fa587bb86539476 \
     --hash=sha256:e4c29570d61c5759b07d9c88154c14b0b189dbf772ac8744c44e226cc7bd75bf

--- a/webapp/crashstats/crashstats/monkeypatches.py
+++ b/webapp/crashstats/crashstats/monkeypatches.py
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-
-def patch():
-    import session_csrf
-
-    session_csrf.monkeypatch()

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -99,7 +99,6 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
-    "session_csrf",
     "django.contrib.admin.apps.SimpleAdminConfig",
     "mozilla_django_oidc",
     "rest_framework",
@@ -131,7 +130,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "crashstats.tokens.middleware.APIAuthenticationMiddleware",
-    "session_csrf.CsrfMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -165,7 +164,6 @@ _CONTEXT_PROCESSORS = [
     "django.template.context_processors.debug",
     "django.template.context_processors.media",
     "django.template.context_processors.request",
-    "session_csrf.context_processor",
     "django.contrib.messages.context_processors.messages",
     "django.template.context_processors.request",
     "crashstats.crashstats.context_processors.settings",
@@ -205,9 +203,6 @@ TEMPLATES = [
         "OPTIONS": {"debug": DEBUG, "context_processors": _CONTEXT_PROCESSORS},
     },
 ]
-
-# Always generate a CSRF token for anonymous users.
-ANON_ALWAYS = True
 
 LOGGING_LEVEL = _config(
     "LOGGING_LEVEL", default="INFO", doc="Logging level for Crash Stats code"

--- a/webapp/crashstats/topcrashers/views.py
+++ b/webapp/crashstats/topcrashers/views.py
@@ -11,8 +11,6 @@ from django.conf import settings
 from django.shortcuts import redirect, render
 from django.utils import timezone
 
-from session_csrf import anonymous_csrf
-
 from crashstats import libproduct
 from crashstats.crashstats import models
 from crashstats.crashstats.decorators import (
@@ -106,7 +104,6 @@ def get_topcrashers_stats(**kwargs):
 
 @track_view
 @pass_default_context
-@anonymous_csrf
 @check_days_parameter([1, 3, 7, 14, 28], default=7)
 def topcrashers(request, days=None, possible_days=None, default_context=None):
     context = default_context or {}

--- a/webapp/crashstats/urls.py
+++ b/webapp/crashstats/urls.py
@@ -7,10 +7,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 
 from crashstats.manage import admin_site
-from crashstats.crashstats.monkeypatches import patch
 
-
-patch()
 
 handler404 = "crashstats.crashstats.views.handler404"
 handler500 = "crashstats.crashstats.views.handler500"


### PR DESCRIPTION
We used django-session-csrf which is a Mozilla maintained library that we wrote back in the heady Mozilla webdev days which had properties our webdev and websec folks wanted. That was a long time ago, Django's built-in csrf module has improved over time, the world has changed (no more Flash), and the library hasn't been actively maintained in some time.

This drops the django-session-csrf and some of the interesting code around it in favor of Django's built-in csrf.

To test:

1. set up a local dev environment
2. process some crash reports
3. try a POST with no csrf token: `curl -X POST http://localhost:8000` -- should return an HTTP 403
4. open the webapp in your browser
5. while not logged in
   1. test quick search (top right-hand corner) with a crash id that you processed
   2. test supersearch, add a facet, add a column
   3. go to topcrashers site and change the filters
   4. go to signature report, add an aggregation, click around
   5. test an API on the API example page: http://localhost:8000/api/
6. log into webapp
   1. test quick search (top right-hand corner) with a crash id that you processed
   2. test supersearch, add a facet, add a column
   3. go to topcrashers site and change the filters
   4. go to signature report, add an aggregation, click around
   5. test an API on the API example page: http://localhost:8000/api/
   6. go to API token page, create a token, delete a token

I think that's most/all of the places where CSRF comes up.