### PR TITLE
OBS-504: Optimize Socorro builds for better FE dev speed 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,10 +27,6 @@ COPY docker/set_up_stackwalker.sh /tmp/set_up_stackwalker.sh
 RUN /tmp/set_up_stackwalker.sh && \
     rm /tmp/set_up_stackwalker.sh
 
-# Install frontend JS deps
-COPY --chown=app:app ./webapp/package*.json /webapp-frontend-deps/
-RUN cd /webapp-frontend-deps/ && npm install
-
 # Install Python dependencies
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir --no-deps -r requirements.txt && \
@@ -44,3 +40,7 @@ ENV PYTHONUNBUFFERED=1 \
     CSSMIN_BINARY=/webapp-frontend-deps/node_modules/.bin/cssmin \
     NPM_ROOT_PATH=/webapp-frontend-deps/ \
     NODE_PATH=/webapp-frontend-deps/node_modules/
+
+# Install frontend JS deps
+COPY --chown=app:app ./webapp/package*.json /webapp-frontend-deps/
+RUN cd /webapp-frontend-deps/ && npm install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,6 @@ COPY docker/set_up_stackwalker.sh /tmp/set_up_stackwalker.sh
 RUN /tmp/set_up_stackwalker.sh && \
     rm /tmp/set_up_stackwalker.sh
 
-# Install frontend JS deps
-COPY --chown=app:app ./webapp/package*.json /webapp-frontend-deps/
-RUN cd /webapp-frontend-deps/ && npm install
-
 COPY --chown=app:app requirements.txt /app/
 RUN pip install --no-cache-dir --no-deps -r requirements.txt && \
     pip check --disable-pip-version-check
@@ -41,6 +37,10 @@ ENV PYTHONUNBUFFERED=1 \
     CSSMIN_BINARY=/webapp-frontend-deps/node_modules/.bin/cssmin \
     NPM_ROOT_PATH=/webapp-frontend-deps/ \
     NODE_PATH=/webapp-frontend-deps/node_modules/
+
+# Install frontend JS deps
+COPY --chown=app:app ./webapp/package*.json /webapp-frontend-deps/
+RUN cd /webapp-frontend-deps/ && npm install
 
 # app should own everything under /app in the container
 USER app

--- a/justfile
+++ b/justfile
@@ -12,8 +12,8 @@ _env:
       cp docker/config/.env.dist .env
     fi
 
-# Build docker images
-build *args: _env
+# Build docker images (excludes devcontainer – unneeded for prod)
+build *args='app test processor crontabber webapp stage_submitter fakesentry oidcprovider collector fakecollector symbolsserver statsd elasticsearch postgresql pubsub memcached gcs-emulator': _env
     docker compose build --progress plain {{args}}
 
 # Set up Postgres, Elasticsearch, local Pub/Sub, and local GCS services.

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ _env:
       cp docker/config/.env.dist .env
     fi
 
-# Build docker images (excludes devcontainer – unneeded for prod)
+# Build docker images
 build *args='app fakesentry oidcprovider elasticsearch postgresql pubsub memcached gcs-emulator': _env
     docker compose build --progress plain {{args}}
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ _env:
     fi
 
 # Build docker images (excludes devcontainer – unneeded for prod)
-build *args='app test processor crontabber webapp stage_submitter fakesentry oidcprovider collector fakecollector symbolsserver statsd elasticsearch postgresql pubsub memcached gcs-emulator': _env
+build *args='app fakesentry oidcprovider elasticsearch postgresql pubsub memcached gcs-emulator': _env
     docker compose build --progress plain {{args}}
 
 # Set up Postgres, Elasticsearch, local Pub/Sub, and local GCS services.


### PR DESCRIPTION
Currently when making changes to the FE build process (package.json, etc), most of the app image rebuilds unnecessarily.  These FE changes also trigger a rebuild of the “devcontainer” image.  Consequently, every change takes ~5 minutes on my machine.

With this PR build times are reduced to under 30 seconds (as tested on my machine)