### PR TITLE
circleci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
           # yamllint disable rule:line-length
           command: |
             make my.env
-            docker compose up -d localstack elasticsearch postgresql statsd fakesentry
             docker compose run --rm test-ci shell ./bin/test.sh
           # yamllint enable rule:line-length
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   main:
     docker:
-      - image: cimg/python:3.10.9
+      - image: cimg/python:3.10.13
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
Fixes a couple of minor issues I noticed when looking at CI failures.

- Remove `docker compose up ...` in CI step
- Update cimg/python image to 3.10.13 hoping that picked up a new docker client, but it didn't

We see this warning when running `make build`:

```
--progress is a global compose flag, better use `docker compose --progress xx build ...
```

I really thought I also saw it when we were looking at CI failures the other day, but when I fix it CI fails saying that it doesn't know about `docker --progress xx`. I think that in CI while the docker server is up to date, the docker plugins and docker client aren't. I updated the `cimg/python` image, but that didn't change anything.

Anyhow, something we'll have to look at in the future.