### PR TITLE
bug-1912979: fix rerererereprocessing problem in local dev env

### DIFF
--- a/bin/pubsub_cli.py
+++ b/bin/pubsub_cli.py
@@ -79,7 +79,11 @@ def create_subscription(ctx, project_id, topic_name, subscription_name):
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(project_id, subscription_name)
     try:
-        subscriber.create_subscription(name=subscription_path, topic=topic_path)
+        subscriber.create_subscription(
+            name=subscription_path,
+            topic=topic_path,
+            ack_deadline_seconds=600,
+        )
         click.echo(f"Subscription created: {subscription_path}")
     except AlreadyExists:
         click.echo("Subscription already created.")


### PR DESCRIPTION
We need to set the ack_deadline_seconds otherwise it defaults to 10 seconds which isn't long enough and causes crash ids to get read again. And again. And again. And again again.

This _only_ affects the local dev environment, so I'm putting it up for review for reals.