### PR TITLE
bug-1867814: remove irrelevant comment

### DIFF
--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2623,9 +2623,6 @@ properties:
     permissions: ["public"]
     source_annotation: IPCShutdownState
   ipc_system_error:
-    # NOTE(willkg): CrashAnnotations.yaml lists this as a string, but the
-    # values are all integers and we've been indexing it as an integer for
-    # years so we'll keep doing that.
     description: >
       Description of the last system error that occurred during IPC operation.
     type: integer


### PR DESCRIPTION
Previously `CrashAnnotations.yaml` listed `ipc_system_error` as a string, but Socorro treated it as an integer. We had a note because of the discrepancy.

That's no longer true--`CrashAnnotations.yaml` has been fixed. We can remove the note.