### PR TITLE
Adding a "thismonth" option to the date argument for fetch_crashids

### DIFF
--- a/socorro/scripts/fetch_crashids.py
+++ b/socorro/scripts/fetch_crashids.py
@@ -108,7 +108,7 @@ def fetch_crashids(host, params, num_results):
             MAX_PAGE,
             # The number of results Super Search can return to us that is hasn't returned so far
             total - crashids_count,
-            # The numver of results we want that we haven't gotten, yet
+            # The number of results we want that we haven't gotten, yet
             num_results - crashids_count,
         )
 
@@ -137,8 +137,8 @@ def main(argv=None):
         "--date",
         default="",
         help=(
-            'date to pull crash ids from as YYYY-MM-DD, "thisweek", "yesterday", '
-            + '"today", or "now"; defaults to "yesterday"'
+            'date to pull crash ids from as YYYY-MM-DD, "thismonth", "thisweek", '
+            + '"yesterday", "today", or "now"; defaults to "yesterday"'
         ),
     )
     parser.add_argument(
@@ -199,6 +199,10 @@ def main(argv=None):
             startdate = startdate.strftime("%Y-%m-%dT%H:%M:%S.000Z")
             enddate = enddate.strftime("%Y-%m-%dT%H:%M:%S.000Z")
             params["_sort"] = "-date"
+
+        elif datestamp == "thismonth":
+            startdate = utc_now() - datetime.timedelta(days=30)
+            enddate = utc_now() + datetime.timedelta(days=1)
 
         elif datestamp == "thisweek":
             startdate = utc_now() - datetime.timedelta(days=7)


### PR DESCRIPTION
This adds a "thismonth" value to the value domain for the `--date" argument because it's not uncommon to be testing signature generation changes for situations that have happened in the last month, but not in the last week.

```
$ just shell

app@socorro:/app$ socorro-cmd fetch_crashids --date=thisweek --signature-contains=g_malloc

app@socorro:/app$ socorro-cmd fetch_crashids --date=thismonth --signature-contains=g_malloc
9c924bb4-cc8d-4071-afef-000140241031
72d845fc-6f33-4f44-9203-1dc490241104
e4a0a8dd-341b-430a-9f6a-2ad0c0241028
aef97233-ca73-4ba9-a6d1-c8a280241104
ede7036b-4927-41a0-834e-9e4a80241105
4ea1423a-fce6-45a9-95e2-6a05e0241110
f17cd077-17a7-46cd-a378-2dc8a0241102
8d1cc235-dcbd-4606-a99d-eaf840241104
2b89f970-0451-43fc-a237-ecf7a0241106
```