### PR TITLE
bug-1898800: fix csrf token storage

### DIFF
--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -126,13 +126,13 @@ MIDDLEWARE = [
     # CORS needs to go before other response-generating middlewares
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "crashstats.tokens.middleware.APIAuthenticationMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # If you run crashstats behind a load balancer, your `REMOTE_ADDR` header
     # will be that of the load balancer instead of the actual user. The
@@ -491,6 +491,7 @@ SECRET_KEY = _config(
 )
 
 CSRF_COOKIE_NAME = "crashstatscsrfcookie"
+CSRF_USE_SESSIONS = True
 
 SESSION_COOKIE_SECURE = _config(
     "SESSION_COOKIE_SECURE",

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -490,6 +490,8 @@ SECRET_KEY = _config(
     doc="Make this unique, and don't share it with anybody. It cannot be blank.",
 )
 
+CSRF_COOKIE_NAME = "crashstatscsrfcookie"
+
 SESSION_COOKIE_SECURE = _config(
     "SESSION_COOKIE_SECURE",
     default="true",


### PR DESCRIPTION
This changes Crash Stats to store the csrf token in the session rather than in the cookie.

This also adjusts the order of the middleware per Django's documented conventions.

This also sets the `CSRF_COOKIE_NAME` to "crashstatscsrftoken" to make it distinguishable in the local dev environment from other things creating a "csrftoken". It shouldn't get created anymore and now it's a lot easier to verify that.

To test:

1. check out this pr, then switch to the first commit
2. set up your local dev environment
3. run `make run`
4. go to `localhost:8000` in a fresh private window and log in
5. check firefox dev tools Storage tab Cookies

You'll see the csrf cookie from crash stats code (crashstatscsrftoken) and the one from the oidc provider (csrftoken) which we use in the local dev environment.

![image](https://github.com/mozilla-services/socorro/assets/820826/6eb89872-e338-47a2-93bf-568957a9e7fc)

1. do the above steps with the tip of this pr branch -- make sure to use a fresh private window so you're not picking up cookies from the last round

You'll see only the csrf cookie from the oidc provider (csrftoken).

![image](https://github.com/mozilla-services/socorro/assets/820826/4f9720f7-5826-49d5-8994-3319ca52250a)
