### PR TITLE
bug-1889185: implement stage submitter and fake collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,13 @@ runservices: my.env  ## | Run service containers (Postgres, SQS, etc)
 		statsd \
 		symbolsserver
 
+.PHONY: runsubmitter
+runsubmitter: my.env  ## | Run stage_submitter and fakecollector
+	${DC} up \
+		--attach stage_submitter \
+		--attach fakecollector \
+		stage_submitter fakecollector
+
 .PHONY: stop
 stop: my.env  ## | Stop all service containers.
 	${DC} stop

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -37,6 +37,12 @@ crontabber)  ## Run crontabber service
 webapp)  ## Run webapp service
     /app/bin/run_service_webapp.sh "$@"
     ;;
+stage_submitter)  ## Runs the stage submitter
+    /app/bin/run_service_stage_submitter.sh
+    ;;
+fakecollector)  ## Runs a local fake collector
+    /app/bin/run_fakecollector.sh
+    ;;
 symbolsserver)  ## Runs a local symbols server
     /app/bin/run_symbolsserver.sh
     ;;

--- a/bin/run_fakecollector.sh
+++ b/bin/run_fakecollector.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: bin/run_fakecollector.sh
+#
+# Runs a fake collector that parses submissions and outputs details to
+# the log.
+#
+# Note: This is not a production-ready server. It's intended only for
+# debugging.
+
+set -euxo pipefail
+
+PORT=8000
+
+python fakecollector/collector.py --port=${PORT}

--- a/bin/run_service_stage_submitter.sh
+++ b/bin/run_service_stage_submitter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: bin/run_service_stage_submitter.sh
+#
+# Runs the stage submitter service.
+#
+# Note: This should be called from inside a container.
+
+set -euo pipefail
+
+export PROCESS_NAME=stage_submitter
+
+# Run the stage_submitter
+python socorro/stage_submitter/submitter.py

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -54,6 +54,7 @@ echo ">>> run tests"
 
 # Run socorro tests
 "${PYTEST}"
+CLOUD_PROVIDER=GCP "${PYTEST}" -m gcp
 
 # Collect static and then run pytest in the webapp
 pushd webapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,20 @@ services:
     volumes:
       - .:/app
 
+  stage_submitter:
+    image: local/socorro_app
+    env_file:
+      - docker/config/local_dev.env
+      - my.env
+    depends_on:
+      - fakesentry
+      - localstack
+      - gcs-emulator
+      - pubsub
+    command: ["stage_submitter"]
+    volumes:
+      - .:/app
+
   # https://github.com/willkg/kent
   fakesentry:
     build:
@@ -174,6 +188,17 @@ services:
       - "8888:8000"
     volumes:
       - .:/socorro
+
+  fakecollector:
+    image: local/socorro_app
+    env_file:
+      - docker/config/local_dev.env
+      - my.env
+    command: ["fakecollector"]
+    ports:
+      - "9000:8000"
+    volumes:
+      - .:/app
 
   symbolsserver:
     image: local/socorro_app

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -103,6 +103,10 @@ SESSION_COOKIE_SECURE=False
 # -----------
 SENTRY_PORT=8090
 
+# stage_submitter
+# ---------------
+STAGE_SUBMITTER_DESTINATIONS=http://fakecollector:8000/submit|20
+
 # oidcprovider
 # ------------
 OIDC_RP_CLIENT_ID=1

--- a/docs/service/index.rst
+++ b/docs/service/index.rst
@@ -11,3 +11,4 @@ in concert with one another.
    processor
    webapp
    cron
+   stage_submitter

--- a/docs/service/stage_submitter.rst
+++ b/docs/service/stage_submitter.rst
@@ -1,0 +1,70 @@
+.. _stage_submitter-chapter:
+
+===============
+Stage Submitter
+===============
+
+Code is in ``socorro/stage_submitter/``.
+
+Run script is in ``/app/bin/run_service_stage_submitter.sh``.
+
+The stage submitter runs in the production environment to send a subset of
+crash reports to a stage environment. The payloads are built from raw crash
+data such that they are very much like the original payload the production
+collector received.
+
+
+Configuration
+=============
+
+Re-uses processor configuration for queue and storage.
+
+Additionally has:
+
+.. everett:option:: STAGE_SUBMITTER_LOGGING_LEVEL
+   :default: ``"INFO"``
+   :parser: ``str``
+
+   Default logging level for the stage submitter. Should be one of DEBUG, INFO,
+   WARNING, ERROR.
+
+
+.. everett:option:: STAGE_SUBMITTER_DESTINATIONS
+   :default: ``""``
+   :parser: ``ListOf(str)``
+
+   Comma-separated pairs of ``DESTINATION_URL|SAMPLE`` where the ``DESTINATION_URL``
+   is an https url to submit the crash report to and ``SAMPLE`` is a number
+   between 0 and 100 representing the sample rate. For example:
+
+   * ``https://example.com|20``
+   * ``https://example.com|30,https://example2.com|100``
+
+
+
+Running in a local dev environment
+==================================
+
+To run the stage submitter and fake collector, do:
+
+::
+
+  $ make runservices
+  $ make runsubmitter
+
+After doing this, you can enter a Socorro container shell and use
+``bin/process_crash.sh`` to pull down crash data, put it into storage, and
+publish the crash id to the standard queue.
+
+::
+
+  $ make shell
+  app@socorro:/app$ ./bin/process_crash.sh a206b51a-5955-4704-be1f-cf1ac0240514
+
+
+The stage submitter will consume the crash id from the standard queue, download
+the data from storage, assemble a crash report payload, and submit it to the
+fake collector.
+
+The fake collector will log headers, annotations, and file information for any
+crash reports submitted to it.

--- a/fakecollector/collector.py
+++ b/fakecollector/collector.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# This is a fake collector that handles incoming HTTP POST requests to /submit and logs
+# headers, annotations, and files in the submission.
+
+import json
+import logging
+
+import click
+from werkzeug.exceptions import HTTPException, MethodNotAllowed
+from werkzeug.formparser import parse_form_data
+from werkzeug.routing import Map, Rule
+from werkzeug.wrappers import Request, Response
+
+from socorro.lib.liblogging import set_up_logging
+from socorro.lib.libooid import create_new_ooid
+
+
+def truncate(val, length=80):
+    if len(val) > 80:
+        val = val[:80-3] + "..."
+    return val
+
+
+class App:
+    def __init__(self):
+        self.logger = logging.getLogger(f"{__name__}.App")
+        self.url_map = Map([
+            Rule("/submit", endpoint="submit"),
+        ])
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        adapter = self.url_map.bind_to_environ(request.environ)
+        try:
+            endpoint, values = adapter.match()
+            response = getattr(self, f"on_{endpoint}")(request, **values)
+            return response(environ, start_response)
+        except HTTPException:
+            self.logger.exception("exception in handling")
+
+    def on_submit(self, request):
+        """Handle POST /submit requests
+
+        These are crash report submissions, so it parses the payload and then logs
+        headers, annotations, and files found in the payload.
+
+        It always returns a CrashID response.
+
+        """
+        if request.method != "POST":
+            raise MethodNotAllowed(["POST"])
+
+        self.logger.info("handling POST /submit")
+
+        content_length = int(request.headers["Content-Length"])
+        self.logger.info("content_length: %s", f"{content_length:,}")
+
+        # "multipart/form-data" or "multipart/mixed"
+        content_type = request.headers["Content-Type"]
+        self.logger.info("content_type: %s", content_type)
+
+        user_agent = request.headers["User-Agent"]
+        self.logger.info("user-agent: %s", user_agent)
+
+        # "gzip" or anything else
+        content_encoding = request.headers.get("Content-Encoding", "")
+        self.logger.info("content_encoding: %s", content_encoding)
+
+        stream, form, files = parse_form_data(request.environ, max_content_length=content_length)
+        crash_id = form.get("uuid") or create_new_ooid()
+        for key, val in form.to_dict().items():
+            if key == "extra":
+                data = json.loads(val)
+                for data_key, data_val in data.items():
+                    self.logger.info("annotation (extra): %s=%s", data_key, truncate(data_val))
+            else:
+                self.logger.info("annotation: %s=%s", key, truncate(val))
+
+        for key, filestorage in files.items():
+            data = filestorage.stream.read()
+            self.logger.info("file: %s %s %s", key, f"{len(data):,}", filestorage.content_type)
+
+        return Response(f"CrashID={crash_id}")
+
+
+@click.command
+@click.option("--host", default="0.0.0.0", help="host to bind to")
+@click.option("--port", default=8000, type=int, help="port to listen on")
+def main(host, port):
+    set_up_logging(local_dev_env=True, host_id="localhost")
+
+    from werkzeug.serving import run_simple
+    app = App()
+    run_simple(host, port, app, use_debugger=True, use_reloader=True)
+
+
+if __name__ == '__main__':
+    from collector import main
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,3 +21,7 @@ filterwarnings =
     # pubsub deprecated the return_immediately flag because it negatively impacts performance, but
     # that performance cost is fine for our use case, especially in tests.
     ignore:The return_immediately flag is deprecated and should be set to False.:DeprecationWarning:google.pubsub_v1
+
+markers =
+    aws: tests that require aws backends to be configured in the environment. this is the default.
+    gcp: tests that require gcp backends to be configured in the environment. skipped unless explicitly requested.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 # -rsxX        - show skipped, failed, and passed tests
 # --tb=native  - print native traceback
 # -p no:django - disable the pytest-django plugin for Socorro tests
-addopts = -rsxX --tb=native -p no:django
+addopts = -rsxX --tb=native -p no:django -m 'not gcp'
 norecursedirs = .git docs config docker __pycache__
 testpaths = socorro/
 

--- a/socorro/lib/liblogging.py
+++ b/socorro/lib/liblogging.py
@@ -72,6 +72,7 @@ def set_up_logging(
             "fillmore": {"handlers": ["mozlog"], "level": logging.ERROR},
             "markus": {"handlers": ["console"], "level": logging.INFO},
             "socorro": {"handlers": ["console"], "level": logging_level},
+            "collector": {"handlers": ["console"], "level": logging.INFO},
             "py.warnings": {"handlers": ["console"]},
         }
 

--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -418,3 +418,29 @@ BETAVERSIONRULE_VERSION_STRING_API = _config(
     default="https://crash-stats.mozilla.org/api/VersionString",
     doc="URL for the version string API endpoint in the Crash Stats webapp.",
 )
+
+
+# Stage submitter configuration
+STAGE_SUBMITTER_LOGGING_LEVEL = _config(
+    "STAGE_SUBMITTER_LOGGING_LEVEL",
+    default="INFO",
+    doc=(
+        "Default logging level for the stage submitter. Should be one of DEBUG, INFO, "
+        "WARNING, ERROR."
+    ),
+)
+
+STAGE_SUBMITTER_DESTINATIONS = _config(
+    "STAGE_SUBMITTER_DESTINATIONS",
+    default="",
+    doc=(
+        "Comma-separated pairs of ``DESTINATION_URL|SAMPLE`` where the "
+        "``DESTINATION_URL`` is an https url to submit the crash report to "
+        "and ``SAMPLE`` is a number between 0 and 100 representing the sample "
+        "rate. For example:\n"
+        "\n"
+        "* ``https://example.com|20``\n"
+        "* ``https://example.com|30,https://example2.com|100``"
+    ),
+    parser=ListOf(str),
+)

--- a/socorro/stage_submitter/__init__.py
+++ b/socorro/stage_submitter/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/socorro/stage_submitter/submitter.py
+++ b/socorro/stage_submitter/submitter.py
@@ -1,0 +1,455 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+This defines the stage submitter application. It's designed to run as a standalone
+service.
+
+It consumes crash ids from a queue, determines what to do with them, pulls the crash
+data from storage, assembles a payload, and submits them to a destination.
+
+It pulls all its configuration from socorro.settings reusing processor configuration
+where convenient.
+
+To run::
+
+    $ /app/bin/run_submitter.sh
+
+"""
+
+from contextlib import suppress
+import dataclasses
+from email.header import Header
+import gzip
+import json
+import io
+import logging
+import pathlib
+import random
+import sys
+import traceback
+from typing import Callable
+
+from fillmore.libsentry import set_up_sentry
+from fillmore.scrubber import Scrubber, SCRUB_RULES_DEFAULT
+import markus
+import requests
+import sentry_sdk
+
+from socorro import settings
+from socorro.external.crashstorage_base import CrashIDNotFound
+from socorro.lib.libdockerflow import get_release_name, get_version_info
+from socorro.lib.liblogging import set_up_logging
+from socorro.libclass import build_instance_from_settings
+
+
+# Metrics client to use
+METRICS = markus.get_metrics("socorro.submitter")
+
+# Default user agent to use when submitting to a destination url
+DEFAULT_USER_AGENT = "stage-submitter/2.0"
+
+# Boundary to use. This is the result of uuid.uuid4().hex. We just need a unique string
+# to denote the boundary between parts in the payload.
+BOUNDARY = "01659896d5dc42cabd7f3d8a3dcdd3bb"
+
+
+@dataclasses.dataclass
+class Crash:
+    crash_id: str
+    finished_func: Callable[[], None]
+
+
+@dataclasses.dataclass
+class Destination:
+    url: str
+    sample: int
+
+
+def get_destinations(value_list):
+    """Parse Destination instances from list of strings
+
+    :arg value_list: list of `|` delimited strings
+
+    :returns: list of Destination instances
+
+    """
+    destinations = []
+    for item in value_list:
+        url, sample = item.split("|")
+        destinations.append(Destination(url=url, sample=int(sample)))
+    return destinations
+
+
+COLLECTOR_KEYS_TO_REMOVE = [
+    "metadata",
+    "submitted_timestamp",
+    "version",
+]
+
+
+def remove_collector_keys(raw_crash):
+    """Given a raw crash, removes keys added by a collector
+
+    :arg raw_crash: dict of annotations and collector-added data
+
+    :returns: mutated raw_crash
+
+    """
+    for key in COLLECTOR_KEYS_TO_REMOVE:
+        if key in raw_crash:
+            del raw_crash[key]
+
+    return raw_crash
+
+
+def smart_bytes(thing):
+    """This converts things to a string representation then to bytes
+
+    :arg thing: the thing to convert to bytes
+
+    :returns: bytes
+
+    """
+    if isinstance(thing, bytes):
+        return thing
+
+    if isinstance(thing, str):
+        return thing.encode("utf-8")
+
+    return repr(thing).encode("utf-8")
+
+
+def multipart_encode(raw_crash, dumps, payload_type, payload_compressed):
+    """Takes a raw_crash and list of (name, dump) and converts to a multipart/form-data
+
+    This returns a tuple of two things:
+
+    1. a ``bytes`` object with the HTTP POST payload
+    2. a dict of headers with ``Content-Type`` and ``Content-Length`` in it
+
+    :arg raw_crash: dict of crash annotations
+    :arg dumps: list of (name, dump) tuples
+    :arg payload_type: either "multipart" or "json"
+    :arg payload_compressed: either "1" or "0"
+
+    :returns: tuple of (bytes, headers dict)
+
+    """
+    boundary_line = smart_bytes(f"--{BOUNDARY}\r\n")
+
+    # NOTE(willkg): This is the result of uuid.uuid4().hex. We just need a
+    # unique string to denote the boundary between parts in the payload.
+    output = io.BytesIO()
+
+    # If the payload of the original crash report had the crash annotations in
+    # the "extra" field as a JSON blob, we should do the same here
+    if payload_type == "json":
+        output.write(boundary_line)
+        output.write(b'Content-Disposition: form-data; name="extra"\r\n')
+        output.write(b"Content-Type: application/json\r\n")
+        output.write(b"\r\n")
+        extra_data = json.dumps(raw_crash, sort_keys=True, separators=(",", ":"))
+        output.write(smart_bytes(extra_data))
+        output.write(b"\r\n")
+
+    else:
+        # Package up raw crash metadata--sort them so they're stable in the payload
+        for key, val in sorted(raw_crash.items()):
+            output.write(boundary_line)
+            output.write(
+                smart_bytes(
+                    'Content-Disposition: form-data; name="%s"\r\n'
+                    % Header(key).encode()
+                )
+            )
+            output.write(b"Content-Type: text/plain; charset=utf-8\r\n")
+            output.write(b"\r\n")
+            output.write(smart_bytes(val))
+            output.write(b"\r\n")
+
+    # Insert dump data--sort them so they're stable in the payload
+    for name, data in sorted(dumps.items()):
+        output.write(boundary_line)
+
+        if name == "dump":
+            name = "upload_file_minidump"
+
+        # dumps are sent as streams
+        output.write(
+            smart_bytes(
+                'Content-Disposition: form-data; name="%s"; filename="file.dump"\r\n'
+                % Header(name).encode()
+            )
+        )
+        output.write(b"Content-Type: application/octet-stream\r\n")
+        output.write(b"\r\n")
+        output.write(data)
+        output.write(b"\r\n")
+
+    # Add end boundary
+    output.write(smart_bytes(f"--{BOUNDARY}--\r\n"))
+    output = output.getvalue()
+
+    # Generate headers
+    headers = {
+        "Content-Type": f"multipart/form-data; boundary={BOUNDARY}",
+        "Content-Length": str(len(output)),
+    }
+
+    # Compress if it we need to
+    if payload_compressed == "1":
+        bio = io.BytesIO()
+        g = gzip.GzipFile(fileobj=bio, mode="w")
+        g.write(output)
+        g.close()
+        output = bio.getbuffer()
+        headers["Content-Length"] = str(len(output))
+        headers["Content-Encoding"] = "gzip"
+
+    return output, headers
+
+
+def get_payload_type(raw_crash):
+    """Determines payload type from collector metadata in raw crash
+
+    :arg raw_crash: the raw crash data as a Python dict
+
+    :returns: payload type or "unknown"
+
+    """
+    if raw_crash.get("metadata", {}).get("payload") is not None:
+        return raw_crash["metadata"]["payload"]
+
+    return "unknown"
+
+
+def get_payload_compressed(raw_crash):
+    """Determines whether the payload was compressed from collector metadata in raw crash
+
+    :arg raw_crash: the raw crash data as a Python dict
+
+    :returns: "1" or "0"
+
+    """
+    return raw_crash.get("metadata", {}).get("payload_compressed", "0")
+
+
+def count_sentry_scrub_error(msg):
+    """Counts sentry scrub errors"""
+    METRICS.incr("sentry_scrub_error", value=1, tags=["service:submitter"])
+
+
+def handle_exception(exctype, value, tb):
+    """Handles exception that bubbles up to top-level before process exits"""
+    logger = logging.getLogger(__name__)
+    logger.error(
+        "unhandled exception. Exiting. "
+        + "".join(traceback.format_exception(exctype, value, tb))
+    )
+
+
+sys.excepthook = handle_exception
+
+
+class SubmitterApp:
+    def __init__(self):
+        self.basedir = pathlib.Path(__file__).resolve().parent.parent.parent
+        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+
+    def set_up(self):
+        set_up_logging(
+            local_dev_env=settings.LOCAL_DEV_ENV,
+            logging_level=settings.STAGE_SUBMITTER_LOGGING_LEVEL,
+            host_id=settings.HOST_ID,
+        )
+        markus.configure(backends=settings.MARKUS_BACKENDS)
+
+        scrubber = Scrubber(
+            rules=SCRUB_RULES_DEFAULT,
+            error_handler=count_sentry_scrub_error,
+        )
+        set_up_sentry(
+            sentry_dsn=settings.SENTRY_DSN,
+            release=get_release_name(self.basedir),
+            host_id=settings.HOST_ID,
+            before_send=scrubber,
+        )
+
+        self.log_config()
+
+        # This re-uses settings from the processor
+        self.queue = build_instance_from_settings(settings.QUEUE)
+        self.source = build_instance_from_settings(settings.CRASH_SOURCE)
+
+        # Build destinations
+        self.destinations = get_destinations(settings.STAGE_SUBMITTER_DESTINATIONS)
+
+        self.logger.info("starting up")
+
+    def log_config(self):
+        version_info = get_version_info(self.basedir)
+        data = ", ".join(
+            [f"{key!r}: {val!r}" for key, val in sorted(version_info.items())]
+        )
+        data = data or "no version data"
+        self.logger.info("version.json: %s", data)
+
+        settings.log_settings(logger=self.logger)
+
+    def source_iterator(self):
+        """Iterate yielding crash ids."""
+        while True:
+            for crash_id, data in self.queue.new_crashes():
+                if crash_id is None:
+                    continue
+                # NOTE(willkg): new_crashes() always returns a tuple of one element for
+                # the crash id for whatever reason
+                crash_id = crash_id[0]
+                finished_func = data["finished_func"]
+                yield Crash(crash_id=crash_id, finished_func=finished_func)
+
+    def sample(self, destinations):
+        """Applies sampling returning only the destinations we need to send to
+
+        :arg destinations: list of Destination instances
+
+        :returns: list of Destination instances to send to; sometimes an empty list
+
+        """
+        return [
+            dest
+            for dest in destinations
+            if dest.sample >= 100 or random.randint(0, 100) > dest.sample
+        ]
+
+    def process(self, crash):
+        with METRICS.timer("process"):
+            with sentry_sdk.push_scope() as scope:
+                crash_id = crash.crash_id
+                self.logger.debug(f"processing {crash}")
+
+                scope.set_extra("crash_id", crash)
+
+                # sample and determine destinations
+                destinations = []
+                for dest in self.destinations:
+                    if dest.sample < 100 and random.randint(0, 100) > dest.sample:
+                        METRICS.incr("ignore")
+                    else:
+                        METRICS.incr("accept")
+                        destinations.append(dest)
+
+                if not destinations:
+                    # If there's no where we need to post it to, we just move on--no
+                    # need to do more work
+                    return
+
+                try:
+                    raw_crash = self.source.get_raw_crash(crash_id)
+                    dumps = self.source.get_dumps(crash_id)
+                except CrashIDNotFound:
+                    # If the crash data isn't found, we just move on--no need to capture
+                    # errors here
+                    self.logger.warning(
+                        "warning: crash cannot be found in storage: %s", crash_id
+                    )
+                    return
+
+                # FIXME(willkg): crashstorage converts "upload_file_minidump" to "dump",
+                # so we need to convert that back; however, it's not clear this works
+                # in _all_ cases
+                if "dump" in dumps.keys():
+                    dumps["upload_file_minidump"] = dumps["dump"]
+                    del dumps["dump"]
+
+                payload_type = get_payload_type(raw_crash)
+                payload_compressed = get_payload_compressed(raw_crash)
+
+                # Get the metadata.user_agent if there is one, or use default agent
+                user_agent = (
+                    raw_crash.get("metadata", {}).get("user_agent")
+                    or DEFAULT_USER_AGENT
+                )
+
+                # Remove keys created by the collector from the raw crash
+                raw_crash = remove_collector_keys(raw_crash)
+
+                # Assemble payload and headers
+                payload, headers = multipart_encode(
+                    raw_crash=raw_crash,
+                    dumps=dumps,
+                    payload_type=payload_type,
+                    payload_compressed=payload_compressed,
+                )
+
+                # Set the User-Agent header so the collector captures this in the metadata
+                headers["User-Agent"] = user_agent
+
+                # Post to all destinations
+                for destination in destinations:
+                    try:
+                        # POST crash to new environment
+                        # FIXME(willkg): retryable post
+                        requests.post(destination.url, headers=headers, data=payload)
+
+                    except Exception:
+                        METRICS.incr("unknown_submit_error", value=1)
+                        self.logger.exception(
+                            "Error: http post failed for unknown reason: %s", crash_id
+                        )
+
+    def run_loop(self):
+        """Run cache manager in a loop."""
+        crashes = self.source_iterator()
+        while True:
+            crash = next(crashes)
+            crash_id = crash.crash_id
+            finished_func = crash.finished_func
+
+            try:
+                self.process(crash)
+            except Exception:
+                METRICS.incr("unknown_process_error", value=1)
+                self.logger.exception(
+                    "error: processing failed for unknown reason: %s", crash_id
+                )
+            finally:
+                try:
+                    finished_func()
+                except Exception:
+                    METRICS.incr("unknown_finished_func_error", value=1)
+                    self.logger.exception(
+                        "error: finished_func failed for unknown reason: %s", crash_id
+                    )
+
+        self.shutdown()
+
+    def run_once(self):
+        """Runs a nonblocking event generator once."""
+        crashes = self.source_iterator()
+        crash = next(crashes)
+        self.process(crash)
+
+    def shutdown(self):
+        """Shut down an event generator."""
+        with suppress(AttributeError):
+            self.queue.close()
+
+        with suppress(AttributeError):
+            self.source.close()
+
+
+def main():
+    app = SubmitterApp()
+    app.set_up()
+    app.run_loop()
+
+
+if __name__ == "__main__":
+    # NOTE(willkg): we need to do this so that the submitter logger isn't `__main__`
+    # which causes problems when logging
+    from socorro.stage_submitter.submitter import main
+
+    main()

--- a/socorro/tests/stage_submitter/conftest.py
+++ b/socorro/tests/stage_submitter/conftest.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from contextlib import contextmanager
+
+import requests_mock
+import pytest
+
+
+class FakeCollector:
+    """Fakes a collector that the submitter submits to
+
+    :attribute payloads: the list of payloads that was received since this was
+        created or the last time ``.clear()`` was called
+
+    """
+
+    def __init__(self):
+        self.payloads = []
+
+    def clear(self):
+        self.payloads = []
+
+    def handle_post(self, request, context):
+        self.payloads.append(request)
+        context.status = 200
+        # FIXME(willkg): this should return the same crash id that it got--but
+        # that requires parsing the payload. :(
+        crashid = "xxx"
+        return "CrashID=bp-%s" % crashid
+
+    @contextmanager
+    def setup_mock(self):
+        with requests_mock.mock(real_http=True) as rm:
+            rm.post("//antenna:8000/submit", text=self.handle_post)
+            rm.post("//antenna_2:8000/submit", text=self.handle_post)
+            yield self
+
+
+@pytest.fixture
+def mock_collector():
+    """Creates a mock collector that lets you observe posted payloads"""
+    with FakeCollector().setup_mock() as fm:
+        yield fm

--- a/socorro/tests/stage_submitter/test_submitter.py
+++ b/socorro/tests/stage_submitter/test_submitter.py
@@ -149,7 +149,6 @@ def test_basic(queue_helper, storage_helper, mock_collector):
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -223,7 +222,6 @@ def test_multiple_destinations(queue_helper, storage_helper, mock_collector):
     ):
         app = get_app()
         app.run_once()
-        app.shutdown()
 
     # Verify payload was submitted
     #
@@ -266,7 +264,6 @@ def test_annotations_as_json(queue_helper, storage_helper, mock_collector):
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -318,7 +315,6 @@ def test_multiple_dumps(queue_helper, storage_helper, mock_collector):
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -387,7 +383,6 @@ def test_compressed(queue_helper, storage_helper, mock_collector):
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -455,7 +450,6 @@ def test_sample_accepted(queue_helper, monkeypatch, storage_helper, mock_collect
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -492,7 +486,6 @@ def test_sample_skipped(queue_helper, monkeypatch, storage_helper, mock_collecto
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify no payload was submitted
     assert len(mock_collector.payloads) == 0
@@ -542,7 +535,6 @@ def test_different_samples(queue_helper, monkeypatch, storage_helper, mock_colle
         app = get_app()
         with MetricsMock() as metricsmock:
             app.run_once()
-            app.shutdown()
 
     # Verify only second destination got a payload
     assert len(mock_collector.payloads) == 1
@@ -584,7 +576,6 @@ def test_user_agent(queue_helper, storage_helper, mock_collector):
     ):
         app = get_app()
         app.run_once()
-        app.shutdown()
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1

--- a/socorro/tests/stage_submitter/test_submitter.py
+++ b/socorro/tests/stage_submitter/test_submitter.py
@@ -24,7 +24,7 @@ def get_app():
     return app
 
 
-def generate_s3_key(kind, crash_id):
+def generate_storage_key(kind, crash_id):
     """Generates the key in S3 for this object kind
 
     :arg kind: the kind of thing to fetch
@@ -34,12 +34,12 @@ def generate_s3_key(kind, crash_id):
 
     """
     if kind == "raw_crash":
-        return "v1/raw_crash/20%s/%s" % (crash_id[-6:], crash_id)
+        return f"v1/raw_crash/20{crash_id[-6:]}/{crash_id}"
     if kind == "dump_names":
-        return "v1/dump_names/%s" % crash_id
+        return f"v1/dump_names/{crash_id}"
     if kind in (None, "", "upload_file_minidump"):
         kind = "dump"
-    return "v1/%s/%s" % (kind, crash_id)
+    return f"v1/{kind}/{crash_id}"
 
 
 def jsonify(data):
@@ -50,18 +50,18 @@ def save_crash(storage_helper, bucket, raw_crash, dumps):
     crash_id = raw_crash["uuid"]
 
     # Save raw crash
-    key = generate_s3_key("raw_crash", crash_id)
+    key = generate_storage_key("raw_crash", crash_id)
     data = jsonify(raw_crash).encode("utf-8")
     storage_helper.upload(bucket, key, data)
 
     # Save dump_names
-    key = generate_s3_key("dump_names", crash_id)
+    key = generate_storage_key("dump_names", crash_id)
     data = jsonify(list(dumps.keys())).encode("utf-8")
     storage_helper.upload(bucket, key, data)
 
     # Save dumps
     for name, data in dumps.items():
-        key = generate_s3_key(name, crash_id)
+        key = generate_storage_key(name, crash_id)
         data = data.encode("utf-8")
         storage_helper.upload(bucket, key, data)
 

--- a/socorro/tests/stage_submitter/test_submitter.py
+++ b/socorro/tests/stage_submitter/test_submitter.py
@@ -1,0 +1,594 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import gzip
+import json
+import random
+
+from markus.testing import MetricsMock
+import pytest
+
+from socorro import settings
+from socorro.stage_submitter.submitter import (
+    get_payload_compressed,
+    get_payload_type,
+    remove_collector_keys,
+    SubmitterApp,
+)
+
+
+def get_app():
+    app = SubmitterApp()
+    app.set_up()
+    return app
+
+
+def generate_s3_key(kind, crash_id):
+    """Generates the key in S3 for this object kind
+
+    :arg kind: the kind of thing to fetch
+    :arg crash_id: the crash id
+
+    :returns: the key name
+
+    """
+    if kind == "raw_crash":
+        return "v1/raw_crash/20%s/%s" % (crash_id[-6:], crash_id)
+    if kind == "dump_names":
+        return "v1/dump_names/%s" % crash_id
+    if kind in (None, "", "upload_file_minidump"):
+        kind = "dump"
+    return "v1/%s/%s" % (kind, crash_id)
+
+
+def jsonify(data):
+    return json.dumps(data, sort_keys=True)
+
+
+def save_crash(storage_helper, bucket, raw_crash, dumps):
+    crash_id = raw_crash["uuid"]
+
+    # Save raw crash
+    key = generate_s3_key("raw_crash", crash_id)
+    data = jsonify(raw_crash).encode("utf-8")
+    storage_helper.upload(bucket, key, data)
+
+    # Save dump_names
+    key = generate_s3_key("dump_names", crash_id)
+    data = jsonify(list(dumps.keys())).encode("utf-8")
+    storage_helper.upload(bucket, key, data)
+
+    # Save dumps
+    for name, data in dumps.items():
+        key = generate_s3_key(name, crash_id)
+        data = data.encode("utf-8")
+        storage_helper.upload(bucket, key, data)
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, "unknown"),
+        ({"metadata": {"payload": "json"}}, "json"),
+    ],
+)
+def test_get_payload_type(raw_crash, expected):
+    assert get_payload_type(raw_crash) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, "0"),
+        ({"metadata": {"payload_compressed": "1"}}, "1"),
+    ],
+)
+def test_get_payload_compressed(raw_crash, expected):
+    assert get_payload_compressed(raw_crash) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, {}),
+        (
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "metadata": {
+                    "collector_notes": [],
+                    "dump_checksums": {},
+                    "payload_compressed": "0",
+                    "payload": "multipart",
+                },
+                "version": 2,
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+                "submitted_timestamp": "2022-09-14T15:45:55.222222",
+            },
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            },
+        ),
+    ],
+)
+def test_remove_collector_keys(raw_crash, expected):
+    assert remove_collector_keys(raw_crash) == expected
+
+
+def test_basic(queue_helper, storage_helper, mock_collector):
+    bucket = storage_helper.get_crashstorage_bucket()
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "Product": "Firefox",
+            "uuid": crash_id,
+            "Version": "60.0",
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs, make sure it doesn't get sampled by setting sample to 100, and
+    # invoke the Lambda function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|100"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    assert mock_collector.payloads[0].hostname == "antenna"
+
+    # Verify default user agent was used
+    headers = mock_collector.payloads[0].headers
+    assert headers["User-Agent"] == "stage-submitter/2.0"
+
+    # Stare at some multipart/form-data
+    post_payload = mock_collector.payloads[0].text
+    assert (
+        post_payload == "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="Product"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "Firefox\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="Version"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "60.0\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="uuid"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "de1bb258-cbbf-4589-a673-34f800160918\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="upload_file_minidump"; filename="file.dump"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "abcdef\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
+
+    metricsmock.assert_incr("socorro.submitter.accept")
+
+
+def test_multiple_destinations(queue_helper, storage_helper, mock_collector):
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "Product": "Firefox",
+            "uuid": crash_id,
+            "Version": "60.0",
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs, configure to send to two destinations with sample set to 100, and
+    # invoke the Lambda function
+    with settings.override(
+        # NOTE(willkg):antenna and antenna_2 are set up in the collector mock.
+        STAGE_SUBMITTER_DESTINATIONS=[
+            "http://antenna:8000/submit|100",
+            "http://antenna_2:8000/submit|100",
+        ],
+    ):
+        app = get_app()
+        app.run_once()
+        app.shutdown()
+
+    # Verify payload was submitted
+    #
+    # We only have one collector mock, but we can distinguish between the destinations
+    # by looking at the payload request hostname
+    assert len(mock_collector.payloads) == 2
+    assert mock_collector.payloads[0].hostname == "antenna"
+    assert mock_collector.payloads[1].hostname == "antenna_2"
+
+    # The payloads sent to antenna and antenna_2 should be the same
+    assert mock_collector.payloads[0].text == mock_collector.payloads[1].text
+
+
+def test_annotations_as_json(queue_helper, storage_helper, mock_collector):
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "uuid": crash_id,
+            "Product": "Firefox",
+            "Version": "60.0",
+            "metadata": {
+                "payload": "json",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs, make sure it doesn't get sampled, and invoke the Lambda
+    # function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|100"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    post_payload = mock_collector.payloads[0].text
+
+    # Who doesn't like reading raw multipart/form-data? Woo hoo!
+    assert (
+        post_payload == "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="extra"\r\n'
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"Product":"Firefox","Version":"60.0","uuid":"de1bb258-cbbf-4589-a673-34f800160918"}\r\n'
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="upload_file_minidump"; filename="file.dump"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "abcdef\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
+
+    metricsmock.assert_incr("socorro.submitter.accept")
+
+
+def test_multiple_dumps(queue_helper, storage_helper, mock_collector):
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "uuid": crash_id,
+            "Product": "Firefox",
+            "Version": "60.0",
+        },
+        dumps={
+            "upload_file_minidump": "abcdef",
+            "upload_file_minidump_content": "abcdef2",
+        },
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs, make sure it doesn't get sampled, and invoke the Lambda
+    # function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|100"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    post_payload = mock_collector.payloads[0].text
+
+    # Who doesn't like reading raw multipart/form-data? Woo hoo!
+    assert (
+        post_payload == "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="Product"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "Firefox\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="Version"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "60.0\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="uuid"\r\n'
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "de1bb258-cbbf-4589-a673-34f800160918\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="upload_file_minidump"; filename="file.dump"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "abcdef\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="upload_file_minidump_content"; '
+        'filename="file.dump"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "abcdef2\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
+
+    metricsmock.assert_incr("socorro.submitter.accept")
+
+
+def test_compressed(queue_helper, storage_helper, mock_collector):
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "uuid": crash_id,
+            "Product": "Firefox",
+            "Version": "60.0",
+            "metadata": {
+                "payload_compressed": "1",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs, make sure it doesn't get sampled, and invoke the Lambda
+    # function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|100"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    req = mock_collector.payloads[0]
+
+    # Assert the header
+    assert req.headers["Content-Encoding"] == "gzip"
+
+    # Assert the length and payload are correct and payload is compressed
+    post_payload = req.body
+    assert len(post_payload) == int(req.headers["Content-Length"])
+
+    unzipped_payload = gzip.decompress(post_payload)
+    assert (
+        unzipped_payload == b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="Product"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"Firefox\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="Version"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"60.0\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="uuid"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"de1bb258-cbbf-4589-a673-34f800160918\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="upload_file_minidump"; '
+        b'filename="file.dump"\r\n'
+        b"Content-Type: application/octet-stream\r\n\r\n"
+        b"abcdef\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
+
+    metricsmock.assert_incr("socorro.submitter.accept")
+
+
+def test_sample_accepted(queue_helper, monkeypatch, storage_helper, mock_collector):
+    def always_20(*args, **kwargs):
+        return 20
+
+    monkeypatch.setattr(random, "randint", always_20)
+
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "uuid": crash_id,
+            "Product": "Firefox",
+            "Version": "60.0",
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture the log and set sample value above the mocked randint--this should
+    # get submitted
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|30"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    metricsmock.assert_incr("socorro.submitter.accept")
+
+
+def test_sample_skipped(queue_helper, monkeypatch, storage_helper, mock_collector):
+    def always_20(*args, **kwargs):
+        return 20
+
+    monkeypatch.setattr(random, "randint", always_20)
+
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "uuid": crash_id,
+            "Product": "Firefox",
+            "Version": "60.0",
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture the logs and set sample value below the mocked randint--this
+    # should get skipped
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|10"]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify no payload was submitted
+    assert len(mock_collector.payloads) == 0
+
+    metricsmock.assert_not_incr("socorro.submitter.accept")
+    metricsmock.assert_incr("socorro.submitter.ignore")
+
+
+def test_different_samples(queue_helper, monkeypatch, storage_helper, mock_collector):
+    def always_20(*args, **kwargs):
+        return 20
+
+    monkeypatch.setattr(random, "randint", always_20)
+
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "Product": "Firefox",
+            "uuid": crash_id,
+            "Version": "60.0",
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs and invoke lambda function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=[
+            # sampled at 5--will get sampled
+            "http://antenna:8000/submit|5",
+            # sampled at 30--will get accepted
+            "http://antenna_2:8000/submit|30",
+        ]
+    ):
+        app = get_app()
+        with MetricsMock() as metricsmock:
+            app.run_once()
+            app.shutdown()
+
+    # Verify only second destination got a payload
+    assert len(mock_collector.payloads) == 1
+    assert mock_collector.payloads[0].hostname == "antenna_2"
+    metricsmock.assert_incr("socorro.submitter.accept")
+    metricsmock.assert_incr("socorro.submitter.ignore")
+
+
+def test_user_agent(queue_helper, storage_helper, mock_collector):
+    user_agent = "crash-reporter/1.0"
+
+    bucket = storage_helper.get_crashstorage_bucket()
+    storage_helper.create_bucket(bucket)
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    save_crash(
+        storage_helper=storage_helper,
+        bucket=bucket,
+        raw_crash={
+            "Product": "Firefox",
+            "uuid": crash_id,
+            "Version": "60.0",
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+                "user_agent": user_agent,
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    queue_helper.publish("standard", crash_id)
+
+    # Capture logs and invoke lambda function
+    with settings.override(
+        STAGE_SUBMITTER_DESTINATIONS=["http://antenna:8000/submit|100"]
+    ):
+        app = get_app()
+        app.run_once()
+        app.shutdown()
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+
+    # Verify user agent is from raw crash
+    headers = mock_collector.payloads[0].headers
+    assert headers["User-Agent"] == user_agent


### PR DESCRIPTION
This implements a stage submitter that pulls crash ids from QUEUE and crash data from STORAGE, packages that up into a crash report payload, and submits it to STAGE_SUBMITTER_DESTINATIONS.

This creates a `make runsubmitter` system that runs the stage submitter and a fake collector allowing you to use `bin/process_crash.sh` to set everything up and publish a crash id to the standard queue which the submitter will see and submit a crash to the fake collector. The fake collector will parse the payload and log headers, annotations, and files.

This adds stage submitter tests.

To test:

1. `make build`
2. `make setup`
3. `make runservices`
4. `make runsubmitter`
5. in another terminal, run `make shell` and then you can use `bin/process_crash.sh` to download crash data, put it in storage, and publish the crash id to the standard queue
   1. if it's sampled, then you'll see a `socorro.submitter.sample` incr metric
   2. if it's accepted, then you'll see a `socorro.submitter.accept` incr metric and you'll see the headers, annotations, and files logged by the fake collector

Light documentation is provided in `docs/services/stage_submitter.rst`.