### PR TITLE
bug-1100790: fix super search platform queries

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1713,6 +1713,8 @@ FIELDS = {
         "name": "platform",
         "namespace": "processed_crash",
         "query_type": "enum",
+        # FIXME(willkg): storage_mapping should either be not_analyzed or analyzed as a
+        # keyword and not whatever this is
         "storage_mapping": {
             "fields": {
                 "full": {"index": "not_analyzed", "type": "string"},

--- a/socorro/tests/external/es/test_supersearch.py
+++ b/socorro/tests/external/es/test_supersearch.py
@@ -463,17 +463,11 @@ class TestIntegrationSuperSearch:
         now = utc_now()
         crashstorage = self.build_crashstorage()
         api = SuperSearchWithFields(crashstorage=crashstorage)
-        sigs = (
-            "js::break_your_browser",
-            "mozilla::js::function",
-            "js<isKewl>",
-            "foo(bar)",
-        )
 
         es_helper.index_crash(
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
-                "signature": sigs[0],
+                "signature": "js::break_your_browser",
                 "app_notes": "foo bar mozilla",
                 "product": "WaterWolf",
                 "date_processed": now,
@@ -482,7 +476,7 @@ class TestIntegrationSuperSearch:
         es_helper.index_crash(
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
-                "signature": sigs[1],
+                "signature": "mozilla::js::function",
                 "app_notes": "foo bar",
                 "product": "WaterWolf",
                 "date_processed": now,
@@ -491,7 +485,7 @@ class TestIntegrationSuperSearch:
         es_helper.index_crash(
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
-                "signature": sigs[2],
+                "signature": "js<isKewl>",
                 "app_notes": "foo mozilla",
                 "product": "EarthRacoon",
                 "date_processed": now,
@@ -500,7 +494,7 @@ class TestIntegrationSuperSearch:
         es_helper.index_crash(
             processed_crash={
                 "uuid": create_new_ooid(timestamp=now),
-                "signature": sigs[3],
+                "signature": "foo(bar)",
                 "app_notes": "mozilla bar",
                 "product": "EarthRacoon",
                 "date_processed": now,
@@ -508,27 +502,38 @@ class TestIntegrationSuperSearch:
         )
         es_helper.refresh()
 
+        # Search for signatures matching "js" or containing "::"
         res = api.get(signature=["js", "~::"])
         assert res["total"] == 3
-        assert sorted([x["signature"] for x in res["hits"]]), sorted(
-            [sigs[0], sigs[1], sigs[2]]
-        )
+        signatures = [x["signature"] for x in res["hits"]]
+        assert list(sorted(signatures)) == [
+            "js::break_your_browser",
+            "js<isKewl>",
+            "mozilla::js::function",
+        ]
 
+        # Search for signatures matching "js" or containing "::" AND product is
+        # "Unknown" -- there are none
         res = api.get(signature=["js", "~::"], product=["Unknown"])
         assert res["total"] == 0
         assert len(res["hits"]) == 0
 
-        res = api.get(signature=["js", "~::"], product=["WaterWolf", "EarthRacoon"])
-        assert res["total"] == 3
-        assert sorted([x["signature"] for x in res["hits"]]) == sorted(
-            [sigs[0], sigs[1], sigs[2]]
-        )
-
-        res = api.get(signature=["js", "~::"], app_notes=["foo bar"])
+        # Search for signatures matching "js" or containing "::" AND product is
+        # "WaterWolf"
+        res = api.get(signature=["js", "~::"], product=["WaterWolf"])
         assert res["total"] == 2
-        assert sorted([x["signature"] for x in res["hits"]]) == sorted(
-            [sigs[0], sigs[1]]
-        )
+        signatures = [x["signature"] for x in res["hits"]]
+        assert list(sorted(signatures)) == [
+            "js::break_your_browser",
+            "mozilla::js::function",
+        ]
+
+        # Search for signatures matching "js" or containing "::" AND app_notes is
+        # exactly "foo bar"
+        res = api.get(signature=["js", "~::"], app_notes=["=foo bar"])
+        assert res["total"] == 1
+        signatures = [x["signature"] for x in res["hits"]]
+        assert list(sorted(signatures)) == ["mozilla::js::function"]
 
     def test_get_with_pagination(self, es_helper):
         crashstorage = self.build_crashstorage()

--- a/webapp/crashstats/documentation/jinja2/docs/supersearch/home.html
+++ b/webapp/crashstats/documentation/jinja2/docs/supersearch/home.html
@@ -228,21 +228,18 @@
           <td>not</td>
           <td><code>!</code></td>
           <td><i>all</i></td>
-          <td>Meta operator, to put before any other operator to turn it into the opposite.</td>
+          <td>Meta operator to put before any other operator to turn it into the opposite.</td>
         </tr>
         <tr>
-          <td>has terms</td>
+          <td>matches</td>
           <td><code></code></td>
-          <td>enum, keyword, integer, float, string</td>
+          <td>all field types</td>
           <td>
             <p>Default operator.</p>
             <p>
-              For enum, keyword, integer, and float, the field contains
-              at least one instance of the specified term.
-            </p>
-            <p>
-              For analyzed strings, the analyzed field value contains at least
-              one instance of the value. This is case-insensitive.
+              The field value matches the searched value. This will use the
+              analyzer of the field, so it's not case-sensitive, handles
+              differences in spaces and punctuation, and matches closely.
             </p>
           </td>
         </tr>
@@ -250,31 +247,31 @@
           <td>contains</td>
           <td><code>~</code></td>
           <td>string</td>
-          <td>The field contains the given substring. This is case-sensitive.</td>
+          <td>The field value contains the searched value as a substring. This is case-sensitive.</td>
         </tr>
         <tr>
           <td>is exactly</td>
           <td><code>=</code></td>
           <td>string</td>
-          <td>The field is exactly the given value.</td>
+          <td>The field value is exactly the searched value.</td>
         </tr>
         <tr>
           <td>starts with</td>
           <td><code>^</code></td>
           <td>string</td>
-          <td>The field starts with the given value.</td>
+          <td>The field value starts with the searched value.</td>
         </tr>
         <tr>
           <td>ends with</td>
           <td><code>$</code></td>
           <td>string</td>
-          <td>The field ends with the given substring.</td>
+          <td>The field value ends with the searched value.</td>
         </tr>
         <tr>
           <td>matches regex</td>
           <td><code>@</code></td>
           <td>string</td>
-          <td>The field matches the given regular expression. The accepted syntax is described in the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-regexp-query.html#regexp-syntax">Elasticsearch documentation</a>.</td>
+          <td>The field value matches the given regular expression. The accepted syntax is described in the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-regexp-query.html#regexp-syntax">Elasticsearch documentation</a>.</td>
         </tr>
         <tr>
           <td>does not exist</td>
@@ -282,7 +279,7 @@
           <td>string, boolean, integer, float</td>
           <td>
             <p>
-              The field is missing or has a null value.
+              The field value is missing or has a null value.
             </p>
             <p>
               Note: This will not match empty string values.
@@ -293,31 +290,31 @@
           <td>greater than</td>
           <td><code>&gt;</code></td>
           <td>date, integer, float</td>
-          <td>The field is greater than the given date, float, or integer value.</td>
+          <td>The field value is greater than the searched date, float, or integer value.</td>
         </tr>
         <tr>
           <td>greater than or equal</td>
           <td><code>&gt;=</code></td>
           <td>date, integer, float</td>
-          <td>The field is greater than or equal the given date, float, or integer value.</td>
+          <td>The field value is greater than or equal the searched date, float, or integer value.</td>
         </tr>
         <tr>
           <td>lower than</td>
           <td><code>&lt;</code></td>
           <td>date, integer, float</td>
-          <td>The field is lower than the given date, float, or integer value.</td>
+          <td>The field value is lower than the searched date, float, or integer value.</td>
         </tr>
         <tr>
           <td>lower than or equal</td>
           <td><code>&lt;=</code></td>
           <td>date, integer, float</td>
-          <td>The field is lower than or equal the given date, float, or integer value.</td>
+          <td>The field value is lower than or equal to the searched date, float, or integer value.</td>
         </tr>
         <tr>
           <td>is true</td>
           <td><code>__true__</code></td>
           <td>boolean</td>
-          <td>The field has a value that is truthy.</td>
+          <td>The field value is true.</td>
         </tr>
       </tbody>
     </table>

--- a/webapp/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
+++ b/webapp/crashstats/supersearch/static/supersearch/js/lib/dynamic_form.js
@@ -6,10 +6,10 @@
 
   // All available operators.
   var OPERATORS = {
-    has: 'has terms',
-    '!': 'does not have terms',
-    '=': 'is',
-    '!=': 'is not',
+    match: 'matches',
+    '!': 'does not match',
+    '=': 'is exactly',
+    '!=': 'is not exactly',
     '~': 'contains',
     '!~': 'does not contain',
     '^': 'starts with',
@@ -30,7 +30,7 @@
 
   // Order matters here, the first operator will be used as the default
   // value when no operator is passed for a field.
-  var OPERATORS_BASE = ['has', '!'];
+  var OPERATORS_BASE = ['match', '!'];
   var OPERATORS_RANGE = ['>', '>=', '<', '<='];
   var OPERATORS_REGEX = ['~', '=', '$', '^', '@', '!=', '!~', '!$', '!^', '!@'];
   var OPERATORS_EXISTENCE = ['__null__', '!__null__'];
@@ -210,7 +210,7 @@
       value = value.slice(operator.length);
 
       if (operator === '') {
-        // if the operator is missing, use the default one
+        // if the operator is missing, use the default one which is "match"
         operator = allowed_operators[0];
       }
 


### PR DESCRIPTION
In Crash Stats, if you go to Super Search and then search for `platform="Linux"`, you get back crash reports on the Linux platform. If you search for `platform="Mac OS X"`, you get back crash reports on the Mac OS X platform. However, if you want to search for `platform=["Linux", "Mac OS X"]`, you _only_ get back crash reports for Linux.

This happens for a couple of reasons:

1. the `platform` super search field is an analyzed field despite there being only 5 possible values and being treated as an enum in the search form -- it shouldn't be analyzed, but that's a problem for a different day
2. when you search on a field with a single value, the supersearch code does a "simple_query_search" query, but if you search on a field with 2 or more values, it does a "terms" query -- "simple_query_search" and "terms" queries are _COMPLETELY DIFFERENT_ and "terms" queries will do the wrong thing for analyzed fields and that's why searching for more than one platform with one of them being "Mac OS X" will always fail

Further, it's weird that we're using "simple_query_string" in the first place since that supports a query dsl and all kinds of other stuff.

Fun fact, but the form uses "Windows", but the actual value is "Windows NT". If we were using the actual value, it would also be failing in this way. I bumped into the Windows/Windows NT thing when looking at [bug 1768738](https://bugzilla.mozilla.org/show_bug.cgi?id=1768738).

This has been going on since we built Super Search. This bug is almost 10 years old and really irritating.

Relevant docs:

* https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-simple-query-string-query.html
* https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-terms-query.html
* https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-match-query.html

This PR does a few things:

1. it changes the default query type to a "match" query regardless of whether it's a single value or more than one value
2. it updates the documentation and the query type form field drop down options for "has terms" and "does not have terms" to "matches" and "does not match" because:
   a. that is a lot clearer
   b. it's more correct now that we've changed the code in the way we changed it
4. it fixes a test that was just plain wrong that started failing after I made the code changes

To test this:

1. run the tests
2. set up a local dev environment and process crash reports for Linux, Mac OS X, and Windows NT
3. run the webapp and experiment with different kinds of queries and look for ones where the results are clearly wrong
5. particularly, searching for `platform="Linux"`, `platform="Mac OS X"`, and `platform=["Linux", "Mac OS X"]` should all do the right thing

Here's a list of crash ids I used:

```
# linux
e8b5640c-27a9-4369-81b4-6767c0240625
1f81f372-e460-4b1c-a138-600210240625
42ce5fd9-e630-49b3-b27f-810880240625
c7a504aa-409c-4d09-ad18-a74350240625
c5911799-f37f-4fc0-ad33-d6ee30240625
# mac os x
78f4f538-0763-4c67-9aea-0716b0240625
7aefe685-c192-4d69-b393-d09000240625
82212b3a-b206-488d-8711-7279e0240625
0e8d75ee-8814-4522-af59-2e2570240625
21a8e11d-0033-4814-92b6-087f10240625
# windows nt
afeac5b5-23d2-4a55-ae19-568340240626
30fa927d-17f0-4620-a1a6-b298d0240626
2b57fc66-a481-4744-90dd-405130240626
6df6650e-dc97-4c77-822b-815720240626
8818ad7d-98d2-46df-bb91-0eff40240626
```

Risks of this PR:

The tests are terrible and it's possible that in fundamentally changing the query used for the default operator, we're changing undocumented behavior of Super Search. I spent some quality time today testing Super Search and how queries get built and executed. I believe that any changes here are in good directions, but it's hard to know for sure. If there are problems with these changes, I think we should hone them further in future bugs.

Niceties of this PR:

This forced me to reckon with query building and make it less sus. Improving the search code, docs, and tests is important for the upcoming Elasticsearch migration.

How I'm feeling right now after fixing an almost-10-year-old-bug that has bothered me for a long time:

:100: 