### PR TITLE
OBS-557: Update QS to 6.9.7

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,7 @@
         "moment": "2.29.4",
         "photon-colors": "3.3.2",
         "prop-types": "^15.6.2",
-        "qs": "6.9.4",
+        "qs": "^6.9.7",
         "Select2": "github:select2/select2#3.5.4",
         "tablesorter": "2.31.3"
       },
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
       "engines": {
         "node": ">=0.6"
       },
@@ -4024,9 +4024,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "moment": "2.29.4",
     "photon-colors": "3.3.2",
     "prop-types": "^15.6.2",
-    "qs": "6.9.4",
+    "qs": "6.9.7",
     "Select2": "github:select2/select2#3.5.4",
     "tablesorter": "2.31.3"
   },


### PR DESCRIPTION
The version of QS we're using (6.9.4) has a [high vulnerability](https://github.com/mozilla-services/socorro/security/dependabot/42). This PR updates QS to the minimum patched version, 6.9.7.

Reviewing the [changelog](https://github.com/ljharb/qs/blob/v6.9.7/CHANGELOG.md) suggests this update is low-risk especially since it's a patch version.  This patched version is the last release before major version change.

I searched the code to find where QS is used, apparently in testdrive.js which involves the API.  I spot-checked the API view and functionality. No obvious breakage occurs with anything date-related.

To test:
- spot check API-related aspects of the webapp.

To do:
- use of the QS package appears to be minimal and likely can be rewritten with native code to remove the package altogether.  I [updated a ticket](https://mozilla-hub.atlassian.net/browse/OBS-402) to document this.