### PR TITLE
bug-1887629: add CLOUD_PROVIDER to `/__version__` output

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -32,7 +32,7 @@ urlwait "${ELASTICSEARCH_URL}"
 urlwait "http://${PUBSUB_EMULATOR_HOST}" 10
 urlwait "${STORAGE_EMULATOR_HOST}/storage/v1/b" 10
 python ./bin/waitfor.py --verbose --codes=200,404 "${SENTRY_DSN}"
-python ./bin/waitfor.py --verbose "${LOCAL_DEV_AWS_ENDPOINT_URL}"
+python ./bin/waitfor.py --timeout 20 --verbose "${LOCAL_DEV_AWS_ENDPOINT_URL}"
 
 echo ">>> build sqs things and db things"
 

--- a/webapp/crashstats/monitoring/tests/test_views.py
+++ b/webapp/crashstats/monitoring/tests/test_views.py
@@ -141,6 +141,7 @@ class TestDockerflowHeartbeatViews:
 
 
 class TestDockerflowVersionView:
+    @pytest.mark.aws
     def test_version_no_file(self, client, settings, tmp_path):
         """Test with no version.json file"""
         # The tmp_path definitely doesn't have a version.json in it, so we use
@@ -150,8 +151,23 @@ class TestDockerflowVersionView:
         resp = client.get(reverse("monitoring:dockerflow_version"))
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json; charset=UTF-8"
-        assert smart_str(resp.content) == "{}"
+        version_info = {"cloud": "AWS"}
+        assert json.loads(smart_str(resp.content)) == version_info
 
+    @pytest.mark.gcp
+    def test_version_no_file_gcp(self, client, settings, tmp_path):
+        """Test with no version.json file"""
+        # The tmp_path definitely doesn't have a version.json in it, so we use
+        # that
+        settings.SOCORRO_ROOT = str(tmp_path)
+
+        resp = client.get(reverse("monitoring:dockerflow_version"))
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json; charset=UTF-8"
+        version_info = {"cloud": "GCP"}
+        assert json.loads(smart_str(resp.content)) == version_info
+
+    @pytest.mark.aws
     def test_version_with_file(self, client, settings, tmp_path):
         """Test with a version.json file"""
         settings.SOCORRO_ROOT = str(tmp_path)
@@ -165,7 +181,27 @@ class TestDockerflowVersionView:
         resp = client.get(reverse("monitoring:dockerflow_version"))
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json; charset=UTF-8"
-        assert smart_str(resp.content) == text
+        version_info = json.loads(text)
+        version_info["cloud"] = "AWS"
+        assert json.loads(smart_str(resp.content)) == version_info
+
+    @pytest.mark.gcp
+    def test_version_with_file_gcp(self, client, settings, tmp_path):
+        """Test with a version.json file"""
+        settings.SOCORRO_ROOT = str(tmp_path)
+
+        text = '{"commit": "d6ac5a5d2acf99751b91b2a3ca651d99af6b9db3"}'
+
+        # Create the version.json file in the tmp_path
+        version_json = tmp_path / "version.json"
+        version_json.write_text(text)
+
+        resp = client.get(reverse("monitoring:dockerflow_version"))
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json; charset=UTF-8"
+        version_info = json.loads(text)
+        version_info["cloud"] = "GCP"
+        assert json.loads(smart_str(resp.content)) == version_info
 
 
 class TestBroken:

--- a/webapp/crashstats/monitoring/views.py
+++ b/webapp/crashstats/monitoring/views.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime
+import os
 import uuid
 
 from django.conf import settings
@@ -66,7 +67,11 @@ def dockerflow_version(requst):
     Returns contents of /app/version.json or {}.
 
     """
-    return get_version_info(settings.SOCORRO_ROOT)
+    version_info = get_version_info(settings.SOCORRO_ROOT)
+    # FIXME(willkg): Remove "cloud" after we finish the GCP migration. We use the
+    # environment variable here because settings doesn't have this variable.
+    version_info["cloud"] = os.environ.get("CLOUD_PROVIDER", "AWS")
+    return version_info
 
 
 class HeartbeatException(Exception):


### PR DESCRIPTION
This adds the `CLOUD_PROVIDER` environment variable value to `/__version__` output so we can easily determine which cloud the service is running in.

To test:

1. run the webapp
2. go to `http://localhost:8000/__version__` and verify there's a "cloud" key with the value of `CLOUD_PROVIDER` in it

Note that this is a dirty way of doing what we want and the Dockerflow "standard" doesn't necessarily allow for other things to be in the `/__version__` output, but we'll plan to clean this up post-GCP-migration so it's temporary.