### PR TITLE
bug-1946895: Fix detecting float/double field when building es8 documents

### DIFF
--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -191,8 +191,8 @@ def fix_long(value):
     return value
 
 
-def fix_float(value):
-    """Fix float value so it doesn't exceed Elasticsearch maximums
+def fix_double(value):
+    """Fix double value so it doesn't encode invalid json
 
     :param value: the value to fix
 
@@ -265,8 +265,8 @@ def build_document(src, crash_document, fields, all_keys):
             if value is None:
                 continue
 
-        elif storage_type == "float":
-            value = fix_float(value)
+        elif storage_type == "double":
+            value = fix_double(value)
             if value is None:
                 continue
 

--- a/socorro/tests/external/es/test_crashstorage.py
+++ b/socorro/tests/external/es/test_crashstorage.py
@@ -13,11 +13,11 @@ import pytest
 from socorro import settings
 from socorro.external.es.crashstorage import (
     fix_boolean,
+    fix_double,
     fix_integer,
     fix_keyword,
     fix_long,
     fix_string,
-    fix_float,
 )
 
 from socorro.external.es.super_search_fields import build_mapping
@@ -368,6 +368,22 @@ class TestESCrashStorage:
             ),
             # Booleans are converted
             ("processed_crash.accessibility", "true", True),
+            # Infinity and NaN floats are removed
+            (
+                "processed_crash.uptime_ts",
+                float("inf"),
+                REMOVED_VALUE,
+            ),
+            (
+                "processed_crash.uptime_ts",
+                float("-inf"),
+                REMOVED_VALUE,
+            ),
+            (
+                "processed_crash.uptime_ts",
+                float("nan"),
+                REMOVED_VALUE,
+            ),
         ],
     )
     def test_indexing_bad_data(self, key, value, expected_value, es_helper):
@@ -548,6 +564,6 @@ def test_fix_long(value, expected):
         (float("nan"), None),
     ],
 )
-def test_fix_float(value, expected):
-    new_value = fix_float(value)
+def test_fix_double(value, expected):
+    new_value = fix_double(value)
     assert new_value == expected


### PR DESCRIPTION
renames `fix_float` to `fix_double` because that's the actual es storage type name, and added cases to `test_indexing_bad_data` to show it's actually working this time

This also applies the fix to legacy_es, since the bug also appeared there and that was impacting manual testing on the processor with the problem crash.