### PR TITLE
bug-1898341, bug-1898345: add "host" tag, fix metrics key prefix

### DIFF
--- a/docker/config/gunicorn_config.py
+++ b/docker/config/gunicorn_config.py
@@ -12,19 +12,19 @@ from decouple import config as CONFIG
 
 LOGGING_LEVEL = CONFIG("LOGGING_LEVEL", "INFO")
 LOCAL_DEV_ENV = CONFIG("LOCAL_DEV_ENV", False, cast=bool)
-HOST_ID = socket.gethostname()
+HOSTNAME = CONFIG("HOSTNAME", default=socket.gethostname())
 
 
-class AddHostID(logging.Filter):
+class AddHostname(logging.Filter):
     def filter(self, record):
-        record.host_id = HOST_ID
+        record.hostname = HOSTNAME
         return True
 
 
 logconfig_dict = {
     "version": 1,
     "disable_existing_loggers": False,
-    "filters": {"add_hostid": {"()": AddHostID}},
+    "filters": {"add_hostname": {"()": AddHostname}},
     "handlers": {
         "console": {
             "level": LOGGING_LEVEL,
@@ -35,7 +35,7 @@ logconfig_dict = {
             "level": LOGGING_LEVEL,
             "class": "logging.StreamHandler",
             "formatter": "mozlog",
-            "filters": ["add_hostid"],
+            "filters": ["add_hostname"],
         },
     },
     "formatters": {

--- a/fakecollector/collector.py
+++ b/fakecollector/collector.py
@@ -92,7 +92,7 @@ class App:
 @click.option("--host", default="0.0.0.0", help="host to bind to")
 @click.option("--port", default=8000, type=int, help="port to listen on")
 def main(host, port):
-    set_up_logging(local_dev_env=True, host_id="localhost")
+    set_up_logging(local_dev_env=True, hostname="localhost")
 
     from werkzeug.serving import run_simple
     app = App()

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -5,8 +5,6 @@
 import json
 import logging
 
-import markus
-
 from socorro.external.crashstorage_base import (
     CrashStorageBase,
     CrashIDNotFound,
@@ -97,8 +95,6 @@ class BotoS3CrashStorage(CrashStorageBase):
         )
         self.bucket = bucket
         self.dump_file_suffix = dump_file_suffix
-
-        self.metrics = markus.get_metrics(metrics_prefix)
 
     @classmethod
     def build_connection(cls, region, access_key, secret_access_key, endpoint_url):

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -295,7 +295,10 @@ class ESCrashStorage(CrashStorageBase):
 
         # Create a MetricsInterface that includes the base prefix plus the prefix passed
         # into __init__
-        self.metrics = markus.get_metrics(build_prefix(METRICS.prefix, metrics_prefix))
+        self.metrics = markus.get_metrics(
+            build_prefix(METRICS.prefix, metrics_prefix),
+            filters=list(METRICS.filters),
+        )
 
         self.index = index
         self.index_regex = index_regex

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -23,7 +23,7 @@ from socorro.external.es.super_search_fields import (
     is_indexable,
     parse_mapping,
 )
-
+from socorro.libmarkus import METRICS, build_prefix
 from socorro.lib.libdatetime import JsonDTEncoder, string_to_datetime, utc_now
 
 
@@ -293,7 +293,9 @@ class ESCrashStorage(CrashStorageBase):
 
         self.client = self.build_client(url=url, timeout=timeout)
 
-        self.metrics = markus.get_metrics(metrics_prefix)
+        # Create a MetricsInterface that includes the base prefix plus the prefix passed
+        # into __init__
+        self.metrics = markus.get_metrics(build_prefix(METRICS.prefix, metrics_prefix))
 
         self.index = index
         self.index_regex = index_regex

--- a/socorro/external/gcs/crashstorage.py
+++ b/socorro/external/gcs/crashstorage.py
@@ -5,7 +5,6 @@
 import json
 import os
 
-import markus
 from google.auth.credentials import AnonymousCredentials
 from google.api_core.exceptions import NotFound
 from google.cloud import storage
@@ -93,8 +92,6 @@ class GcsCrashStorage(CrashStorageBase):
 
         self.bucket = bucket
         self.dump_file_suffix = dump_file_suffix
-
-        self.metrics = markus.get_metrics(metrics_prefix)
 
     def load_file(self, path):
         bucket = self.client.bucket(self.bucket)

--- a/socorro/lib/liblogging.py
+++ b/socorro/lib/liblogging.py
@@ -11,16 +11,23 @@ import socket
 def set_up_logging(
     local_dev_env=False,
     logging_level="INFO",
-    host_id=None,
+    hostname=None,
 ):
-    """Initialize Python logging."""
+    """Initialize Python logging.
 
-    if host_id is None:
-        host_id = socket.gethostname()
+    :arg local_dev_env: whether or not this is running in a local development
+        environment
+    :arg logging_level: the logging level to emit records at
+    :arg hostname: the hostname for this instance
 
-    class AddHostID(logging.Filter):
+    """
+
+    if hostname is None:
+        hostname = socket.gethostname()
+
+    class AddHostname(logging.Filter):
         def filter(self, record):
-            record.host_id = host_id
+            record.hostname = hostname
             return True
 
     class AddProcessName(logging.Filter):
@@ -34,7 +41,7 @@ def set_up_logging(
         "version": 1,
         "disable_existing_loggers": False,
         "filters": {
-            "add_hostid": {"()": AddHostID},
+            "add_hostname": {"()": AddHostname},
             "add_processname": {"()": AddProcessName},
         },
         "formatters": {
@@ -59,7 +66,7 @@ def set_up_logging(
                 "level": "DEBUG",
                 "class": "logging.StreamHandler",
                 "formatter": "mozlog",
-                "filters": ["add_hostid", "add_processname"],
+                "filters": ["add_hostname", "add_processname"],
             },
         },
     }

--- a/socorro/libmarkus.py
+++ b/socorro/libmarkus.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Holds Markus utility functions and global state."""
+
+import logging
+import os
+
+import markus
+from markus.filters import AddTagFilter
+
+
+_IS_MARKUS_SETUP = False
+
+# NOTE(willkg): this checks the CLOUD_PROVIDER environ directly here because this can't
+# import socorro.settings; this is temporary--once we finish the GCP migration, we can
+# remove this
+_CLOUD_PROVIDER = os.environ.get("CLOUD_PROVIDER", "AWS").upper()
+
+LOGGER = logging.getLogger(__name__)
+# NOTE(willkg): we need to set the prefix selectively because in AWS we don't have the
+# "socorro" key prefix, but in GCP we want one
+if _CLOUD_PROVIDER == "GCP":
+    METRICS = markus.get_metrics("socorro")
+else:
+    METRICS = markus.get_metrics()
+
+
+def set_up_metrics(statsd_host, statsd_port, hostname, debug=False):
+    """Initialize and configures the metrics system.
+
+    :arg statsd_host: the statsd host to send metrics to
+    :arg statsd_port: the port on the host to send metrics to
+    :arg hostname: the host name
+    :arg debug: whether or not to additionally log metrics to the logger
+
+    """
+    global _IS_MARKUS_SETUP, METRICS
+    if _IS_MARKUS_SETUP:
+        return
+
+    markus_backends = [
+        {
+            "class": "markus.backends.datadog.DatadogMetrics",
+            "options": {
+                "statsd_host": statsd_host,
+                "statsd_port": statsd_port,
+            },
+        }
+    ]
+    if debug:
+        markus_backends.append(
+            {
+                "class": "markus.backends.logging.LoggingMetrics",
+                "options": {
+                    "logger_name": "markus",
+                    "leader": "METRICS",
+                },
+            }
+        )
+
+    if _CLOUD_PROVIDER == "GCP" and hostname:
+        METRICS.filters.append(AddTagFilter(f"host:{hostname}"))
+
+    markus.configure(markus_backends)
+
+    _IS_MARKUS_SETUP = True
+
+
+def build_prefix(*parts):
+    new_prefix = []
+    for part in parts:
+        part = part.strip()
+        if part:
+            new_prefix.append(part)
+
+    return ".".join(parts)

--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -53,8 +53,8 @@ LOCAL_DEV_ENV = _config(
     doc="Whether or not this is a local development environment.",
 )
 
-HOST_ID = _config(
-    "HOST_ID",
+HOSTNAME = _config(
+    "HOSTNAME",
     default=socket.gethostname(),
     doc="Name of the host this is running on.",
 )
@@ -73,27 +73,9 @@ LOGGING_LEVEL = _config(
     doc="Default logging level. Should be one of DEBUG, INFO, WARNING, ERROR.",
 )
 
-# Markus configuration for metrics
-MARKUS_BACKENDS = [
-    {
-        "class": "markus.backends.datadog.DatadogMetrics",
-        "options": {
-            "statsd_host": _config(
-                "STATSD_HOST",
-                default="localhost",
-                doc="statsd host.",
-            ),
-            "statsd_port": _config(
-                "STATSD_PORT",
-                default="8125",
-                parser=int,
-                doc="statsd port.",
-            ),
-        },
-    },
-]
-if LOCAL_DEV_ENV:
-    MARKUS_BACKENDS.append({"class": "markus.backends.logging.LoggingMetrics"})
+
+STATSD_HOST = _config("STATSD_HOST", default="localhost", doc="statsd host.")
+STATSD_PORT = _config("STATSD_PORT", default="8125", parser=int, doc="statsd port.")
 
 
 # Processor configuration
@@ -120,7 +102,7 @@ PROCESSOR = {
         "class": "socorro.processor.pipeline.Pipeline",
         "options": {
             "rulesets": "socorro.mozilla_rulesets.RULESETS",
-            "host_id": HOST_ID,
+            "hostname": HOSTNAME,
         },
     },
     "temporary_path": _config(

--- a/socorro/processor/pipeline.py
+++ b/socorro/processor/pipeline.py
@@ -33,14 +33,14 @@ class Status:
 class Pipeline:
     """Processor pipeline for Mozilla crash ingestion."""
 
-    def __init__(self, rulesets, host_id=None):
+    def __init__(self, rulesets, hostname):
         """
         :arg rulesets: either a dict of name -> list of rules or a Python dotted
             string path to a dict of name -> list of rules
-        :arg host_id: the id of the host this is running on; used for logging
+        :arg hostname: the id of the host this is running on; used for logging
         """
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
-        self.host_id = host_id or "unknown"
+        self.hostname = hostname
 
         if isinstance(rulesets, str):
             rulesets = import_class(rulesets)
@@ -72,7 +72,7 @@ class Pipeline:
         start_time = utc_now()
         processed_crash["started_datetime"] = date_to_string(start_time)
 
-        status.add_note(f">>> Start processing: {start_time} ({self.host_id})")
+        status.add_note(f">>> Start processing: {start_time} ({self.hostname})")
 
         processed_crash["signature"] = "EMPTY: crash failed to process"
 

--- a/socorro/processor/rules/base.py
+++ b/socorro/processor/rules/base.py
@@ -4,10 +4,7 @@
 
 import logging
 
-import markus
-
-
-metrics = markus.get_metrics("processor.rule")
+from socorro.libmarkus import METRICS
 
 
 class Rule:
@@ -65,7 +62,7 @@ class Rule:
 
         """
         class_name = self.__class__.__name__
-        with metrics.timer("act.timing", tags=["rule:%s" % class_name]):
+        with METRICS.timer("processor.rule.act.timing", tags=["rule:%s" % class_name]):
             ret = self.predicate(
                 raw_crash=raw_crash,
                 dumps=dumps,

--- a/socorro/processor/rules/breakpad.py
+++ b/socorro/processor/rules/breakpad.py
@@ -10,8 +10,8 @@ import shlex
 import subprocess
 
 import glom
-import markus
 
+from socorro.libmarkus import METRICS
 from socorro.processor.rules.base import Rule
 
 
@@ -164,10 +164,6 @@ class TruncateStacksRule(Rule):
     MAX_FRAMES = 500
     HALF_MAX_FRAMES = int(MAX_FRAMES / 2)
 
-    def __init__(self):
-        super().__init__()
-        self.metrics = markus.get_metrics("processor.truncatestacksrule")
-
     def truncation_frame(self, truncated_frames):
         return {"truncated": {"msg": f"{len(truncated_frames):,} frames truncated"}}
 
@@ -180,8 +176,8 @@ class TruncateStacksRule(Rule):
             frame in the middle
 
         """
-        self.metrics.gauge("stack_size", len(frames))
-        self.metrics.incr("truncated")
+        METRICS.gauge("processor.truncatestackrule.stack_size", len(frames))
+        METRICS.incr("processor.truncatestackrule.truncated")
 
         first_frames = frames[: self.HALF_MAX_FRAMES]
         truncated_frames = frames[self.HALF_MAX_FRAMES : -self.HALF_MAX_FRAMES]
@@ -331,8 +327,6 @@ class MinidumpStackwalkRule(Rule):
         self.stackwalk_version = self.get_version()
         self.build_directories()
 
-        self.metrics = markus.get_metrics("processor.minidumpstackwalk")
-
     def __repr__(self):
         keys = (
             "dump_field",
@@ -478,8 +472,8 @@ class MinidumpStackwalkRule(Rule):
             status.add_note(msg)
             self.logger.warning("%s (%s)", msg, crash_id)
 
-        self.metrics.incr(
-            "run",
+        METRICS.incr(
+            "processor.minidumpstackwalk.run",
             tags=[
                 "outcome:%s" % ("success" if stackwalker_data["success"] else "fail"),
                 "exitcode:%s" % returncode,

--- a/socorro/processor/rules/general.py
+++ b/socorro/processor/rules/general.py
@@ -5,12 +5,9 @@
 import re
 
 from glom import glom
-import markus
 
+from socorro.libmarkus import METRICS
 from socorro.processor.rules.base import Rule
-
-
-METRICS = markus.get_metrics("processor")
 
 
 class DeNullRule(Rule):
@@ -55,7 +52,7 @@ class DeNullRule(Rule):
                 raw_crash[new_key] = new_val
 
         if had_nulls:
-            METRICS.incr("denullrule.has_nulls")
+            METRICS.incr("processor.denullrule.has_nulls")
 
 
 class DeNoneRule(Rule):
@@ -76,7 +73,7 @@ class DeNoneRule(Rule):
                 del raw_crash[key]
 
         if had_nones:
-            METRICS.incr("denonerule.had_nones")
+            METRICS.incr("processor.denonerule.had_nones")
 
 
 class IdentifierRule(Rule):

--- a/socorro/tests/processor/test_pipeline.py
+++ b/socorro/tests/processor/test_pipeline.py
@@ -123,7 +123,7 @@ class TestPipeline:
             processed_crash = {}
 
             rulesets = {"default": [BadRule()]}
-            processor = Pipeline(rulesets=rulesets)
+            processor = Pipeline(rulesets=rulesets, hostname="testhost")
             processor.process_crash("default", raw_crash, {}, processed_crash, tmp_path)
 
             # Notes were added again
@@ -146,7 +146,7 @@ class TestPipeline:
         processed_crash = {"processor_notes": "previousnotes"}
 
         rulesets = {"default": [CPUInfoRule(), OSInfoRule()]}
-        pipeline = Pipeline(rulesets=rulesets)
+        pipeline = Pipeline(rulesets=rulesets, hostname="testhost")
 
         now = utc_now()
         with freezegun.freeze_time(now):

--- a/socorro/tests/stage_submitter/test_submitter.py
+++ b/socorro/tests/stage_submitter/test_submitter.py
@@ -184,7 +184,10 @@ def test_basic(queue_helper, storage_helper, mock_collector):
         "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    metricsmock.assert_incr("socorro.submitter.accept")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
 
 
 def test_multiple_destinations(queue_helper, storage_helper, mock_collector):
@@ -284,7 +287,10 @@ def test_annotations_as_json(queue_helper, storage_helper, mock_collector):
         "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    metricsmock.assert_incr("socorro.submitter.accept")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
 
 
 def test_multiple_dumps(queue_helper, storage_helper, mock_collector):
@@ -351,7 +357,10 @@ def test_multiple_dumps(queue_helper, storage_helper, mock_collector):
         "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    metricsmock.assert_incr("socorro.submitter.accept")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
 
 
 def test_compressed(queue_helper, storage_helper, mock_collector):
@@ -417,7 +426,10 @@ def test_compressed(queue_helper, storage_helper, mock_collector):
         b"--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    metricsmock.assert_incr("socorro.submitter.accept")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
 
 
 def test_sample_accepted(queue_helper, monkeypatch, storage_helper, mock_collector):
@@ -453,7 +465,10 @@ def test_sample_accepted(queue_helper, monkeypatch, storage_helper, mock_collect
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
-    metricsmock.assert_incr("socorro.submitter.accept")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
 
 
 def test_sample_skipped(queue_helper, monkeypatch, storage_helper, mock_collector):
@@ -490,8 +505,12 @@ def test_sample_skipped(queue_helper, monkeypatch, storage_helper, mock_collecto
     # Verify no payload was submitted
     assert len(mock_collector.payloads) == 0
 
-    metricsmock.assert_not_incr("socorro.submitter.accept")
-    metricsmock.assert_incr("socorro.submitter.ignore")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_not_incr("submitter.accept")
+        metricsmock.assert_incr("submitter.ignore")
+    else:
+        metricsmock.assert_not_incr("socorro.submitter.accept")
+        metricsmock.assert_incr("socorro.submitter.ignore")
 
 
 def test_different_samples(queue_helper, monkeypatch, storage_helper, mock_collector):
@@ -539,8 +558,12 @@ def test_different_samples(queue_helper, monkeypatch, storage_helper, mock_colle
     # Verify only second destination got a payload
     assert len(mock_collector.payloads) == 1
     assert mock_collector.payloads[0].hostname == "antenna_2"
-    metricsmock.assert_incr("socorro.submitter.accept")
-    metricsmock.assert_incr("socorro.submitter.ignore")
+    if settings.CLOUD_PROVIDER == "AWS":
+        metricsmock.assert_incr("submitter.accept")
+        metricsmock.assert_incr("submitter.ignore")
+    else:
+        metricsmock.assert_incr("socorro.submitter.accept")
+        metricsmock.assert_incr("socorro.submitter.ignore")
 
 
 def test_user_agent(queue_helper, storage_helper, mock_collector):

--- a/webapp/crashstats/__init__.py
+++ b/webapp/crashstats/__init__.py
@@ -1,5 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-default_app_config = "crashstats.crashstats.apps.CrashstatsAppConfig"

--- a/webapp/crashstats/__init__.py
+++ b/webapp/crashstats/__init__.py
@@ -1,3 +1,5 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+default_app_config = "crashstats.crashstats.apps.CrashstatsAppConfig"

--- a/webapp/crashstats/crashstats/decorators.py
+++ b/webapp/crashstats/crashstats/decorators.py
@@ -6,7 +6,6 @@ import functools
 import time
 from urllib.parse import urlsplit
 
-import markus
 from markus.utils import generate_tag
 
 from django.contrib.auth.decorators import REDIRECT_FIELD_NAME, user_passes_test
@@ -15,6 +14,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 
 from crashstats.crashstats import utils
+from socorro.libmarkus import METRICS
 
 
 def login_required(
@@ -103,8 +103,6 @@ def pass_default_context(view):
     return inner
 
 
-VIEW_METRICS = markus.get_metrics("webapp.view")
-
 # List of url pattern names (see urls.py files) to use the url path
 # instead of the resolver route
 USE_PATH_VIEWS = [
@@ -175,8 +173,8 @@ def track_view(view):
             path = request.path
 
         delta = (time.time() - start_time) * 1000
-        VIEW_METRICS.timing(
-            "pageview",
+        METRICS.timing(
+            "webapp.view.pageview",
             value=delta,
             tags=[
                 cached_generate_tag("ajax", value=str(is_ajax).lower()),

--- a/webapp/crashstats/crashstats/management/commands/verifyprocessed.py
+++ b/webapp/crashstats/crashstats/management/commands/verifyprocessed.py
@@ -13,7 +13,6 @@ import concurrent.futures
 import datetime
 from functools import partial
 
-import markus
 from more_itertools import chunked
 
 from django.core.management.base import BaseCommand, CommandError
@@ -26,6 +25,7 @@ from crashstats.supersearch.models import SuperSearchUnredacted
 from socorro import settings as socorro_settings
 from socorro.lib.libooid import date_from_ooid
 from socorro.libclass import build_instance_from_settings
+from socorro.libmarkus import METRICS
 
 
 # Number of seconds until we decide a worker has stalled
@@ -33,9 +33,6 @@ WORKER_TIMEOUT = 15 * 60
 
 # Number of prefix variations to pass to a check_crashids subprocess
 CHUNK_SIZE = 4
-
-
-metrics = markus.get_metrics("cron.verifyprocessed")
 
 
 def is_in_storage(crash_dest, crash_id):
@@ -151,7 +148,7 @@ class Command(BaseCommand):
 
     def handle_missing(self, date, missing):
         """Report crash ids for missing processed crashes."""
-        metrics.gauge("missing_processed", len(missing))
+        METRICS.gauge("cron.verifyprocessed.missing_processed", len(missing))
         if missing:
             for crash_id in missing:
                 self.stdout.write(f"Missing: {crash_id}")

--- a/webapp/crashstats/crashstats/models.py
+++ b/webapp/crashstats/crashstats/models.py
@@ -19,13 +19,13 @@ from django.template.defaultfilters import slugify
 from django.urls import reverse, NoReverseMatch
 from django.utils.encoding import iri_to_uri
 
-import markus
 from pymemcache.exceptions import MemcacheServerError
 
 from socorro import settings as socorro_settings
 from socorro.external.boto.crash_data import SimplifiedCrashData, TelemetryCrashData
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
+from socorro.libmarkus import METRICS
 from socorro.lib.libooid import is_crash_id_valid
 from socorro.lib.librequests import session_with_retries
 from socorro.lib.libsocorrodataschema import (
@@ -37,9 +37,6 @@ from socorro.lib.libsocorrodataschema import (
 
 
 logger = logging.getLogger("crashstats.models")
-
-
-metrics = markus.get_metrics("webapp.crashstats.models")
 
 
 RAW_CRASH_SCHEMA = get_schema("raw_crash.schema.yaml")
@@ -324,7 +321,7 @@ class SocorroCommon:
             try:
                 cache.set(cache_key, result, timeout=self.cache_seconds)
             except MemcacheServerError:
-                metrics.incr("cache_set_error")
+                METRICS.incr("webapp.crashstats.models.cache_set_error")
 
         return result
 

--- a/webapp/crashstats/crashstats/tests/test_sentry.py
+++ b/webapp/crashstats/crashstats/tests/test_sentry.py
@@ -179,4 +179,4 @@ def test_count_sentry_scrub_error():
     with MetricsMock() as metricsmock:
         metricsmock.clear_records()
         count_sentry_scrub_error("foo")
-        metricsmock.assert_incr("webapp.crashstats.apps.sentry_scrub_error", value=1)
+        metricsmock.assert_incr("webapp.sentry_scrub_error", value=1)

--- a/webapp/crashstats/cron/management/commands/cronrun.py
+++ b/webapp/crashstats/cron/management/commands/cronrun.py
@@ -9,8 +9,6 @@ import sys
 import time
 import traceback
 
-import markus
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -32,11 +30,10 @@ from crashstats.cron.utils import (
     get_run_times,
     time_to_run,
 )
+from socorro.libmarkus import METRICS
 
 
 logger = logging.getLogger("crashstats.cron")
-
-metrics = markus.get_metrics("cron")
 
 
 class Command(BaseCommand):
@@ -206,7 +203,7 @@ class Command(BaseCommand):
         Log.objects.create(
             app_name=cmd, success=success_date, duration="%.5f" % duration
         )
-        metrics.gauge("job_success_runtime", value=duration, tags=["job:%s" % cmd])
+        METRICS.gauge("cron.job_success_runtime", value=duration, tags=["job:%s" % cmd])
 
     def _remember_failure(self, cmd, duration, exc_type, exc_value, exc_tb):
         Log.objects.create(
@@ -216,7 +213,7 @@ class Command(BaseCommand):
             exc_value=repr(exc_value),
             exc_traceback="".join(traceback.format_tb(exc_tb)),
         )
-        metrics.gauge("job_failure_runtime", value=duration, tags=["job:%s" % cmd])
+        METRICS.gauge("cron.job_failure_runtime", value=duration, tags=["job:%s" % cmd])
 
     @contextlib.contextmanager
     def lock_job(self, cmd):

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -214,23 +214,23 @@ DJANGO_LOGGING_LEVEL = _config(
     doc="Logging level for Django logging (requests, SQL, etc)",
 )
 
-HOST_ID = _config(
-    "HOST_ID",
+HOSTNAME = _config(
+    "HOSTNAME",
     default=socket.gethostname(),
-    doc="Name of the host this is running on. Used in logging.",
+    doc="Name of the host this is running on.",
 )
 
 
-class AddHostID(logging.Filter):
+class AddHostname(logging.Filter):
     def filter(self, record):
-        record.host_id = HOST_ID
+        record.hostname = HOSTNAME
         return True
 
 
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "filters": {"add_hostid": {"()": AddHostID}},
+    "filters": {"add_hostname": {"()": AddHostname}},
     "handlers": {
         "console": {
             "level": LOGGING_LEVEL,
@@ -241,7 +241,7 @@ LOGGING = {
             "level": LOGGING_LEVEL,
             "class": "logging.StreamHandler",
             "formatter": "mozlog",
-            "filters": ["add_hostid"],
+            "filters": ["add_hostname"],
         },
     },
     "formatters": {
@@ -418,25 +418,8 @@ CACHE_IMPLEMENTATION_FETCHES = _config(
 )
 
 # for local development these don't matter
-STATSD_HOST = _config("STATSD_HOST", default="localhost")
-STATSD_PORT = _config("STATSD_PORT", default="8125", parser=int)
-STATSD_PREFIX = _config("STATSD_PREFIX", default="") or None
-
-# set up markus backends for metrics
-MARKUS_BACKENDS = [
-    {
-        "class": "markus.backends.datadog.DatadogMetrics",
-        "options": {
-            "statsd_host": STATSD_HOST,
-            "statsd_port": STATSD_PORT,
-            "statsd_namespace": STATSD_PREFIX,
-        },
-    },
-]
-if LOCAL_DEV_ENV:
-    # Add logging backend in local dev environment so we see metrics without
-    # needing a whole statsd/grafana backend.
-    MARKUS_BACKENDS.append({"class": "markus.backends.logging.LoggingMetrics"})
+STATSD_HOST = _config("STATSD_HOST", default="localhost", doc="statsd host.")
+STATSD_PORT = _config("STATSD_PORT", default="8125", parser=int, doc="statsd port.")
 
 
 CACHES = {


### PR DESCRIPTION
This adds a "host" tag to emitted metrics when running in GCP. This is derived from "HOSTNAME" if it exists, otherwise it defaults to `socket.gethostname()` like our other services.

This changes Sentry and logging to use `HOSTNAME` configuration variable rather than `HOST_ID`. This brings us in line with other services as we migrate to GCP.

This also adds `"socorro."` prefix to all emitted keys, but only for the GCP environments so we don't make a major change to socorro running in AWS at this time. This brings keys in line with our other services.

In order to do this, I had to create a singleton `METRICS` in `socorro/libmarkus.py` and then rework everything to use that.

To test:

1. run the tests--they have assertions about keys and tags
2. run socorro, process crashes, make sure metrics are emitted and look correct
   * processor, webapp, and crontabber metrics keys **are NOT** prefixed with `socorro`
   * keys **do NOT** include a `host` tag
3. set `CLOUD_PROVIDER=GCP`, run socorro, process crashes, make sure metrics are emitted and look correct
   * processor, webapp, and crontabber metrics keys **are** prefixed with `socorro`
   * keys **do** include a `host` tag