### PR TITLE
Update sentry-sdk, fillmore, and kent

### DIFF
--- a/docker/Dockerfile.fakesentry
+++ b/docker/Dockerfile.fakesentry
@@ -17,7 +17,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==1.2.0'
+    pip install --no-cache-dir 'kent==2.0.0'
 
 USER kent
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ dj-database-url==2.1.0
 dockerflow==2024.4.2
 enforce-typing==1.0.0.post1
 everett==3.3.0
-fillmore==1.2.0
+fillmore==2.0.0
 freezegun==1.5.1
 glom==23.5.0
 google-cloud-pubsub==2.21.1
@@ -49,7 +49,7 @@ requests==2.32.3
 requests-mock==1.12.1
 ruff==0.4.2
 semver==3.0.2
-sentry-sdk==1.40.5
+sentry-sdk==2.6.0
 statsd==4.0.1
 urlwait==1.0
 werkzeug==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -341,9 +341,9 @@ face==20.1.1 \
     --hash=sha256:7d59ca5ba341316e58cf72c6aff85cca2541cf5056c4af45cb63af9a814bed3e \
     --hash=sha256:ca3a1d8b8b6aa8e61d62a300e9ee24e09c062aceda549e9a640128e4fa0f4559
     # via glom
-fillmore==1.2.0 \
-    --hash=sha256:1968a2ba5adc17ebef362df51ec958c3d78427a77d2218a2709aabc3598eeceb \
-    --hash=sha256:c95f7172614c256fe162e93ae6d5beb07e45e1fe7f71b94f5a08eab45dc58a40
+fillmore==2.0.0 \
+    --hash=sha256:840901d80799ce50db49c3e377815424a356c3e81c6cea5111684c58113d7ad1 \
+    --hash=sha256:fd1a2c2e829073cef3d49f032033d78dbee48f377eb4b915f29084e76f6facb4
     # via -r requirements.in
 freezegun==1.5.1 \
     --hash=sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9 \
@@ -1258,9 +1258,9 @@ semver==3.0.2 \
     --hash=sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc \
     --hash=sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4
     # via -r requirements.in
-sentry-sdk==1.40.5 \
-    --hash=sha256:d188b407c9bacbe2a50a824e1f8fb99ee1aeb309133310488c570cb6d7056643 \
-    --hash=sha256:d2dca2392cc5c9a2cc9bb874dd7978ebb759682fe4fe889ee7e970ee8dd1c61e
+sentry-sdk==2.6.0 \
+    --hash=sha256:422b91cb49378b97e7e8d0e8d5a1069df23689d45262b86f54988a7db264e874 \
+    --hash=sha256:65cc07e9c6995c5e316109f138570b32da3bd7ff8d0d0ee4aaf2628c3dd8127d
     # via
     #   -r requirements.in
     #   fillmore

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -81,9 +81,9 @@ class ProcessorApp:
             release=release,
             host_id=settings.HOSTNAME,
             # Disable frame-local variables
-            with_locals=False,
+            include_local_variables=False,
             # Disable request data from being added to Sentry events
-            request_bodies="never",
+            max_request_body_size="never",
             # All integrations should be intentionally enabled
             default_integrations=False,
             integrations=[

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -2072,7 +2072,7 @@ class TestSignatureGeneratorRule:
             assert "proto_signature" not in processed_crash
             assert status.notes == ["BadRule: Rule failed: Cough"]
 
-            (event,) = sentry_client.events
+            (event,) = sentry_client.envelope_payloads
             # NOTE(willkg): Some of the extra bits come from the processor app and since
             # we're testing SignatureGenerator in isolation, those don't get added to
             # the sentry scope

--- a/socorro/tests/processor/test_processor_app.py
+++ b/socorro/tests/processor/test_processor_app.py
@@ -5,7 +5,7 @@
 from unittest import mock
 from unittest.mock import ANY
 
-from fillmore.test import diff_event
+from fillmore.test import diff_structure
 from markus.testing import MetricsMock
 import pytest
 
@@ -79,7 +79,7 @@ class TestProcessorApp:
                 metricsmock.assert_gauge("processor.processes_by_status")
 
                 # Assert it didn't throw an exception
-                assert len(sentry_client.events) == 0
+                assert len(sentry_client.envelopes) == 0
 
     def test_transform_success(self, processor_settings):
         app = ProcessorApp()
@@ -278,10 +278,10 @@ def test_transform_get_error(processor_settings, sentry_helper, caplogpp):
         # .get_dumps_as_files(), so there's nothing we need to catch here
         app.transform(crash_id)
 
-        (event,) = sentry_client.events
+        (event,) = sentry_client.envelope_payloads
 
         # Assert that the event is what we expected
-        differences = diff_event(event, TRANSFORM_GET_ERROR)
+        differences = diff_structure(event, TRANSFORM_GET_ERROR)
         assert differences == []
 
         # Assert that the logger logged the appropriate thing
@@ -333,7 +333,7 @@ def test_transform_save_error(processor_settings, sentry_helper, caplogpp, tmp_p
 
             # Assert that the exception was not sent to Sentry and not logged at this
             # point--it gets caught and logged  by the processor
-            assert len(sentry_client.events) == 0
+            assert len(sentry_client.envelopes) == 0
 
             # Assert what got logged. It should be all the messages except the last
             # "completed" one because this kicked up a ValueError in saving

--- a/webapp/crashstats/crashstats/apps.py
+++ b/webapp/crashstats/crashstats/apps.py
@@ -60,9 +60,9 @@ def configure_sentry():
         host_id=settings.HOSTNAME,
         sentry_dsn=settings.SENTRY_DSN,
         # Disable frame-local variables
-        with_locals=False,
+        include_local_variables=False,
         # Disable request data from being added to Sentry events
-        request_bodies="never",
+        max_request_body_size="never",
         # All integrations should be intentionally enabled
         default_integrations=False,
         integrations=[

--- a/webapp/crashstats/crashstats/tests/test_sentry.py
+++ b/webapp/crashstats/crashstats/tests/test_sentry.py
@@ -6,7 +6,7 @@
 
 from unittest.mock import ANY
 
-from fillmore.test import diff_event
+from fillmore.test import diff_structure
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -166,12 +166,12 @@ def test_sentry_scrubbing(sentry_helper, transactional_db):
         )
         assert resp.status_code == 500
 
-        (event,) = sentry_client.events
+        (event,) = sentry_client.envelope_payloads
 
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        differences = diff_event(event, BROKEN_EVENT)
+        differences = diff_structure(event, BROKEN_EVENT)
         assert differences == []
 
 


### PR DESCRIPTION
This updates sentry-sdk to 2.5.1, fillmore to 2.0.0, and kent to 2.0.0. This gets us over the sentry-sdk API change.

This also fixes some flakey cache manager tests that sometimes fails and I think it has to do with there not being enough time between creating the files and reading the first file such that the first file doesn't end up with a measurably recent mtime.