### PR TITLE
bug-1906021: strip whitespace from Android_CPU_ABI2 and other string fields

### DIFF
--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -158,7 +158,14 @@ class CopyFromRawCrashRule(Rule):
                     status.add_note(f"{annotation} has a non-float value")
 
             elif copy_item.type_ == "string":
-                processed_crash[copy_item.key] = value
+                # NOTE(willkg): In 1906021, I noticed that Android_CPU_ABI2 has
+                # whitespace at the end. I looked at all the string values and I
+                # couldn't see any cases where whitespace at the end of a string value
+                # was meaningful, so we strip the whitespace at the end now. If we need
+                # it, we could add a "transform" field to the schema to dictate which
+                # transforms to apply after extracting the value. That would be nice for
+                # splitting on "," and other things, too.
+                processed_crash[copy_item.key] = value.rstrip()
 
             elif copy_item.type_ == "object":
                 # If it's a string, then assume it's json-encoded and decode it

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -308,6 +308,15 @@ class TestCopyFromRawCrashRule:
         assert processed_crash == {copy_item.key: "some string"}
         assert status.notes == []
 
+        raw_crash = {copy_item.annotation: "some string with spaces\r\n   "}
+        dumps = {}
+        processed_crash = {}
+        status = Status()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert processed_crash == {copy_item.key: "some string with spaces"}
+        assert status.notes == []
+
     def test_object(self, tmp_path):
         rule = CopyFromRawCrashRule(schema=SCHEMA_WITH_ALL_TYPES)
         copy_item = self.get_copy_item(rule, "ComplexStructure")


### PR DESCRIPTION
This changes the `CopyFromRawCrashRule` to strip the right side of string field values. I haven't seen anything in crash reports so far where whitespace at the end of a crash annotation value is significant so I think this is safe.

If it turns out not to be safe, we can extend `CopyFromRawCrashRule` to look at a "transforms" field to glean how it should transform the value after copying it. This would be helpful for the increasing number of fields that are comma or semi-colon delimited, too.

To test:

1. process a Fenix crash report
2. view the `Android_CPU_ABI2` value in the raw crash--it has `\r\n` at the end
3. view the `android_cpu_abi2` value in the processed crash--it does not have `\r\n` at the end