### PR TITLE
Rework how supersearch fields permissions are handled

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -255,6 +255,8 @@ def build_document(src, crash_document, fields, all_keys):
 class ESCrashStorage(CrashStorageBase):
     """Indexes documents based on the processed crash to Elasticsearch."""
 
+    SUPERSEARCH_FIELDS = FIELDS
+
     # These regex will catch field names from Elasticsearch exceptions. They
     # have been tested with Elasticsearch 1.4.
     field_name_string_error_re = re.compile(r"field=\"([\w\-.]+)\"")
@@ -420,7 +422,7 @@ class ESCrashStorage(CrashStorageBase):
         return was_deleted
 
     def get_keys_for_indexable_fields(self):
-        """Return keys for FIELDS in "namespace.key" format
+        """Return keys for SUPERSEARCH_FIELDS in "namespace.key" format
 
         NOTE(willkg): Results are cached on this ESCrashStorage instance. If you change
         FIELDS (like in tests), create a new ESCrashStorage instance.
@@ -431,7 +433,7 @@ class ESCrashStorage(CrashStorageBase):
         keys = self._keys_for_indexable_fields_cache
         if keys is None:
             keys = set()
-            for field in FIELDS.values():
+            for field in self.SUPERSEARCH_FIELDS.values():
                 if not is_indexable(field):
                     continue
 
@@ -492,7 +494,9 @@ class ESCrashStorage(CrashStorageBase):
             "crash_id": crash_id,
             "processed_crash": {},
         }
-        build_document(src, crash_document, fields=FIELDS, all_keys=all_valid_keys)
+        build_document(
+            src, crash_document, fields=self.SUPERSEARCH_FIELDS, all_keys=all_valid_keys
+        )
 
         # Capture crash data size metrics
         self.capture_crash_metrics(crash_document)

--- a/socorro/external/legacy_es/crashstorage.py
+++ b/socorro/external/legacy_es/crashstorage.py
@@ -262,6 +262,8 @@ def build_document(src, crash_document, fields, all_keys):
 class LegacyESCrashStorage(CrashStorageBase):
     """Indexes documents based on the processed crash to Elasticsearch."""
 
+    SUPERSEARCH_FIELDS = FIELDS
+
     # These regex will catch field names from Elasticsearch exceptions. They
     # have been tested with Elasticsearch 1.4.
     field_name_string_error_re = re.compile(r"field=\"([\w\-.]+)\"")
@@ -438,7 +440,7 @@ class LegacyESCrashStorage(CrashStorageBase):
         keys = self._keys_for_indexable_fields_cache
         if keys is None:
             keys = set()
-            for field in FIELDS.values():
+            for field in self.SUPERSEARCH_FIELDS.values():
                 if not is_indexable(field):
                     continue
 
@@ -499,7 +501,9 @@ class LegacyESCrashStorage(CrashStorageBase):
             "crash_id": crash_id,
             "processed_crash": {},
         }
-        build_document(src, crash_document, fields=FIELDS, all_keys=all_valid_keys)
+        build_document(
+            src, crash_document, fields=self.SUPERSEARCH_FIELDS, all_keys=all_valid_keys
+        )
 
         # Capture crash data size metrics
         self.capture_crash_metrics(crash_document)

--- a/webapp/crashstats/crashstats/management/commands/updatesignatures.py
+++ b/webapp/crashstats/crashstats/management/commands/updatesignatures.py
@@ -14,7 +14,7 @@ from django.utils.dateparse import parse_datetime
 
 from crashstats.crashstats.models import Signature
 from crashstats.supersearch.models import SuperSearch
-from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
+from crashstats.supersearch.libsupersearch import get_supersearch_fields
 from socorro.lib.libdatetime import string_to_datetime
 
 
@@ -87,7 +87,7 @@ class Command(BaseCommand):
 
         # Do a super search and get the signature, buildid, and date processed for
         # every crash in the range
-        all_fields = SUPERSEARCH_FIELDS
+        all_fields = get_supersearch_fields()
         api = SuperSearch()
         self.stdout.write("Looking at %s to %s" % (start_datetime, end_datetime))
 

--- a/webapp/crashstats/crashstats/tests/conftest.py
+++ b/webapp/crashstats/crashstats/tests/conftest.py
@@ -14,7 +14,7 @@ from django.core.cache import cache
 from crashstats import libproduct
 from crashstats.crashstats.signals import PERMISSIONS
 from crashstats.crashstats.tests.testbase import DjangoTestCase
-from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
+from crashstats.supersearch.libsupersearch import get_supersearch_fields
 
 
 class Response:
@@ -116,7 +116,7 @@ class SuperSearchFieldsMock:
         super().setUp()
 
         def mocked_supersearchfields(**params):
-            results = copy.deepcopy(SUPERSEARCH_FIELDS)
+            results = copy.deepcopy(get_supersearch_fields())
             # to be realistic we want to introduce some dupes that have a
             # different key but its `in_database_name` is one that is already
             # in the hardcoded list (the baseline)

--- a/webapp/crashstats/supersearch/forms.py
+++ b/webapp/crashstats/supersearch/forms.py
@@ -60,9 +60,9 @@ class SearchForm(forms.Form):
                 del self.all_fields[field_name]
                 continue
 
-            if field_data["permissions_needed"]:
+            if field_data["webapp_permissions_needed"]:
                 user_has_permissions = True
-                for permission in field_data["permissions_needed"]:
+                for permission in field_data["webapp_permissions_needed"]:
                     if not user.has_perm(permission):
                         user_has_permissions = False
                         break

--- a/webapp/crashstats/supersearch/libsupersearch.py
+++ b/webapp/crashstats/supersearch/libsupersearch.py
@@ -9,7 +9,6 @@ import elasticsearch_1_9_0 as elasticsearch
 from elasticsearch_dsl_0_0_11 import Search
 
 from socorro import settings as socorro_settings
-from socorro.external.legacy_es.super_search_fields import FIELDS
 from socorro.libclass import build_instance_from_settings
 
 
@@ -25,7 +24,7 @@ def convert_permissions(fields):
 
     :arg fields: super search fields structure to convert permissions of
 
-    :returns: fields with permissions converted
+    :returns: fields with new "webapp_permissions_needed" value with webapp permissions
 
     """
 
@@ -39,12 +38,15 @@ def convert_permissions(fields):
         return [perm for perm in new_permissions if perm]
 
     for val in fields.values():
-        val["permissions_needed"] = _convert(val["permissions_needed"])
+        if "webapp_permissions_needed" not in val:
+            val["webapp_permissions_needed"] = _convert(val["permissions_needed"])
 
     return fields
 
 
-SUPERSEARCH_FIELDS = convert_permissions(FIELDS)
+def get_supersearch_fields():
+    es_crash_dest = build_instance_from_settings(socorro_settings.ES_STORAGE)
+    return convert_permissions(es_crash_dest.SUPERSEARCH_FIELDS)
 
 
 @dataclass

--- a/webapp/crashstats/supersearch/tests/test_forms.py
+++ b/webapp/crashstats/supersearch/tests/test_forms.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from crashstats.supersearch import forms
-from crashstats.supersearch.libsupersearch import SUPERSEARCH_FIELDS
+from crashstats.supersearch.libsupersearch import get_supersearch_fields
 
 
 class TestForms:
@@ -11,7 +11,7 @@ class TestForms:
         self.products = ["WaterWolf", "NightTrain", "SeaMonkey", "Tinkerbell"]
         self.product_versions = ["20.0", "21.0a1", "20.0", "9.5"]
         self.platforms = ["Windows", "Mac OS X", "Linux"]
-        self.all_fields = SUPERSEARCH_FIELDS
+        self.all_fields = get_supersearch_fields()
 
     def test_search_form(self):
         def get_new_form(data):

--- a/webapp/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp/crashstats/supersearch/tests/test_libsupersearch.py
@@ -15,7 +15,7 @@ def test_convert_permissions():
             "permissions_needed": ["public"],
         },
         "version": {
-            "permissions_needed": ["public", "protected"],
+            "permissions_needed": ["protected"],
         },
     }
 
@@ -23,14 +23,17 @@ def test_convert_permissions():
         "build": {
             # No permission -> no required permissions
             "permissions_needed": [],
+            "webapp_permissions_needed": [],
         },
         "product": {
             # "public" -> no required permissions
-            "permissions_needed": [],
+            "permissions_needed": ["public"],
+            "webapp_permissions_needed": [],
         },
         "version": {
             # "protected" -> "crashstats.view_pii"
-            "permissions_needed": ["crashstats.view_pii"],
+            "permissions_needed": ["protected"],
+            "webapp_permissions_needed": ["crashstats.view_pii"],
         },
     }
 

--- a/webapp/crashstats/supersearch/views.py
+++ b/webapp/crashstats/supersearch/views.py
@@ -54,7 +54,7 @@ def get_allowed_fields(user):
     return tuple(
         x["name"]
         for x in SuperSearchFields().get().values()
-        if x["is_exposed"] and user.has_perms(x["permissions_needed"])
+        if x["is_exposed"] and user.has_perms(x["webapp_permissions_needed"])
     )
 
 


### PR DESCRIPTION
In PR #6741, we're moving the code where we convert between the processed crash schema permissions in super search fields to webapp permissions to the general Socorro code. We try really hard to not have webapp things leak into the general Socorro code, so I wanted to experiment with other ways of solving the problem of having two elasticsearch crash storage implementations in respects to super search fields.

This tests that out by adding a `get_supersearch_fields()` function to `webapp/crashstats/supersearch/libsupersearch.py` which imports the specified Elasticsearch crashstorage, gets `SUPERSEARCH_FIELDS` from it, converts the permissions and returns it.

While doing that, I fixed some clarity issues in the code. `convert_permissions` will never have a case where the field has permissions `["public", "protected"]`--that's nonsensical so we shouldn't test that. Also, `convert_permissions` shouldn't stomp on the `permissions_needed` value. Instead, it should put the webapp permissions in a new key and then webapp code should look there.