### PR TITLE
Improve update_siggen.py to include authors

### DIFF
--- a/bin/update_siggen.py
+++ b/bin/update_siggen.py
@@ -60,7 +60,7 @@ def main(argv=None):
                 "git",
                 "log",
                 "%s..%s" % (dest_sha, source_sha),
-                "--oneline",
+                "--pretty=%h  %s  (%an)",
                 "socorro/signature",
             ]
         )


### PR DESCRIPTION
This improves the update_siggen.py to include the authors of commits at the end of the commit summary line. We should be giving credit where credit is due. This information shows up in the merge commits in siggen as well as the HISTORY file and tag annotation.

Before:

```
Dest sha:   2edf2158a00f0dfc58cc542a5beeceb03b2ce954
Source sha: bd98591d35775be47531a51faed03ff4c9839328
fd9a5192f  Bug 1907894 - Add mozilla::Atomic<T> to the irrelevant signature list.
f51eb338c  Bug 1906667 - Add mozilla::media::Interval<T> to the prefix list. (#6663)
e1d2b1a8a  Bug 1905714 - Only match JS::Call exactly in signatures. (#6652)
8cf6cf349  bug-1904528: add SafeVariantClear and VariantCopy to prefix list
```

After:

```
Dest sha:   2edf2158a00f0dfc58cc542a5beeceb03b2ce954
Source sha: bd98591d35775be47531a51faed03ff4c9839328
fd9a5192f  Bug 1907894 - Add mozilla::Atomic<T> to the irrelevant signature list.  (Andrew McCreight)
f51eb338c  Bug 1906667 - Add mozilla::media::Interval<T> to the prefix list. (#6663)  (Andrew McCreight)
e1d2b1a8a  Bug 1905714 - Only match JS::Call exactly in signatures. (#6652)  (Andrew McCreight)
8cf6cf349  bug-1904528: add SafeVariantClear and VariantCopy to prefix list  (Will Kahn-Greene)
```