### PR TITLE
prevent bash from auto-exiting on keypress for `make shell` and `make testshell` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ stop: my.env  ## | Stop all service containers.
 
 .PHONY: shell
 shell: my.env .docker-build  ## | Open a shell in the app container.
-	${DC} run --rm app shell
+	${DC} run --rm --entrypoint /bin/bash app
 
 .PHONY: clean
 clean:  ## | Remove all build, test, coverage, and Python artifacts.
@@ -141,7 +141,7 @@ test-ci: my.env .docker-build  ## | Run unit tests in CI.
 
 .PHONY: testshell
 testshell: my.env .docker-build  ## | Open a shell in the test environment.
-	${DC} run --rm test shell
+	${DC} run --rm --entrypoint /bin/bash test
 
 .PHONY: rebuildreqs
 rebuildreqs: .env .docker-build  ## | Rebuild requirements.txt file after requirements.in changes.


### PR DESCRIPTION
Because:
* Several developers intermittently had issues where the shells from these commands were exiting.
* These commands originally relied on the default entrypoint of the base Docker image, i.e. `ENTRYPOINT ["/usr/bin/tini", "--", "/app/bin/entrypoint.sh"]` in `docker/Dockerfile`, and we believe Tini is interfering with this shell and causing it to exit prematurely[1].

This commit:
* Passes a different entrypoint into these commands to bypass using Tini in the default entrypoint command.

[1]: As @relud observed, and I've confirmed: `docker compose run --rm -ti --entrypoint '/usr/bin/tini' app bash` does the bad thing and `docker compose run --rm -ti --entrypoint '/bin/bash' app` works