### PR TITLE
bug-1685143: automate revoke access

### DIFF
--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -92,14 +92,11 @@ class Command(BaseCommand):
             "--dry-run", action="store_true", help="Whether or not to do a dry run."
         )
 
-    def is_policy_exception(self, user):
+    def is_employee_or_exception(self, user):
         # If this user has a policy exception, then they're allowed
         if PolicyException.objects.filter(user=user).exists():
             return True
 
-        return False
-
-    def has_valid_mozilla_email(self, user):
         if user.email.endswith(VALID_EMAIL_DOMAINS):
             return True
 
@@ -128,15 +125,13 @@ class Command(BaseCommand):
                 self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
             # User may be blocked as a security mitigation. Eg: too many login attempts
-            if is_blocked and self.has_valid_mozilla_email(user):
+            if is_blocked:
                 users_to_remove.append((user, "user has most likely lost employment"))
 
             elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
-            elif not self.is_policy_exception(
-                user
-            ) and not self.has_valid_mozilla_email(user):
+            elif not self.is_employee_or_exception(user):
                 users_to_remove.append((user, "not employee or exception"))
 
             elif user.last_login and user.last_login < cutoff:

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -13,9 +13,11 @@ from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+from django.conf import settings
 
 from crashstats.authentication.models import PolicyException
-
+from socorro.lib.librequests import session_with_retries
+from urllib.parse import urlparse
 
 VALID_EMAIL_DOMAINS = ("mozilla.com", "mozilla.org")
 
@@ -37,6 +39,47 @@ def delta_days(since_datetime):
     """Return the delta in days between now and since_datetime"""
     return (timezone.now() - since_datetime).days
 
+def get_access_token(client_id, client_secret, domain, session):
+    url = f"https://{domain}/oauth/token"
+    audience = f"https://{domain}/api/v2/"
+    payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "client_credentials",
+        "audience": audience,
+    }
+    response = session.post(url, json=payload)
+    if response.status_code != 200:
+        raise RuntimeError(response.status_code)
+    return response.json()["access_token"]
+
+
+def find_users(client_id, client_secret, domain, email, session):
+    access_token = get_access_token(client_id, client_secret, domain, session)
+
+    url = f"https://{domain}/api/v2/users"
+    query = {"q": f'email:"{email}"'}
+    response = session.get(
+        url, params=query, headers={"Authorization": f"Bearer {access_token}"}
+    )
+    if response.status_code != 200:
+        raise RuntimeError(response.status_code)
+
+    return response.json()
+
+def is_blocked_in_auth0(email):
+    session = session_with_retries(total_retries=5)
+    users = find_users(
+        settings.OIDC_RP_CLIENT_ID,
+        settings.OIDC_RP_CLIENT_SECRET,
+        urlparse(settings.OIDC_OP_USER_ENDPOINT).netloc,
+        email,
+        session,
+    )
+    for user in users:
+        if user.get("blocked"):
+            return True
+    return False
 
 class Command(BaseCommand):
     help = "Audits Django groups and removes inactive users."
@@ -72,7 +115,16 @@ class Command(BaseCommand):
         # Go through the users and mark the ones for removal
         users_to_remove = []
         for user in hackers_group.user_set.all():
-            if not user.is_active:
+            is_blocked = False
+            try:
+                if self.is_employee_or_exception(user):
+                    is_blocked = is_blocked_in_auth0(user.email)
+            except RuntimeError as e:
+                self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
+
+            if is_blocked:
+                users_to_remove.append((user, "user has lost employment"))
+            elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
             elif not self.is_employee_or_exception(user):
@@ -100,7 +152,13 @@ class Command(BaseCommand):
             self.stdout.write("Removing: %s (%s)" % (user.email, reason))
             if dryrun is False:
                 hackers_group.user_set.remove(user)
-
+                change_message = f"Removed {user.email} from hackers--{reason}."
+                
+                if reason == "user has lost employment":
+                    user.token_set.all().delete()
+                    self.stdout.write("Removing %s's tokens: (%s)" % (user.email, reason))
+                    change_message = f"Removed {user.email} from hackers and revoked API tokens--{reason}."
+                
                 # Toss a LogEntry in so we can keep track of when people get
                 # de-granted and what did it
                 LogEntry.objects.log_action(
@@ -109,8 +167,7 @@ class Command(BaseCommand):
                     object_id=user.pk,
                     object_repr=user.email,
                     action_flag=CHANGE,
-                    change_message="Removed %s from hackers--%s."
-                    % (user.email, reason),
+                    change_message=change_message,
                 )
 
         self.stdout.write("Total removed: %s" % len(users_to_remove))

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -92,11 +92,14 @@ class Command(BaseCommand):
             "--dry-run", action="store_true", help="Whether or not to do a dry run."
         )
 
-    def is_employee_or_exception(self, user):
+    def is_policy_exception(self, user):
         # If this user has a policy exception, then they're allowed
         if PolicyException.objects.filter(user=user).exists():
             return True
 
+        return False
+
+    def has_valid_mozilla_email(self, user):
         if user.email.endswith(VALID_EMAIL_DOMAINS):
             return True
 
@@ -124,13 +127,16 @@ class Command(BaseCommand):
             except RuntimeError as e:
                 self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
-            if is_blocked:
-                users_to_remove.append((user, "user has lost employment"))
+            # User may be blocked as a security mitigation. Eg: too many login attempts
+            if is_blocked and self.has_valid_mozilla_email(user):
+                users_to_remove.append((user, "user has most likely lost employment"))
 
             elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
-            elif not self.is_employee_or_exception(user):
+            elif not self.is_policy_exception(
+                user
+            ) and not self.has_valid_mozilla_email(user):
                 users_to_remove.append((user, "not employee or exception"))
 
             elif user.last_login and user.last_login < cutoff:

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -39,6 +39,7 @@ def delta_days(since_datetime):
     """Return the delta in days between now and since_datetime"""
     return (timezone.now() - since_datetime).days
 
+
 def get_access_token(client_id, client_secret, domain, session):
     url = f"https://{domain}/oauth/token"
     audience = f"https://{domain}/api/v2/"
@@ -67,6 +68,7 @@ def find_users(client_id, client_secret, domain, email, session):
 
     return response.json()
 
+
 def is_blocked_in_auth0(email):
     session = session_with_retries(total_retries=5)
     users = find_users(
@@ -80,6 +82,7 @@ def is_blocked_in_auth0(email):
         if user.get("blocked"):
             return True
     return False
+
 
 class Command(BaseCommand):
     help = "Audits Django groups and removes inactive users."
@@ -117,13 +120,13 @@ class Command(BaseCommand):
         for user in hackers_group.user_set.all():
             is_blocked = False
             try:
-                if self.is_employee_or_exception(user):
-                    is_blocked = is_blocked_in_auth0(user.email)
+                is_blocked = is_blocked_in_auth0(user.email)
             except RuntimeError as e:
                 self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
             if is_blocked:
                 users_to_remove.append((user, "user has lost employment"))
+
             elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
@@ -152,13 +155,7 @@ class Command(BaseCommand):
             self.stdout.write("Removing: %s (%s)" % (user.email, reason))
             if dryrun is False:
                 hackers_group.user_set.remove(user)
-                change_message = f"Removed {user.email} from hackers--{reason}."
-                
-                if reason == "user has lost employment":
-                    user.token_set.all().delete()
-                    self.stdout.write("Removing %s's tokens: (%s)" % (user.email, reason))
-                    change_message = f"Removed {user.email} from hackers and revoked API tokens--{reason}."
-                
+
                 # Toss a LogEntry in so we can keep track of when people get
                 # de-granted and what did it
                 LogEntry.objects.log_action(
@@ -167,7 +164,8 @@ class Command(BaseCommand):
                     object_id=user.pk,
                     object_repr=user.email,
                     action_flag=CHANGE,
-                    change_message=change_message,
+                    change_message="Removed %s from hackers--%s."
+                    % (user.email, reason),
                 )
 
         self.stdout.write("Total removed: %s" % len(users_to_remove))

--- a/webapp/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp/crashstats/authentication/tests/test_auditgroups.py
@@ -21,7 +21,7 @@ class TestAuditGroupsCommand:
         call_command("auditgroups", stdout=buffer)
         assert "Removing:" not in buffer.getvalue()
 
-    def test_inactive_user_is_removed(self, db):
+    def test_inactive_user_is_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
@@ -29,6 +29,10 @@ class TestAuditGroupsCommand:
         bob.is_active = False
         bob.groups.add(hackers_group)
         bob.save()
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         assert hackers_group.user_set.count() == 1
 
@@ -39,13 +43,18 @@ class TestAuditGroupsCommand:
 
         assert hackers_group.user_set.count() == 0
 
-    def test_old_user_is_removed(self, db):
+    def test_old_user_is_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
         bob.last_login = timezone.now() - datetime.timedelta(days=366)
         bob.groups.add(hackers_group)
         bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         buffer = StringIO()
         call_command("auditgroups", dry_run=False, stdout=buffer)
@@ -54,13 +63,18 @@ class TestAuditGroupsCommand:
             "Removing: bob@mozilla.com (inactive 366d, no tokens)" in buffer.getvalue()
         )
 
-    def test_user_with_invalid_email_removed(self, db):
+    def test_user_with_invalid_email_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@example.com")
         bob.last_login = timezone.now()
         bob.groups.add(hackers_group)
         bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         buffer = StringIO()
         call_command("auditgroups", dry_run=False, stdout=buffer)
@@ -69,13 +83,18 @@ class TestAuditGroupsCommand:
             "Removing: bob@example.com (not employee or exception)" in buffer.getvalue()
         )
 
-    def test_user_with_policy_exception_is_not_removed(self, db):
+    def test_user_with_policy_exception_is_not_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@example.com")
         bob.last_login = timezone.now()
         bob.groups.add(hackers_group)
         bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         policyexception = PolicyException.objects.create(user=bob, comment="friend")
         policyexception.save()
@@ -85,13 +104,18 @@ class TestAuditGroupsCommand:
         assert [u.email for u in hackers_group.user_set.all()] == ["bob@example.com"]
         assert "Removing:" not in buffer.getvalue()
 
-    def test_old_user_with_active_api_tokens_is_not_removed(self, db):
+    def test_old_user_with_active_api_tokens_is_not_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
         bob.last_login = timezone.now() - datetime.timedelta(days=366)
         bob.groups.add(hackers_group)
         bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         token = Token.objects.create(user=bob)
         token.save()
@@ -104,7 +128,7 @@ class TestAuditGroupsCommand:
             in buffer.getvalue()
         )
 
-    def test_active_user_is_not_removed(self, db):
+    def test_active_user_is_not_removed(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
@@ -112,18 +136,70 @@ class TestAuditGroupsCommand:
         bob.groups.add(hackers_group)
         bob.save()
 
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
+
         buffer = StringIO()
         call_command("auditgroups", dry_run=False, stdout=buffer)
         assert [u.email for u in hackers_group.user_set.all()] == ["bob@mozilla.com"]
         assert "Removing:" not in buffer.getvalue()
 
-    def test_dry_run_true(self, db):
+    def test_user_blocked_in_auth0_is_removed(self, db, monkeypatch):
+        hackers_group = Group.objects.get(name="Hackers")
+
+        bob = User.objects.create(username="bob", email="bob@mozilla.com")
+        bob.last_login = timezone.now()
+        bob.groups.add(hackers_group)
+        bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: True,
+        )
+
+        assert hackers_group.user_set.count() == 1
+
+        buffer = StringIO()
+        call_command("auditgroups", dry_run=False, stdout=buffer)
+        assert hackers_group.user_set.count() == 0
+        assert (
+            "Removing: bob@mozilla.com (user has lost employment)" in buffer.getvalue()
+        )
+
+    def test_user_not_blocked_in_auth0_is_not_removed(self, db, monkeypatch):
+        hackers_group = Group.objects.get(name="Hackers")
+
+        bob = User.objects.create(username="bob", email="bob@mozilla.com")
+        bob.last_login = timezone.now()
+        bob.groups.add(hackers_group)
+        bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
+
+        assert hackers_group.user_set.count() == 1
+
+        buffer = StringIO()
+        call_command("auditgroups", dry_run=False, stdout=buffer)
+        assert hackers_group.user_set.count() == 1
+        assert "Removing:" not in buffer.getvalue()
+
+    def test_dry_run_true(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 
         bob = User.objects.create(username="bob", email="bob@mozilla.com")
         bob.last_login = timezone.now() - datetime.timedelta(days=366)
         bob.groups.add(hackers_group)
         bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: False,
+        )
 
         assert hackers_group.user_set.count() == 1
 

--- a/webapp/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp/crashstats/authentication/tests/test_auditgroups.py
@@ -165,7 +165,8 @@ class TestAuditGroupsCommand:
         call_command("auditgroups", dry_run=False, stdout=buffer)
         assert hackers_group.user_set.count() == 0
         assert (
-            "Removing: bob@mozilla.com (user has lost employment)" in buffer.getvalue()
+            "Removing: bob@mozilla.com (user has most likely lost employment)"
+            in buffer.getvalue()
         )
 
     def test_user_not_blocked_in_auth0_is_not_removed(self, db, monkeypatch):
@@ -187,6 +188,28 @@ class TestAuditGroupsCommand:
         call_command("auditgroups", dry_run=False, stdout=buffer)
         assert hackers_group.user_set.count() == 1
         assert "Removing:" not in buffer.getvalue()
+
+    def test_blocked_user_with_invalid_email_and_no_exception(self, db, monkeypatch):
+        hackers_group = Group.objects.get(name="Hackers")
+
+        bob = User.objects.create(username="bob", email="bob@gmail.com")
+        bob.last_login = timezone.now()
+        bob.groups.add(hackers_group)
+        bob.save()
+
+        monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
+            lambda email: True,
+        )
+
+        assert hackers_group.user_set.count() == 1
+
+        buffer = StringIO()
+        call_command("auditgroups", dry_run=False, stdout=buffer)
+        assert hackers_group.user_set.count() == 0
+        assert (
+            "Removing: bob@gmail.com (not employee or exception)" in buffer.getvalue()
+        )
 
     def test_dry_run_true(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")

--- a/webapp/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp/crashstats/authentication/tests/test_auditgroups.py
@@ -189,28 +189,6 @@ class TestAuditGroupsCommand:
         assert hackers_group.user_set.count() == 1
         assert "Removing:" not in buffer.getvalue()
 
-    def test_blocked_user_with_invalid_email_and_no_exception(self, db, monkeypatch):
-        hackers_group = Group.objects.get(name="Hackers")
-
-        bob = User.objects.create(username="bob", email="bob@gmail.com")
-        bob.last_login = timezone.now()
-        bob.groups.add(hackers_group)
-        bob.save()
-
-        monkeypatch.setattr(
-            "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
-            lambda email: True,
-        )
-
-        assert hackers_group.user_set.count() == 1
-
-        buffer = StringIO()
-        call_command("auditgroups", dry_run=False, stdout=buffer)
-        assert hackers_group.user_set.count() == 0
-        assert (
-            "Removing: bob@gmail.com (not employee or exception)" in buffer.getvalue()
-        )
-
     def test_dry_run_true(self, db, monkeypatch):
         hackers_group = Group.objects.get(name="Hackers")
 

--- a/webapp/crashstats/cron/__init__.py
+++ b/webapp/crashstats/cron/__init__.py
@@ -24,7 +24,7 @@ JOBS = [
     {
         # Audit hackers group every week
         "cmd": "auditgroups",
-        "frequency": "7d",
+        "frequency": "1d",
         "time": "05:00",
     },
     {


### PR DESCRIPTION
Because:
- We want to automatically off board users that have lost employment by removing them from the hackers group as well as removing their tokens. [bug-1685143](https://bugzilla.mozilla.org/show_bug.cgi?id=1685143)

This PR:
- Added a function `is_blocked_in_auth0` to send a query to Auth0 and check if a user is blocked. A Mozilla user is blocked if they have lost employment or have too many login attempts
- The `auditgroups` cronjob checks if a Mozilla user is blocked in auth0. If so, we remove them from the `hackers_group`