### PR TITLE
bug-1926948: upgrade dev to postgresql 16.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,7 @@ services:
 
   # https://hub.docker.com/_/postgres/
   postgresql:
-    image: postgres:12.7
+    image: postgres:16.4
     ports:
       - "8574:5432"
     environment:


### PR DESCRIPTION
socorro dev is on PostgreSQL 12 right now, which will be EoL on November 14, 2024. for additional details see https://mozilla-hub.atlassian.net/browse/OBS-367