### PR TITLE
OBS-361: Remove tini and set up stop signals.

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -29,28 +29,28 @@ shift
 
 case ${SERVICE} in
 processor)  ## Run processor service
-    /app/bin/run_service_processor.sh "$@"
+    exec /app/bin/run_service_processor.sh "$@"
     ;;
 crontabber)  ## Run crontabber service
-    /app/bin/run_service_crontabber.sh "$@"
+    exec /app/bin/run_service_crontabber.sh "$@"
     ;;
 webapp)  ## Run webapp service
-    /app/bin/run_service_webapp.sh "$@"
+    exec /app/bin/run_service_webapp.sh "$@"
     ;;
 stage_submitter)  ## Runs the stage submitter
-    /app/bin/run_service_stage_submitter.sh
+    exec /app/bin/run_service_stage_submitter.sh
     ;;
 fakecollector)  ## Runs a local fake collector
-    /app/bin/run_fakecollector.sh
+    exec /app/bin/run_fakecollector.sh
     ;;
 symbolsserver)  ## Runs a local symbols server
-    /app/bin/run_symbolsserver.sh
+    exec /app/bin/run_symbolsserver.sh
     ;;
 shell)  ## Open a shell or run something else
     if [ -z "$*" ]; then
-        bash
+        exec bash
     else
-        "$@"
+        exec "$@"
     fi
     ;;
 *)

--- a/bin/run_cache_manager.sh
+++ b/bin/run_cache_manager.sh
@@ -15,4 +15,4 @@ set -euo pipefail
 export PROCESS_NAME=cache_manager
 
 # Run the processor
-python socorro/processor/cache_manager.py
+exec python socorro/processor/cache_manager.py

--- a/bin/run_fakecollector.sh
+++ b/bin/run_fakecollector.sh
@@ -16,4 +16,4 @@ set -euxo pipefail
 
 PORT=8000
 
-python fakecollector/collector.py --port=${PORT}
+exec python fakecollector/collector.py --port=${PORT}

--- a/bin/run_processor.sh
+++ b/bin/run_processor.sh
@@ -15,4 +15,4 @@ set -euo pipefail
 export PROCESS_NAME=processor
 
 # Run the processor
-python socorro/processor/processor_app.py
+exec python socorro/processor/processor_app.py

--- a/bin/run_service_processor.sh
+++ b/bin/run_service_processor.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 PROCESSOR_WORKERS=${PROCESSOR_WORKERS:-"1"}
 
 # Run honcho with PROCESSOR_WORKERS number of processor worker processes
-honcho \
+exec honcho \
     --procfile /app/processor/Procfile \
     --app-root /app \
     --no-prefix \

--- a/bin/run_service_stage_submitter.sh
+++ b/bin/run_service_stage_submitter.sh
@@ -15,4 +15,4 @@ set -euo pipefail
 export PROCESS_NAME=stage_submitter
 
 # Run the stage_submitter
-python socorro/stage_submitter/submitter.py
+exec python socorro/stage_submitter/submitter.py

--- a/bin/run_service_webapp.sh
+++ b/bin/run_service_webapp.sh
@@ -29,10 +29,10 @@ if [ "${1:-}" == "--dev" ]; then
     echo "Running webapp in local dev environment."
     echo "Connect with your browser using: http://localhost:8000/ "
     echo "******************************************************************"
-    cd /app/webapp/ && ${CMDPREFIX} python manage.py runserver 0.0.0.0:8000
+    cd /app/webapp/ && exec ${CMDPREFIX} python manage.py runserver 0.0.0.0:8000
 
 else
-    ${CMDPREFIX} gunicorn \
+    exec ${CMDPREFIX} gunicorn \
         --pythonpath /app/webapp/ \
         --timeout "${GUNICORN_TIMEOUT}" \
         --workers="${GUNICORN_WORKERS}" \

--- a/bin/run_symbolsserver.sh
+++ b/bin/run_symbolsserver.sh
@@ -22,4 +22,4 @@ then
 fi
 
 echo "Running local symbols server at ${SYMBOLS_PATH} ..."
-python -m http.server --directory "${SYMBOLS_PATH}" --bind 0.0.0.0 "${PORT}"
+exec python -m http.server --directory "${SYMBOLS_PATH}" --bind 0.0.0.0 "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,7 @@ services:
     ports:
       - "8090:8090"
     command: run --host 0.0.0.0 --port 8090
+    stop_signal: SIGINT
 
   # https://hub.docker.com/r/mozilla/oidc-testprovider
   oidcprovider:
@@ -160,6 +161,9 @@ services:
     image: local/socorro_oidcprovider
     ports:
       - "8080:8080"
+    # The next line can be removed if this PR is included in the image we use:
+    # https://github.com/mozilla/docker-test-mozilla-django-oidc/pull/84
+    stop_signal: SIGKILL
 
   # -----------------------------
   # External services
@@ -204,6 +208,7 @@ services:
       - docker/config/local_dev.env
       - my.env
     command: ["symbolsserver"]
+    stop_signal: SIGINT
     ports:
       - "8070:8070"
     volumes:
@@ -261,6 +266,7 @@ services:
       - --host-port=0.0.0.0:${PUBSUB_PORT:-5010}
     ports:
       - 5010:5010
+    stop_signal: SIGINT
 
   # https://hub.docker.com/_/memcached/
   memcached:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,4 +62,4 @@ RUN cd /app/webapp/ && TOOL_ENV=True python manage.py collectstatic --noinput
 
 # Set entrypoint for this image. The entrypoint script takes a service
 # to run as the first argument. See the script for available arguments.
-ENTRYPOINT ["/usr/bin/tini", "--", "/app/bin/entrypoint.sh"]
+ENTRYPOINT ["/app/bin/entrypoint.sh"]

--- a/docker/Dockerfile.fakesentry
+++ b/docker/Dockerfile.fakesentry
@@ -8,7 +8,7 @@ WORKDIR /app/
 RUN groupadd -r kent && useradd --no-log-init -r -g kent kent
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl tini && \
+    apt-get install -y --no-install-recommends curl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -21,5 +21,5 @@ RUN pip install -U 'pip>=20' && \
 
 USER kent
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/kent-server"]
+ENTRYPOINT ["/usr/local/bin/kent-server"]
 CMD ["run"]

--- a/docker/Dockerfile.oidcprovider
+++ b/docker/Dockerfile.oidcprovider
@@ -1,10 +1,6 @@
 FROM mozilla/oidc-testprovider:oidc_testprovider-v0.10.9
 
-RUN apt-get update && \
-    apt install tini && \
-    rm -rf /var/lib/apt/lists/*
-
 # Modify redirect_urls specified in "fixtures.json" to fit our needs.
 COPY ./docker/config/oidcprovider-fixtures.json /code/fixtures.json
 
-CMD ["/usr/bin/tini", "--", "./bin/run.sh"]
+CMD ["./bin/run.sh"]

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -26,9 +26,6 @@ PACKAGES_TO_INSTALL=(
     # For scripts
     git
 
-    # For running services
-    tini
-
     # For nodejs and npm
     curl
 


### PR DESCRIPTION
The tini process was originally added to make Docker comtainers quite properly when receiving the TERM signal on `docker compose stop`. Some containers don't react to this signal, so terminating them will hang for ten seconds before Docker Compose sends SIGKILL.

The changes in this PR are similar to https://github.com/mozilla-services/tecken/pull/3049.

I added `exec` to run the main command to a bunch of shell scripts. This ensures the shell script doesn't linger around, and the _actual_ main process receives the signals, which is a lot more useful.

https://mozilla-hub.atlassian.net/browse/OBS-361