### PR TITLE
bug-1863963: fix site title to Mozilla Crash Stats

### DIFF
--- a/webapp/crashstats/crashstats/jinja2/400.html
+++ b/webapp/crashstats/crashstats/jinja2/400.html
@@ -1,4 +1,4 @@
-{% extends "error.html" %}
+{% extends "error_base.html" %}
 
 {% block page_title %}Bad Request{% endblock %}
 

--- a/webapp/crashstats/crashstats/jinja2/404.html
+++ b/webapp/crashstats/crashstats/jinja2/404.html
@@ -1,4 +1,4 @@
-{% extends "error.html" %}
+{% extends "error_base.html" %}
 
 {% block page_title %}Page Not Found{% endblock %}
 

--- a/webapp/crashstats/crashstats/jinja2/500.html
+++ b/webapp/crashstats/crashstats/jinja2/500.html
@@ -1,4 +1,4 @@
-{% extends "error.html" %}
+{% extends "error_base.html" %}
 
 {% block page_title %}Internal Server Error{% endblock %}
 

--- a/webapp/crashstats/crashstats/jinja2/crashstats_base.html
+++ b/webapp/crashstats/crashstats/jinja2/crashstats_base.html
@@ -24,7 +24,7 @@
 
   <body>
     <div class="page-header">
-      {% include "header_title.html" %}
+      <a class="title" href="/"><span>Mozilla Crash Stats</span></a>
 
       <form id="simple_search" method="get" action="{{ url('crashstats:quick_search') }}" data-no-csrf>
         <label for="q" class="visually-hidden">Search</label>

--- a/webapp/crashstats/crashstats/jinja2/error_base.html
+++ b/webapp/crashstats/crashstats/jinja2/error_base.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <div class="page-header">
-      {% include "header_title.html" %}
+      <a class="title" href="/"><span>Mozilla Crash Stats</span></a>
     </div>
     {% block content %}{% endblock %}
     <div id="footer" class="page-footer">

--- a/webapp/crashstats/crashstats/jinja2/footer_nav.html
+++ b/webapp/crashstats/crashstats/jinja2/footer_nav.html
@@ -1,6 +1,6 @@
 <div class="nav">
   <div class="about">
-    <b>Mozilla Crash Reports</b> - Powered by <a href="https://github.com/mozilla-services/socorro">Socorro</a> - All dates are UTC
+    <b>Mozilla Crash Stats</b> - Powered by <a href="https://github.com/mozilla-services/socorro">Socorro</a> - All dates are UTC
   </div>
   <ul>
     <li><a href="{{ url('documentation:home') }}">Help</a></li>

--- a/webapp/crashstats/crashstats/jinja2/header_title.html
+++ b/webapp/crashstats/crashstats/jinja2/header_title.html
@@ -1,3 +1,0 @@
-<a class="title" href="/">
-  <span>Mozilla Crash Reports</span>
-</a>

--- a/webapp/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp/crashstats/signature/jinja2/signature/signature_report.html
@@ -1,7 +1,7 @@
 {% from "supersearch/macros/date_filters.html" import date_filters %}
 
 {% extends "crashstats_base.html" %}
-{% block page_title %}{{ signature }} - Signature report - Mozilla Crash Reports{% endblock %}
+{% block page_title %}{{ signature }} - Signature report - Mozilla Crash Stats{% endblock %}
 
 {% block summary_page_tags %}
   <meta property="og:title" content="Crash Stats signature report: [@{{ signature }}]">

--- a/webapp/crashstats/supersearch/jinja2/supersearch/search.html
+++ b/webapp/crashstats/supersearch/jinja2/supersearch/search.html
@@ -1,7 +1,7 @@
 {% from "supersearch/macros/date_filters.html" import date_filters %}
 
 {% extends "crashstats_base.html" %}
-{% block page_title %}Search - Mozilla Crash Reports{% endblock %}
+{% block page_title %}Search - Mozilla Crash Stats{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/webapp/crashstats/supersearch/jinja2/supersearch/search_custom.html
+++ b/webapp/crashstats/supersearch/jinja2/supersearch/search_custom.html
@@ -1,5 +1,5 @@
 {% extends "crashstats_base.html" %}
-{% block page_title %}Search - Mozilla Crash Reports{% endblock %}
+{% block page_title %}Search - Mozilla Crash Stats{% endblock %}
 
 {% block content %}
   <div id="mainbody"


### PR DESCRIPTION
"crash reports" is the name of the collector, so it's always been a dissonance that the header of the Crash Stats site said Crash Reports.

While doing this, I also fixed the hierarchy of error templates and removed an unneeded header_title.html template.

Currently we have:

![image](https://github.com/user-attachments/assets/ee43e14b-d48c-40f5-bb83-dc5bbc9706ad)

This fixes it to:

![image](https://github.com/user-attachments/assets/759b99fb-34f9-42ca-9e74-23d70ec68b1c)
