### PR TITLE
OBS-572: update jquery-ui

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -13,7 +13,7 @@
         "d3": "5.1.0",
         "filesize": "6.1.0",
         "jquery": "3.5.1",
-        "jquery-ui": "1.13.0",
+        "jquery-ui": "1.13.2",
         "jquery.json-viewer": "1.5.0",
         "jssha": "3.1.2",
         "metrics-graphics": "2.15.6",
@@ -1592,9 +1592,10 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "node_modules/jquery-ui": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.0.tgz",
-      "integrity": "sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.2.tgz",
+      "integrity": "sha512-wBZPnqWs5GaYJmo1Jj0k/mrSkzdQzKDwhXNtHKcBdAcKVxMM3KNYFq+iJ2i1rwiG53Z8M4mTn3Qxrm17uH1D4Q==",
+      "license": "MIT",
       "dependencies": {
         "jquery": ">=1.8.0 <4.0.0"
       }
@@ -3507,9 +3508,9 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-ui": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.0.tgz",
-      "integrity": "sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.2.tgz",
+      "integrity": "sha512-wBZPnqWs5GaYJmo1Jj0k/mrSkzdQzKDwhXNtHKcBdAcKVxMM3KNYFq+iJ2i1rwiG53Z8M4mTn3Qxrm17uH1D4Q==",
       "requires": {
         "jquery": ">=1.8.0 <4.0.0"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,7 +33,7 @@
     "d3": "5.1.0",
     "filesize": "6.1.0",
     "jquery": "3.5.1",
-    "jquery-ui": "1.13.0",
+    "jquery-ui": "1.13.2",
     "jquery.json-viewer": "1.5.0",
     "jssha": "3.1.2",
     "metrics-graphics": "2.15.6",


### PR DESCRIPTION
Our version of jquery-ui (1.13.0) has a [moderate vulnerability](https://github.com/mozilla-services/socorro/security/dependabot/38). This PR updates jquery-ui to the minimum patched version, 1.13.2.

Reviewing the [changelog](https://jqueryui.com/changelog/1.13.2/) suggests this update is low-risk especially since it's a patch version.

I searched the code to find where jquery-ui is used, apparently in supersearch. I spot-checked the supersearch UI and date picker – no obvious breakage occurs.

To test:

    spot check jquery-ui aspects of the webapp: search, report, and signature report