### PR TITLE
bug-1877291: process crash reports we discover weren't processed

### DIFF
--- a/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
+++ b/webapp/crashstats/crashstats/tests/test_verifyprocessed.py
@@ -164,7 +164,7 @@ class TestVerifyProcessed:
         captured = capsys.readouterr()
         assert ("All crashes for %s were processed." % TODAY) in captured.out
 
-    def test_handle_missing_some_missing(self, capsys, db):
+    def test_handle_missing_some_missing(self, capsys, db, queue_helper):
         crash_ids = [create_new_ooid(), create_new_ooid()]
         crash_ids.sort()
         cmd = Command()
@@ -175,3 +175,5 @@ class TestVerifyProcessed:
         assert "Missing: %s" % crash_ids[1] in captured.out
 
         assert crash_ids == list(self.fetch_crashids())
+
+        assert queue_helper.get_published_crashids("reprocessing") == crash_ids


### PR DESCRIPTION
verifyprocessed is a Django management command that runs every day, looks at the previous day of raw crashes, checks to see if there's a processed crash and data in Elasticsearch, and adds a MissingProcessedCrash record if there wasn't.

This fixes the command so it also tosses the crash id in the reprocessing queue.

This fix allows Socorro to self-heal. Currently it notes that some crash reports weren't processed, but doesn't do anything to fix that.

In 2024, we've had one crash report that wasn't processed:

https://crash-stats.mozilla.org/siteadmin/crashstats/missingprocessedcrash/

It doesn't happen often except when the collector has problems connecting to the queue. In that case, we get a burst of crash reports that weren't processed and it's time-consuming to fix manually.