### PR TITLE
bug-1954596: update stackwalker to v0.25.0

### DIFF
--- a/docker/set_up_stackwalker.sh
+++ b/docker/set_up_stackwalker.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # This should be a url to a .tar.gz file from the release page:
 # https://github.com/rust-minidump/rust-minidump/releases
-URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20250207.0/socorro-stackwalker.2024-10-10.v0.22.2.tar.gz"
+URL="https://github.com/mozilla-services/socorro-stackwalk/releases/download/v20250321.0/socorro-stackwalker.2025-03-19.v0.25.0.tar.gz"
 
 TARFILE="stackwalker.tar.gz"
 TARGETDIR="/stackwalk-rust"


### PR DESCRIPTION
This updates the stackwalker to v0.25.0. One thing this picks up is a new field in the stackwalker output: soft_errors.

However, the value for that field is documented as "object" and we don't know what that is so we can't put it in the schema. If they want that field to be public or if they want us to do something with it in Crash Stats, they'll have to flesh out the structure of the object.

https://github.com/rust-minidump/rust-minidump/blob/4bc0e1bb3a19f22d5b7c4057112197ac5f6ea2d9/minidump-processor/json-schema.md#L692-L693

To test:

1. build socorro
2. process some crash reports and df1ce584-5ad2-4b35-9c0f-a00ed0250321
3. verify that the stackwalker doesn't crash
4. log into `http://localhost:8000` with an account with protected data access
5. view df1ce584-5ad2-4b35-9c0f-a00ed0250321 and look at the Raw Data and Minidumps tab and search for "soft_errors"--it should be an empty list:
   ```
   soft_errors: [],
   ```