### PR TITLE
bug-1918223: fix moz_crash_reason and reason formatting in create bug Description field.

### DIFF
--- a/webapp/crashstats/libbugzilla.py
+++ b/webapp/crashstats/libbugzilla.py
@@ -134,10 +134,12 @@ def crash_report_to_description(crash_report_url, processed_crash):
     ]
     if processed_crash.get("moz_crash_reason"):
         lines.append("")
-        lines.append(f"MOZ_CRASH Reason: ```{processed_crash['moz_crash_reason']}```")
+        lines.append(
+            f"MOZ_CRASH Reason:\n```\n{processed_crash['moz_crash_reason'].strip()}\n```\n"
+        )
     elif processed_crash.get("reason"):
         lines.append("")
-        lines.append(f"Reason: ```{processed_crash['reason']}```")
+        lines.append(f"Reason:\n```\n{processed_crash['reason'].strip()}\n```\n")
 
     frames = None
     if threads := mini_glom(processed_crash, "json_dump.threads", default=None):

--- a/webapp/crashstats/tests/test_libbugzilla.py
+++ b/webapp/crashstats/tests/test_libbugzilla.py
@@ -595,7 +595,10 @@ class Testcrash_report_to_description:
             """\
             Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
 
-            Reason: ```SIGSEGV /0x00000080```
+            Reason:
+            ```
+            SIGSEGV /0x00000080
+            ```
 
             Top 1 frame:
             ```
@@ -666,7 +669,10 @@ class Testcrash_report_to_description:
             """\
             Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
 
-            Reason: ```SIGSEGV /0x00000080```
+            Reason:
+            ```
+            SIGSEGV /0x00000080
+            ```
 
             Top 1 frame:
             ```
@@ -701,7 +707,10 @@ class Testcrash_report_to_description:
             """\
             Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
 
-            MOZ_CRASH Reason: ```good data```
+            MOZ_CRASH Reason:
+            ```
+            good data
+            ```
 
             Top 1 frame:
             ```
@@ -737,7 +746,10 @@ class Testcrash_report_to_description:
             """\
             Crash report: http://localhost:8000/report/index/2ae0a833-f43d-4d9b-8c13-f99e70240401
 
-            MOZ_CRASH Reason: ```MOZ_CRASH(Quota manager shutdown timed out) (good)```
+            MOZ_CRASH Reason:
+            ```
+            MOZ_CRASH(Quota manager shutdown timed out) (good)
+            ```
 
             Top 1 frame:
             ```


### PR DESCRIPTION
Because:
* The `moz_crash_reason` value (and similarly, the `reason` value) was not displaying properly in the Bugzilla create bug page due to some extra whitespace and missing newline characters in the value of the `comment` query parameter passed in the create bug URL.

This commit:
* Trims any whitespace on these values.
* Adds a newline character before and after the triple backticks.

Note: Shortly after bug-1919789 was fixed (which temporarily blocked this bug), I can no longer reproduce the issue in this bug locally or in prod, however, it makes sense to make these changes anyway, so that the formatting will reflect standard Markdown formatting regardless of the current Bugzilla create bug URL implementation.

Here's a screenshot of what the Preview looks like in the Bugzilla create bug page with the crash from the ticket (`2827f0eb-4a80-421e-a287-4c77f0240911`) in local development:

![Screenshot 2024-09-20 at 12 01 19 PM](https://github.com/user-attachments/assets/054ce7cf-5011-46d7-a00f-570772f317fe)