### PR TITLE
bug-1911612: add logger decorator to ESCrashStorage and SuperSearchUnredacted methods

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -106,7 +106,15 @@ class CrashStorageBase:
         # implementation. This may be fetched by a client of the crashstorge so that it
         # can determine if it can try a failed storage operation again.
         self.exceptions_eligible_for_retry = ()
+
+        # Configure logger
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
 
     def close(self):
         """Close resources used by this crashstorage."""

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -4,11 +4,9 @@
 
 import copy
 import datetime
-import functools
 import json
 import re
 import time
-import traceback
 
 import elasticsearch_1_9_0 as elasticsearch
 from elasticsearch_1_9_0.exceptions import NotFoundError
@@ -28,6 +26,7 @@ from socorro.external.es.super_search_fields import (
 )
 from socorro.libmarkus import METRICS, build_prefix
 from socorro.lib.libdatetime import JsonDTEncoder, string_to_datetime, utc_now
+from socorro.lib.util import es_usage_logger
 
 
 # Additional custom analyzers for crash report data
@@ -47,29 +46,6 @@ MAX_STRING_FIELD_VALUE_SIZE = 32_766
 # Valid Elasticsearch keys contain one or more ascii alphanumeric characters,
 # underscore, and hyphen and that's it
 VALID_KEY = re.compile(r"^[a-zA-Z0-9_-]+$")
-
-
-# Bug 1911612: Temporary decorator to log the method name, arguments and traceback
-# for each ESCrashStorage and SuperSearch method to better understand where ES gets
-# used by the webapp.
-def es_usage_logger(func):
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        stack_trace = "".join(traceback.format_stack())
-        class_name = self.__class__.__name__
-        method_name = func.__name__
-        self.logger.info(
-            "Bug 1911612"
-            # f"{class_name}.{method_name} called",
-            # f"Arguments were: {args}, {kwargs}",
-            # f"Traceback: {stack_trace}",
-        )
-
-        # Call the original function with its arguments and ensure we
-        # return whatever it returns.
-        return func(self, *args, **kwargs)
-
-    return wrapper
 
 
 def is_valid_key(key):

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from functools import wraps
+import json
 import traceback
 import time
 
@@ -156,9 +157,16 @@ def es_usage_logger(func):
         stack_trace = "".join(traceback.format_stack())
         class_name = self.__class__.__name__
         method_name = func.__name__
-        self.logger.info(
-            f"Bug 1911612,\n{class_name}.{method_name} method called,\nArguments were: {args}, {kwargs},\nTraceback:\n{stack_trace}",
-        )
+
+        log_entry_part_one = {
+            "bug_id": "1911612",
+            "method": f"{class_name}.{method_name}",
+            "arguments": {"args": args, "kwargs": kwargs},
+        }
+
+        log_entry_part_two = f"\ntraceback:\n{stack_trace}"
+
+        self.logger.info(json.dumps(log_entry_part_one, indent=4) + log_entry_part_two)
 
         # Call the original function with its arguments and ensure we
         # return whatever it returns.

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import copy
+import logging
 
 from crashstats import libproduct
 from crashstats.crashstats import models
@@ -16,6 +17,7 @@ from socorro.external.es import supersearch
 from socorro.external.es.super_search_fields import get_source_key
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
+from socorro.lib.util import es_usage_logger
 
 
 SUPERSEARCH_META_PARAMS = (
@@ -225,10 +227,14 @@ class SuperSearchUnredacted(SuperSearch):
 
         self.API_REQUIRED_PERMISSIONS = tuple(permissions.keys())
 
+        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+
+    @es_usage_logger
     def get_implementation(self):
         es_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
         return supersearch.SuperSearch(crashstorage=es_crash_dest)
 
+    @es_usage_logger
     def get(self, **kwargs):
         # SuperSearch requires that the list of fields be passed to it.
         kwargs["_fields"] = self.all_fields


### PR DESCRIPTION
This is a WIP to share my progress with others and to provide context for questions I expect I may ask in the coming days as I pursue some additional lines of inquiry.

### Overall approach

To comprehensively identify where and how Elasticsearch is used by the webapp, willkg suggested adding a logging decorator to output the traceback among other important information for key ES interfaces. This could then be used to audit the tests locally, but also to report this information in the webapp container in production on a temporary basis (perhaps a month?), so that any gaps in test coverage can also be identified.