### PR TITLE
Enable token expiration date selector

### DIFF
--- a/webapp/crashstats/tokens/forms.py
+++ b/webapp/crashstats/tokens/forms.py
@@ -8,10 +8,15 @@ from crashstats.crashstats.forms import BaseModelForm
 from crashstats.tokens import models
 
 
+class DateInput(forms.DateInput):
+    input_type = "date"
+
+
 class GenerateTokenForm(BaseModelForm):
     class Meta:
         model = models.Token
-        fields = ("permissions", "notes")
+        fields = ("permissions", "notes", "expires")
+        widgets = {"expires": DateInput()}
 
     def __init__(self, *args, **kwargs):
         possible_permissions = kwargs.pop("possible_permissions")
@@ -30,6 +35,10 @@ class GenerateTokenForm(BaseModelForm):
         else:
             del self.fields["permissions"]
         self.fields["notes"].help_text = "Optional. Entirely for your own records."
+        self.fields["expires"].required = False
+        self.fields["expires"].help_text = (
+            "Optional. Select the token expiration date."
+        )
 
     def clean_notes(self):
         value = self.cleaned_data["notes"]

--- a/webapp/crashstats/tokens/views.py
+++ b/webapp/crashstats/tokens/views.py
@@ -41,7 +41,9 @@ def home(request):
                             "You do not have this permission"
                         )
             token = models.Token.objects.create(
-                user=request.user, notes=form.cleaned_data["notes"]
+                user=request.user,
+                notes=form.cleaned_data["notes"],
+                expires=form.cleaned_data["expires"],
             )
             if "permissions" in form.cleaned_data:
                 for permission in form.cleaned_data["permissions"]:


### PR DESCRIPTION
This introduces a new field to the `GenerateTokenForm` with a widget to select the token expiration date. By default this widget is set to the date `TOKENS_DEFAULT_EXPIRATION_DAYS` days from the current date, but users can set it to any date.  