### PR TITLE
Bug 1959806 - Use Firefox for Android as the product

### DIFF
--- a/product_details/Fenix.json
+++ b/product_details/Fenix.json
@@ -14,8 +14,8 @@
   "in_buildhub": false,
   "bug_links": [
     [
-      "Fenix",
-      "https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix&component=General&bug_type=%(bug_type)s&keywords=crash&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
+      "Firefox for Android",
+      "https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox for Android&component=General&bug_type=%(bug_type)s&keywords=crash&op_sys=Android&rep_platform=%(rep_platform)s&cf_crash_signature=%(signature)s&short_desc=%(title)s&comment=%(description)s&format=__default__"
     ],
     [
       "GeckoView",


### PR DESCRIPTION
This product has been renamed from "Fenix" to "Firefox for Android".