### PR TITLE
OBS-397: ESBuild watch mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
       "browser": true,
-      "jquery": true
+      "jquery": true,
+      "node": true
   },
   "extends": ["plugin:prettier/recommended", "eslint:recommended"],
   "parserOptions": {

--- a/bin/run_service_webapp.sh
+++ b/bin/run_service_webapp.sh
@@ -29,7 +29,7 @@ if [ "${1:-}" == "--dev" ]; then
     echo "Running webapp in local dev environment."
     echo "Connect with your browser using: http://localhost:8000/ "
     echo "******************************************************************"
-    cd /app/webapp/ && exec ${CMDPREFIX} python manage.py runserver 0.0.0.0:8000
+    cd /app/webapp/ && (node esbuild --watch & exec ${CMDPREFIX} python manage.py runserver 0.0.0.0:8000)
 
 else
     exec ${CMDPREFIX} gunicorn \

--- a/webapp/esbuild.js
+++ b/webapp/esbuild.js
@@ -74,13 +74,12 @@ const options = {
   sourcemap: true,
   splitting: false,
   treeShaking: true,
-}
+};
 
-
-if(process.argv.includes("--watch")){
-  const ctx = await esbuild.context(options)
-  await ctx.watch()
-  console.info('ESBuild watch-mode enabled')
-}else{
-  esbuild.build(options)
+if (process.argv.includes('--watch')) {
+  const ctx = await esbuild.context(options);
+  await ctx.watch();
+  console.info('ESBuild watch-mode enabled');
+} else {
+  esbuild.build(options);
 }

--- a/webapp/esbuild.js
+++ b/webapp/esbuild.js
@@ -55,7 +55,7 @@ const entryPoints = [
   },
 ];
 
-await esbuild.build({
+const options = {
   bundle: true,
   entryPoints,
   format: 'esm',
@@ -74,4 +74,13 @@ await esbuild.build({
   sourcemap: true,
   splitting: false,
   treeShaking: true,
-});
+}
+
+
+if(process.argv.includes("--watch")){
+  const ctx = await esbuild.context(options)
+  await ctx.watch()
+  console.info('ESBuild watch-mode enabled')
+}else{
+  esbuild.build(options)
+}


### PR DESCRIPTION
This PR is based off https://github.com/mozilla-services/socorro/pull/6864 which should be merged first.

Adds ESBuild's "watch" mode to dev environment, so that changes to CSS/JS update automatically without requiring rebuild and container/server restart.

To test:
1. run `just build`.  Notice the ESBuild summary showing built files and elapsed time (e.g. ⚡ Done in 211ms)
2. run `just setup`
3. run `just run`.  The Django development should start alongside ESBuild's "watch" mode.  Look for console logs "ESBuild watch-mode enabled" and "[watch] build finished, watching for changes..."
4. make a change to a CSS file, for example: in webapp/crashstats/crashstats/static/crashstats/css/crashstats-base.css add `* {background: chartreuse;}` after the @import lines.
5. Look for change confirmation in console logs, "[watch] build finished".  If you reload crashstats homepage in-browser, it should hurt your eyes.