### PR TITLE
OBS-427: Support verify_certs with self-issued certs for elastic cloud

### DIFF
--- a/socorro/external/es/connection_context.py
+++ b/socorro/external/es/connection_context.py
@@ -18,14 +18,17 @@ class ConnectionContext:
         self,
         url="http://localhost:9200",
         timeout=30,
+        ca_certs=None,
         **kwargs,
     ):
         """
         :arg url: the url to the elasticsearch instances
         :arg timeout: the time in seconds before a query to elasticsearch fails
+        :arg ca_certs: path to a certs.pem file for verifying self-issued certs
         """
         self.url = url
         self.timeout = timeout
+        self.ca_certs = ca_certs
 
     def connection(self, name=None, timeout=None):
         """Returns an instance of elasticsearch-py's Elasticsearch class as
@@ -40,7 +43,8 @@ class ConnectionContext:
         return Elasticsearch(
             hosts=self.url,
             request_timeout=timeout,
-            verify_certs=False,
+            verify_certs=True,
+            ca_certs=self.ca_certs,
         )
 
     def indices_client(self, name=None):

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -276,10 +276,11 @@ class ESCrashStorage(CrashStorageBase):
         metrics_prefix="processor.es",
         timeout=30,
         shards_per_index=10,
+        ca_certs=None,
     ):
         super().__init__()
 
-        self.client = self.build_client(url=url, timeout=timeout)
+        self.client = self.build_client(url=url, timeout=timeout, ca_certs=ca_certs)
 
         # Create a MetricsInterface that includes the base prefix plus the prefix passed
         # into __init__
@@ -299,8 +300,8 @@ class ESCrashStorage(CrashStorageBase):
         self._mapping_cache = {}
 
     @classmethod
-    def build_client(cls, url, timeout):
-        return ConnectionContext(url=url, timeout=timeout)
+    def build_client(cls, url, timeout, ca_certs=None):
+        return ConnectionContext(url=url, timeout=timeout, ca_certs=ca_certs)
 
     def build_query(self):
         """Return new instance of Query."""

--- a/socorro/mozilla_settings.py
+++ b/socorro/mozilla_settings.py
@@ -234,6 +234,15 @@ elif ELASTICSEARCH_MODE == "PREFER_NEW":
                 "ELASTICSEARCH_URL",
                 doc="Elasticsearch url.",
             ),
+            "ca_certs": _config(
+                "ELASTICSEARCH_CA_CERTS",
+                default="",
+                parser=or_none(str),
+                doc=(
+                    "Path to a certs.pem file to verify certs for Elasticsearch "
+                    "clusters that use self-issued certificates."
+                ),
+            ),
         },
     }
 


### PR DESCRIPTION
This only impacts https urls, which right now we only use for elastic cloud.

In stage we are currently depending on `verify_certs=False` to connect to elastic cloud, and this will allow us to instead use a `certs.pem` provided by elastic cloud to verify their https certs.