### PR TITLE
Fix signature generation docs

### DIFF
--- a/socorro/signature/cmd_doc.py
+++ b/socorro/signature/cmd_doc.py
@@ -84,11 +84,11 @@ def main(argv=None):
 
     with open(args.output, "w") as fp:
         fp.write(".. THIS IS AUTOGEMERATED USING:\n")
-        fp.write("   \n")
+        fp.write("\n")
         fp.write("   %s\n" % (" ".join(sys.argv)))
-        fp.write("   \n")
+        fp.write("\n")
         fp.write("Signature generation ruleset\n")
-        fp.write("============================n")
+        fp.write("============================\n")
         fp.write("\n")
         fp.write("\n")
         fp.write(

--- a/socorro/signature/pipeline.rst
+++ b/socorro/signature/pipeline.rst
@@ -1,9 +1,10 @@
 .. THIS IS AUTOGEMERATED USING:
-   
+
    ./socorro-cmd signature-doc socorro.signature.generator.DEFAULT_RULESET socorro/signature/pipeline.rst
-   
+
 Signature generation ruleset
-============================n
+============================
+
 
 This is the signature generation ruleset defined at ``socorro.signature.generator.DEFAULT_RULESET``:
 


### PR DESCRIPTION
This fixes some whitespace issues with signature generation docs.

Old output:

![image](https://github.com/user-attachments/assets/04be6bc8-019f-4b26-9d17-e0c18fb0d0da)

New output:

![image](https://github.com/user-attachments/assets/3bc04be4-91c6-408f-9a42-8ef972684f99)
