### PR TITLE
Bug 1996652 - Add more arrayish things to the prefix list.

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -43,6 +43,7 @@ CxxThrowException
 __delayLoadHelper2
 dlmalloc
 dvm
+ElementAt
 EtwEventEnabled
 extent_
 enum\$<T>::unwrap
@@ -102,10 +103,14 @@ memset
 MessageLoop::PostTask_Helper
 MessageLoop::PostTask
 moz_malloc_size_of
+mozilla::Array<T>
+mozilla::BitSet<T>
 mozilla::CheckedInt
 mozilla::CrashOnDanglingCheckedUnsafePtr::NotifyCheckFailure
 mozilla::detail::InvalidArrayIndex_CRASH
+mozilla::detail::nsTStringLengthStorage<T>
 mozilla::detail::nsTStringRepr<T>::
+mozilla::EnumeratedArray<T>
 mozilla::Variant<T>::
 mozilla::dom::AutoJSAPI::Init
 mozilla::dom::Promise::


### PR DESCRIPTION
These are all showing up after InvalidArrayIndex_CRASH in signatures, so let's peel back another frame to see the call sites.