### PR TITLE
bug-1945553: Fix json encoding error with empty aggregations object

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -8,7 +8,7 @@ import datetime
 import re
 
 from elasticsearch.exceptions import NotFoundError, BadRequestError
-from elasticsearch_dsl import A, Q, Search
+from elasticsearch_dsl import A, Q, Search, AggResponse
 
 from socorro.external.es.base import generate_list_of_indexes
 from socorro.external.es.search_common import SearchBase
@@ -428,7 +428,7 @@ class SuperSearch(SearchBase):
                 total = search.count()
 
                 aggregations = getattr(results, "aggregations", {})
-                if aggregations:
+                if isinstance(aggregations, AggResponse):
                     aggregations = self.format_aggregations(aggregations)
 
                 shards = getattr(results, "_shards", {})

--- a/socorro/tests/external/es/test_supersearch.py
+++ b/socorro/tests/external/es/test_supersearch.py
@@ -868,6 +868,8 @@ class TestIntegrationSuperSearch:
         }
         res = api.get(**kwargs)
         assert res["facets"] == {}
+        # check that empty facets are converted to dict
+        assert isinstance(res["facets"], dict)
         # hits should still work as normal
         assert res["hits"]
         assert len(res["hits"]) == res["total"]


### PR DESCRIPTION
for es8+ search results may contain an AggResponse object under the `aggregations` key, instead a missing attribute like in es1.4, so here we convert that empty object to a dict