### PR TITLE
bug-1942406: Fix search_phase_execution_exception: Result window is too large

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -392,6 +392,13 @@ class SuperSearch(SearchBase):
 
         # Pagination.
         results_to = results_from + results_number
+        if results_to > 10_000:
+            # In ES 8+ index.max_result_window defaults to 10,000
+            # https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules.html
+            raise BadArgumentError(
+                "_results_offset",
+                msg="_results_offset + _results_number cannot be greater than 10,000",
+            )
         search = search[results_from:results_to]
 
         # Create facets.

--- a/socorro/tests/external/es/test_supersearch.py
+++ b/socorro/tests/external/es/test_supersearch.py
@@ -159,6 +159,22 @@ class TestIntegrationSuperSearch:
         with pytest.raises(BadArgumentError):
             api.get(_columns=["date"], _results_number=-1)
 
+    def test_get_with_bad_results_offset(self, es_helper):
+        """_results_offset + _results_number be <= 10,000"""
+        crashstorage = self.build_crashstorage()
+        api = SuperSearchWithFields(crashstorage=crashstorage)
+
+        api.get(
+            _results_offset=10_000 - 50,
+            _results_number=50,
+        )
+
+        with pytest.raises(BadArgumentError):
+            api.get(
+                _results_offset=10_000,
+                _results_number=50,
+            )
+
     def test_get_with_enum_operators(self, es_helper):
         now = utc_now()
         crashstorage = self.build_crashstorage()


### PR DESCRIPTION
In ES 8+ index.max_result_window defaults to 10,000: https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules.html