### PR TITLE
bug-1928808: fix _report_type validation

### DIFF
--- a/webapp/crashstats/topcrashers/forms.py
+++ b/webapp/crashstats/topcrashers/forms.py
@@ -16,4 +16,10 @@ class TopCrashersForm(BaseForm):
     _facets_size = forms.IntegerField(required=False)
     _tcbs_mode = forms.CharField(required=False)
     _range_type = forms.CharField(required=False)
-    _report_type = forms.CharField(required=False)
+
+    # NOTE(willkg): _report_type choices must match the TopCrashers form options in the
+    # jinja2 template
+    _report_type = forms.ChoiceField(
+        choices=[("any", "any"), ("hang", "hang"), ("crash", "crash")],
+        required=False,
+    )


### PR DESCRIPTION
This fixes `_report_type` validation in the TopCrashers form so it doesn't create bad Super Search queries which kick up an HTTP 500.

Previously, the form did no useful validation (why even have a form?). Now it enforces that `_report_type` is one of "any", "hang", or "crash" which are the only three values it should have. If it gets a different value, the form will cause the view to raise an HTTP 400 with an error saying that the `_report_type` value isn't one of the available choices.

I did manual testing:

1. go to `http://localhost:8000/` and chose "TopCrashers" from the dropdown in the quick navigation bar
2. on the TopCrashers report, click through the three report types -- this should work fine
3. now manually edit the url and change `_report_type` to something like "pumpkin" -- this should return an HTTP 400 error page

![image](https://github.com/user-attachments/assets/af49f00e-a982-4104-8dc7-653fee596d57)
