### PR TITLE
bug-1900806: add code_id to missing_symbols field

### DIFF
--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2796,9 +2796,13 @@ properties:
     type: ["string", "null"]
     permissions: ["public"]
   missing_symbols:
-    description: >
-      Set of `;` delimited `module/version/debugid` strings of modules that the
-      stackwalker couldn't find symbols for.
+    description: |
+      Set of `;` delimited module information strings that the stackwalker
+      couldn't find symbols for. Module information strings have one of
+      these forms:
+
+      * module/version/debugid
+      * module/version/debugid/codeid
     type: string
     permissions: ["public"]
   modules_in_stack:

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -1527,14 +1527,27 @@ class TestMissingSymbolsRule:
                 },
                 "libxul_2.dll/1.0/51C36FAFFD214DB4A0D91D93B38336CEA",
             ),
+            # With a code id
+            (
+                {
+                    "filename": "ntdll.dll",
+                    "version": "10.0.14393.6343",
+                    "debug_id": "0879DB9512094636AA777326F6A5C01E1",
+                    "code_id": "6502749b182000",
+                    "missing_symbols": True,
+                },
+                "ntdll.dll/10.0.14393.6343/0879DB9512094636AA777326F6A5C01E1/6502749b182000",
+            ),
+            # Clean up fields
             (
                 {
                     "filename": " l\nib (foo)",
                     "version": "1.0/5",
                     "debug_id": "this is bad",
+                    "code_id": "ou812",
                     "missing_symbols": True,
                 },
-                "libfoo/1.0\\/5/bad",
+                "libfoo/1.0\\/5/bad/812",
             ),
         ],
     )


### PR DESCRIPTION
This adds the code_id to the misisng_symbols field. Now the field will have one of two shapes:

* module/version/debugid
* module/version/debugid/codeid

This doesn't affect how we index this field in Elasticsearch. Further, we can reprocess existing crash reports to pick up the codeid information once this is deployed to production if we want to do that.

To test:

1. build socorro local dev environment
2. index some crash reports with missing symbols:
   * 2cca63d3-2d4a-4981-adac-562030240605
   * 6a61e999-b227-4779-8fff-475960240605
   * e27ddaf3-3760-4d8b-9380-a5b570240605
   ```
   ./bin/process_crashes.sh 2cca63d3-2d4a-4981-adac-562030240605 6a61e999-b227-4779-8fff-475960240605 e27ddaf3-3760-4d8b-9380-a5b570240605
   ```
3. use supersearchfacet to get a facet of `missing_symbol` (make sure to include today in the date range)
   ```
   $ supersearchfacet --host=http://localhost:8000/ --_facets=missing_symbols --end-date=2024-06-06
   missing_symbols
    missing_symbols                                                                  | count 
   ----------------------------------------------------------------------------------|-------
    ashshell.dll/24.4.9067.0/279a5e694253439293510083cfe5d1461/6628e8933c2000        | 1     
    ctxwebauthnhook.dll/7.33.3000.10/9009a93593484a878b1bc5bbe06813f31/644fd20a7c000 | 1     
    umppc18511.dll/7.15.18511.0/bc9ce3500d8c4469a2b36acfc3de1b581/663f762514000      | 1     
    total                                                                            | 2     
   ```