### PR TITLE
bug-1884041: support java_exception in crash_report_to_description

### DIFF
--- a/webapp/crashstats/libbugzilla.py
+++ b/webapp/crashstats/libbugzilla.py
@@ -20,15 +20,16 @@ def truncate(text, max_length):
     return text
 
 
-def bugzilla_thread_frames(thread):
-    """Build frame information for bug creation link
+def minidump_thread_to_frames(thread):
+    """Build frame information from minidump output for a thread
 
     Extract frame info for the top frames of a crashing thread to be included in the
     Bugzilla summary when reporting the crash.
 
     :arg thread: dict of thread information including "frames" list
 
-    :returns: list of frame information dicts
+    :returns: list of frame information dicts with keys "frame", "module", "signature",
+        "source"
 
     """
 
@@ -50,18 +51,43 @@ def bugzilla_thread_frames(thread):
     for frame in islice(frame_generator(thread), MAX_FRAMES):
         # Source is an empty string if data isn't available
         source = frame.get("file") or ""
-        if frame.get("line"):
-            source += ":{}".format(frame["line"])
+        if source and frame.get("line") is not None:
+            source = f"{source}:{frame['line']}"
 
-        signature = frame.get("signature") or ""
-
-        signature = truncate(signature, 80)
+        signature = truncate(frame.get("signature") or "", 80)
 
         frames.append(
             {
                 "frame": frame.get("frame", "?"),
                 "module": frame.get("module") or "?",
                 "signature": signature,
+                "source": source,
+            }
+        )
+
+    return frames
+
+
+def java_exception_to_frames(stack):
+    """Build frame information from java_exception stack
+
+    :arg stack: a java_exception values item
+
+    :returns: list of frame information dicts with keys "frame", "module", "signature",
+        "source"
+
+    """
+    frames = []
+    for i, frame in enumerate(islice(stack, MAX_FRAMES)):
+        source = frame.get("filename") or "<nofile>"
+        if frame.get("lineno"):
+            source = f"{source}:{frame['lineno']}"
+
+        frames.append(
+            {
+                "frame": i,
+                "module": frame.get("module") or "?",
+                "signature": truncate(frame.get("function") or "?", 80),
                 "source": source,
             }
         )
@@ -80,40 +106,55 @@ def crash_report_to_description(crash_report_url, processed_crash):
         lines.append("")
         lines.append(f"Reason: ```{processed_crash['reason']}```")
 
-    # If there's a java_stack_trace, add that; this is a big string blob, so we truncate
-    # it at 5,000 characters but don't otherwise format it
-    if processed_crash.get("java_stack_trace"):
+    frames = None
+    if "json_dump" in processed_crash:
+        # Generate frames from the stackwalker output from parsing a minidump
+        threads = processed_crash.get("json_dump", {}).get("threads")
+        if threads:
+            if processed_crash.get("crashing_thread") is None:
+                lines.append("")
+                lines.append("No crashing thread identified; using thread 0.")
+
+            thread_index = processed_crash.get("crashing_thread") or 0
+            frames = minidump_thread_to_frames(threads[thread_index])
+
+    if not frames and "java_exception" in processed_crash:
+        stacktraces = (
+            processed_crash["java_exception"].get("exception", {}).get("values", [])
+        )
+        if stacktraces:
+            frames = java_exception_to_frames(
+                stacktraces[0]["stacktrace"].get("frames", [])
+            )
+
+    if frames:
+        lines.append("")
+        if len(frames) == 1:
+            lines.append(f"Top {len(frames)} frame:")
+        else:
+            lines.append(f"Top {len(frames)} frames:")
+        lines.append("```")
+        for frame in frames:
+            signature = truncate(frame["signature"], 80)
+            lines.append(
+                f"{frame['frame']:<2} {frame['module']}  {signature}  {frame['source']}"
+            )
+        lines.append("```")
+
+    elif processed_crash.get("java_stack_trace"):
+        # If there are no frames from a parsed minidump or a java_except value, then use
+        # the java_stack_trace if that exists; this is a big string blob, so we convert
+        # tabs to spaces, truncate it at 5,000 characters but don't otherwise format it
+        java_stack_trace = processed_crash["java_stack_trace"].replace("\t", "    ")
         lines.append("")
         lines.append("Java stack trace:")
         lines.append("```")
-        lines.append(truncate(processed_crash["java_stack_trace"], 5000))
+        lines.append(truncate(java_stack_trace, 5000))
         lines.append("```")
 
-    # Generate frames from the stackwalker output from parsing a minidump
-    frames = None
-    threads = processed_crash.get("json_dump", {}).get("threads")
-    if threads:
-        if processed_crash.get("crashing_thread") is None:
-            lines.append("")
-            lines.append("No crashing thread identified; using thread 0.")
-
-        thread_index = processed_crash.get("crashing_thread") or 0
-        frames = bugzilla_thread_frames(threads[thread_index])
-
-        if frames:
-            lines.append("")
-            lines.append(f"Top {len(frames)} frames of crashing thread:")
-            lines.append("```")
-            for frame in frames:
-                signature = truncate(frame["signature"], 80)
-                lines.append(
-                    f"{frame['frame']:<2} {frame['module']}  {signature}  {frame['source']}"
-                )
-            lines.append("```")
-
-        else:
-            lines.append("")
-            lines.append("No stack.")
+    else:
+        lines.append("")
+        lines.append("No stack.")
 
     # Remove any trailing white space--we don't want to waste characters
     lines = [line.rstrip() for line in lines]

--- a/webapp/crashstats/tests/test_libbugzilla.py
+++ b/webapp/crashstats/tests/test_libbugzilla.py
@@ -1,0 +1,677 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from textwrap import dedent
+
+import pytest
+
+from crashstats.libbugzilla import (
+    crash_report_to_description,
+    minidump_thread_to_frames,
+    truncate,
+)
+
+
+@pytest.mark.parametrize(
+    "text, length, expected",
+    [
+        pytest.param("", 80, "", id="empty-string"),
+        pytest.param("abc123", 80, "abc123", id="basic-string"),
+        pytest.param("a" * 15, 10, ("a" * 7) + "...", id="truncated-string"),
+    ],
+)
+def test_truncate(text, length, expected):
+    assert truncate(text, length) == expected
+
+
+@pytest.mark.parametrize(
+    "thread, expected",
+    [
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 1,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:1",
+                },
+            ],
+            id="everything_there",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 0,
+                    },
+                    {
+                        "frame": 1,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 1,
+                    },
+                    {
+                        "frame": 2,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 2,
+                    },
+                    {
+                        "frame": 3,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 3,
+                    },
+                    {
+                        "frame": 4,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 4,
+                    },
+                    {
+                        "frame": 5,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 5,
+                    },
+                    {
+                        "frame": 6,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 6,
+                    },
+                    {
+                        "frame": 7,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 7,
+                    },
+                    {
+                        "frame": 8,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 8,
+                    },
+                    {
+                        "frame": 9,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 9,
+                    },
+                    {
+                        "frame": 10,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 10,
+                    },
+                    {
+                        "frame": 11,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 11,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:0",
+                },
+                {
+                    "frame": 1,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:1",
+                },
+                {
+                    "frame": 2,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:2",
+                },
+                {
+                    "frame": 3,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:3",
+                },
+                {
+                    "frame": 4,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:4",
+                },
+                {
+                    "frame": 5,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:5",
+                },
+                {
+                    "frame": 6,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:6",
+                },
+                {
+                    "frame": 7,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:7",
+                },
+                {
+                    "frame": 8,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:8",
+                },
+                {
+                    "frame": 9,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:9",
+                },
+            ],
+            id="more_than_ten_frames",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(" + ("char* x, " * 15) + "int y)",
+                        "file": "fake.cpp",
+                        "line": 1,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, char* x, char* x, char* x, char* x, char* x, char* x, char*...",
+                    "source": "fake.cpp:1",
+                },
+            ],
+            id="long_frame_signature",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": 1,
+                        "inlines": [
+                            {
+                                "file": "foo_inline.cpp",
+                                "line": 100,
+                                "function": "_foo_inline",
+                            },
+                            {
+                                "file": "foo_inline.cpp",
+                                "line": 4,
+                                "function": "_foo_inline_amd64",
+                            },
+                        ],
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "_foo_inline",
+                    "source": "foo_inline.cpp:100",
+                },
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "_foo_inline_amd64",
+                    "source": "foo_inline.cpp:4",
+                },
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp:1",
+                },
+            ],
+            id="inline_functions",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": None,
+                        "signature": "(unloaded unmod@0xe4df)",
+                        "file": None,
+                        "line": None,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "?",
+                    "signature": "(unloaded unmod@0xe4df)",
+                    "source": "",
+                },
+            ],
+            id="unloaded_module",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": "fake.cpp",
+                        "line": None,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "fake.cpp",
+                },
+            ],
+            id="missing_lineno",
+        ),
+        pytest.param(
+            {
+                "frames": [
+                    {
+                        "frame": 0,
+                        "module": "fake_module",
+                        "signature": "foo::bar(char* x, int y)",
+                        "file": None,
+                        "line": 1,
+                    },
+                ]
+            },
+            [
+                {
+                    "frame": 0,
+                    "module": "fake_module",
+                    "signature": "foo::bar(char* x, int y)",
+                    "source": "",
+                },
+            ],
+            id="missing_file",
+        ),
+    ],
+)
+def test_minidump_thread_to_frames(thread, expected):
+    assert minidump_thread_to_frames(thread) == expected
+
+
+class Testcrash_report_to_description:
+    URL = "http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401"
+
+    def test_comment(self):
+        processed_crash = {
+            "reason": "SIGSEGV /0x00000080",
+            "crashing_thread": 0,
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "fake_module",
+                                "signature": "foo::bar(char* x, int y)",
+                                "file": "fake.cpp",
+                                "line": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Reason: ```SIGSEGV /0x00000080```
+
+            Top 1 frame:
+            ```
+            0  fake_module  foo::bar(char* x, int y)  fake.cpp:1
+            ```"""
+        )
+
+    def test_comment_no_data(self):
+        processed_crash = {}
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            No stack."""
+        )
+
+    def test_comment_no_frame_data(self):
+        """If a frame is missing everything, do not throw an error."""
+        processed_crash = {
+            "crashing_thread": 0,
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {},
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        # NOTE(willkg): This is a silly looking stack, but the important part here is
+        # that it produces something and doesn't throw an error
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Top 1 frame:
+            ```
+            ?  ?
+            ```"""
+        )
+
+    def test_comment_reason(self):
+        """Verify Reason makes it into the comment."""
+        processed_crash = {
+            "reason": "SIGSEGV /0x00000080",
+            "crashing_thread": 0,
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "fake_module",
+                                "signature": "foo::bar(char* x, int y)",
+                                "file": "fake.cpp",
+                                "line": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Reason: ```SIGSEGV /0x00000080```
+
+            Top 1 frame:
+            ```
+            0  fake_module  foo::bar(char* x, int y)  fake.cpp:1
+            ```"""
+        )
+
+    def test_comment_moz_crash_reason(self):
+        """Verify moz_crash_reason makes it into comment--but not moz_crash_reason_raw."""
+        processed_crash = {
+            "moz_crash_reason": "good data",
+            "moz_crash_reason_raw": "bad data",
+            "crashing_thread": 0,
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "fake_module",
+                                "signature": "foo::bar(char* x, int y)",
+                                "file": "fake.cpp",
+                                "line": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            MOZ_CRASH Reason: ```good data```
+
+            Top 1 frame:
+            ```
+            0  fake_module  foo::bar(char* x, int y)  fake.cpp:1
+            ```"""
+        )
+
+    def test_comment_moz_crash_reason_upstages_reason(self):
+        """Verify moz_crash_reason shows up but not reason when they're both there."""
+        processed_crash = {
+            "reason": "EXCEPTION_BREAKPOINT",
+            "moz_crash_reason": "MOZ_CRASH(Quota manager shutdown timed out) (good)",
+            "moz_crash_reason_raw": "MOZ_CRASH(Quota manager shutdown timed out) (bad)",
+            "crashing_thread": 0,
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "fake_module",
+                                "signature": "foo::bar(char* x, int y)",
+                                "file": "fake.cpp",
+                                "line": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            MOZ_CRASH Reason: ```MOZ_CRASH(Quota manager shutdown timed out) (good)```
+
+            Top 1 frame:
+            ```
+            0  fake_module  foo::bar(char* x, int y)  fake.cpp:1
+            ```"""
+        )
+
+    def test_comment_crashing_thread_none(self):
+        """Verify no crashing thread is treated as thread 0 with note."""
+        processed_crash = {
+            "json_dump": {
+                "threads": [
+                    {
+                        "frames": [
+                            {
+                                "frame": 0,
+                                "module": "fake_module",
+                                "signature": "foo::bar(char* x, int y)",
+                                "file": "fake.cpp",
+                                "line": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            No crashing thread identified; using thread 0.
+
+            Top 1 frame:
+            ```
+            0  fake_module  foo::bar(char* x, int y)  fake.cpp:1
+            ```"""
+        )
+
+    def test_comment_java_stack_trace(self):
+        """If there's a java stack trace, use that instead
+
+        Also verify tabs get converted to 4-spaces.
+
+        """
+        processed_crash = {
+            "java_stack_trace": dedent(
+                """\
+                java.lang.NoClassDefFoundError: kotlinx.coroutines.channels.BufferedChannel
+                \tat kotlinx.coroutines.channels.ChannelKt.Channel$default(Channel.kt:44)
+                \tat androidx.datastore.core.SimpleActor.<init>(SimpleActor.kt:18)
+                \tat androidx.datastore.core.SingleProcessDataStore.<init>(SingleProcessDataStore.kt:68)
+                \tat androidx.datastore.DataStoreSingletonDelegate.getValue(DataStoreDelegate.kt:81)"""
+            )
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Java stack trace:
+            ```
+            java.lang.NoClassDefFoundError: kotlinx.coroutines.channels.BufferedChannel
+                at kotlinx.coroutines.channels.ChannelKt.Channel$default(Channel.kt:44)
+                at androidx.datastore.core.SimpleActor.<init>(SimpleActor.kt:18)
+                at androidx.datastore.core.SingleProcessDataStore.<init>(SingleProcessDataStore.kt:68)
+                at androidx.datastore.DataStoreSingletonDelegate.getValue(DataStoreDelegate.kt:81)
+            ```"""
+        )
+
+    def test_comment_java_exception(self):
+        """If there's a java_exception, use that."""
+        processed_crash = {
+            "java_exception": {
+                "exception": {
+                    "values": [
+                        {
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "module": "kotlinx.coroutines.channels.ChannelKt",
+                                        "function": "Channel$default",
+                                        "in_app": True,
+                                        "lineno": 44,
+                                        "filename": "Channel.kt",
+                                    },
+                                    {
+                                        "module": "androidx.datastore.core.SimpleActor",
+                                        "function": "<init>",
+                                        "in_app": True,
+                                        "lineno": 18,
+                                        "filename": "SimpleActor.kt",
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Top 2 frames:
+            ```
+            0  kotlinx.coroutines.channels.ChannelKt  Channel$default  Channel.kt:44
+            1  androidx.datastore.core.SimpleActor  <init>  SimpleActor.kt:18
+            ```"""
+        )
+
+    def test_comment_java_exception_upstages_java_stack_trace(self):
+        """Use java_exception instead of java_stack_trace."""
+        processed_crash = {
+            "java_stack_trace": dedent(
+                """\
+                java.lang.NoClassDefFoundError: kotlinx.coroutines.channels.BufferedChannel
+                \tat kotlinx.coroutines.channels.ChannelKt.Channel$default(Channel.kt:44)
+                \tat androidx.datastore.core.SimpleActor.<init>(SimpleActor.kt:18)
+                \tat androidx.datastore.core.SingleProcessDataStore.<init>(SingleProcessDataStore.kt:68)
+                \tat androidx.datastore.DataStoreSingletonDelegate.getValue(DataStoreDelegate.kt:81)"""
+            ),
+            "java_exception": {
+                "exception": {
+                    "values": [
+                        {
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "module": "kotlinx.coroutines.channels.ChannelKt",
+                                        "function": "Channel$default",
+                                        "in_app": True,
+                                        "lineno": 44,
+                                        "filename": "Channel.kt",
+                                    },
+                                    {
+                                        "module": "androidx.datastore.core.SimpleActor",
+                                        "function": "<init>",
+                                        "in_app": True,
+                                        "lineno": 18,
+                                        "filename": "SimpleActor.kt",
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+        comment = crash_report_to_description(self.URL, processed_crash)
+        assert comment == dedent(
+            """\
+            Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
+
+            Top 2 frames:
+            ```
+            0  kotlinx.coroutines.channels.ChannelKt  Channel$default  Channel.kt:44
+            1  androidx.datastore.core.SimpleActor  <init>  SimpleActor.kt:18
+            ```"""
+        )


### PR DESCRIPTION
This adds support for java_exception field when generating the
description for creating new bugs.

This also creates `webapp/crashstats/tests/test_libbugzilla.py` and
moves a bunch of tests from `test_jinja_helpers.py` so that
`test_libbugzilla.py` tests all the requirements for the functions.

I also switched the comment-building tests to use dedent instead of
string delimiters, newlines, and such. It's a little easier to
manipulate and a lot easier to read and verify.

This also re-does `test_corrected_os_version_name` so it's parametrized.
