### PR TITLE
bug-1884718: update stackwalker to v0.21.1

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20240228.0/socorro-stackwalker.2024-01-31.v0.20.0.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20240311.0/socorro-stackwalker.2024-03-01.v0.21.1.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This updates the stackwalker to v0.21.1 which picks up the following changes:
```
e7ecb41 (HEAD -> main, tag: v0.21.1, origin/main, origin/HEAD) chore: Release
dff1530 Updated the release notes for the next version
b65c81a Updated all the dependencies
10eefc4 Merge pull request #968 from afranchuk/dont-require-system-info
73097b4 Only require the MinidumpSystemInfo stream when using local debug info.
2611865 (tag: v0.21.0) chore: Release
2f56803 Updated cargo-dist configuration using version 0.11.1
c154dbd Updated the release notes for the next version
52ffeda Updated all the dependencies
58a239c Allow passing the path to a symbol files in --symbols-path
7b28df6 Merge pull request #963 from rust-minidump/dependabot/cargo/framehop-0.9.0
9030821 Merge pull request #955 from lissyx/get-soname
936ca21 Bump framehop from 0.8.0 to 0.9.0
a66b5c5 Merge pull request #957 from rust-minidump/dependabot/cargo/cachemap2-0.3.0
e4c370c Bump cachemap2 from 0.2.0 to 0.3.0
2cf996d Merge pull request #958 from rust-minidump/dependabot/cargo/num-derive-0.4.2
15a3020 Bump num-derive from 0.4.1 to 0.4.2
74c8656 Merge pull request #952 from rust-minidump/dependabot/cargo/time-0.3.34
3649152 Merge pull request #950 from rust-minidump/dependabot/cargo/env_logger-0.11.1
f33622a Merge pull request #948 from rust-minidump/dependabot/cargo/num-traits-0.2.18
bd1959b Bug 1847098 - Parse version number for Elf files
19931a1 Bump num-traits from 0.2.17 to 0.2.18
d4f6c7f Allow compile-time and runtime selection of symbolication in the DebugInfoSymbolProvider.
b5c57e8 Use a trait object to abstract over framehop platforms.
3e18614 Use framehop and wholesym rather than symbolic for the local debuginfo symbol provider.
6714a70 Remove redundant imports
556ebab Bump clap from 4.4.18 to 4.5.0
b66d682 Bump cab from 0.4.1 to 0.5.0
b5d23e8 clippy
4221d28 parse threadinfolist stream
21673cb Validate `stack_memory` once in `walk_stack`
0289d14 Bump time from 0.3.31 to 0.3.34
fe29edb Bump env_logger from 0.10.2 to 0.11.1
a708dec Get `MinidumpModule` before constructing `CfiStackWalker`
631f649 Reduce duplication a bit more
e0e680c Use a constructor for `CfiStackWalker`
5127da5 Finish refactoring all the args
bb2c07d Turn `args` into a ref and thread it through more fns
f87387e Combine all the arguments into a struct
9d1166b Move `stack_memory` unwrapping one up
88153c0 Unwrap `stack_memory` in the outer `get_caller_frame`
78f52e6 Actually just remove the whole `Unwind` trait
a8ebe53 Use AFIT for the `Unwind` trait
34019f0 Fix CI badge
7146857 Remove unnecessary chrono dependency
```

I did regression testing when building the rust-minidump release binary in:

https://github.com/mozilla-services/socorro-stackwalk/pull/14