### PR TITLE
enable github actions CI on merge queue

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
I tried to merge #6733 via the merge queue but CI isn't running, but it helpfully links to docs that indicate we need to trigger ci on the `merge_group` event: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions