### PR TITLE
bug-1926077: remove enclosing square bracket(s) from module name in signature generation

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -151,8 +151,6 @@ class CSignatureTool:
             if function.endswith(ref):
                 function = function[: -len(ref)].strip()
 
-        # Convert `anonymous namespace' to (anonymous namespace)
-
         # Drop the prefix and return type if there is any if it's not operator
         # overloading--operator overloading syntax doesn't have the things
         # we're dropping here and can look curious, so don't try
@@ -247,6 +245,12 @@ class CSignatureTool:
 
         # If there's a module, use that
         if module:
+            # Remove extra ] at beginning or end if present; see Bug 1926077
+            if module.startswith("["):
+                module = module[1:]
+            if module.endswith("]"):
+                module = module[:-1]
+
             return module
 
         # If there are unloaded modules, use the first one

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -245,11 +245,8 @@ class CSignatureTool:
 
         # If there's a module, use that
         if module:
-            # Remove extra ] at beginning or end if present; see Bug 1926077
-            if module.startswith("["):
-                module = module[1:]
-            if module.endswith("]"):
-                module = module[:-1]
+            # Remove extra [ and/or ] at beginning or end if present; see Bug 1926077
+            module = module.strip("[]")
 
             return module
 

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -299,6 +299,7 @@ class TestCSignatureTool:
             (("module]", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
             (("[module]", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
             (("[module", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
+            (("[[[module]]", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
         ],
     )
     def test_normalize_frame(self, args, expected):

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -295,6 +295,10 @@ class TestCSignatureTool:
                 ),
                 "(unloaded unmod)",
             ),
+            # no function or line, so uses module; module name has extra bracket(s)
+            (("module]", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
+            (("[module]", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
+            (("[module", "", "\\a\\b\\c\\source", "", "0xfff"), "module"),
         ],
     )
     def test_normalize_frame(self, args, expected):


### PR DESCRIPTION
Because:
* Some module names have extra square brackets, in particular one at the end (bug-1926561).
* This causes Crash Stats report Bugzilla tab not to list related bugs.

This commit:
* Removes enclosing square bracket(s) from module names in stack frames.

I tested this locally by processing the crash mentioned in the bug. The extra closing bracket gets removed as desired:

**Before**
![Screenshot 2024-10-24 at 5 50 20 PM](https://github.com/user-attachments/assets/b27566f2-add2-43f1-8d4b-7be9594184ee)

Bugzilla tab does not list the expected bug, Bug-1923773:
![Screenshot 2024-10-24 at 6 01 53 PM](https://github.com/user-attachments/assets/2e916882-4f2b-41cf-8f1c-7bfbdc09e55b)

**After**
![Screenshot 2024-10-24 at 5 11 48 PM](https://github.com/user-attachments/assets/bc4af42e-430e-4468-a483-f469ae51ecdb)

I also verified that the crash bug that wasn't originally showing up in the reports view Bugzilla tab is now showing up:
![Screenshot 2024-10-24 at 6 00 00 PM](https://github.com/user-attachments/assets/f3549b4d-c6cd-478b-ba01-e513277e702b)

