### PR TITLE
bug-1904645: fix gcs_cli.py deleting buckets with more than 256 objects

### DIFF
--- a/bin/gcs_cli.py
+++ b/bin/gcs_cli.py
@@ -74,7 +74,12 @@ def delete_bucket(bucket_name):
         click.echo(f"GCS bucket {bucket_name!r} at {endpoint_url!r} does not exist.")
         return
 
-    bucket.delete(force=True)
+    # delete blobs before deleting bucket, because bucket.delete(force=True) doesn't
+    # work if there are more than 256 blobs in the bucket.
+    for blob in bucket.list_blobs():
+        blob.delete()
+
+    bucket.delete()
     click.echo(f"GCS bucket {bucket_name!r} at {endpoint_url!r} deleted.")
 
 


### PR DESCRIPTION
from python help for `Bucket.delete`:

>    If ``force=True`` and the bucket contains more than 256 objects / blobs
>    this will cowardly refuse to delete the objects (or the bucket). This
>    is to prevent accidental bucket deletion and to prevent extremely long
>    runtime of this method. Also note that ``force=True`` is not supported
>    in a ``Batch`` context.
