### PR TITLE
bug-1943891: support Marionette and RemoteAgent crash annotations

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -2,11 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from contextlib import suppress
 import logging
+from contextlib import suppress
 
 from socorro.lib.libsocorrodataschema import get_schema
-
 
 logger = logging.getLogger(__name__)
 
@@ -1037,6 +1036,9 @@ FIELDS = {
         "query_type": "integer",
         "storage_mapping": {"type": "integer"},
     },
+    "marionette": boolean_field(
+        name="marionette",
+    ),
     "memory_explicit": {
         "data_validation_type": "int",
         "form_field_choices": [],
@@ -1326,6 +1328,9 @@ FIELDS = {
         "query_type": "enum",
         "storage_mapping": {"type": "keyword"},
     },
+    "remote_agent": boolean_field(
+        name="remote_agent",
+    ),
     "remote_type": {
         "data_validation_type": "enum",
         "form_field_choices": [],

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2777,6 +2777,13 @@ properties:
       `major_version`, this is 0.
     type: integer
     permissions: ["public"]
+  marionette:
+    description: >
+      Set to `true` when Marionette (WebDriver Classic) is enabled.
+    type: boolean
+    default: false
+    permissions: ["public"]
+    source_annotation: Marionette
   mdsw_return_code:
     description: >
       Exit code of the stackwalker process when processing
@@ -3053,6 +3060,13 @@ properties:
     type: string
     permissions: ["public"]
     source_annotation: ReleaseChannel
+  remote_agent:
+    description: >
+      Set to `true` when the Remote Agent (WebDriver BiDi) is enabled.
+    type: boolean
+    default: false
+    permissions: ["public"]
+    source_annotation: RemoteAgent
   remote_type:
     description: >
       Type of the content process, can be set to `web`, `file`, or `extension`.

--- a/socorro/schemas/raw_crash.schema.yaml
+++ b/socorro/schemas/raw_crash.schema.yaml
@@ -726,6 +726,14 @@ properties:
     type: string
     permissions: ["public"]
 
+  Marionette:
+    data_reviews:
+      - https://phabricator.services.mozilla.com/D233482#8114805
+    description: >
+      Set to 1 when Marionette (WebDriver Classic) is enabled.
+    type: string
+    permissions: ["public"]
+  
   ModuleSignatureInfo:
     data_reviews:
       - unknown
@@ -908,6 +916,14 @@ properties:
       - "esr"
     permissions: ["public"]
 
+  RemoteAgent:
+    data_reviews:
+      - https://phabricator.services.mozilla.com/D233482#8114805
+    description: >
+      Set to 1 when the Remote Agent (WebDriver BiDi) is enabled.
+    type: string
+    permissions: ["public"]
+  
   RemoteType:
     data_reviews:
       - unknown

--- a/socorro/tests/schemas/test_socorro_data_schemas.py
+++ b/socorro/tests/schemas/test_socorro_data_schemas.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from click.testing import CliRunner
 import jsonschema
 import pytest
+from click.testing import CliRunner
 
 from socorro.lib.libmarkdown import get_markdown
 from socorro.lib.libsocorrodataschema import (
-    get_schema,
     FlattenKeys,
+    get_schema,
     split_path,
     transform_schema,
 )
@@ -104,6 +104,7 @@ PUBLIC_RAW_CRASH_FIELDS = {
     "MacMemoryPressureNormalTime",
     "MacMemoryPressureSysctl",
     "MacMemoryPressureWarningTime",
+    "Marionette",
     "Notes",
     "OOMAllocationSize",
     "PluginFilename",
@@ -114,6 +115,7 @@ PUBLIC_RAW_CRASH_FIELDS = {
     "ProductName",
     "QuotaManagerShutdownTimeout",
     "ReleaseChannel",
+    "RemoteAgent",
     "SafeMode",
     "SecondsSinceLastCrash",
     "ShutdownProgress",
@@ -509,6 +511,7 @@ PUBLIC_PROCESSED_CRASH_FIELDS = {
     "mac_memory_pressure_sysctl",
     "mac_memory_pressure_warning_time",
     "major_version",
+    "marionette",
     "mdsw_status_string",
     "memory_measures",
     "memory_measures.explicit",
@@ -548,6 +551,7 @@ PUBLIC_PROCESSED_CRASH_FIELDS = {
     "quota_manager_shutdown_timeout",
     "reason",
     "release_channel",
+    "remote_agent",
     "report_type",
     "safe_mode",
     "shutdown_progress",


### PR DESCRIPTION
Based off of #6429 

To do:

- [x] Update data review link in `socorro/schemas/raw_crash.schema.yaml` [once I have one](https://bugzilla.mozilla.org/show_bug.cgi?id=1943891#c18).
- [x] Determine if a SuperSearch results page issue[1] is a Crash Stats bug or not.

Because:
* Firefox devs want to search processed crash reports based on the Marionette and RemoteAgent annotations.

This PR:
* Adds `Marionette` and `RemoteAgent` fields to the raw crash schema.
* Adds `marionette` and `remote_agent` fields to the processed crash schema.
* Ensures the values for each field are copied and normalized (`0` -> `false`, 1 -> `true`, field omitted in raw crash -> `false`).
* Sets the fields as public.
* Adds the fields to SuperSearch, so they will be indexed.

I have verified that this works locally[1] with the following STR for crash IDs `8b0d4f98-5851-41a7-a67a-e08690250902` (has `Marionette: 1` and `RemoteAgent: 1`) and `ab5a27b6-47c3-40ed-aa07-bce510250905` (has neither field):
1. Open both crash reports in separate tabs in prod Crash Stats: [report with both fields](https://crash-stats.mozilla.org/report/index/8b0d4f98-5851-41a7-a67a-e08690250902#tab-annotations) and [report without both fields](https://crash-stats.mozilla.org/report/index/ab5a27b6-47c3-40ed-aa07-bce510250905#tab-annotations).
2. With Socorro running locally, [reprocess](https://socorro.readthedocs.io/en/latest/dev.html#processing-crashes) the crashes.
3. Open both crash reports in local Crash Stats: [report with both fields](http://localhost:8000/report/index/8b0d4f98-5851-41a7-a67a-e08690250902) and [report without both fields](http://localhost:8000/report/index/ab5a27b6-47c3-40ed-aa07-bce510250905).
4. Expected in local:
a. The report with both fields now has `Marionette` and `RemoteAgent` annotations listed under the "Public data" section in the Crash Annotations tab.
b. Both reports show up in SuperSearches filtering or faceting by "marionette" and/or "remote agent".

---

[1]: The only weird thing is that the report with neither field in it is listed as blank in the search results when the fields are included as columns. If the processed crash has the correct `False` value for both fields, then it may be a bug with the Crash Stats webapp. In that case, I'd file a follow up ticket to fix that.

<img width="1201" height="440" alt="Screenshot 2025-09-05 at 3 12 46 PM" src="https://github.com/user-attachments/assets/92e20b14-3c9a-4544-b47f-4df70770e06b" />

Update 2025-09-08: I was able to determine that the fields are correctly `false` in Elasticsearch, so this is an unrelated bug with the Crash Stats website and not with my patch. I filed bug-1987459 to fix that issue.

