### PR TITLE
replace Django `test` command with `pytest` in webapp test docs

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -432,7 +432,7 @@ Running the webapp tests (make sure you run ``./manage.py collectstatic`` first)
 
    app@socorro:/app$ cd webapp
    app@socorro:/app/webapp$ ./manage.py collectstatic
-   app@socorro:/app/webapp$ ./manage.py test
+   app@socorro:/app/webapp$ pytest
 
 .. Note::
 


### PR DESCRIPTION
Because:
* The `./manage.py test` command uses the `test` command from `setuptools`, which uses `unittest` under the hood.
* Our webapp tests run with `pytest`, and we have test-specific overrides configured in `webapp/pytest.ini` that won't get applied when the tests are run outside of `pytest` leading to test failures.

This commit:
* Updates the docs to use the pytest command.