### PR TITLE
obs-512: fix webapp/static and webapp/node_modules directory ownership

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,9 @@ _env:
 
 # Build docker images
 build *args='app fakesentry oidcprovider elasticsearch postgresql pubsub memcached gcs-emulator': _env
+    # Create these two directories using the current user so they don't end up
+    # created by Docker with the wrong ownership; ignore errors
+    -mkdir webapp/static/ webapp/node_modules/
     docker compose build --progress plain {{args}}
 
 # Set up Postgres, Elasticsearch, local Pub/Sub, and local GCS services.
@@ -56,7 +59,7 @@ clean:
     -rm -rf .cache
     @echo "Skipping deletion of symbols/ in case you have data in there."
 
-# Generate Sphinx HTML documetation.
+# Generate Sphinx HTML documentation.
 docs: _env
     docker compose run --rm app shell make -C docs/ clean
     docker compose run --rm app shell make -C docs/ html


### PR DESCRIPTION
This ensures these two directories are owned by the host user rather than root during image building and container running.

To test:

1. delete `webapp/static/` and `webapp/node_modules/` if they exist
2. run `just clean`
3. run `just build`
4. ensure `webapp/static/` and `webapp/node_modules/` are owned by the host user and not root (this is only a problem on Linux)
5. run `just build` to make sure it builds even if the directories exist