### PR TITLE
bug-1902001: fix source highlight with bad urls

### DIFF
--- a/webapp/crashstats/sources/tests/test_views.py
+++ b/webapp/crashstats/sources/tests/test_views.py
@@ -67,6 +67,14 @@ def test_highlight_url(client, requests_mock):
     assert response["content-security-policy"]
 
 
+def test_highlight_bad_url(client, requests_mock):
+    url = reverse("sources:highlight_url")
+
+    # Invalid url is treated as a 404
+    response = client.get(url, {"url": "http://example.com[@a.xxx.org/?"})
+    assert response.status_code == 404
+
+
 def test_highlight_line(client, requests_mock):
     requests_mock.get(
         f"https://{HOST}/200.h",

--- a/webapp/crashstats/sources/views.py
+++ b/webapp/crashstats/sources/views.py
@@ -53,7 +53,12 @@ def highlight_url(request):
     if not url:
         return HttpResponseBadRequest("No url specified.")
 
-    parsed = urlsplit(url)
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        # If the value can't be parsed as a url, then treat it as if the document
+        # doesn't exist. Bug #1902001.
+        return HttpResponseNotFound("Document at URL does not exist.")
 
     # We will only pull urls from allowed hosts
     if parsed.netloc not in ALLOWED_SOURCE_HOSTS:


### PR DESCRIPTION
If the url provided isn't a valid url, treat it as if the document doesn't exist and return an HTTP 404.

To test:

```
> curl "http://localhost:8000/sources/highlight/?url=https://crash-stats.allizom.org\[@a.xxx.org/?"
```

Compare that with:

```
> curl "https://crash-stats.allizom.org/sources/highlight/?url=https://crash-stats.allizom.org\[@a.xxx.org/?"
```

(You need the `\[` because otherwise curl thinks the `[` means something and kicks up `curl: (3) bad range specification in URL position 78:`.)