### PR TITLE
CRINGE-58: Reduce Dependabot cadence to monthly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
@@ -12,7 +12,7 @@ updates:
       - "/docker"
       - "/docker/images/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: python
@@ -22,6 +22,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 10


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/CRINGE-58