### PR TITLE
bug-1906112: upgrade markus to 5.0.0 and fix metrics-related issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 extensions = [
     "sphinx.ext.graphviz",
     "exts.adr_log",
+    "exts.document_metrics",
     "everett.sphinxext",
 ]
 
@@ -67,8 +68,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "Socorro"
-copyright = "2013-2023 Mozilla Foundation"
-author = "Socorro team"
+copyright = "2013-2024 Mozilla Foundation"
+author = "Observability Team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/exts/document_metrics.py
+++ b/docs/exts/document_metrics.py
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Generates the documentation for metrics."""
+
+import importlib
+import sys
+import textwrap
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import ViewList
+
+
+def build_table(table):
+    col_size = [0] * len(table[0])
+    for row in table:
+        for i, col in enumerate(row):
+            col_size[i] = max(col_size[i], len(col))
+
+    col_size = [width + 2 for width in col_size]
+
+    yield "  ".join("=" * width for width in col_size)
+    yield "  ".join(
+        header + (" " * (width - len(header)))
+        for header, width in zip(table[0], col_size, strict=True)
+    )
+    yield "  ".join("=" * width for width in col_size)
+    for row in table[1:]:
+        yield "  ".join(
+            col + (" " * (width - len(col)))
+            for col, width in zip(row, col_size, strict=True)
+        )
+    yield "  ".join("=" * width for width in col_size)
+
+
+class AutoMetricsDirective(Directive):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+    option_spec = {}
+
+    def add_line(self, line, source, *lineno):
+        """Add a line to the result"""
+        self.result.append(line, source, *lineno)
+
+    def generate_docs(self, clspath):
+        modpath, name = clspath.rsplit(".", 1)
+        importlib.import_module(modpath)
+        module = sys.modules[modpath]
+        metrics = getattr(module, name)
+
+        sourcename = f"metrics of {clspath}"
+
+        # First build a table of metric items
+        self.add_line("Table of metrics:", sourcename)
+        self.add_line("", sourcename)
+
+        table = []
+        table.append(("Key", "Type"))
+        for key, metric in metrics.items():
+            table.append((f":py:data:`{key}`", metric["type"]))
+
+        for line in build_table(table):
+            self.add_line(line, sourcename)
+
+        self.add_line("", sourcename)
+        self.add_line("Metrics details:", sourcename)
+        self.add_line("", sourcename)
+
+        for key, metric in metrics.items():
+            self.add_line(f".. py:data:: {key}", sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+            self.add_line(f"   **Type**: ``{metric['type']}``", sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+            for line in textwrap.dedent(metric["description"]).splitlines():
+                self.add_line(f"   {line}", sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+
+    def run(self):
+        self.reporter = self.state.document.reporter
+        self.result = ViewList()
+
+        self.generate_docs(self.arguments[0])
+
+        if not self.result:
+            return []
+
+        node = nodes.paragraph()
+        node.document = self.state.document
+        self.state.nested_parse(self.result, 0, node)
+        return node.children
+
+
+def setup(app):
+    """Register directive in Sphinx."""
+    app.add_directive("autometrics", AutoMetricsDirective)
+
+    return {
+        "version": 1.0,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ and Super Search is located at `<https://crash-stats.mozilla.org/documentation/>
 
    dev
    configuration
+   metrics
    contributing
    service/index
    flows/index

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,13 @@
+.. _metrics-chapter:
+
+=======
+Metrics
+=======
+
+StatsD Metrics in Socorro
+=========================
+
+Socorro uses `StatsD <https://github.com/statsd/statsd>`__ with
+`DogStatsD extensions <https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent>`__.
+
+.. autometrics:: socorro.libmarkus.STATSD_METRICS

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ isoweek==1.3.3
 jinja2==3.1.4
 jsonschema==4.23.0
 lxml==5.2.2
-markus[datadog]==4.2.0
+markus[datadog]==5.0.0
 markdown-it-py==3.0.0
 more-itertools==10.3.0
 mozilla-django-oidc==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -786,9 +786,9 @@ markupsafe==2.1.3 \
     # via
     #   jinja2
     #   werkzeug
-markus==4.2.0 \
-    --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \
-    --hash=sha256:9dd41ce53b25a3e806b0d065808fec00c4ec945e80cf5a72431bf9b61b44d7fb
+markus==5.0.0 \
+    --hash=sha256:14fe47ebe3d3447cc5eebcd4691f71e7f38dee6338e4eb5d72d64d67f289c6ff \
+    --hash=sha256:fd0f0de0914a3ae645cc1eac760dca2fa28943fbbb3671692e09916f7f2e2237
     # via -r requirements.in
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \

--- a/socorro/libmarkus.py
+++ b/socorro/libmarkus.py
@@ -12,7 +12,7 @@ from markus.filters import AddTagFilter, RegisteredMetricsFilter
 import yaml
 
 
-_IS_MARKUS_SETUP = False
+_IS_MARKUS_SET_UP = False
 
 LOGGER = logging.getLogger(__name__)
 METRICS = markus.get_metrics("socorro")
@@ -40,8 +40,8 @@ def set_up_metrics(statsd_host, statsd_port, hostname, debug=False):
     :arg debug: whether or not to additionally log metrics to the logger
 
     """
-    global _IS_MARKUS_SETUP, METRICS
-    if _IS_MARKUS_SETUP:
+    global _IS_MARKUS_SET_UP, METRICS
+    if _IS_MARKUS_SET_UP:
         return
 
     markus_backends = [
@@ -76,7 +76,7 @@ def set_up_metrics(statsd_host, statsd_port, hostname, debug=False):
 
     markus.configure(markus_backends)
 
-    _IS_MARKUS_SETUP = True
+    _IS_MARKUS_SET_UP = True
 
 
 def build_prefix(*parts):

--- a/socorro/libmarkus.py
+++ b/socorro/libmarkus.py
@@ -5,15 +5,30 @@
 """Holds Markus utility functions and global state."""
 
 import logging
+from pathlib import Path
 
 import markus
-from markus.filters import AddTagFilter
+from markus.filters import AddTagFilter, RegisteredMetricsFilter
+import yaml
 
 
 _IS_MARKUS_SETUP = False
 
 LOGGER = logging.getLogger(__name__)
 METRICS = markus.get_metrics("socorro")
+
+
+# Complete index of all metrics. This is used in documentation and to filter outgoing
+# metrics.
+def _load_registered_metrics():
+    # Load the metrics yaml file in this directory
+    path = Path(__file__).parent / "statsd_metrics.yaml"
+    with open(path) as fp:
+        data = yaml.safe_load(fp)
+    return data
+
+
+STATSD_METRICS = _load_registered_metrics()
 
 
 def set_up_metrics(statsd_host, statsd_port, hostname, debug=False):
@@ -48,6 +63,13 @@ def set_up_metrics(statsd_host, statsd_port, hostname, debug=False):
                 },
             }
         )
+
+        # In local dev and test environments, we want the RegisteredMetricsFilter to
+        # raise exceptions when metrics are used incorrectly.
+        metrics_filter = RegisteredMetricsFilter(
+            registered_metrics=STATSD_METRICS, raise_error=True
+        )
+        METRICS.filters.append(metrics_filter)
 
     if hostname:
         METRICS.filters.append(AddTagFilter(f"host:{hostname}"))

--- a/socorro/processor/cache_manager.py
+++ b/socorro/processor/cache_manager.py
@@ -48,9 +48,7 @@ HEARTBEAT_INTERVAL = 60
 
 
 def count_sentry_scrub_error(msg):
-    # NOTE(willkg): we re-use the processor prefix here and differentiate with the
-    # service tag.
-    METRICS.incr("processor.sentry_scrub_error", value=1, tags=["service:cachemanager"])
+    METRICS.incr("sentry_scrub_error", value=1, tags=["service:cachemanager"])
 
 
 class LastUpdatedOrderedDict(OrderedDict):

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -47,7 +47,7 @@ from socorro.lib.task_manager import respond_to_SIGTERM
 
 
 def count_sentry_scrub_error(msg):
-    METRICS.incr("processor.sentry_scrub_error", value=1, tags=["service:processor"])
+    METRICS.incr("sentry_scrub_error", value=1, tags=["service:processor"])
 
 
 class ProcessorApp:

--- a/socorro/stage_submitter/submitter.py
+++ b/socorro/stage_submitter/submitter.py
@@ -235,7 +235,7 @@ def get_payload_compressed(raw_crash):
 
 def count_sentry_scrub_error(msg):
     """Counts sentry scrub errors"""
-    METRICS.incr("submitter.sentry_scrub_error", value=1, tags=["service:submitter"])
+    METRICS.incr("submitter.sentry_scrub_error", value=1)
 
 
 def handle_exception(exctype, value, tb):

--- a/socorro/stage_submitter/submitter.py
+++ b/socorro/stage_submitter/submitter.py
@@ -235,7 +235,7 @@ def get_payload_compressed(raw_crash):
 
 def count_sentry_scrub_error(msg):
     """Counts sentry scrub errors"""
-    METRICS.incr("submitter.sentry_scrub_error", value=1)
+    METRICS.incr("sentry_scrub_error", value=1, tags=["service:submitter"])
 
 
 def handle_exception(exctype, value, tb):

--- a/socorro/statsd_metrics.yaml
+++ b/socorro/statsd_metrics.yaml
@@ -1,0 +1,295 @@
+# statsd metrics emitted using Markus.
+#
+# When adding a new metric, make sure to add it here first.
+---
+
+socorro.cron.job_failure_runtime:
+  type: "gauge"
+  description: |
+    Gauge (but should be a timing) of the duration for a failed cron job.
+
+    Tags:
+
+    * ``job``: short string for the job that failed
+
+socorro.cron.job_success_runtime:
+  type: "gauge"
+  description: |
+    Gauge (but should be a timing) of the duration for a successful cron job.
+
+    Tags:
+
+    * ``job``: short string for the job that failed
+
+socorro.cron.verifyprocessed.missing_processed:
+  type: "gauge"
+  description: |
+    Gauge of crash reports for which there was no processed crash file.
+
+socorro.processor.betaversionrule.cache:
+  type: "incr"
+  description: |
+    Counter for whether the BetaVersionRule pulled version information from
+    cache or not.
+
+    Tags:
+
+    * ``result``: ``hit`` or ``miss``
+
+socorro.processor.betaversionrule.lookup:
+  type: "incr"
+  description: |
+    Counter for whether the BetaVersionRule did a lookup using the Crash Stats
+    VersionString API.
+
+    Tags:
+
+    * ``result``: ``success`` or ``fail``
+
+socorro.processor.cache_manager.evict:
+  type: "incr"
+  description: |
+    Counter for file evictions.
+
+socorro.processor.cache_manager.q_overflow:
+  type: "incr"
+  description: |
+    Counter for inotify Q_OVERFLOW events in cache manager.
+
+socorro.processor.cache_manager.usage:
+  type: "gauge"
+  description: |
+    Gauge for total size of cache. In bytes.
+
+socorro.processor.cache_manager.file_sizes.avg:
+  type: "gauge"
+  description: |
+    Gauge for the average file size for files in the cache. In bytes.
+
+socorro.processor.cache_manager.file_sizes.median:
+  type: "gauge"
+  description: |
+    Gauge for the median file size for files in the cache. In bytes.
+
+socorro.processor.cache_manager.file_sizes.ninety_five:
+  type: "gauge"
+  description: |
+    Gauge for the 95 percentile file size for files in the cache. In bytes.
+
+socorro.processor.cache_manager.file_sizes.max:
+  type: "gauge"
+  description: |
+    Gauge for max file size in cache. In bytes.
+
+socorro.processor.cache_manager.files.count:
+  type: "gauge"
+  description: |
+    Total number of files in the cache.
+
+socorro.processor.cache_manager.files.gt_500:
+  type: "gauge"
+  description: |
+    Total number of files in cache greater than 500mb.
+
+socorro.processor.denonerule.had_nones:
+  type: "incr"
+  description: |
+    Counter for how many crash annotation values were ``None``.
+
+    All crash annotation values should be strings, so ``None`` isn't valid and
+    usually comes from a bug in the crash reporter.
+
+socorro.processor.denullrule.has_nulls:
+  type: "incr"
+  description: |
+    Counter for how many nulls were in keys and values for crash annotations.
+
+socorro.processor.dest1.save_processed_crash:
+  type: "timing"
+  description: |
+    Used in tests.
+
+socorro.processor.es.crash_document_size:
+  type: "histogram"
+  description: |
+    Size of crash document. In bytes.
+
+socorro.processor.es.index:
+  type: "histogram"
+  description: |
+    Total time it took to index the crash document in Elasticsearch.
+
+socorro.processor.es.indexerror:
+  type: "incr"
+  description: |
+    Counter for errors when indexing a document in Elasticsearch.
+
+    Tags:
+
+    * ``error``: the error code indicating what happened
+
+socorro.processor.es.save_processed_crash:
+  type: "timing"
+  description: |
+    Timer for how long it takes to save the processed crash to Elasticsearch.
+
+socorro.processor.ingestion_timing:
+  type: "timing"
+  description: |
+    Timer for how long it took for a crash report to be ingested. This is the
+    time between the submitted timestamp all the way through when processing
+    was completed.
+
+    This uses the ``submitted_timestamp`` from the collector as the start time.
+
+socorro.processor.minidumpstackwalk.run:
+  type: "incr"
+  description: |
+    Counter for minidump stackwalk executions.
+
+    Tags:
+
+    * ``outcome``: either ``success`` or ``fail``
+    * ``exitcode``: the exit code of the minidump stackwalk process
+
+socorro.processor.open_files:
+  type: "gauge"
+  description: |
+    Gauge of currently open files for all processes running in the container.
+
+socorro.processor.processes_by_type:
+  type: "gauge"
+  description: |
+    Gauge of processes by type.
+
+    Tags:
+
+    * ``proctype``: one of ``shell``, ``python``, ``stackwalker``, or ``other``
+
+socorro.processor.processes_by_status:
+  type: "gauge"
+  description: |
+    Gauge of processes by process status.
+
+    Tags:
+
+    * ``procstatus``: one of ``running``, ``sleeping``, or other process
+      statuses.
+
+socorro.processor.process_crash:
+  type: "timing"
+  description: |
+    Timer for how long it takes to process a crash report.
+
+    Tags:
+
+    * ``ruleset``: the ruleset used for processing
+
+socorro.processor.rule.act.timing:
+  type: "timing"
+  description: |
+    Timer for how long it takes for the rule to run.
+
+    Tags:
+
+    * ``rule``: rule class name
+
+socorro.processor.save_processed_crash:
+  type: "incr"
+  description: |
+    Counter for number of crash reports successfully processed and saved to
+    storage.
+
+socorro.processor.sentry_scrub_error:
+  type: "incr"
+  description: |
+    Emitted when there are errors scrubbing Sentry events. Monitor these
+    because it means we're missing Sentry event data.
+
+    Tags:
+
+    * ``service``: either ``processor`` or ``cache_manager``
+
+socorro.processor.storage.save_processed_crash:
+  type: "timing"
+  description: |
+    Timer for how long it takes to save the processed crash to storage bucket.
+
+socorro.processor.telemetry.save_processed_crash:
+  type: "timing"
+  description: |
+    Timer for how long it takes to save the processed crash to Telemetry
+    storage bucket.
+
+socorro.processor.truncatestackrule.stack_size:
+  type: "gauge"
+  description: |
+    Gauge for stack sizes.
+
+socorro.processor.truncatestackrule.truncated:
+  type: "incr"
+  description: |
+    Counter for stacks that were truncated because they were too large.
+
+socorro.submitter.accept:
+  type: "incr"
+  description: |
+    Counter for how many destinations the crash report was resubmitted to.
+
+socorro.submitter.ignore:
+  type: "incr"
+  description: |
+    Counter for how many destinations were ignored for resubmitting the crash
+    report.
+
+socorro.submitter.process:
+  type: "timing"
+  description: |
+    Timer for how long it takes to process a crash report which involves
+    figuring out where the crash report should get sent to, downloading the
+    data, creating the payload, and submitting it.
+
+socorro.submitter.sentry_scrub_error:
+  type: "incr"
+  description: |
+    Emitted when there are errors scrubbing Sentry events. Monitor these
+    because it means we're missing Sentry event data.
+
+socorro.submitter.unknown_finished_func_error:
+  type: "incr"
+  description: |
+    Counter for how many unknown finished func errors were encountered.
+
+socorro.submitter.unknown_process_error:
+  type: "incr"
+  description: |
+    Counter for how many unknown process errors were encountered.
+
+socorro.submitter.unknown_submit_error:
+  type: "incr"
+  description: |
+    Counter for how many unknown submit errors were encountered.
+
+socorro.webapp.crashstats.models.cache_set_error:
+  type: "incr"
+  description: |
+    Counter for errors when caching middleware model request results.
+
+socorro.webapp.view.pageview:
+  type: "timing"
+  description: |
+    Timer for how long it takes to handle an HTTP request.
+
+    Tags:
+
+    * ``ajax``: whether or not the request was an AJAX request
+    * ``api``: whether or not the request was an API request (path starts with
+      ``/api/``)
+    * ``path``: the path of the request
+    * ``status``: the HTTP response code
+
+socorro.webapp.sentry_scrub_error:
+  type: "incr"
+  description: |
+    Emitted when there are errors scrubbing Sentry events. Monitor these
+    because it means we're missing Sentry event data.

--- a/socorro/statsd_metrics.yaml
+++ b/socorro/statsd_metrics.yaml
@@ -3,23 +3,15 @@
 # When adding a new metric, make sure to add it here first.
 ---
 
-socorro.cron.job_failure_runtime:
-  type: "gauge"
+socorro.cron.job_run:
+  type: "timing"
   description: |
-    Gauge (but should be a timing) of the duration for a failed cron job.
+    Duration of how long it took to run the cron job.
 
     Tags:
 
     * ``job``: short string for the job that failed
-
-socorro.cron.job_success_runtime:
-  type: "gauge"
-  description: |
-    Gauge (but should be a timing) of the duration for a successful cron job.
-
-    Tags:
-
-    * ``job``: short string for the job that failed
+    * ``result``: ``success`` or ``failure``
 
 socorro.cron.verifyprocessed.missing_processed:
   type: "gauge"

--- a/socorro/statsd_metrics.yaml
+++ b/socorro/statsd_metrics.yaml
@@ -200,16 +200,6 @@ socorro.processor.save_processed_crash:
     Counter for number of crash reports successfully processed and saved to
     storage.
 
-socorro.processor.sentry_scrub_error:
-  type: "incr"
-  description: |
-    Emitted when there are errors scrubbing Sentry events. Monitor these
-    because it means we're missing Sentry event data.
-
-    Tags:
-
-    * ``service``: either ``processor`` or ``cache_manager``
-
 socorro.processor.storage.save_processed_crash:
   type: "timing"
   description: |
@@ -231,6 +221,17 @@ socorro.processor.truncatestackrule.truncated:
   description: |
     Counter for stacks that were truncated because they were too large.
 
+socorro.sentry_scrub_error:
+  type: "incr"
+  description: |
+    Emitted when there are errors scrubbing Sentry events. Monitor these
+    because it means we're missing Sentry event data.
+
+    Tags:
+
+    * ``service``: ``webapp``, ``submitter``, ``processor`` or
+      ``cache_manager``
+
 socorro.submitter.accept:
   type: "incr"
   description: |
@@ -248,12 +249,6 @@ socorro.submitter.process:
     Timer for how long it takes to process a crash report which involves
     figuring out where the crash report should get sent to, downloading the
     data, creating the payload, and submitting it.
-
-socorro.submitter.sentry_scrub_error:
-  type: "incr"
-  description: |
-    Emitted when there are errors scrubbing Sentry events. Monitor these
-    because it means we're missing Sentry event data.
 
 socorro.submitter.unknown_finished_func_error:
   type: "incr"
@@ -287,9 +282,3 @@ socorro.webapp.view.pageview:
       ``/api/``)
     * ``path``: the path of the request
     * ``status``: the HTTP response code
-
-socorro.webapp.sentry_scrub_error:
-  type: "incr"
-  description: |
-    Emitted when there are errors scrubbing Sentry events. Monitor these
-    because it means we're missing Sentry event data.

--- a/socorro/tests/conftest.py
+++ b/socorro/tests/conftest.py
@@ -25,6 +25,7 @@ import requests_mock
 
 from socorro import settings
 from socorro.libclass import build_instance_from_settings
+from socorro.libmarkus import set_up_metrics
 from socorro.lib.libdatetime import utc_now
 from socorro.lib.libooid import create_new_ooid, date_from_ooid
 
@@ -34,6 +35,16 @@ REPOROOT = pathlib.Path(__file__).parent.parent.parent
 
 # Add bin directory to Python path
 sys.path.insert(0, str(REPOROOT / "bin"))
+
+
+def pytest_sessionstart():
+    # Make sure Markus is set up with the RegisteredMetricsFilter
+    set_up_metrics(
+        statsd_host=settings.STATSD_HOST,
+        statsd_port=settings.STATSD_PORT,
+        hostname=settings.HOSTNAME,
+        debug=settings.LOCAL_DEV_ENV,
+    )
 
 
 @pytest.fixture

--- a/socorro/tests/external/es/test_crashstorage.py
+++ b/socorro/tests/external/es/test_crashstorage.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from unittest import mock
 
 import glom
-from markus.testing import MetricsMock
+from markus.testing import AnyTagValue, MetricsMock
 import pytest
 
 from socorro import settings
@@ -265,10 +265,10 @@ class TestESCrashStorage:
                 )
 
             mm.assert_histogram_once(
-                "socorro.processor.es.index", tags=["outcome:successful"]
+                "socorro.processor.es.index", tags=["outcome:successful", AnyTagValue("host")]
             )
             mm.assert_histogram_once(
-                "socorro.processor.es.index", tags=["outcome:failed"]
+                "socorro.processor.es.index", tags=["outcome:failed", AnyTagValue("host")]
             )
 
     def test_delete_expired_indices(self, es_helper):

--- a/socorro/tests/external/es/test_crashstorage.py
+++ b/socorro/tests/external/es/test_crashstorage.py
@@ -265,10 +265,12 @@ class TestESCrashStorage:
                 )
 
             mm.assert_histogram_once(
-                "socorro.processor.es.index", tags=["outcome:successful", AnyTagValue("host")]
+                "socorro.processor.es.index",
+                tags=["outcome:successful", AnyTagValue("host")],
             )
             mm.assert_histogram_once(
-                "socorro.processor.es.index", tags=["outcome:failed", AnyTagValue("host")]
+                "socorro.processor.es.index",
+                tags=["outcome:failed", AnyTagValue("host")],
             )
 
     def test_delete_expired_indices(self, es_helper):

--- a/socorro/tests/processor/rules/test_breakpad.py
+++ b/socorro/tests/processor/rules/test_breakpad.py
@@ -6,7 +6,7 @@ import copy
 import json
 from unittest import mock
 
-from markus.testing import MetricsMock
+from markus.testing import AnyTagValue, MetricsMock
 import pytest
 
 from socorro.lib.libsocorrodataschema import get_schema, validate_instance
@@ -907,7 +907,7 @@ class TestMinidumpStackwalkRule:
 
             mm.assert_incr(
                 "socorro.processor.minidumpstackwalk.run",
-                tags=["outcome:success", "exitcode:0"],
+                tags=["outcome:success", "exitcode:0", AnyTagValue("host")],
             )
 
     def test_stackwalker_timeout(self, tmp_path):
@@ -948,7 +948,7 @@ class TestMinidumpStackwalkRule:
 
             mm.assert_incr(
                 "socorro.processor.minidumpstackwalk.run",
-                tags=["outcome:fail", "exitcode:-9"],
+                tags=["outcome:fail", "exitcode:-9", AnyTagValue("host")],
             )
 
     def test_stackwalker_bad_output(self, tmp_path):

--- a/socorro/tests/processor/test_cache_manager.py
+++ b/socorro/tests/processor/test_cache_manager.py
@@ -7,7 +7,7 @@ import time
 from unittest.mock import ANY
 
 from fillmore.test import diff_structure
-from markus.testing import MetricsMock
+from markus.testing import AnyTagValue, MetricsMock
 import pytest
 
 from socorro import settings
@@ -482,8 +482,8 @@ def test_count_sentry_scrub_error():
     with MetricsMock() as metricsmock:
         metricsmock.clear_records()
         count_sentry_scrub_error("foo")
-        records = metricsmock.filter_records(
-            "incr", stat="socorro.processor.sentry_scrub_error", value=1
+        metricsmock.assert_incr(
+            stat="socorro.sentry_scrub_error",
+            value=1,
+            tags=["service:cachemanager", AnyTagValue("host")],
         )
-        assert len(records) == 1
-        assert {"service:cachemanager"}.issubset(records[0].tags)

--- a/socorro/tests/processor/test_cache_manager.py
+++ b/socorro/tests/processor/test_cache_manager.py
@@ -177,20 +177,23 @@ def test_eviction_of_least_recently_used(cm, tmp_path):
 
     file2 = tmp_path / "xul__dandelion.symc"
     file2.write_bytes(b"ab")
+    time.sleep(0.5)
 
     file3 = tmp_path / "xul__orchid.symc"
     file3.write_bytes(b"ab")
+    time.sleep(0.5)
 
     file4 = tmp_path / "xul__iris.symc"
     file4.write_bytes(b"ab")
+    time.sleep(0.5)
 
     # Run events and verify LRU
     cm.run_once()
     assert cm.lru == {str(file1): 2, str(file2): 2, str(file3): 2, str(file4): 2}
     assert cm.total_size == 8
+    time.sleep(0.5)
 
     # Access rose so it's recently used
-    time.sleep(0.5)
     file1.read_bytes()
 
     # Add new file which will evict files--but not rose which was accessed
@@ -298,19 +301,20 @@ def test_nested_directories_evict(cm, tmp_path):
 
     subdir2 = dir1 / "subdir2"
     subdir2.mkdir()
+    time.sleep(0.5)
 
     # Run to pick up new subsubdirectories and watch them
-    time.sleep(0.5)
     cm.run_once()
 
     # Create two files in the subsubdirectory with 9 bytes
     file1 = subdir1 / "file1.symc"
     file1.write_bytes(b"abcde")
+    time.sleep(0.5)
 
     file2 = subdir2 / "file2.symc"
     file2.write_bytes(b"abcd")
-
     time.sleep(0.5)
+
     cm.run_once()
     assert cm.lru == {str(file1): 5, str(file2): 4}
 
@@ -318,7 +322,8 @@ def test_nested_directories_evict(cm, tmp_path):
     file3 = dir1 / "file3.symc"
     file3.write_bytes(b"ab")
 
-    # Run to handle CREATE file3 which kicks off the eviction
+    # Run to handle CREATE file3 which kicks off the eviction of file 1
+    # because it's the oldest
     cm.run_once()
 
     # Run to handle DELETE | ISDIR for subdir1

--- a/socorro/tests/processor/test_processor_app.py
+++ b/socorro/tests/processor/test_processor_app.py
@@ -6,7 +6,7 @@ from unittest import mock
 from unittest.mock import ANY
 
 from fillmore.test import diff_structure
-from markus.testing import MetricsMock
+from markus.testing import AnyTagValue, MetricsMock
 import pytest
 
 from socorro import settings
@@ -294,7 +294,11 @@ def test_count_sentry_scrub_error():
     with MetricsMock() as metricsmock:
         metricsmock.clear_records()
         count_sentry_scrub_error("foo")
-        metricsmock.assert_incr("socorro.processor.sentry_scrub_error", value=1)
+        metricsmock.assert_incr(
+            "socorro.sentry_scrub_error",
+            value=1,
+            tags=["service:processor", AnyTagValue("host")],
+        )
 
 
 def test_transform_save_error(processor_settings, sentry_helper, caplogpp, tmp_path):

--- a/webapp/conftest.py
+++ b/webapp/conftest.py
@@ -2,14 +2,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+
 import pytest
 
 from django.core.cache import cache
 from django.contrib.auth.models import Group
 
+from socorro import settings as socorro_settings
+from socorro.libmarkus import set_up_metrics
+
 
 # Load the socorro/tests/conftest.py file so webapp tests can use those pytest fixtures
 pytest_plugins = ["socorro.tests.conftest"]
+
+
+def pytest_sessionstart(session):
+    # Make sure Markus is set up with the RegisteredMetricsFilter
+    set_up_metrics(
+        statsd_host=socorro_settings.STATSD_HOST,
+        statsd_port=socorro_settings.STATSD_PORT,
+        hostname=socorro_settings.HOSTNAME,
+        debug=socorro_settings.LOCAL_DEV_ENV,
+    )
 
 
 def pytest_runtest_setup(item):

--- a/webapp/crashstats/crashstats/apps.py
+++ b/webapp/crashstats/crashstats/apps.py
@@ -44,7 +44,7 @@ SCRUB_RULES_WEBAPP = [
 
 
 def count_sentry_scrub_error(msg):
-    METRICS.incr("webapp.sentry_scrub_error", 1)
+    METRICS.incr("sentry_scrub_error", 1, tags=["service:webapp"])
 
 
 def configure_sentry():

--- a/webapp/crashstats/crashstats/tests/test_sentry.py
+++ b/webapp/crashstats/crashstats/tests/test_sentry.py
@@ -7,7 +7,7 @@
 from unittest.mock import ANY
 
 from fillmore.test import diff_structure
-from markus.testing import MetricsMock
+from markus.testing import AnyTagValue, MetricsMock
 from werkzeug.test import Client
 
 from django.contrib.auth.models import User
@@ -178,4 +178,8 @@ def test_count_sentry_scrub_error():
     with MetricsMock() as metricsmock:
         metricsmock.clear_records()
         count_sentry_scrub_error("foo")
-        metricsmock.assert_incr("socorro.webapp.sentry_scrub_error", value=1)
+        metricsmock.assert_incr(
+            "socorro.sentry_scrub_error",
+            value=1,
+            tags=["service:webapp", AnyTagValue("host")],
+        )

--- a/webapp/crashstats/cron/management/commands/cronrun.py
+++ b/webapp/crashstats/cron/management/commands/cronrun.py
@@ -203,7 +203,9 @@ class Command(BaseCommand):
         Log.objects.create(
             app_name=cmd, success=success_date, duration="%.5f" % duration
         )
-        METRICS.gauge("cron.job_success_runtime", value=duration, tags=["job:%s" % cmd])
+        METRICS.timing(
+            "cron.job_run", value=duration, tags=[f"job:{cmd}", "result:success"]
+        )
 
     def _remember_failure(self, cmd, duration, exc_type, exc_value, exc_tb):
         Log.objects.create(
@@ -213,7 +215,9 @@ class Command(BaseCommand):
             exc_value=repr(exc_value),
             exc_traceback="".join(traceback.format_tb(exc_tb)),
         )
-        METRICS.gauge("cron.job_failure_runtime", value=duration, tags=["job:%s" % cmd])
+        METRICS.histogram(
+            "cron.job_run", value=duration, tags=[f"job:{cmd}", "result:failure"]
+        )
 
     @contextlib.contextmanager
     def lock_job(self, cmd):


### PR DESCRIPTION
This upgrades markus to 5.0.0. It adds a specification for all metrics emitted. It adds autodocumentation of those metrics to the docs.

While doing this, I found a handful of issues:

1. markus wasn't set up at test session start, so tests may or may not be running with the markus filters set up; now we set up markus at pytest session start
2. `sentry_scrub_error` had a key per service; now we have a single key with the service specified as a tag which makes it easier to have a single dashboard panel covering all sentry scrub errors
3. cronrun emitted separate metrics for success and failure with the timing as a gauge; now it's a timing and one key with the result as a tag