### PR TITLE
Bug 1943919 - Add TppRaiseInvalidParameter to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -238,6 +238,7 @@ strstr
 syscall
 SysFreeString
 TlsGetValue
+TppRaiseInvalidParameter
 __ulock_wait
 __unlink
 unlink


### PR DESCRIPTION
We don't want to add this function to the irrelevant list because it conveys an important bit of information (that we're crashing because an invalid paramter has been passed to a Windows system function), but we still want to skip over it in order to be able to tell different crashes apart.