### PR TITLE
bug-1900995: remove SignatureParentIDNotEqualsChildID rule

### DIFF
--- a/socorro/signature/generator.py
+++ b/socorro/signature/generator.py
@@ -16,7 +16,6 @@ from .rules import (
     SignatureGenerationRule,
     SignatureIPCChannelError,
     SignatureIPCMessageName,
-    SignatureParentIDNotEqualsChildID,
     SignatureRunWatchDog,
     SignatureShutdownTimeout,
     SigTruncate,
@@ -35,7 +34,6 @@ DEFAULT_RULESET = [
     SignatureRunWatchDog,
     SignatureIPCChannelError,
     SignatureIPCMessageName,
-    SignatureParentIDNotEqualsChildID,
     StackOverflowSignature,
     HungProcess,
     # NOTE(willkg): These should always come last and in this order

--- a/socorro/signature/pipeline.rst
+++ b/socorro/signature/pipeline.rst
@@ -94,19 +94,17 @@ This is the signature generation ruleset defined at ``socorro.signature.generato
    
    Appends ``ipc_message_name`` value to signature.
 
-10. **Rule: SignatureParentIDNotEqualsChildID**
-    
-    Stomp on the signature if ``moz_crash_reason`` is ``parentBuildID != childBuildID``.
-    
-    In the case where the assertion fails, then the parent buildid and the child buildid are
-    different. This causes a lot of strangeness particularly in symbolification, so the signatures
-    end up as junk. Instead, we want to bucket all these together so we replace the signature.
-
-11. **Rule: StackOverflowSignature**
+10. **Rule: StackOverflowSignature**
     
     Prepends ``stackoverflow``
     
     See `bug #1796389 <https://bugzilla.mozilla.org/show_bug.cgi?id=1796389>`__.
+
+11. **Rule: HungProcess**
+    
+    Prepends ``hang: <hang_type>`` to the signature of hangs.
+    
+    See bug `#1826703 <https://bugzilla.mozilla.org/show_bug.cgi?id=1826703>`__.
 
 12. **Rule: SigFixWhitespace**
     

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -1096,31 +1096,6 @@ class SignatureIPCMessageName(Rule):
         return True
 
 
-class SignatureParentIDNotEqualsChildID(Rule):
-    """Stomp on the signature if ``moz_crash_reason`` is ``parentBuildID != childBuildID``.
-
-    In the case where the assertion fails, then the parent buildid and the child buildid are
-    different. This causes a lot of strangeness particularly in symbolification, so the signatures
-    end up as junk. Instead, we want to bucket all these together so we replace the signature.
-
-    """
-
-    def predicate(self, crash_data, result):
-        value = "MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)"
-        return crash_data.get("moz_crash_reason") == value
-
-    def action(self, crash_data, result):
-        result.info(
-            self.name,
-            'Signature replaced with MOZ_RELEASE_ASSERT, was: "%s"',
-            result.signature,
-        )
-
-        # The MozCrashReason lists the assertion that failed, so we put "!=" in the signature
-        result.set_signature(self.name, "parentBuildID != childBuildID")
-        return True
-
-
 class HungProcess(Rule):
     """Prepends ``hang: <hang_type>`` to the signature of hangs.
 

--- a/socorro/signature/schema.rst
+++ b/socorro/signature/schema.rst
@@ -84,10 +84,6 @@ This is the schema for the signature generation crash data structure::
                                        // gets generated when the Socorro processor runs the
                                        // minidump through minidump-stackwalk. If you're not
                                        // using minidump-stackwalk, you can ignore this.
-
-    moz_crash_reason: <string>,        // Optional, This is the MOZ_CRASH_REASON value. This
-                                       // doesn't affect anything unless the value is
-                                       // "MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)".
   }
 
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -2038,42 +2038,6 @@ class TestSignatureIPCMessageName:
         assert result.signature == "fooo::baar | IPC_Message_Name=foo, bar"
 
 
-class TestSignatureParentIDNotEqualsChildID:
-    def test_predicate_no_moz_crash_reason(self):
-        rule = rules.SignatureParentIDNotEqualsChildID()
-        result = {"signature": "", "notes": []}
-        assert rule.predicate({}, result) is False
-
-    def test_predicate_empty_moz_crash_reason(self):
-        rule = rules.SignatureParentIDNotEqualsChildID()
-        crash_data = {"moz_crash_reason": ""}
-        result = {"signature": "", "notes": []}
-        assert rule.predicate(crash_data, result) is False
-
-    def test_predicate_match(self):
-        rule = rules.SignatureParentIDNotEqualsChildID()
-        crash_data = {
-            "moz_crash_reason": "MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)"
-        }
-        result = generator.Result()
-        result.signature = "fooo::baar"
-        assert rule.predicate(crash_data, result) is True
-
-    def test_action(self):
-        rule = rules.SignatureParentIDNotEqualsChildID()
-        crash_data = {
-            "moz_crash_reason": "MOZ_RELEASE_ASSERT(parentBuildID == childBuildID)"
-        }
-        result = generator.Result()
-        result.signature = "fooo::baar"
-        action_result = rule.action(crash_data, result)
-        assert action_result is True
-        assert result.signature == "parentBuildID != childBuildID"
-        assert result.notes == [
-            'SignatureParentIDNotEqualsChildID: Signature replaced with MOZ_RELEASE_ASSERT, was: "fooo::baar"'  # noqa
-        ]
-
-
 class TestHungProcess:
     def test_predicate_no_match(self):
         result = generator.Result()

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -92,8 +92,6 @@ def convert_to_crash_data(processed_crash):
         "ipc_channel_error": glom(processed_crash, "ipc_channel_error", default=None),
         # text or None
         "ipc_message_name": glom(processed_crash, "ipc_message_name", default=None),
-        # text
-        "moz_crash_reason": glom(processed_crash, "moz_crash_reason", default=None),
         # list of str; for example:
         # ["upload_file_minidump_browser", "upload_file_minidump_content"]
         "additional_minidumps": glom(


### PR DESCRIPTION
This removes a signature generation rule that used moz_crash_reason data to stomp on the signature in a certain situation. The assertion that triggered crash reports for this situation is no longer in the code base so this rule no longer has any effect. This removes the rule and the use of moz_crash_reason.

There isn't a good way to test this beyond running the tests. The related bug covers investigation of the situation.