### PR TITLE
bug 1894925: change blocking timeout to 5

### DIFF
--- a/bin/waitfor.py
+++ b/bin/waitfor.py
@@ -12,7 +12,6 @@ Usage: bin/waitfor.py [--timeout T] [--verbose] [--codes CODES] URL
 """
 
 import argparse
-import socket
 import urllib.error
 import urllib.request
 from urllib.parse import urlsplit
@@ -49,34 +48,32 @@ def main(args):
         url = parsed_url.geturl()
 
     if parsed.verbose:
-        print(
-            "Testing %s for %s with timeout %d..."
-            % (url, repr(ok_codes), parsed.timeout)
-        )
-
-    socket.setdefaulttimeout(1)
+        print(f"Testing {url} for {ok_codes!r} with timeout {parsed.timeout}...")
 
     start_time = time.time()
 
     last_fail = ""
     while True:
         try:
-            with urllib.request.urlopen(url) as resp:
+            with urllib.request.urlopen(url, timeout=5) as resp:
                 if resp.code in ok_codes:
                     sys.exit(0)
-                last_fail = "HTTP status code: %s" % resp.code
+                last_fail = f"HTTP status code: {resp.code}"
+        except TimeoutError as error:
+            last_fail = f"TimeoutError: {error}"
         except urllib.error.URLError as error:
             if hasattr(error, "code") and error.code in ok_codes:
                 sys.exit(0)
-            last_fail = "URLError: %s" % error
+            last_fail = f"URLError: {error}"
 
         if parsed.verbose:
             print(last_fail)
 
-        time.sleep(1)
+        time.sleep(0.5)
 
-        if time.time() - start_time > parsed.timeout:
-            print("Failed. %s" % last_fail)
+        delta = time.time() - start_time
+        if delta > parsed.timeout:
+            print(f"Failed: {last_fail}, elapsed: {delta:.2f}s")
             sys.exit(1)
 
 


### PR DESCRIPTION
This changes the blocking timeout to 5s for waitfor--previously it used the socket default timeout of 1s.

The theory is that in CI, it's taking longer than 1s for localstack to respond sometimes which causes CI to fail.