### PR TITLE
bug-1928934: fix super search fields in signature report forms

### DIFF
--- a/webapp/crashstats/documentation/jinja2/docs/supersearch/api.html
+++ b/webapp/crashstats/documentation/jinja2/docs/supersearch/api.html
@@ -92,7 +92,7 @@
 
         <p class="description">
           Use this parameter to get a large number of results instead of setting
-          an arbitraty big <code>_results_number</code> value. Run queries in a
+          an arbitrary big <code>_results_number</code> value. Run queries in a
           loop, incrementing this by the value of <code>_results_number</code>,
           and concatenate the content of the <code>hits</code> key.
         </p>
@@ -146,7 +146,7 @@
           run an aggregation on <code>field_1</code>, then for each bucket of
           that aggregation, it will aggregate on <code>field_2</code>, and then
           for each bucket of that sub-aggregation, it will aggregate on
-          <code>field_3</code>. Theoratically, we could have any number of
+          <code>field_3</code>. Theoretically, we could have any number of
           levels of aggregations, but in practice we only allow all "level 1"
           aggregations, and a few "level 2" and "level 3".
         </p>
@@ -300,6 +300,9 @@
               {% endfor %}
             </p>
 
+            {# NOTE(willkg): we use permissions_needed so it matches the
+            protected crash schema rather than the webapp permissions which
+            users won't understand #}
             {% if filter.permissions_needed %}
               <p class="permissions">{{ filter.permissions_needed | join(', ') }}</p>
             {% endif %}

--- a/webapp/crashstats/signature/tests/test_views.py
+++ b/webapp/crashstats/signature/tests/test_views.py
@@ -9,10 +9,12 @@ from urllib.parse import quote
 
 import pyquery
 
+from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 from django.utils.encoding import smart_str
 
 from crashstats.crashstats import models
+from crashstats.signature.views import get_fields
 from socorro.lib.libdatetime import date_to_string, utc_now
 from socorro.lib.libooid import create_new_ooid, date_from_ooid
 
@@ -661,3 +663,16 @@ class TestViews:
             < content.find("Related Crash Signatures")
             < content.find("Bugs for <code>OOM | small</code>")
         )
+
+    def test_get_fields(self, db, user_helper):
+        # Create anonymous user and get fields
+        user = AnonymousUser()
+        fields = get_fields(user)
+        len_public_fields = len(fields)
+        assert len(fields) > 0
+
+        # Create user with protected data access, get fields, and make sure there are
+        # more of them than if the user didn't have protected data access
+        user = user_helper.create_protected_user()
+        fields = get_fields(user)
+        assert len(fields) > len_public_fields

--- a/webapp/crashstats/signature/views.py
+++ b/webapp/crashstats/signature/views.py
@@ -79,8 +79,7 @@ def get_fields(user):
     :returns: a list of dicts with "id" and "text" keys
 
     """
-    print(repr(user), user)
-    fields = sorted(
+    return sorted(
         x["name"]
         for x in SuperSearchFields().get().values()
         if x["is_exposed"]
@@ -88,8 +87,6 @@ def get_fields(user):
         and user.has_perms(x["webapp_permissions_needed"])
         and x["name"] != "signature"  # exclude the signature field
     )
-
-    return [{"id": field, "text": field.replace("_", " ")} for field in fields]
 
 
 @track_view
@@ -106,7 +103,9 @@ def signature_report(request, params, default_context=None):
     context["signature"] = signature
 
     fields = get_fields(request.user)
-    context["fields"] = fields
+    context["fields"] = [
+        {"id": field, "text": field.replace("_", " ")} for field in fields
+    ]
 
     columns = request.GET.getlist("_columns")
     columns = [x for x in columns if x in fields]


### PR DESCRIPTION
In 9b425e50, I changed the name of the field the webapp permissions were stored in, but missed updating the signature report view. This fixes that and adds a test.

To test:

1. process a crash report
2. go to `localhost:8000`
3. if you're logged in, log out
4. go to the crash report then click on the signature to go to the signature report
5. go to the "Aggregations" tab and click on the "Aggregate on..." drop down -- there should be fields
6. go to the "Reports" tab -- there should be fields listed in the unlabeled columns field
7. go to the "Graphs" tab and click on "Crashes per day, by ..." drop down -- there should be fields