### PR TITLE
bug 1888223: remove priority from protected data access request link

### DIFF
--- a/webapp/crashstats/documentation/jinja2/docs/protected_data_access.html
+++ b/webapp/crashstats/documentation/jinja2/docs/protected_data_access.html
@@ -50,7 +50,7 @@ The most recent copy of this agreement is at: https://crash-stats.mozilla.org/do
       </li>
       <li>
         Fill out a
-        <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_status=NEW&bug_type=task&component=General&defined_groups=1&filed_via=standard_formform_name=enter_bug&groups=mozilla-employee-confidential&op_sys=All&priority=P2&product=Socorro&rep_platform=All&short_desc=grant%20YOURNAME%20access%20to%20protected%20data">protected data access request</a>.
+        <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_status=NEW&bug_type=task&component=General&defined_groups=1&filed_via=standard_formform_name=enter_bug&groups=mozilla-employee-confidential&op_sys=All&product=Socorro&rep_platform=All&short_desc=grant%20YOURNAME%20access%20to%20protected%20data">protected data access request</a>.
       </li>
     </ol>
     <p>


### PR DESCRIPTION
To test, do this:

1. build socorro and then `make run`
2. go to http://localhost:8000/documentation/protected_data_access/
3. click on link to request protected data access
4. make sure the priority isn't set to `P3`--it should be `--`