### PR TITLE
Update obs-common to pick up the ack_deadline_timeout fix

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -81,4 +81,4 @@ urllib3>=1.8, <2.0 # via elasticsearch==1.9.0
 
 # Mozilla obs-team libraries that are published to GAR instead of pypi
 --extra-index-url https://us-python.pkg.dev/moz-fx-cavendish-prod/cavendish-prod-python/simple/
-obs-common==2024.12.3.post2
+obs-common==2024.12.06

--- a/requirements.txt
+++ b/requirements.txt
@@ -832,8 +832,8 @@ oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
     # via -r requirements.in
-obs-common==2024.12.3.post2 \
-    --hash=sha256:20c4337f682a32bd9a29188faa021a59441e64cba3c05be0558a76343d70598a
+obs-common==2024.12.6 \
+    --hash=sha256:50082b51f88c05116eb8479cf18d8308be879e4bb8e0e3abd05cfffe070c50f7
     # via -r requirements.in
 opentelemetry-api==1.27.0 \
     --hash=sha256:953d5871815e7c30c81b56d910c707588000fff7a3ca1c73e6531911d53065e7 \


### PR DESCRIPTION
This fixes subscription creation in the local dev environment so the ack deadline is 600 seconds which gives the processor enough time to retrieve a crash id, process the crash, and ack the crash id. Prior to this fix, subscriptions would use the default 10 seconds and that's not enough time to process crash reports.

We fixed this originally in bug-1912979, but that fix was dropped when we moved utilities to obs-common.