### PR TITLE
bug-1886018: Fix flaky tests due to pubsub duplicate delivery

### DIFF
--- a/webapp/crashstats/crashstats/tests/test_models.py
+++ b/webapp/crashstats/crashstats/tests/test_models.py
@@ -491,7 +491,7 @@ class TestReprocessing:
         api.post(crash_ids=crash_id)
 
         crash_ids = queue_helper.get_published_crashids("reprocessing")
-        assert crash_ids == [crash_id]
+        assert set(crash_ids) == {crash_id}
 
         # Now try an invalid crash id
         with pytest.raises(BadArgumentError):
@@ -505,4 +505,4 @@ class TestPriorityJob:
         api.post(crash_ids="some-crash-id")
 
         crash_ids = queue_helper.get_published_crashids("priority")
-        assert crash_ids == ["some-crash-id"]
+        assert set(crash_ids) == {"some-crash-id"}


### PR DESCRIPTION
by comparing delivered crash ids as sets instead of as lists