### PR TITLE
OBS-87: install postgres cli tools for db maintenance

### DIFF
--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -31,6 +31,9 @@ PACKAGES_TO_INSTALL=(
 
     # For nodejs and npm
     curl
+
+    # For database maintenance
+    postgresql-client
 )
 
 # Install Ubuntu packages


### PR DESCRIPTION
this installs tools `psql`, `pg_dump` and `pg_restore` which are needed for the plan to migrate the postgres from aws to gcp.