### PR TITLE
bug-1925594: don't verify certs for Elasticsearch

### DIFF
--- a/socorro/external/es/connection_context.py
+++ b/socorro/external/es/connection_context.py
@@ -40,7 +40,7 @@ class ConnectionContext:
         return Elasticsearch(
             hosts=self.url,
             request_timeout=timeout,
-            verify_certs=True,
+            verify_certs=False,
         )
 
     def indices_client(self, name=None):


### PR DESCRIPTION
This only impacts new Elasticsearch 8 which adds HTTPS. Previously for Elasticsearch 1.4, this option did nothing, because we weren't using HTTPS.

This change is to test the new ES 8 cluster with socorro in stage (e.g. can we get the stage processor to write to both the old and new ES clusters?). We will discuss setting up a CA instead of disabling this before deploying Elasticsearch 8 in prod ([OBS-427](https://mozilla-hub.atlassian.net/browse/OBS-427)).