### PR TITLE
Bug 1885919 - Add IPC::MessageReader::FatalError to sentinels list

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -81,6 +81,7 @@ guard_dispatch_icall_nop
 # NOTE(willkg): we want to skip handle_error but not handle_errorf
 handle_error$
 IPC::EnumSerializer<T>::Write
+IPC::ReadParam
 IPC::WriteParam
 JSContext::checkImpl
 js::ContextChecks::check

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -71,6 +71,7 @@ InfallibleAllocPolicy
 InvalidArrayIndex_CRASH
 invalid_parameter_noinfo
 _invalid_parameter_noinfo
+IPC::
 je_
 _JNIEnv
 JSContext::check

--- a/socorro/signature/siglists/signature_sentinels.txt
+++ b/socorro/signature/siglists/signature_sentinels.txt
@@ -34,3 +34,7 @@ __assert_fail
 
 # Rust allocation errors
 alloc::alloc::handle_alloc_error
+
+# IPC fatal errors
+IPC::MessageReader::FatalError
+IPC::MessageWriter::FatalError

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -125,9 +125,9 @@ class TestCSignatureTool:
                     "trust": "cfi",
                 },
                 {
-                    "file": "F_766591945_______________________________________",
+                    "file": "F_766591945_____",
                     "frame": 5,
-                    "function": "F_1428703866________________________________",
+                    "function": "F_1428703866_____",
                     "function_offset": "0xc1",
                     "line": 203,
                     "module": "NPSWF32_14_0_0_125.dll",
@@ -148,7 +148,7 @@ class TestCSignatureTool:
             "WaitForMultipleObjectsExImplementation",
             "RealMsgWaitForMultipleObjectsEx",
             "MsgWaitForMultipleObjects",
-            "F_1428703866________________________________",
+            "F_1428703866_____",
         ]
         assert frame_signatures_list == expected
 
@@ -932,9 +932,9 @@ FRAMES_FROM_JSON_DUMP = {
             "trust": "cfi",
         },
         {
-            "file": "F117835525________________________________________",
+            "file": "F117835525_____",
             "frame": 5,
-            "function": "F_1152915508__________________________________",
+            "function": "F_1152915508_____",
             "function_offset": "0xbb",
             "line": 118,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -943,9 +943,9 @@ FRAMES_FROM_JSON_DUMP = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 6,
-            "function": "F2166389______________________________________",
+            "function": "F2166389_____",
             "function_offset": "0xe5",
             "line": 552,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -954,9 +954,9 @@ FRAMES_FROM_JSON_DUMP = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 7,
-            "function": "F_917831355___________________________________",
+            "function": "F_917831355_____",
             "function_offset": "0x29b",
             "line": 488,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -965,9 +965,9 @@ FRAMES_FROM_JSON_DUMP = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 8,
-            "function": "F1315696776________________________________",
+            "function": "F1315696776_____",
             "function_offset": "0xd",
             "line": 439,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -976,9 +976,9 @@ FRAMES_FROM_JSON_DUMP = {
             "trust": "cfi",
         },
         {
-            "file": "F_766591945_______________________________________",
+            "file": "F_766591945_____",
             "frame": 9,
-            "function": "F_1428703866________________________________",
+            "function": "F_1428703866_____",
             "function_offset": "0xc1",
             "line": 203,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1051,9 +1051,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES = {
             "trust": "cfi",
         },
         {
-            "file": "F117835525________________________________________",
+            "file": "F117835525_____",
             "frame": 5,
-            "function": "F_1152915508__________________________________",
+            "function": "F_1152915508_____",
             "function_offset": "0xbb",
             "line": 118,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1062,9 +1062,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 6,
-            "function": "F2166389______________________________________",
+            "function": "F2166389_____",
             "function_offset": "0xe5",
             "line": 552,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1073,9 +1073,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 7,
-            "function": "F_917831355___________________________________",
+            "function": "F_917831355_____",
             "function_offset": "0x29b",
             "line": 488,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1084,9 +1084,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 8,
-            "function": "F1315696776________________________________",
+            "function": "F1315696776_____",
             "function_offset": "0xd",
             "line": 439,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1095,9 +1095,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES = {
             "trust": "cfi",
         },
         {
-            "file": "F_766591945_______________________________________",
+            "file": "F_766591945_____",
             "frame": 9,
-            "function": "F_1428703866________________________________",
+            "function": "F_1428703866_____",
             "function_offset": "0xc1",
             "line": 203,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1169,9 +1169,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES_AND_SPECIAL_CASE = {
             "trust": "cfi",
         },
         {
-            "file": "F117835525________________________________________",
+            "file": "F117835525_____",
             "frame": 5,
-            "function": "F_1152915508__________________________________",
+            "function": "F_1152915508_____",
             "function_offset": "0xbb",
             "line": 118,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1180,9 +1180,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES_AND_SPECIAL_CASE = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 6,
-            "function": "F2166389______________________________________",
+            "function": "F2166389_____",
             "function_offset": "0xe5",
             "line": 552,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1191,9 +1191,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES_AND_SPECIAL_CASE = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 7,
-            "function": "F_917831355___________________________________",
+            "function": "F_917831355_____",
             "function_offset": "0x29b",
             "line": 488,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1202,9 +1202,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES_AND_SPECIAL_CASE = {
             "trust": "cfi",
         },
         {
-            "file": "F_851861807_______________________________________",
+            "file": "F_851861807_____",
             "frame": 8,
-            "function": "F1315696776________________________________",
+            "function": "F1315696776_____",
             "function_offset": "0xd",
             "line": 439,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1213,9 +1213,9 @@ FRAMES_FROM_JSON_DUMP_WITH_TEMPLATES_AND_SPECIAL_CASE = {
             "trust": "cfi",
         },
         {
-            "file": "F_766591945_______________________________________",
+            "file": "F_766591945_____",
             "frame": 9,
-            "function": "F_1428703866________________________________",
+            "function": "F_1428703866_____",
             "function_offset": "0xc1",
             "line": 203,
             "module": "NPSWF32_14_0_0_125.dll",
@@ -1261,9 +1261,7 @@ class TestSignatureGenerationRule:
         # the call to be tested
         assert sgr.action(crash_data, result) is True
 
-        expected = (
-            "MsgWaitForMultipleObjects | F_1152915508__________________________________"
-        )
+        expected = "MsgWaitForMultipleObjects | F_1152915508_____"
         assert result.signature == expected
 
         expected_normalized_frames = [
@@ -1272,11 +1270,11 @@ class TestSignatureGenerationRule:
             "WaitForMultipleObjectsExImplementation",
             "RealMsgWaitForMultipleObjectsEx",
             "MsgWaitForMultipleObjects",
-            "F_1152915508__________________________________",
-            "F2166389______________________________________",
-            "F_917831355___________________________________",
-            "F1315696776________________________________",
-            "F_1428703866________________________________",
+            "F_1152915508_____",
+            "F2166389_____",
+            "F_917831355_____",
+            "F1315696776_____",
+            "F_1428703866_____",
         ]
         expected_proto_signature = " | ".join(expected_normalized_frames)
 
@@ -1304,11 +1302,11 @@ class TestSignatureGenerationRule:
             "WaitForMultipleObjectsExImplementation",
             "RealMsgWaitForMultipleObjectsEx",
             "MsgWaitForMultipleObjects",
-            "F_1152915508__________________________________",
-            "F2166389______________________________________",
-            "F_917831355___________________________________",
-            "F1315696776________________________________",
-            "F_1428703866________________________________",
+            "F_1152915508_____",
+            "F2166389_____",
+            "F_917831355_____",
+            "F1315696776_____",
+            "F_1428703866_____",
         ]
         expected_proto_signature = " | ".join(expected_normalized_frames)
         assert result.extra["proto_signature"] == expected_proto_signature
@@ -1330,7 +1328,7 @@ class TestSignatureGenerationRule:
 
         assert (
             result.signature
-            == "<name omitted> | IPC::ParamTraits<mozilla::net::NetAddr>::Write"
+            == "<name omitted> | IPC::ParamTraits<mozilla::net::NetAddr>::Write | MsgWaitForMultipleObjects | F_1152915508_____"  # noqa
         )
         expected_normalized_frames = [
             "NtWaitForMultipleObjects",
@@ -1338,11 +1336,11 @@ class TestSignatureGenerationRule:
             "IPC::ParamTraits<mozilla::net::NetAddr>::Write",
             "RealMsgWaitForMultipleObjectsEx",
             "MsgWaitForMultipleObjects",
-            "F_1152915508__________________________________",
-            "F2166389______________________________________",
-            "F_917831355___________________________________",
-            "F1315696776________________________________",
-            "F_1428703866________________________________",
+            "F_1152915508_____",
+            "F2166389_____",
+            "F_917831355_____",
+            "F1315696776_____",
+            "F_1428703866_____",
         ]
         expected_proto_signature = " | ".join(expected_normalized_frames)
         assert result.extra["proto_signature"] == expected_proto_signature
@@ -1825,10 +1823,7 @@ class TestSignatureWatchDogRule:
         assert sgr.action(crash_data, result) is True
 
         # Verify the signature has been re-generated based on thread 0.
-        expected = (
-            "shutdownhang | MsgWaitForMultipleObjects | "
-            "F_1152915508__________________________________"
-        )
+        expected = "shutdownhang | MsgWaitForMultipleObjects | " "F_1152915508_____"
         assert result.signature == expected
         assert result.notes == []
 


### PR DESCRIPTION
This is for: https://bugzilla.mozilla.org/show_bug.cgi?id=1885919

The idea would be for crashes with signatures like `mozilla::ipc::FatalError | mozilla::ipc::IProtocol::HandleFatalError | IPC::MessageReader::FatalError` to produce `IPC::MessageWriter::FatalError | IPC::ParamTraitsIPC<mozilla::UniquePtr<void*, mozilla::detail::FileHandleDeleter> >::Read(IPC::MessageReader*, mozilla::UniquePtr<void*, mozilla::detail::FileHandleDeleter>*)` instead.

No idea if this works...