### PR TITLE
bug-1100790: stop lowercasing supersearch field values

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -1714,7 +1714,7 @@ FIELDS = {
         "namespace": "processed_crash",
         "query_type": "enum",
         # FIXME(willkg): storage_mapping should either be not_analyzed or analyzed as a
-        # keyword and not whatever this is
+        # keyword
         "storage_mapping": {
             "fields": {
                 "full": {"index": "not_analyzed", "type": "string"},

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -245,10 +245,6 @@ class SuperSearch(SearchBase):
 
                 if param.data_type in ("date", "datetime"):
                     param.value = libdatetime.date_to_string(param.value)
-                elif param.data_type == "enum":
-                    param.value = [x.lower() for x in param.value]
-                elif param.data_type == "str" and not param.operator:
-                    param.value = [x.lower() for x in param.value]
 
                 # Operators needing wildcards, and the associated value
                 # transformation with said wildcards.


### PR DESCRIPTION
Because "match" queries will analyze the values using the same analyzer as the field, we shouldn't be lowercasing search values. When we do, it changes them such that the analyzed search value doesn't match the analyzed field value.

These changes fix the "match" operator for at least these fields:

* android_version
* crashing_thread_name
* crash_report_keys
* mac_memory_pressure
* xpcom_spin_event_loop_stack

To test:

1. process some crash reports
2. do a super search in local dev environment for `crash_report_keys` matches `BuildID`

In stage and prod (this isn't something I broke when reworking things to use a "match" query), you get "no results" despite `crash_report_keys` containing a list of all the crash annotations in the crash report and every crash report containing a `BuildID`.

stage: https://crash-stats.allizom.org/search/?crash_report_keys=BuildID&date=%3E%3D2024-06-24T20%3A59%3A00.000Z&date=%3C2024-07-01T20%3A59%3A00.000Z&_facets=signature&_facets=android_version&page=1&_sort=-date&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform

prod: https://crash-stats.mozilla.org/search/?crash_report_keys=BuildID&product=Firefox&date=%3E%3D2024-06-24T21%3A06%3A00.000Z&date=%3C2024-07-01T21%3A06%3A00.000Z&_facets=signature&page=1&_sort=-date&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform

With this change, you'll see results in your local dev environment.