### PR TITLE
Ignore generated crashdata files/folders from check-in

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ __pycache__
 .cache
 node_modules
 symbols/
+crashdata
+crashids.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ symbols/
 
 # docs things
 docs/_build/
+
+# exclude generated crashdata
+crashids.txt
+crashdata


### PR DESCRIPTION
Upon populating crash data, the files and data appear locally and are at risk of being checked in.  Especially since the data might be sensitive, we should explicitly ignore these files.