### PR TITLE
obs-530: fix readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,9 @@
 ---
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-20.04
   tools:


### PR DESCRIPTION
This adds a configuration parameter that they now require that points to the configuration.