### PR TITLE
OBS-270: Use Python images based on Debian bookworm.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # This should be kept in sync with the python version used in docker/Dockerfile
-FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/python:3.11-bullseye@sha256:105bf6a63ab025206f019a371a735fec6553db0be520030c7a2fd0e002947232 AS devcontainer_amd64
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/python:3.11-bookworm@sha256:138c451b17c1c5930f77e71a6510a0bae1d7b77feff5e0a714a22fa3d757a51f AS devcontainer_amd64
 
 ARG userid=10001
 ARG groupid=10001

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,11 +3,9 @@
 # =========================================================================
 
 # https://hub.docker.com/_/python
-# NOTE(willkg): stick with slim-bullseye which matches how we build the
-# stackwalker
 # NOTE(smarnach): To upgrade Python to a new minor or major version, see
 # https://socorro.readthedocs.io/en/latest/dev.html#upgrading-to-a-new-python-version
-FROM --platform=linux/amd64 python:3.11.11-slim-bullseye@sha256:0b646b5876b055bb20095864557b6773625385136de57e39ac6bc08588c0fe50 AS app_amd64
+FROM --platform=linux/amd64 python:3.11.11-slim-bookworm@sha256:42420f737ba91d509fc60d5ed65ed0492678a90c561e1fa08786ae8ba8b52eda AS app_amd64
 
 # Set up user and group
 ARG groupid=10001

--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20241010.0/socorro-stackwalker.2024-10-10.v0.22.2.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20250207.0/socorro-stackwalker.2024-10-10.v0.22.2.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"

--- a/docker/set_up_ubuntu.sh
+++ b/docker/set_up_ubuntu.sh
@@ -37,9 +37,14 @@ PACKAGES_TO_INSTALL=(
 apt-get install -y "${PACKAGES_TO_INSTALL[@]}"
 
 # Install nodejs and npm from Nodesource's 14.x branch
-curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-echo 'deb https://deb.nodesource.com/node_18.x buster main' > /etc/apt/sources.list.d/nodesource.list
-echo 'deb-src https://deb.nodesource.com/node_18.x buster main' >> /etc/apt/sources.list.d/nodesource.list
+curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x bookworm main' > /etc/apt/sources.list.d/nodesource.list
+# Give Nodesource packages priority over the packages included in the Debian distribution
+cat > /etc/apt/preferences.d/nodesource <<EOF
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 600
+EOF
 apt-get update
 apt-get install -y nodejs
 


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/OBS-270

Debian bookworm contains a nodejs package with a newer version than we install from Nodesource. I had to add an apt pin to prefer the Nodesource version over the version included in Debian. I also removed the use of `apt-key`, which has been deprecated for a long time now.