### PR TITLE
Add APP_DATA::FreeCachedMem, SysFreeString and VariantClear to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -201,6 +201,7 @@ Rtl
 _Rtl
 __Rtl
 __rust_start_panic
+SafeVariantClear
 SEC_.*Item
 seckey_
 SECKEY_
@@ -240,6 +241,7 @@ __ulock_wait
 __unlink
 unlink
 VariantClear
+VariantCopy
 vcruntime140\.dll
 _VEC_memcpy
 _VEC_memzero

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -15,6 +15,7 @@ Allocator<T>::malloc
 AllocInfo::Get<T>
 alloc::raw_vec::capacity_overflow
 _alloca_probe
+APP_DATA::FreeCachedMem
 arena_
 BaseAllocator
 BaseGetNamedObjectDirectory
@@ -233,10 +234,12 @@ strlen
 strncpy
 strstr
 syscall
+SysFreeString
 TlsGetValue
 __ulock_wait
 __unlink
 unlink
+VariantClear
 vcruntime140\.dll
 _VEC_memcpy
 _VEC_memzero


### PR DESCRIPTION
See [bug 1904528](https://bugzilla.mozilla.org/show_bug.cgi?id=1904528): Add APP_DATA::FreeCachedMem, SysFreeString and VariantClear to the prefix list for better triage of [bug 1900964](https://bugzilla.mozilla.org/show_bug.cgi?id=1900964). I think this will automatically apply for VariantClearWorker as well?