### PR TITLE
Bug 1978426 - Add std::unique_ptr to the irrelevant signature list.

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -264,6 +264,7 @@ std::io::stdio::_eprint
 std::panicking::
 std::sys_common::backtrace::__rust_end_short_backtrace<T>
 std::terminate
+std::unique_ptr
 stdext::_?(h|H)ash
 __str
 system@framework@.*\.art

--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -259,7 +259,6 @@ zzz_AsmCodeRange_
 .*DebugAbort
 mozilla::ipc::MessageChannel::~MessageChannel
 mozilla::MakeUnique<.*>
-mozilla::UniquePtr<T>::reset
 
 # Always continue for .dll files
 .*\.dll


### PR DESCRIPTION
Also, remove a UniquePtr thing from the prefix list, as UniquePtr is in the irrelevant signature list already.