### PR TITLE
Bug 1978948: Have signature generation Ignore wgpu_hal error utils

### DIFF
--- a/socorro/signature/siglists/irrelevant_signature_re.txt
+++ b/socorro/signature/siglists/irrelevant_signature_re.txt
@@ -270,6 +270,7 @@ __str
 system@framework@.*\.art
 _Unwind_Resume
 {virtual override thunk}
+wgpu_hal::auxil::dxgi::result
 wil::details::DebugBreak
 
 # These frames have platform variants and bucket poorly so we nix them


### PR DESCRIPTION
Adjust signature pattern lists to ignore frames in the Rust modules `wgpu_hal::auxil::dxgi::result` and `windows_result::error::Error`.

These are "part of panic/error/crash handling code that kicks off after the cause of the crash to handle the crash", which the instructions linked below say belong on the "ignore" list.

https://socorro.readthedocs.io/en/latest/signaturegeneration.html#philosophy-on-signature-generation