### PR TITLE
Fix TestCustomQuery test that fails at beginning of year

### DIFF
--- a/webapp/crashstats/supersearch/tests/test_views.py
+++ b/webapp/crashstats/supersearch/tests/test_views.py
@@ -492,11 +492,14 @@ class TestCustomQuery:
         # Assert the available indices are there
         template = preferred_es_helper.get_index_template()
         now = utc_now()
-        indices = [
-            (now - datetime.timedelta(days=7)).strftime(template),
-            now.strftime(template),
-        ]
-        assert ",".join(indices) in smart_str(response.content)
+        indices = set()
+        # NOTE(willkg): we have to build the list of indices this way because
+        # the index name is based on the week number and this handles the
+        # end-of-year/beginning-of-year case correctly.
+        for i in range(7):
+            indices.add((now - datetime.timedelta(days=i)).strftime(template))
+        index_value = ",".join(sorted(indices))
+        assert index_value in smart_str(response.content)
 
     def test_search_query(self, client, db, preferred_es_helper, user_helper):
         user = user_helper.create_protected_plus_user()

--- a/webapp/crashstats/supersearch/tests/test_views.py
+++ b/webapp/crashstats/supersearch/tests/test_views.py
@@ -496,7 +496,7 @@ class TestCustomQuery:
         # NOTE(willkg): we have to build the list of indices this way because
         # the index name is based on the week number and this handles the
         # end-of-year/beginning-of-year case correctly.
-        for i in range(7):
+        for i in range(8):
             indices.add((now - datetime.timedelta(days=i)).strftime(template))
         index_value = ",".join(sorted(indices))
         assert index_value in smart_str(response.content)


### PR DESCRIPTION
The index name template uses week number and when we calculate the expected index names by adding 7 days to figure out the next week number, that doesn't work at the beginning of the year when the previous year includes a partial week.

This fixes that by changing the code to figure out week numbers by incrementing by one day, generating index names, throwing those in a set, and then turning that into a sorted list.