### PR TITLE
bug-1885978: remove raw crash from indexing code

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -216,7 +216,7 @@ def fix_datetime(value):
 def build_document(src, crash_document, fields, all_keys):
     """Given a source document and fields and valid keys, builds a document to index.
 
-    :param dict src: the source document with raw_crash and processed_crash keys
+    :param dict src: the source document with "processed_crash" key
     :param dict crash_document: the document to fill
     :param list fields: the list of fields in super search fields
     :param set all_keys: the list of valid keys
@@ -270,7 +270,7 @@ def build_document(src, crash_document, fields, all_keys):
 
 
 class ESCrashStorage(CrashStorageBase):
-    """This sends raw and processed crash reports to Elasticsearch."""
+    """Indexes documents based on the processed crash to Elasticsearch."""
 
     # These regex will catch field names from Elasticsearch exceptions. They
     # have been tested with Elasticsearch 1.4.
@@ -498,14 +498,10 @@ class ESCrashStorage(CrashStorageBase):
         es_doctype = self.get_doctype()
         all_valid_keys = self.get_keys(index_name, es_doctype)
 
-        src = {
-            "raw_crash": copy.deepcopy(raw_crash),
-            "processed_crash": copy.deepcopy(processed_crash),
-        }
+        src = {"processed_crash": copy.deepcopy(processed_crash)}
 
         crash_document = {
             "crash_id": crash_id,
-            "raw_crash": {},
             "processed_crash": {},
         }
         build_document(src, crash_document, fields=FIELDS, all_keys=all_valid_keys)
@@ -533,8 +529,6 @@ class ESCrashStorage(CrashStorageBase):
                 # we can fix it later.
                 self.logger.exception(f"something went wrong when capturing {key}")
 
-        _capture("raw_crash_size", crash_document["raw_crash"])
-        _capture("processed_crash_size", crash_document["processed_crash"])
         _capture("crash_document_size", crash_document)
 
     def _index_crash(self, connection, es_index, es_doctype, crash_document, crash_id):

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -297,8 +297,8 @@ def boolean_field(
     show up in aggregations.
 
     :param name: the name used to query the field in super search
-    :param namespace: either "raw_crash" or "processed_crash"; note that we're moving
-        to a model where we pull everything from the processed_crash, so prefer that
+    :param namespace: either "processed_crash" or some dotted path to a key deep in
+        the processed crash
     :param in_database_name: the field in the processed crash to pull this data from
 
     :returns: super search field specification as a dict
@@ -332,8 +332,8 @@ def keyword_field(
     names, fields that have a limited set of choices, etc.
 
     :param name: the name used to query the field in super search
-    :param namespace: either "raw_crash" or "processed_crash"; note that we're moving
-        to a model where we pull everything from the processed_crash, so prefer that
+    :param namespace: either "processed_crash" or some dotted path to a key deep in
+        the processed crash
     :param in_database_name: the field in the processed crash to pull this data from
     :param choices: a list of valid values for the dropdown
 
@@ -367,8 +367,8 @@ def integer_field(
     """Generates a whole number field.
 
     :param name: the name used to query the field in super search
-    :param namespace: either "raw_crash" or "processed_crash"; note that we're moving
-        to a model where we pull everything from the processed_crash, so prefer that
+    :param namespace: either "processed_crash" or some dotted path to a key deep in
+        the processed crash
     :param in_database_name: the field in the processed crash to pull this data from
     :param storage_mapping_type: the storage mapping type to use for Elasticsearch;
         "short", "integer", "long"
@@ -403,8 +403,8 @@ def float_field(
     """Generates a floating point field.
 
     :param name: the name used to query the field in super search
-    :param namespace: either "raw_crash" or "processed_crash"; note that we're moving
-        to a model where we pull everything from the processed_crash, so prefer that
+    :param namespace: either "processed_crash" or some dotted path to a key deep in
+        the processed crash
     :param in_database_name: the field in the processed crash to pull this data from
 
     :returns: super search field specification as a dict

--- a/socorro/tests/conftest.py
+++ b/socorro/tests/conftest.py
@@ -240,19 +240,19 @@ class ElasticsearchHelper:
     def refresh(self):
         self.conn.refresh()
 
-    def index_crash(self, raw_crash, processed_crash, refresh=True):
+    def index_crash(self, processed_crash, refresh=True):
         """Index a single crash and refresh"""
-        self._crashstorage.save_processed_crash(raw_crash, processed_crash)
+        self._crashstorage.save_processed_crash(
+            raw_crash={},
+            processed_crash=processed_crash,
+        )
 
         if refresh:
             self.refresh()
 
-    def index_many_crashes(
-        self, number, raw_crash=None, processed_crash=None, loop_field=None
-    ):
+    def index_many_crashes(self, number, processed_crash=None, loop_field=None):
         """Index multiple crashes and refresh at the end"""
         processed_crash = processed_crash or {}
-        raw_crash = raw_crash or {}
 
         crash_ids = []
         for i in range(number):
@@ -262,9 +262,7 @@ class ElasticsearchHelper:
             if loop_field is not None:
                 processed_copy[loop_field] = processed_crash[loop_field] % i
 
-            self.index_crash(
-                raw_crash=raw_crash, processed_crash=processed_copy, refresh=False
-            )
+            self.index_crash(processed_crash=processed_copy, refresh=False)
 
         self.refresh()
         return crash_ids

--- a/socorro/tests/external/es/test_analyzers.py
+++ b/socorro/tests/external/es/test_analyzers.py
@@ -34,7 +34,6 @@ class TestIntegrationAnalyzers:
 
         value1 = "/path/to/dll;;foo;C:\\bar\\boo"
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": crash_id_1,
                 "app_init_dlls": value1,
@@ -43,7 +42,6 @@ class TestIntegrationAnalyzers:
         )
         value2 = "/path/to/dll;D:\\bar\\boo"
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": crash_id_2,
                 "app_init_dlls": value2,

--- a/socorro/tests/external/es/test_query.py
+++ b/socorro/tests/external/es/test_query.py
@@ -31,7 +31,6 @@ class TestIntegrationQuery:
 
         datestamp = date_to_string(utc_now())
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(),
                 "date_processed": datestamp,
@@ -39,7 +38,6 @@ class TestIntegrationQuery:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(),
                 "date_processed": datestamp,

--- a/socorro/tests/external/es/test_super_search_fields.py
+++ b/socorro/tests/external/es/test_super_search_fields.py
@@ -97,7 +97,6 @@ class Test_build_mapping:
         properties = mapping[doctype]["properties"]
 
         print(json.dumps(properties, indent=4, sort_keys=True))
-        assert "raw_crash" not in properties
         assert "processed_crash" in properties
 
         processed_crash = properties["processed_crash"]["properties"]
@@ -218,8 +217,7 @@ def test_validate_super_search_fields(name, properties):
         if properties.get("destination_keys"):
             for key in properties["destination_keys"]:
                 possible_keys = [
-                    # Old keys we're probably migrating from
-                    f"raw_crash.{properties['in_database_name']}",
+                    # Old key we're possibly migrating from
                     f"processed_crash.{properties['in_database_name']}",
                     # New key we're probably migrating to
                     f"processed_crash.{properties['name']}",

--- a/socorro/tests/external/es/test_supersearch.py
+++ b/socorro/tests/external/es/test_supersearch.py
@@ -74,7 +74,6 @@ class TestIntegrationSuperSearch:
         api = SuperSearchWithFields(crashstorage=crashstorage)
 
         es_helper.index_crash(
-            raw_crash={"ProductName": "Firefox"},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -131,7 +130,6 @@ class TestIntegrationSuperSearch:
         api = SuperSearchWithFields(crashstorage=crashstorage)
 
         es_helper.index_crash(
-            raw_crash={"ProductName": "WaterWolf"},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "WaterWolf",
@@ -140,7 +138,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={"ProductName": "NightTrain"},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "NightTrain",
@@ -149,7 +146,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={"ProductName": "NightTrain"},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "NightTrain",
@@ -191,7 +187,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -199,7 +194,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "mozilla::js::function",
@@ -207,7 +201,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "json_Is_Kewl",
@@ -215,7 +208,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "OhILoveMyBrowser",
@@ -223,7 +215,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -352,7 +343,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "build": 2000,
@@ -360,7 +350,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "build": 2001,
@@ -368,7 +357,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "build": 1999,
@@ -427,7 +415,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={"Accessibility": True},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "date_processed": now,
@@ -435,7 +422,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={"Accessibility": False},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "date_processed": now,
@@ -443,7 +429,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={"Accessibility": True},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "date_processed": now,
@@ -452,7 +437,6 @@ class TestIntegrationSuperSearch:
         )
         es_helper.index_crash(
             # Missing value means it's neither true nor false
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "date_processed": now,
@@ -487,7 +471,6 @@ class TestIntegrationSuperSearch:
         )
 
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": sigs[0],
@@ -497,7 +480,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": sigs[1],
@@ -507,7 +489,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": sigs[2],
@@ -517,7 +498,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": sigs[3],
@@ -555,9 +535,7 @@ class TestIntegrationSuperSearch:
         api = SuperSearchWithFields(crashstorage=crashstorage)
         number_of_crashes = 21
         processed_crash = {"signature": "something"}
-        es_helper.index_many_crashes(
-            number_of_crashes, raw_crash={}, processed_crash=processed_crash
-        )
+        es_helper.index_many_crashes(number_of_crashes, processed_crash=processed_crash)
 
         kwargs = {"_results_number": "10"}
         res = api.get(**kwargs)
@@ -585,7 +563,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "WaterWolf",
@@ -594,7 +571,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "WaterWolf",
@@ -603,7 +579,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "product": "NightTrain",
@@ -655,7 +630,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -665,7 +639,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -675,7 +648,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -685,7 +657,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -700,7 +671,6 @@ class TestIntegrationSuperSearch:
         processed_crash = {"version": "10.%s"}
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -787,7 +757,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -797,7 +766,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -807,7 +775,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -817,7 +784,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -832,7 +798,6 @@ class TestIntegrationSuperSearch:
         processed_crash = {"version": "10.%s"}
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -855,7 +820,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -865,7 +829,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -875,7 +838,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -885,7 +847,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -900,7 +861,6 @@ class TestIntegrationSuperSearch:
         processed_crash = {"version": "10.%s"}
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -939,7 +899,6 @@ class TestIntegrationSuperSearch:
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -950,7 +909,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -961,7 +919,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -972,7 +929,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -991,7 +947,6 @@ class TestIntegrationSuperSearch:
         }
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -1173,7 +1128,6 @@ class TestIntegrationSuperSearch:
         the_day_before = now - datetime.timedelta(days=2)
 
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1183,7 +1137,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1193,7 +1146,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1203,7 +1155,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -1221,7 +1172,6 @@ class TestIntegrationSuperSearch:
         }
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -1393,7 +1343,6 @@ class TestIntegrationSuperSearch:
         day_before_int = int(the_day_before.strftime(time_str))
 
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1404,7 +1353,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=yesterday),
                 "signature": "js::break_your_browser",
@@ -1415,7 +1363,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=the_day_before),
                 "signature": "js::break_your_browser",
@@ -1426,7 +1373,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "foo(bar)",
@@ -1446,7 +1392,6 @@ class TestIntegrationSuperSearch:
         }
         es_helper.index_many_crashes(
             number_of_crashes,
-            raw_crash={},
             processed_crash=processed_crash,
             loop_field="version",
         )
@@ -1581,7 +1526,6 @@ class TestIntegrationSuperSearch:
         api = SuperSearchWithFields(crashstorage=crashstorage)
         now = utc_now()
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1613,7 +1557,6 @@ class TestIntegrationSuperSearch:
         api = SuperSearchWithFields(crashstorage=crashstorage)
         now = utc_now()
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1623,7 +1566,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",
@@ -1633,7 +1575,6 @@ class TestIntegrationSuperSearch:
             },
         )
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
                 "signature": "js::break_your_browser",

--- a/webapp/crashstats/crashstats/tests/test_updatemissing.py
+++ b/webapp/crashstats/crashstats/tests/test_updatemissing.py
@@ -30,13 +30,12 @@ class TestUpdateMissing:
 
     def create_processed_crash_in_es(self, es_helper, crash_id):
         crash_date = date_from_ooid(crash_id)
-        raw_crash = {}
         processed_crash = {
             "uuid": crash_id,
             "signature": "OOM | Small",
             "date_processed": crash_date,
         }
-        es_helper.index_crash(raw_crash=raw_crash, processed_crash=processed_crash)
+        es_helper.index_crash(processed_crash=processed_crash)
 
     def test_past_missing_still_missing(self, capsys, db):
         # Create a MissingProcessedCrash row, but don't put the processed crash in the

--- a/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -45,13 +45,12 @@ class TestVerifyProcessed:
 
     def create_processed_crash_in_es(self, es_helper, crash_id):
         crash_date = date_from_ooid(crash_id)
-        raw_crash = {}
         processed_crash = {
             "uuid": crash_id,
             "signature": "OOM | Small",
             "date_processed": crash_date,
         }
-        es_helper.index_crash(raw_crash=raw_crash, processed_crash=processed_crash)
+        es_helper.index_crash(processed_crash=processed_crash)
 
     def test_get_threechars(self):
         cmd = Command()

--- a/webapp/crashstats/signature/tests/test_views.py
+++ b/webapp/crashstats/signature/tests/test_views.py
@@ -69,9 +69,7 @@ class TestViews:
         crash4 = build_crash_data(crash4_id, build=None)
 
         for crash_data in [crash1, crash2, crash3, crash4]:
-            es_helper.index_crash(
-                raw_crash={}, processed_crash=crash_data, refresh=False
-            )
+            es_helper.index_crash(processed_crash=crash_data, refresh=False)
         es_helper.refresh()
 
         start_date, end_date = get_date_range(crash1_id)
@@ -207,7 +205,7 @@ class TestViews:
         crash_ids = []
         for i in range(140):
             data = build_crash_data(i)
-            es_helper.index_crash(raw_crash={}, processed_crash=data, refresh=False)
+            es_helper.index_crash(processed_crash=data, refresh=False)
             crash_ids.append(data["uuid"])
 
         es_helper.refresh()
@@ -282,7 +280,7 @@ class TestViews:
         crash_ids = []
         for i in range(len(products)):
             data = build_crash_data(i, products)
-            es_helper.index_crash(raw_crash={}, processed_crash=data, refresh=False)
+            es_helper.index_crash(processed_crash=data, refresh=False)
             crash_ids.append(data["uuid"])
 
         es_helper.refresh()
@@ -336,7 +334,7 @@ class TestViews:
         crash_ids = []
         for i, item in enumerate(test_data):
             data = build_crash_data(i, days=item[0], product=item[1])
-            es_helper.index_crash(raw_crash={}, processed_crash=data, refresh=False)
+            es_helper.index_crash(processed_crash=data, refresh=False)
             crash_ids.append(data["uuid"])
 
         es_helper.refresh()
@@ -424,9 +422,7 @@ class TestViews:
         )
 
         for crash_data in [crash1, crash2, crash3, crash4]:
-            es_helper.index_crash(
-                raw_crash={}, processed_crash=crash_data, refresh=False
-            )
+            es_helper.index_crash(processed_crash=crash_data, refresh=False)
         es_helper.refresh()
 
         url = reverse("signature:signature_comments")
@@ -466,7 +462,7 @@ class TestViews:
         crash_ids = []
         for i in range(140):
             data = build_crash_data(i)
-            es_helper.index_crash(raw_crash={}, processed_crash=data, refresh=False)
+            es_helper.index_crash(processed_crash=data, refresh=False)
             crash_ids.append(data["uuid"])
 
         es_helper.refresh()
@@ -590,7 +586,7 @@ class TestViews:
             ),
         ]
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         start_date, end_date = get_date_range(date=utc_now())

--- a/webapp/crashstats/supersearch/tests/test_views.py
+++ b/webapp/crashstats/supersearch/tests/test_views.py
@@ -136,7 +136,7 @@ class TestViews:
             ),
         ]
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         url = reverse("supersearch:search_results")
@@ -259,7 +259,6 @@ class TestViews:
         """Test that users with protected data access can see all fields."""
         crash_id = create_new_ooid()
         es_helper.index_crash(
-            raw_crash={},
             processed_crash={
                 "uuid": crash_id,
                 "date_processed": utc_now(),
@@ -398,7 +397,7 @@ class TestViews:
         crash_ids = []
         for i in range(140):
             data = build_crash_data(i)
-            es_helper.index_crash(raw_crash={}, processed_crash=data, refresh=False)
+            es_helper.index_crash(processed_crash=data, refresh=False)
             crash_ids.append(data["uuid"])
 
         es_helper.refresh()

--- a/webapp/crashstats/topcrashers/tests/test_views.py
+++ b/webapp/crashstats/topcrashers/tests/test_views.py
@@ -43,7 +43,7 @@ class TestTopCrasherViews:
                 }
             )
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         # Test Bugzilla data is rendered
@@ -89,7 +89,7 @@ class TestTopCrasherViews:
                 }
             )
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         # Check the first appearance date is there
@@ -174,7 +174,7 @@ class TestTopCrasherViews:
             )
 
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         startup_crash_msg = 'title="Startup Crash"'
@@ -225,7 +225,7 @@ class TestTopCrasherViews:
             )
 
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         # Redirects to the most recent featured version
@@ -265,7 +265,7 @@ class TestTopCrasherViews:
                 }
             )
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
 
         for _ in range(5):
             crash_data.append(
@@ -285,7 +285,7 @@ class TestTopCrasherViews:
                 }
             )
         for item in crash_data:
-            es_helper.index_crash(raw_crash={}, processed_crash=item, refresh=False)
+            es_helper.index_crash(processed_crash=item, refresh=False)
         es_helper.refresh()
 
         url = reverse("topcrashers:topcrashers")


### PR DESCRIPTION
In bug 1763264, we finished all the work to stop using the raw crash when indexing crash report data. The only data we're indexing now comes from the processed crash after being normalized and validated by processor rules. This radically reduces problems with indexing from weird values.

This cleans up the remnants of those old days by removing `raw_crash` from building documents, indexing, and related documentation. This also removes a deepcopy call which will speed up indexing a little.