### PR TITLE
Reverse preference for importlib_resources

### DIFF
--- a/socorro/signature/siglists_utils.py
+++ b/socorro/signature/siglists_utils.py
@@ -5,10 +5,11 @@
 from pathlib import Path
 import re
 
+# Use importlib_resources if it's there. Otherwise use the built-in version.
 try:
-    from importlib import resources as importlib_resources
-except ImportError:
     import importlib_resources
+except ImportError:
+    from importlib import resources as importlib_resources
 
 
 # This is a hack because sentinels can be a tuple, with the second item being


### PR DESCRIPTION
Python 3.8 has a `importlib.resources`, but it doesn't include the `files()` function. So for Python 3.8, siggen will require `importlib_resources`.

That's great, except we needed to invert the `importlib_resources` preference so it now prefers the backport library if it's there and uses the built-in library if it's not.

This fixes https://github.com/willkg/socorro-siggen/issues/124 .