### PR TITLE
 bug-1908543: fix permadelete for gcs

### DIFF
--- a/bin/permadelete_crash_data.py
+++ b/bin/permadelete_crash_data.py
@@ -8,7 +8,7 @@
 Given a set of crash reports ids via a file, removes all crash report data from
 all crash storage:
 
-* S3
+* Crash storage
 
   * raw crash
   * dump_names
@@ -30,15 +30,12 @@ Usage::
 
 """
 
-import json
 import logging
 import os
 
 import click
-from elasticsearch_dsl import Search
 
 from socorro import settings
-from socorro.external.boto.crashstorage import build_keys
 from socorro.libclass import build_instance_from_settings
 
 
@@ -57,160 +54,6 @@ def crashid_generator(fn):
             yield line
 
 
-def get_s3_crashstorage():
-    """Return an S3ConnectionContext."""
-    return build_instance_from_settings(settings.CRASH_DESTINATIONS["s3"])
-
-
-def s3_delete_object(client, bucket, key):
-    """Deletes a specific object from S3.
-
-    Requires s3:DeleteObject.
-
-    :arg client: the s3 client
-    :arg bucket: the bucket name
-    :arg key: the key of the object to delete
-
-    :return: True if the delete was fine or already not there; False if there was an
-        error
-
-    """
-    try:
-        client.delete_object(Bucket=bucket, Key=key)
-        click.echo(f"s3: deleted {key!r}")
-        return True
-    except Exception:
-        logger.exception("ERROR: s3: when deleting %r", key)
-        return False
-
-
-def s3_fetch_object(client, bucket, key):
-    """Fetch an object from S3 with appropriate handling for issues.
-
-    Requires s3:GetObject.
-
-    :arg client: the s3 client
-    :arg bucket: the bucket name
-    :arg key: the key of the object to delete
-
-    :returns: Body or None
-
-    """
-    try:
-        resp = client.get_object(Bucket=bucket, Key=key)
-        return resp["Body"].read()
-    except client.exceptions.NoSuchKey:
-        click.echo(f"s3: not found: {key!r}")
-    except Exception:
-        logger.exception("ERROR: s3: when fetching %r", key)
-
-
-def s3_delete(crashid):
-    """Delete crash report data from S3."""
-    s3_crashstorage = get_s3_crashstorage()
-    bucket = s3_crashstorage.bucket
-    s3_client = s3_crashstorage.connection.client
-
-    keys = build_keys("raw_crash", crashid)
-    for key in keys:
-        obj = s3_fetch_object(s3_client, bucket, key)
-        if obj:
-            s3_delete_object(s3_client, bucket, key)
-
-    # Fetch dump_names which tells us which dumps exist
-    keys = build_keys("dump_names", crashid)
-    dump_names = []
-    for key in keys:
-        data = s3_fetch_object(s3_client, bucket, key)
-        if data:
-            try:
-                # dump_names is a JSON encoded list of strings
-                dump_names.extend(json.loads(data))
-            except Exception:
-                logger.exception(
-                    "ERROR: %s: s3: when parsing dump_names json" % crashid
-                )
-
-    if dump_names:
-        # For each dump, delete it if it exists
-        dump_errors = 0
-
-        for dump_name in dump_names:
-            # Handle dump_name -> key goofiness
-            if dump_name in (None, "", "upload_file_minidump"):
-                dump_name = "dump"
-
-            keys = build_keys(dump_name, crashid)
-            for key in keys:
-                # If the dump is not there, that's fine; but if deleting the dump kicks
-                # up an error, we want to make sure we don't delete dump_names.
-                obj = s3_fetch_object(s3_client, bucket, key)
-                if obj:
-                    if not s3_delete_object(s3_client, bucket, key):
-                        dump_errors += 1
-
-        # If there were no errors, then we try to delete dump_names
-        if dump_errors == 0:
-            keys = build_keys("dump_names", crashid)
-            for key in keys:
-                s3_delete_object(s3_client, bucket, key)
-
-    # Delete processed crash
-    keys = build_keys("processed_crash", crashid)
-    for key in keys:
-        obj = s3_fetch_object(s3_client, bucket, key)
-        if obj:
-            s3_delete_object(s3_client, bucket, key)
-
-
-def get_es_crashstorage():
-    """Return an Elasticsearch ConnectionContext."""
-    return build_instance_from_settings(settings.CRASH_DESTINATIONS["es"])
-
-
-def es_fetch_document(es_crashstorage, crashid):
-    """Fetch a crash report document from Elasticsearch.
-
-    :returns: Elasticsearch document as a dict or None
-
-    """
-    doc_type = es_crashstorage.get_doctype()
-
-    with es_crashstorage.client() as conn:
-        try:
-            search = Search(using=conn, doc_type=doc_type)
-            search = search.filter("term", **{"processed_crash.uuid": crashid})
-            results = search.execute().to_dict()
-            hits = results["hits"]["hits"]
-            if hits:
-                return hits[0]
-        except Exception:
-            logger.exception("ERROR: es: when fetching %s %s" % (doc_type, crashid))
-
-    click.echo(f"es: not found: {doc_type} {crashid}")
-
-
-def es_delete_document(es_crashstorage, index, doc_type, doc_id):
-    """Delete document in Elasticsearch."""
-    with es_crashstorage.client() as conn:
-        try:
-            conn.delete(index=index, doc_type=doc_type, id=doc_id)
-            click.echo(f"es: deleted {index} {doc_type} {doc_id}")
-        except Exception:
-            logger.exception(
-                "ERROR: es: when deleting %s %s %s" % (index, doc_type, doc_id)
-            )
-
-
-def es_delete(crashid):
-    """Delete crash report data from Elasticsearch."""
-    es_crashstorage = get_es_crashstorage()
-
-    resp = es_fetch_document(es_crashstorage, crashid)
-    if resp:
-        es_delete_document(es_crashstorage, resp["_index"], resp["_type"], resp["_id"])
-
-
 @click.command()
 @click.argument("crashidsfile", nargs=1)
 @click.pass_context
@@ -227,12 +70,17 @@ def cmd_permadelete(ctx, crashidsfile):
         click.echo(f"File {crashidsfile!r} does not exist.")
         return 1
 
+    crashstorage = build_instance_from_settings(settings.STORAGE)
+    es_crashstorage = build_instance_from_settings(settings.ES_STORAGE)
+
     crashids = crashid_generator(crashidsfile)
 
     for crashid in crashids:
         click.echo(f"Working on {crashid!r}")
-        s3_delete(crashid)
-        es_delete(crashid)
+        # delete from storage
+        crashstorage.delete_crash(crashid)
+        # delete from es
+        es_crashstorage.delete_crash(crashid)
 
     click.echo("Done!")
 

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -195,13 +195,13 @@ class CrashStorageBase:
         """
         raise NotImplementedError("get_processed_crash is not implemented")
 
-    def remove(self, crash_id):
+    def delete_crash(self, crash_id):
         """Delete crash report data from storage
 
         :param crash_id: crash report id
 
         """
-        raise NotImplementedError("remove is not implemented")
+        raise NotImplementedError("delete_crash is not implemented")
 
 
 class InMemoryCrashStorage(CrashStorageBase):
@@ -257,7 +257,7 @@ class InMemoryCrashStorage(CrashStorageBase):
         except KeyError as exc:
             raise CrashIDNotFound(f"{crash_id} not found") from exc
 
-    def remove(self, crash_id):
+    def delete_crash(self, crash_id):
         with suppress(KeyError):
             del self._raw_crash_data[crash_id]
 

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -231,7 +231,7 @@ class FSPermanentStorage(CrashStorageBase):
             + self._get_radix(crash_id)
         )
 
-    def remove(self, crash_id):
+    def delete_crash(self, crash_id):
         parent_dir = self._get_radixed_parent_directory(crash_id)
         if not os.path.exists(parent_dir):
             raise CrashIDNotFound

--- a/socorro/tests/external/fs/test_fspermanentstorage.py
+++ b/socorro/tests/external/fs/test_fspermanentstorage.py
@@ -113,7 +113,7 @@ class TestFSPermanentStorage:
         fs.get_dumps(crash_id)
 
         # Remove the data
-        fs.remove(crash_id)
+        fs.delete_crash(crash_id)
         assert not os.path.exists(fs._get_radixed_parent_directory(crash_id))
         with pytest.raises(CrashIDNotFound):
             fs.get_raw_crash(crash_id)

--- a/socorro/tests/external/test_crashstorage_base.py
+++ b/socorro/tests/external/test_crashstorage_base.py
@@ -27,7 +27,7 @@ class TestCrashStorageBase:
             crashstorage.get_processed_crash(crash_id)
 
         with pytest.raises(NotImplementedError):
-            crashstorage.remove(crash_id)
+            crashstorage.delete_crash(crash_id)
 
         crashstorage.close()
 


### PR DESCRIPTION
this adds `delete_crash` methods to the gcs and es crash storage classes, so that backend-specific code lives within the implementation.

blocks #6669