### PR TITLE
bug-1933774: omit collector-added fields from Crash Annotations tab

### DIFF
--- a/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -909,17 +909,19 @@
             </div>
             <table class="record data-table hardwrapped">
               <tbody>
-                {% for key in public_raw_keys %}
-                  <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
-                    <th class="w-2/12" scope="row">
-                      {% if key %}
-                        {{ key }}
-                      {% else %}
-                        <i>empty key</i>
-                      {% endif %}
-                    </th>
-                    <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
-                  </tr>
+                {% for key in public_annotations %}
+                  {% if key not in fields_from_collector %}
+                    <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
+                      <th class="w-2/12" scope="row">
+                        {% if key %}
+                          {{ key }}
+                        {% else %}
+                          <i>empty key</i>
+                        {% endif %}
+                      </th>
+                      <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
+                    </tr>
+                  {% endif %}
                 {% endfor %}
               </tbody>
             </table>
@@ -936,17 +938,19 @@
               </div>
               <table class="record data-table hardwrapped">
                 <tbody>
-                  {% for key in protected_raw_keys %}
-                    <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
-                      <th class="w-2/12" scope="row">
-                        {% if key %}
-                          {{ key }}
-                        {% else %}
-                          <i>empty key</i>
-                        {% endif %}
-                      </th>
-                      <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
-                    </tr>
+                  {% for key in protected_annotations %}
+                    {% if key not in fields_from_collector %}
+                      <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
+                        <th class="w-2/12" scope="row">
+                          {% if key %}
+                            {{ key }}
+                          {% else %}
+                            <i>empty key</i>
+                          {% endif %}
+                        </th>
+                        <td class="w-10/12"><pre>{{ raw[key] }}</pre></td>
+                      </tr>
+                    {% endif %}
                   {% endfor %}
                 </tbody>
               </table>
@@ -1204,6 +1208,10 @@
                     <td>{{ raw.submitted_timestamp | human_readable_iso_date }} UTC</td>
                   </tr>
                   <tr>
+                    <th scope="row">version</th>
+                    <td>{{ raw.version }}</td>
+                  </tr>
+                  <tr>
                     <th scope="row">Throttleable</th>
                     <td>{{ raw.Throttleable|default("--") }}</td>
                   </tr>
@@ -1273,7 +1281,7 @@
                             {% if report and report.stackwalk_version %}
                               {{ report.stackwalk_version }}
                             {% endif %}
-                            {# FIXME(willkg): this is the old locaion; remove in December 2022 #}
+                            {# FIXME(willkg): this is the old location; remove in December 2022 #}
                             {% if report and report.json_dump and report.json_dump.stackwalk_version %}
                               {{ report.json_dump.stackwalk_version }}
                             {% endif %}

--- a/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1281,10 +1281,6 @@
                             {% if report and report.stackwalk_version %}
                               {{ report.stackwalk_version }}
                             {% endif %}
-                            {# FIXME(willkg): this is the old location; remove in December 2022 #}
-                            {% if report and report.json_dump and report.json_dump.stackwalk_version %}
-                              {{ report.json_dump.stackwalk_version }}
-                            {% endif %}
                           </td>
                         </tr>
                         <tr>

--- a/webapp/crashstats/crashstats/views.py
+++ b/webapp/crashstats/crashstats/views.py
@@ -202,19 +202,30 @@ def report_index(request, crash_id, default_context=None):
         )
         context["report"]["mac_crash_info"] = mac_crash_info
 
-    all_public_raw_keys = raw_api.public_keys()
-    context["public_raw_keys"] = [x for x in context["raw"] if x in all_public_raw_keys]
+    all_public_annotations = raw_api.public_keys()
+    context["public_annotations"] = [
+        x for x in context["raw"] if x in all_public_annotations
+    ]
+
     if request.user.has_perm("crashstats.view_pii"):
         # If the user can see PII or this is their crash report, include everything
-        context["protected_raw_keys"] = [
-            x for x in context["raw"] if x not in all_public_raw_keys
+        context["protected_annotations"] = [
+            x for x in context["raw"] if x not in all_public_annotations
         ]
     else:
-        context["protected_raw_keys"] = []
+        context["protected_annotations"] = []
 
-    # Sort keys case-insensitively
-    context["public_raw_keys"].sort(key=lambda s: s.lower())
-    context["protected_raw_keys"].sort(key=lambda s: s.lower())
+    # Set of fields added to the raw crash by the collector that are not annotations
+    context["fields_from_collector"] = {
+        "metadata",
+        "uuid",
+        "submitted_timestamp",
+        "version",
+    }
+
+    # Sort annotation keys case-insensitively
+    context["public_annotations"].sort(key=lambda s: s.lower())
+    context["protected_annotations"].sort(key=lambda s: s.lower())
 
     data_urls = []
     if request.user.has_perm("crashstats.view_pii"):


### PR DESCRIPTION
This removes the collector-added fields from the Crash Annotations tab. For anyone who isn't a crash ingestion system maintainer, these fields are confusing because they're not part of the crash report payload.

After these changes, the fields will be omitted from the public and protected annotations lists in the Crash Annotations tab.

This also adds "version" to the Debug tab. This value represents the schema version of the raw crash structure. It's relevant to crash ingestion internals and nothing else, so having it in the Debug tab is helpful (though at this point, everything is version 2 so it's not wildly interesting anymore).

This also removes a few lines from the report view template that said we could remove them in 2022. That day has long passed.

To test:

1. process a crash report
2. view the crash report--make sure "uuid", "version" (lowercase v--"Version" (uppercase v) is an annotation), "metadata", and "submitted_timestamp" don't show up in the "Crash Annotations" tab
3. log in using an account with protected data access
4. view the crash report--make sure "uuid", "version" (lowercase v--"Version" (uppercase v) is an annotation), "metadata", and "submitted_timestamp" don't show up in the "Crash Annotations" tab