### PR TITLE
bug-1886019: generalize s3 references to make room for gcs

### DIFF
--- a/bin/process_crashes.sh
+++ b/bin/process_crashes.sh
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Pulls down crash data for specified crash ids, syncs to the S3 bucket, and
-# sends the crash ids to the Pub/Sub queue.
+# Pulls down crash data for specified crash ids, syncs to the cloud storage
+# bucket, and sends the crash ids to the queue.
 #
 # Usage: ./bin/process_crashes.sh
 #

--- a/bin/upload_telemetry_schema.py
+++ b/bin/upload_telemetry_schema.py
@@ -25,25 +25,24 @@ METRICS = markus.get_metrics("processor")
 @click.option(
     "--destination_key",
     default="telemetry_socorro_crash.json",
-    help="the key in the S3 bucket to save the schema to",
+    help="the key in the bucket to save the schema to",
 )
 @click.pass_context
 def upload(ctx, destination_key):
-    """Uploads schema to S3 bucket for Telemetry
+    """Uploads schema to bucket for Telemetry
 
-    We always send a copy of the crash (mainly processed crash) to a S3 bucket
+    We always send a copy of the crash (mainly processed crash) to a bucket
     meant for Telemetry to ingest. When they ingest, they need a copy of our
     telemetry_socorro_crash.json JSON Schema file.
 
     They use that not to understand the JSON we store but the underlying
-    structure (types, nesting etc.) necessary for storing it in .parquet files
-    in S3.
+    structure (types, nesting etc.) necessary for storing it in .parquet files.
 
     To get a copy of the telemetry_socorro_crash.json they can take it from the git
     repository but that's fragile since it depends on github.com always being available.
 
-    By uploading it to S3 not only do we bet on S3 being more read-reliable
-    that github.com's server but by being in S3 AND unavailable that means the
+    By uploading it not only do we bet on the bucket being more read-reliable
+    than github.com's server but by being in the bucket AND unavailable that means the
     whole ingestion process has to halt/pause anyway.
 
     """

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -264,7 +264,7 @@ Glossary
        The Socorro collector parses the HTTP POST payload into a set of crash
        annotations and minidumps. It collects the crash annotations along with
        some metadata generated at collection in a raw crash structure. It
-       saves this to AWS S3.
+       saves this to cloud storage.
 
        The Socorro processor takes the raw crash and minidumps and passes them
        through the processing pipeline to generate a processed crash.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -25,13 +25,14 @@ Important services in the diagram:
   rejected. It generates a :term:`crash id` for the :term:`crash report`. It
   parses the HTTP POST payload into a raw crash with
   :term:`crash annotations <crash annotation>` and :term:`minidump` files. It
-  saves this crash data to AWS S3 and publishes :term:`crash ids <crash id>` to
-  AWS SQS for processing.
+  saves this crash data to cloud storage and publishes
+  :term:`crash ids <crash id>` to a queue for processing.
 
 * **Processor:** Processes :term:`crash reports <crash report>`, normalizes and
   validates data, extracts data from :term:`minidumps <minidump>`, generates
   :term:`crash signatures <crash signature>`, performs other analysis, and
-  saves everything as a :term:`processed crash` to AWS S3 and Elasticsearch.
+  saves everything as a :term:`processed crash` to cloud storage and
+  Elasticsearch.
 
 * **Webapp (aka Crash Stats):** Web user interface for looking at, searching,
   and analyzing :term:`processed crash` data.
@@ -113,8 +114,9 @@ crash id to the crash reporter in the HTTP response. The crash reporter records
 the crash id on the user's machine. The user can see crash reports in
 ``about:crashes``.
 
-The collector saves the crash report data to AWS S3 as a :term:`raw crash` and
-:term:`minidumps <minidump>` in a directory structure like this:
+The collector saves the crash report data to cloud storage as a
+:term:`raw crash` and :term:`minidumps <minidump>` in a directory structure
+like this:
 
 .. code-block:: text
 
@@ -156,8 +158,8 @@ always set to ``0``.
 Processed by Processor
 ----------------------
 
-The processor pulls :term:`crash ids <crash id>` from the AWS SQS queues. It
-fetches the :term:`raw crash` and :term:`minidumps <minidump>` from AWS S3.
+The processor pulls :term:`crash ids <crash id>` from the queues. It fetches
+the :term:`raw crash` and :term:`minidumps <minidump>` from cloud storage.
 
 It passes the crash data through the processing pipeline which generates a
 :term:`processed crash`.
@@ -175,9 +177,9 @@ There are other rules, too.
 After the crash gets through the processing pipeline, the processed crash is
 saved to several places:
 
-1. AWS S3
+1. cloud storage (e.g. AWS S3 or GCS)
 2. Elasticsearch
-3. AWS S3 (different bucket) to be ingested into Telemetry BigQuery
+3. cloud storage (different bucket) to be ingested into Telemetry BigQuery
 
 .. seealso::
 

--- a/docs/service/collector.rst
+++ b/docs/service/collector.rst
@@ -5,8 +5,8 @@ Collector
 =========
 
 The collector's job is to collect incoming crash reports, generate crash ids,
-save that data to AWS S3 as soon as possible, and publish a crash report id
-to AWS SQS for processing.
+save that data to cloud storage as soon as possible, and publish a crash report id
+to a queue for processing.
 
 Antenna is the name of the collector that we're using now.
 

--- a/docs/tests/system_checklist.rst
+++ b/docs/tests/system_checklist.rst
@@ -82,7 +82,7 @@ Checklist
 
     * Log into Sentry and check for errors.
 
-    * Submit a crash to the collector. Verify raw crash made it to S3.
+    * Submit a crash to the collector. Verify raw crash made it to cloud storage.
 
 
     Processor
@@ -103,11 +103,11 @@ Checklist
       * stage: check Grafana stage dashboard
       * prod: check Grafana prod dashboard
 
-    Is the processor saving crash data to Elasticsearch? To S3?
+    Is the processor saving crash data to Elasticsearch? To cloud storage?
 
     * Check Grafana "processor.es.save_processed_crash"
 
-    * Check Grafana "processor.s3.save_processed_crash"
+    * Check Grafana "processor.storage.save_processed_crash"
 
     * Check Grafana "processor.telemetry.save_processed_crash"
 

--- a/socorro/external/crash_data_mixin.py
+++ b/socorro/external/crash_data_mixin.py
@@ -2,28 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import logging
-
 from socorro.lib import external_common, MissingArgumentError, BadArgumentError, libooid
-from socorro.external.boto.crashstorage import (
-    BotoS3CrashStorage,
-    CrashIDNotFound,
-    TelemetryBotoS3CrashStorage,
-)
+from socorro.external.crashstorage_base import CrashIDNotFound
 
 
-class SimplifiedCrashData(BotoS3CrashStorage):
-    """Fetches data from BotoS3CrashStorage
+class SimplifiedCrashDataMixin:
+    """Fetch data from crash storage
 
     The difference between this and the base CrashData class is that this one
     only makes the get() and if it fails it does NOT try to put the crash ID
     back into the priority jobs queue.
 
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
     def get(self, **kwargs):
         """Return JSON data of a crash report, given its uuid."""
@@ -68,8 +58,8 @@ class SimplifiedCrashData(BotoS3CrashStorage):
             raise CrashIDNotFound(params["uuid"]) from cidnf
 
 
-class TelemetryCrashData(TelemetryBotoS3CrashStorage):
-    """Fetches data from TelemetryBotoS3CrashStorage"""
+class TelemetryCrashDataMixin:
+    """Fetch data from telemetry crash storage."""
 
     def get(self, **kwargs):
         """Return JSON data of a crash report, given its uuid."""

--- a/socorro/external/sqs/crashqueue.py
+++ b/socorro/external/sqs/crashqueue.py
@@ -169,7 +169,7 @@ class SQSCrashQueue(CrashQueueBase):
             # which is unhelpful for granularity purposes.
             ClientError,
             # This raises a ValueError "invalid endpoint" if it has problems
-            # getting the s3 credentials and then tries "s3..amazonaws.com"--we
+            # getting the sqs credentials and then tries "sqs..amazonaws.com"--we
             # want to retry that, too.
             ValueError,
         ],

--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -231,7 +231,7 @@ if CLOUD_PROVIDER == "AWS":
 elif CLOUD_PROVIDER == "GCP":
     QUEUE = QUEUE_PUBSUB
 
-S3_STORAGE = {
+STORAGE = {
     "class": "socorro.external.boto.crashstorage.BotoS3CrashStorage",
     "options": {
         "metrics_prefix": "processor.s3",
@@ -301,14 +301,14 @@ TELEMETRY_STORAGE = {
     },
 }
 
-# Crash report storage source pulls from S3
-CRASH_SOURCE = S3_STORAGE
+# Crash report storage source pulls from cloud storage
+CRASH_SOURCE = STORAGE
 
 # Each key in this list corresponds to a key in this dict containing a crash report data
 # destination configuration
-CRASH_DESTINATIONS_ORDER = ["s3", "es", "telemetry"]
+CRASH_DESTINATIONS_ORDER = ["storage", "es", "telemetry"]
 CRASH_DESTINATIONS = {
-    "s3": S3_STORAGE,
+    "storage": STORAGE,
     "es": ES_STORAGE,
     "telemetry": TELEMETRY_STORAGE,
 }

--- a/socorro/tests/conftest.py
+++ b/socorro/tests/conftest.py
@@ -152,12 +152,12 @@ class S3Helper:
         if self._buckets_seen is not None:
             self._buckets_seen.add(bucket_name)
 
-    def upload_fileobj(self, bucket_name, key, data):
+    def upload(self, bucket_name, key, data):
         """Puts an object into the specified bucket."""
         self.create_bucket(bucket_name)
         self.conn.upload_fileobj(Fileobj=io.BytesIO(data), Bucket=bucket_name, Key=key)
 
-    def download_fileobj(self, bucket_name, key):
+    def download(self, bucket_name, key):
         """Fetches an object from the specified bucket"""
         self.create_bucket(bucket_name)
         resp = self.conn.get_object(Bucket=bucket_name, Key=key)
@@ -179,8 +179,8 @@ def s3_helper():
     * ``get_client()``
     * ``get_crashstorage_bucket()``
     * ``create_bucket(bucket_name)``
-    * ``upload_fileobj(bucket_name, key, value)``
-    * ``download_fileobj(bucket_name, key)``
+    * ``upload(bucket_name, key, data)``
+    * ``download(bucket_name, key)``
     * ``list(bucket_name)``
 
     """
@@ -548,3 +548,9 @@ def queue_helper(cloud_provider):
 
     with helper as _helper:
         yield _helper
+
+
+@pytest.fixture
+def storage_helper(s3_helper):
+    """Generate and return a cloud storage helper using env config."""
+    yield s3_helper

--- a/socorro/tests/external/boto/test_connection_context.py
+++ b/socorro/tests/external/boto/test_connection_context.py
@@ -35,12 +35,12 @@ class TestS3ConnectionContext:
 
         objects = s3_helper.list(bucket)
         assert objects == ["/test/testfile.txt"]
-        assert s3_helper.download_fileobj(bucket, path) == file_data
+        assert s3_helper.download(bucket, path) == file_data
 
         # Stomp on that file with a new one
         file_data2 = b"test file contents 2"
         conn.save_file(bucket=bucket, path=path, data=file_data2)
-        assert s3_helper.download_fileobj(bucket, path) == file_data2
+        assert s3_helper.download(bucket, path) == file_data2
 
     def test_load_file_doesnt_exist(self, s3_helper):
         """Test loading a file that isn't there."""
@@ -62,6 +62,6 @@ class TestS3ConnectionContext:
         file_data = b"test file contents"
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(bucket, path, file_data)
+        s3_helper.upload(bucket, path, file_data)
         data = conn.load_file(bucket=bucket, path=path)
         assert data == file_data

--- a/socorro/tests/external/boto/test_crash_data.py
+++ b/socorro/tests/external/boto/test_crash_data.py
@@ -14,7 +14,7 @@ from socorro.lib.libooid import create_new_ooid
 
 
 CRASHDATA_SETTINGS = {
-    "class": "socorro.external.boto.crash_data.SimplifiedCrashData",
+    "class": "socorro.external.boto.crashstorage.BotoS3CrashStorage",
     "options": {
         "bucket": os.environ["CRASHSTORAGE_S3_BUCKET"],
         "region": os.environ["CRASHSTORAGE_S3_REGION"],
@@ -25,7 +25,7 @@ CRASHDATA_SETTINGS = {
 }
 
 TELEMETRY_SETTINGS = {
-    "class": "socorro.external.boto.crash_data.TelemetryCrashData",
+    "class": "socorro.external.boto.crashstorage.TelemetryBotoS3CrashStorage",
     "options": {
         "bucket": os.environ["TELEMETRY_S3_BUCKET"],
         "region": os.environ["TELEMETRY_S3_REGION"],
@@ -44,7 +44,7 @@ class TestSimplifiedCrashData:
         crash_id = create_new_ooid()
         s3_helper.create_bucket(bucket)
 
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/processed_crash/{crash_id}",
             data=json.dumps({"foo": "bar"}).encode("utf-8"),
@@ -70,7 +70,7 @@ class TestSimplifiedCrashData:
         crash_id = create_new_ooid()
         s3_helper.create_bucket(bucket)
 
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b"\xa0",
@@ -122,7 +122,7 @@ class TestTelemetryCrashData:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/crash_report/20{crash_id[-6:]}/{crash_id}",
             data=json.dumps({"foo": "bar"}).encode("utf-8"),

--- a/socorro/tests/external/boto/test_crashstorage.py
+++ b/socorro/tests/external/boto/test_crashstorage.py
@@ -96,7 +96,7 @@ class TestBotoS3CrashStorage:
 
         # Verify the raw_crash made it to the right place and has the right
         # contents
-        raw_crash = s3_helper.download_fileobj(
+        raw_crash = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/raw_crash/20{crash_id[-6:]}/{crash_id}",
         )
@@ -104,7 +104,7 @@ class TestBotoS3CrashStorage:
         assert json.loads(raw_crash) == original_raw_crash
 
         # Verify dump_names made it to the right place and has the right contents
-        dump_names = s3_helper.download_fileobj(
+        dump_names = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/dump_names/{crash_id}",
         )
@@ -128,7 +128,7 @@ class TestBotoS3CrashStorage:
         )
 
         # Verify the raw_crash made it to the right place and has the right contents
-        raw_crash = s3_helper.download_fileobj(
+        raw_crash = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/raw_crash/20{crash_id[-6:]}/{crash_id}",
         )
@@ -137,20 +137,20 @@ class TestBotoS3CrashStorage:
 
         # Verify dump_names made it to the right place and has the right
         # contents
-        dump_names = s3_helper.download_fileobj(
+        dump_names = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/dump_names/{crash_id}",
         )
         assert sorted(json.loads(dump_names)) == ["content_dump", "dump"]
 
         # Verify dumps
-        dump = s3_helper.download_fileobj(
+        dump = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
         )
         assert dump == b"fake dump"
 
-        content_dump = s3_helper.download_fileobj(
+        content_dump = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/content_dump/{crash_id}",
         )
@@ -175,7 +175,7 @@ class TestBotoS3CrashStorage:
         )
 
         # Verify processed crash is saved
-        processed_crash = s3_helper.download_fileobj(
+        processed_crash = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/processed_crash/{crash_id}",
         )
@@ -191,7 +191,7 @@ class TestBotoS3CrashStorage:
         original_raw_crash = {"submitted_timestamp": date_to_string(now)}
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/raw_crash/20{crash_id[-6:]}/{crash_id}",
             data=dict_to_str(original_raw_crash).encode("utf-8"),
@@ -219,7 +219,7 @@ class TestBotoS3CrashStorage:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b"this is a raw dump",
@@ -244,7 +244,7 @@ class TestBotoS3CrashStorage:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b"this is a raw dump",
@@ -260,7 +260,7 @@ class TestBotoS3CrashStorage:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b"this is a raw dump",
@@ -275,22 +275,22 @@ class TestBotoS3CrashStorage:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump_names/{crash_id}",
             data=b'["dump", "content_dump", "city_dump"]',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b'this is "dump", the first one',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/content_dump/{crash_id}",
             data=b'this is "content_dump", the second one',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/city_dump/{crash_id}",
             data=b'this is "city_dump", the last one',
@@ -318,22 +318,22 @@ class TestBotoS3CrashStorage:
         crash_id = create_new_ooid()
 
         s3_helper.create_bucket(bucket)
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump_names/{crash_id}",
             data=b'["dump", "content_dump", "city_dump"]',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/dump/{crash_id}",
             data=b'this is "dump", the first one',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/content_dump/{crash_id}",
             data=b'this is "content_dump", the second one',
         )
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/city_dump/{crash_id}",
             data=b'this is "city_dump", the last one',
@@ -376,7 +376,7 @@ class TestBotoS3CrashStorage:
             "json_dump": {"sensitive": 22},
         }
 
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/processed_crash/{crash_id}",
             data=dict_to_str(processed_crash).encode("utf-8"),
@@ -433,7 +433,7 @@ class TestTelemetryBotoS3CrashStorage:
         )
 
         # Get the crash data we just saved from the bucket and verify it's contents
-        crash_data = s3_helper.download_fileobj(
+        crash_data = s3_helper.download(
             bucket_name=bucket,
             key=f"v1/crash_report/20{crash_id[-6:]}/{crash_id}",
         )
@@ -470,7 +470,7 @@ class TestTelemetryBotoS3CrashStorage:
         }
 
         # Save the data to S3 so we have something to get
-        s3_helper.upload_fileobj(
+        s3_helper.upload(
             bucket_name=bucket,
             key=f"v1/crash_report/20{crash_id[-6:]}/{crash_id}",
             data=json.dumps(crash_data).encode("utf-8"),

--- a/socorro/tests/test_upload_telemetry_schema.py
+++ b/socorro/tests/test_upload_telemetry_schema.py
@@ -3,14 +3,10 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
-import os
 
 from click.testing import CliRunner
 
 from upload_telemetry_schema import upload
-
-
-TELEMETRY_BUCKET = os.environ["TELEMETRY_S3_BUCKET"]
 
 
 def test_it_runs():
@@ -20,9 +16,10 @@ def test_it_runs():
     assert result.exit_code == 0
 
 
-def test_upload(s3_helper):
+def test_upload(storage_helper):
     """Tests whether the file is uploaded and has the right properites"""
-    s3_helper.create_bucket(TELEMETRY_BUCKET)
+    telemetry_bucket = storage_helper.get_telemetry_bucket()
+    storage_helper.create_bucket(telemetry_bucket)
 
     runner = CliRunner()
     result = runner.invoke(upload)
@@ -30,8 +27,8 @@ def test_upload(s3_helper):
     assert result.exit_code == 0
 
     # Get the crash data we just saved from the bucket and verify it's contents
-    crash_data = s3_helper.download_fileobj(
-        bucket_name=TELEMETRY_BUCKET,
+    crash_data = storage_helper.download(
+        bucket_name=telemetry_bucket,
         key="telemetry_socorro_crash.json",
     )
     schema = json.loads(crash_data)

--- a/webapp/crashstats/api/tests/test_views.py
+++ b/webapp/crashstats/api/tests/test_views.py
@@ -598,11 +598,11 @@ class TestCrashVerify:
             mock_ss.return_value.get.side_effect = mocked_supersearch_get
             yield
 
-    def create_s3_buckets(self, s3_helper):
-        bucket = s3_helper.get_crashstorage_bucket()
-        s3_helper.create_bucket(bucket)
-        telemetry_bucket = s3_helper.get_telemetry_bucket()
-        s3_helper.create_bucket(telemetry_bucket)
+    def create_storage_buckets(self, storage_helper):
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.create_bucket(bucket)
+        telemetry_bucket = storage_helper.get_telemetry_bucket()
+        storage_helper.create_bucket(telemetry_bucket)
 
     def test_bad_uuid(self, client):
         url = reverse("api:crash_verify")
@@ -612,8 +612,8 @@ class TestCrashVerify:
         data = json.loads(resp.content)
         assert data == {"error": "unknown crash id"}
 
-    def test_elastcsearch_has_crash(self, s3_helper, client):
-        self.create_s3_buckets(s3_helper)
+    def test_elastcsearch_has_crash(self, storage_helper, client):
+        self.create_storage_buckets(storage_helper)
 
         uuid = create_new_ooid()
 
@@ -627,20 +627,20 @@ class TestCrashVerify:
         assert data == {
             "uuid": uuid,
             "elasticsearch_crash": True,
-            "s3_raw_crash": False,
-            "s3_processed_crash": False,
-            "s3_telemetry_crash": False,
+            "raw_crash": False,
+            "processed_crash": False,
+            "telemetry_crash": False,
         }
 
-    def test_raw_crash_has_crash(self, s3_helper, client):
-        self.create_s3_buckets(s3_helper)
+    def test_raw_crash_has_crash(self, storage_helper, client):
+        self.create_storage_buckets(storage_helper)
 
         uuid = create_new_ooid()
         crash_data = {"submitted_timestamp": "2018-03-14-09T22:21:18.646733+00:00"}
 
-        bucket = s3_helper.get_crashstorage_bucket()
+        bucket = storage_helper.get_crashstorage_bucket()
         raw_crash_key = "v1/raw_crash/20%s/%s" % (uuid[-6:], uuid)
-        s3_helper.upload_fileobj(
+        storage_helper.upload(
             bucket_name=bucket,
             key=raw_crash_key,
             data=json.dumps(crash_data).encode("utf-8"),
@@ -655,14 +655,14 @@ class TestCrashVerify:
 
         assert data == {
             "uuid": uuid,
-            "s3_raw_crash": True,
-            "s3_processed_crash": False,
+            "raw_crash": True,
+            "processed_crash": False,
             "elasticsearch_crash": False,
-            "s3_telemetry_crash": False,
+            "telemetry_crash": False,
         }
 
-    def test_processed_has_crash(self, s3_helper, client):
-        self.create_s3_buckets(s3_helper)
+    def test_processed_has_crash(self, storage_helper, client):
+        self.create_storage_buckets(storage_helper)
 
         uuid = create_new_ooid()
         crash_data = {
@@ -671,8 +671,8 @@ class TestCrashVerify:
             "completed_datetime": "2022-03-14 10:56:50.902884",
         }
 
-        bucket = s3_helper.get_crashstorage_bucket()
-        s3_helper.upload_fileobj(
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.upload(
             bucket_name=bucket,
             key="v1/processed_crash/%s" % uuid,
             data=json.dumps(crash_data, cls=DateTimeEncoder).encode("utf-8"),
@@ -687,14 +687,14 @@ class TestCrashVerify:
 
         assert data == {
             "uuid": uuid,
-            "s3_processed_crash": True,
-            "s3_raw_crash": False,
+            "processed_crash": True,
+            "raw_crash": False,
             "elasticsearch_crash": False,
-            "s3_telemetry_crash": False,
+            "telemetry_crash": False,
         }
 
-    def test_telemetry_has_crash(self, s3_helper, client):
-        self.create_s3_buckets(s3_helper)
+    def test_telemetry_has_crash(self, storage_helper, client):
+        self.create_storage_buckets(storage_helper)
 
         uuid = create_new_ooid()
         crash_data = {
@@ -703,8 +703,8 @@ class TestCrashVerify:
             "uuid": uuid,
         }
 
-        telemetry_bucket = s3_helper.get_telemetry_bucket()
-        s3_helper.upload_fileobj(
+        telemetry_bucket = storage_helper.get_telemetry_bucket()
+        storage_helper.upload(
             bucket_name=telemetry_bucket,
             key="v1/crash_report/20%s/%s" % (uuid[-6:], uuid),
             data=json.dumps(crash_data).encode("utf-8"),
@@ -719,9 +719,9 @@ class TestCrashVerify:
 
         assert data == {
             "uuid": uuid,
-            "s3_telemetry_crash": True,
-            "s3_raw_crash": False,
-            "s3_processed_crash": False,
+            "telemetry_crash": True,
+            "raw_crash": False,
+            "processed_crash": False,
             "elasticsearch_crash": False,
         }
 

--- a/webapp/crashstats/api/views.py
+++ b/webapp/crashstats/api/views.py
@@ -476,14 +476,14 @@ def crash_verify(request):
 
     data = {"uuid": crash_id}
 
-    # Check S3 crash bucket for raw and processed crash data
+    # Check crash bucket for raw and processed crash data
     raw_api = models.RawCrash()
     try:
         raw_api.get(crash_id=crash_id, dont_cache=True, refresh_cache=True)
         has_raw_crash = True
     except CrashIDNotFound:
         has_raw_crash = False
-    data["s3_raw_crash"] = has_raw_crash
+    data["raw_crash"] = has_raw_crash
 
     processed_api = models.ProcessedCrash()
     try:
@@ -491,7 +491,7 @@ def crash_verify(request):
         has_processed_crash = True
     except CrashIDNotFound:
         has_processed_crash = False
-    data["s3_processed_crash"] = has_processed_crash
+    data["processed_crash"] = has_processed_crash
 
     # Check Elasticsearch for crash data
     supersearch_api = supersearch_models.SuperSearch()
@@ -507,14 +507,14 @@ def crash_verify(request):
         results["total"] == 1 and results["hits"][0]["uuid"] == crash_id
     )
 
-    # Check S3 telemetry bucket for crash data
+    # Check telemetry bucket for crash data
     telemetry_api = models.TelemetryCrash()
     try:
         telemetry_api.get(crash_id=crash_id, dont_cache=True, refresh_cache=True)
         has_telemetry_crash = True
     except CrashIDNotFound:
         has_telemetry_crash = False
-    data["s3_telemetry_crash"] = has_telemetry_crash
+    data["telemetry_crash"] = has_telemetry_crash
 
     return http.JsonResponse(data, status=200)
 
@@ -661,14 +661,14 @@ class CrashVerifyAPI(SocorroAPIView):
 
         data = {"uuid": crash_id}
 
-        # Check S3 crash bucket for raw and processed crash data
+        # Check crash bucket for raw and processed crash data
         raw_api = models.RawCrash()
         try:
             raw_api.get(crash_id=crash_id, dont_cache=True, refresh_cache=True)
             has_raw_crash = True
         except CrashIDNotFound:
             has_raw_crash = False
-        data["s3_raw_crash"] = has_raw_crash
+        data["raw_crash"] = has_raw_crash
 
         processed_api = models.ProcessedCrash()
         try:
@@ -676,7 +676,7 @@ class CrashVerifyAPI(SocorroAPIView):
             has_processed_crash = True
         except CrashIDNotFound:
             has_processed_crash = False
-        data["s3_processed_crash"] = has_processed_crash
+        data["processed_crash"] = has_processed_crash
 
         # Check Elasticsearch for crash data
         supersearch_api = supersearch_models.SuperSearch()
@@ -692,14 +692,14 @@ class CrashVerifyAPI(SocorroAPIView):
             results["total"] == 1 and results["hits"][0]["uuid"] == crash_id
         )
 
-        # Check S3 telemetry bucket for crash data
+        # Check telemetry bucket for crash data
         telemetry_api = models.TelemetryCrash()
         try:
             telemetry_api.get(crash_id=crash_id, dont_cache=True, refresh_cache=True)
             has_telemetry_crash = True
         except CrashIDNotFound:
             has_telemetry_crash = False
-        data["s3_telemetry_crash"] = has_telemetry_crash
+        data["telemetry_crash"] = has_telemetry_crash
 
         return Response(data)
 

--- a/webapp/crashstats/crashstats/management/commands/updatemissing.py
+++ b/webapp/crashstats/crashstats/management/commands/updatemissing.py
@@ -9,7 +9,7 @@ This command checks known missing crashes to see if they've since been processed
 from django.core.management.base import BaseCommand
 
 from crashstats.crashstats.management.commands.verifyprocessed import (
-    is_in_s3,
+    is_in_storage,
     check_elasticsearch,
 )
 from crashstats.supersearch.models import SuperSearchUnredacted
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 
     def check_past_missing(self):
         """Check the table for missing crashes and check to see if they exist."""
-        s3_crash_dest = build_instance_from_settings(socorro_settings.S3_STORAGE)
+        crash_dest = build_instance_from_settings(socorro_settings.STORAGE)
 
         supersearch = SuperSearchUnredacted()
 
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         no_longer_missing = []
 
         for crash_id in crash_ids:
-            if is_in_s3(s3_crash_dest, crash_id):
+            if is_in_storage(crash_dest, crash_id):
                 missing = check_elasticsearch(supersearch, crash_id)
                 if not missing:
                     no_longer_missing.append(crash_id)

--- a/webapp/crashstats/crashstats/models.py
+++ b/webapp/crashstats/crashstats/models.py
@@ -23,7 +23,6 @@ import markus
 from pymemcache.exceptions import MemcacheServerError
 
 from socorro import settings as socorro_settings
-from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
 from socorro.lib.libooid import is_crash_id_valid
@@ -532,7 +531,7 @@ class SocorroMiddleware(SocorroCommon):
 
 
 class TelemetryCrash(SocorroMiddleware):
-    """Model for data we store in the S3 bucket to send to Telemetry"""
+    """Model for data we store in the bucket to send to Telemetry"""
 
     required_params = ("crash_id",)
     aliases = {"crash_id": "uuid"}
@@ -542,9 +541,7 @@ class TelemetryCrash(SocorroMiddleware):
     delete = None
 
     def get_implementation(self):
-        s3_settings = socorro_settings.TELEMETRY_STORAGE["options"]
-        # FIXME(willkg): change this to BotoS3CrashStorage
-        return TelemetryCrashData(**s3_settings)
+        return build_instance_from_settings(socorro_settings.TELEMETRY_STORAGE)
 
 
 class PermissionsReducerError(Exception):
@@ -627,9 +624,7 @@ class ProcessedCrash(SocorroMiddleware):
     API_ALLOWLIST = None
 
     def get_implementation(self):
-        # FIXME(willkg): change this to BotoS3CrashStorage
-        s3_settings = socorro_settings.S3_STORAGE["options"]
-        return SimplifiedCrashData(**s3_settings)
+        return build_instance_from_settings(socorro_settings.STORAGE)
 
     def get(self, crash_id, dont_cache=False, refresh_cache=False):
         data = self.fetch(
@@ -736,9 +731,7 @@ class RawCrash(SocorroMiddleware):
     API_BINARY_PERMISSIONS = ("crashstats.view_rawdump",)
 
     def get_implementation(self):
-        s3_settings = socorro_settings.S3_STORAGE["options"]
-        # FIXME(willkg): change this to BotoS3CrashStorage
-        return SimplifiedCrashData(**s3_settings)
+        return build_instance_from_settings(socorro_settings.STORAGE)
 
     def public_keys(self):
         """Return list of public annotations."""

--- a/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -29,15 +29,15 @@ class TestVerifyProcessed:
             "crash_id", flat=True
         )
 
-    def create_raw_crash_in_s3(self, s3_helper, bucket_name, crash_id):
-        s3_helper.upload_fileobj(
+    def create_raw_crash_in_storage(self, storage_helper, bucket_name, crash_id):
+        storage_helper.upload(
             bucket_name=bucket_name,
             key=f"v1/raw_crash/{TODAY}/{crash_id}",
             data=b"test",
         )
 
-    def create_processed_crash_in_s3(self, s3_helper, bucket_name, crash_id):
-        s3_helper.upload_fileobj(
+    def create_processed_crash_in_storage(self, storage_helper, bucket_name, crash_id):
+        storage_helper.upload(
             bucket_name=bucket_name,
             key=f"v1/processed_crash/{crash_id}",
             data=b"test",
@@ -62,23 +62,23 @@ class TestVerifyProcessed:
         assert threechars[0] == "000"
         assert threechars[-1] == "fff"
 
-    def test_no_crashes(self, s3_helper, monkeypatch):
+    def test_no_crashes(self, storage_helper, monkeypatch):
         """Verify no crashes in bucket result in no missing crashes."""
         monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
-        bucket = os.environ["CRASHSTORAGE_S3_BUCKET"]
-        s3_helper.create_bucket(bucket)
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.create_bucket(bucket)
 
         cmd = Command()
         missing = cmd.find_missing(num_workers=1, date=TODAY)
         assert missing == []
 
-    def test_no_missing_crashes(self, s3_helper, es_helper, monkeypatch):
+    def test_no_missing_crashes(self, storage_helper, es_helper, monkeypatch):
         """Verify raw crashes with processed crashes result in no missing crashes."""
         monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
-        bucket = os.environ["CRASHSTORAGE_S3_BUCKET"]
-        s3_helper.create_bucket(bucket)
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.create_bucket(bucket)
 
         # Create a few raw and processed crashes
         crashids = [
@@ -87,11 +87,11 @@ class TestVerifyProcessed:
             "000" + create_new_ooid()[3:],
         ]
         for crash_id in crashids:
-            self.create_raw_crash_in_s3(
-                s3_helper, bucket_name=bucket, crash_id=crash_id
+            self.create_raw_crash_in_storage(
+                storage_helper, bucket_name=bucket, crash_id=crash_id
             )
-            self.create_processed_crash_in_s3(
-                s3_helper, bucket_name=bucket, crash_id=crash_id
+            self.create_processed_crash_in_storage(
+                storage_helper, bucket_name=bucket, crash_id=crash_id
             )
             self.create_processed_crash_in_es(es_helper, crash_id=crash_id)
 
@@ -101,49 +101,57 @@ class TestVerifyProcessed:
         missing = cmd.find_missing(num_workers=1, date=TODAY)
         assert missing == []
 
-    def test_missing_crashes(self, s3_helper, es_helper, monkeypatch):
+    def test_missing_crashes(self, storage_helper, es_helper, monkeypatch):
         """Verify it finds a missing crash."""
         monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
-        bucket = os.environ["CRASHSTORAGE_S3_BUCKET"]
-        s3_helper.create_bucket(bucket)
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.create_bucket(bucket)
 
         # Create a raw and processed crash
         crash_id_1 = "000" + create_new_ooid()[3:]
-        self.create_raw_crash_in_s3(s3_helper, bucket_name=bucket, crash_id=crash_id_1)
-        self.create_processed_crash_in_s3(
-            s3_helper, bucket_name=bucket, crash_id=crash_id_1
+        self.create_raw_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_1
+        )
+        self.create_processed_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_1
         )
         self.create_processed_crash_in_es(es_helper, crash_id=crash_id_1)
 
         # Create a raw crash
         crash_id_2 = "000" + create_new_ooid()[3:]
-        self.create_raw_crash_in_s3(s3_helper, bucket_name=bucket, crash_id=crash_id_2)
+        self.create_raw_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_2
+        )
 
         cmd = Command()
         missing = cmd.find_missing(num_workers=1, date=TODAY)
         assert missing == [crash_id_2]
 
-    def test_missing_crashes_es(self, s3_helper, es_helper, monkeypatch):
+    def test_missing_crashes_es(self, storage_helper, es_helper, monkeypatch):
         """Verify it finds a processed crash missing in ES."""
         monkeypatch.setattr(Command, "get_threechars", get_threechars_subset)
 
-        bucket = os.environ["CRASHSTORAGE_S3_BUCKET"]
-        s3_helper.create_bucket(bucket)
+        bucket = storage_helper.get_crashstorage_bucket()
+        storage_helper.create_bucket(bucket)
 
         # Create a raw and processed crash
         crash_id_1 = "000" + create_new_ooid()[3:]
-        self.create_raw_crash_in_s3(s3_helper, bucket_name=bucket, crash_id=crash_id_1)
-        self.create_processed_crash_in_s3(
-            s3_helper, bucket_name=bucket, crash_id=crash_id_1
+        self.create_raw_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_1
+        )
+        self.create_processed_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_1
         )
         self.create_processed_crash_in_es(es_helper, crash_id=crash_id_1)
 
         # Create a raw crash
         crash_id_2 = "000" + create_new_ooid()[3:]
-        self.create_raw_crash_in_s3(s3_helper, bucket_name=bucket, crash_id=crash_id_2)
-        self.create_processed_crash_in_s3(
-            s3_helper, bucket_name=bucket, crash_id=crash_id_2
+        self.create_raw_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_2
+        )
+        self.create_processed_crash_in_storage(
+            storage_helper, bucket_name=bucket, crash_id=crash_id_2
         )
 
         cmd = Command()

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -117,8 +117,8 @@ class SuperSearch(ESSocorroMiddleware):
         )
 
     def get_implementation(self):
-        s3_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
-        return supersearch.SuperSearch(crashstorage=s3_crash_dest)
+        es_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
+        return supersearch.SuperSearch(crashstorage=es_crash_dest)
 
     def _get_extended_params(self):
         # Add histogram fields for all 'date','integer', or 'float' fields.
@@ -226,8 +226,8 @@ class SuperSearchUnredacted(SuperSearch):
         self.API_REQUIRED_PERMISSIONS = tuple(permissions.keys())
 
     def get_implementation(self):
-        s3_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
-        return supersearch.SuperSearch(crashstorage=s3_crash_dest)
+        es_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
+        return supersearch.SuperSearch(crashstorage=es_crash_dest)
 
     def get(self, **kwargs):
         # SuperSearch requires that the list of fields be passed to it.
@@ -277,5 +277,5 @@ class Query(ESSocorroMiddleware):
     possible_params = ("indices",)
 
     def get_implementation(self):
-        s3_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
-        return query.Query(crashstorage=s3_crash_dest)
+        es_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
+        return query.Query(crashstorage=es_crash_dest)


### PR DESCRIPTION
the GCS implementation PR was quite large, this PR is my attempt at breaking some of that work out to be reviewed separately.

<details><summary>test plan</summary>

### run CI tests locally
```bash
make build
make lint
make test
```

### check aws mode works
```bash
echo CLOUD_PROVIDER=AWS > my.env
make runservices
make setup
make run
```
separate shell
```bash
make shell
./bin/socorro_aws_s3.sh ls --recursive telemetry-bucket
./socorro-cmd fetch_crashids --num=3 | tee crashids | ./bin/process_crashes.sh
sleep 5
./bin/socorro_aws_s3.sh ls --recursive dev-bucket
./bin/socorro_aws_s3.sh ls --recursive telemetry-bucket
cat crashids | xargs -i bash -c 'curl -s webapp:8000/api/CrashVerify/?crash_id={}; echo'
```

### expectation:

before sleep: 3 raw crashes and dumps in dev-bucket, nothing in telemetry-bucket
after sleep: 3 processed crashes added to dev-bucket and telemetry-bucket, CrashVerify api returns true for all locations

</details>