### PR TITLE
CRINGE-56: Use X-Forwarded-Host header to infer hostname for absolute URLs.

### DIFF
--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -83,6 +83,9 @@ STATIC_URL = "/static/"
 
 ALLOWED_HOSTS = _config("ALLOWED_HOSTS", default="", parser=ListOf(str))
 
+# When behind a reverse proxy that sets the Host header, use the original Host header
+# for absolute URLs. This is relevant for the OIDC callback URL.
+USE_X_FORWARDED_HOST = True
 
 # Defines the views served for root URLs.
 ROOT_URLCONF = "crashstats.urls"


### PR DESCRIPTION
This makes sure the OIDC callback URL is correct when behind Fastly.

https://mozilla-hub.atlassian.net/browse/CRINGE-56