### PR TITLE
bug-1910376: increase stage submitter request timeout to 10 seconds

### DIFF
--- a/socorro/stage_submitter/submitter.py
+++ b/socorro/stage_submitter/submitter.py
@@ -353,7 +353,7 @@ class SubmitterApp:
                     # need to do more work
                     return
 
-                session = session_with_retries()
+                session = session_with_retries(default_timeout=10.0)
 
                 try:
                     raw_crash = self.source.get_raw_crash(crash_id)


### PR DESCRIPTION
because stage submitter threw some errors last night due to the stage collector latency spiking above the current timeout of 3 seconds for a short while.