### PR TITLE
OBS-556: Update Moment to 2.29.4

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -17,7 +17,7 @@
         "jquery.json-viewer": "1.5.0",
         "jssha": "3.1.2",
         "metrics-graphics": "2.15.6",
-        "moment": "2.29.2",
+        "moment": "2.29.4",
         "photon-colors": "3.3.2",
         "prop-types": "^15.6.2",
         "qs": "6.9.4",
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -3892,9 +3892,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,7 +28,7 @@
     "jquery.json-viewer": "1.5.0",
     "jssha": "3.1.2",
     "metrics-graphics": "2.15.6",
-    "moment": "2.29.2",
+    "moment": "2.29.4",
     "photon-colors": "3.3.2",
     "prop-types": "^15.6.2",
     "qs": "6.9.4",


### PR DESCRIPTION
The version of Moment we're using has a [vulnerability](https://github.com/mozilla-services/socorro/security/dependabot/37).  This PR updates Moment to the minimum patched version, 2.29.4.

According to the [changelog](https://github.com/moment/moment/blob/000ac1800e620f770f4eb31b5ae908f6167b0ab2/CHANGELOG.md), not too much has changed between versions other than the patch for the vulnerability, which itself looks low-risk.

I also spot-checked the Signature Report view that likely uses Moment (given its inclusion of the Moment package in the HTML).  No obvious breakage occurs with anything date-related.

To test:  
- spot check date-related aspects of the webapp, including Signature Report