### PR TITLE
bug-2031036: Failure to remove arguments in signature with "(anonymous namespace)"

### DIFF
--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -175,20 +175,23 @@ class CSignatureTool:
             exceptions=("name omitted", "IPC::ParamTraits", " in "),
         )
 
+        def cpp_argument_exceptions(exceptions, before_token, after_token, token):
+            exceptions = ["(anonymous namespace)", "operator"]
+            for s in exceptions:
+                if before_token.endswith(s):
+                    return True
+                if s == token:
+                    return True
+            return False
+
         # Collapse arguments
         if self.collapse_arguments:
-            function = function.replace(
-                "(anonymous namespace)", "anonymous_namespace_placeholder"
-            )
             function = collapse(
                 function,
                 open_string="(",
                 close_string=")",
                 replacement="",
-                exceptions=("operator",),
-            )
-            function = function.replace(
-                "anonymous_namespace_placeholder", "(anonymous namespace)"
+                is_exception=cpp_argument_exceptions,
             )
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -177,13 +177,15 @@ class CSignatureTool:
 
         # Collapse arguments
         if self.collapse_arguments:
+            function = function.replace("(anonymous namespace)", "placeholder")
             function = collapse(
                 function,
                 open_string="(",
                 close_string=")",
                 replacement="",
-                exceptions=("anonymous namespace", "operator"),
+                exceptions=("operator",),
             )
+            function = function.replace("placeholder", "(anonymous namespace)")
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if "clone .cold" in function:

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -12,7 +12,7 @@ from glom import glom
 
 from .siglists_utils import get_signature_list_content
 from .utils import (
-    collapse,
+    replace_enclosed_slices,
     drop_bad_characters,
     drop_prefix_and_return_type,
     get_crashing_thread,
@@ -115,18 +115,20 @@ class CSignatureTool:
         function = drop_prefix_and_return_type(function)
 
         # Collapse types
-        function = collapse(
+        function = replace_enclosed_slices(
             function,
-            open_string="<",
-            close_string=">",
-            replacement="<T>",
-            exceptions=(" as ",),
+            opening_token="<",
+            closing_token=">",
+            replace=lambda before, inside, after: inside if " as " in inside else "<T>",
         )
 
         # Collapse arguments
         if self.collapse_arguments:
-            function = collapse(
-                function, open_string="(", close_string=")", replacement=""
+            function = replace_enclosed_slices(
+                function,
+                opening_token="(",
+                closing_token=")",
+                replace=lambda before, inside, after: "",
             )
 
         if self.signatures_with_line_numbers_re.match(function):
@@ -167,28 +169,50 @@ class CSignatureTool:
         #
         # NOTE(willkg): The " in " is for handling "<unknown in foobar.dll>". bug
         # #1685178
-        function = collapse(
-            function,
-            open_string="<",
-            close_string=">",
-            replacement="<T>",
-            exceptions=("name omitted", "IPC::ParamTraits", " in "),
+        def get_type_replacement(before, inside, after):
+            exceptions = ["name omitted", "IPC::ParamTraits", " as "]
+            for s in exceptions:
+                if before.endswith(s):
+                    s_without_outer_tokens = inside[1:-1]
+
+                    inside_substring = replace_enclosed_slices(
+                        s_without_outer_tokens, "<", ">", get_type_replacement
+                    )
+                    return f"<{inside_substring}>"
+                if s in inside:
+                    return inside
+            return "<T>"
+
+        function = replace_enclosed_slices(
+            function, opening_token="<", closing_token=">", replace=get_type_replacement
         )
 
         # Collapse arguments
-        if self.collapse_arguments:
-            function = collapse(
-                function,
-                open_string="(",
-                close_string=")",
-                replacement="",
-                exceptions=("(anonymous namespace)", "operator"),
-            )
+        def get_argument_replacement(before, inside, after):
+            exceptions = ["(anonymous namespace)", "operator"]
+            for s in exceptions:
+                if before.endswith(s):
+                    return inside
+                if s in inside and not (s.startswith("(") and s.endswith(")")):
+                    return inside
+                if s == inside:
+                    return inside
+            return ""
+
+        function = replace_enclosed_slices(
+            function,
+            opening_token="(",
+            closing_token=")",
+            replace=get_argument_replacement,
+        )
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if "clone .cold" in function:
-            function = collapse(
-                function, open_string="[", close_string="]", replacement=""
+            function = replace_enclosed_slices(
+                function,
+                opening_token="[",
+                closing_token="]",
+                replace=lambda before, inside, after: "",
             )
 
         if self.signatures_with_line_numbers_re.match(function):

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -176,7 +176,8 @@ class CSignatureTool:
         )
 
         def cpp_argument_exceptions(exceptions, before_token, after_token, token):
-            exceptions = ["(anonymous namespace)", "operator"]
+            if not exceptions:
+                return False
             for s in exceptions:
                 if before_token.endswith(s):
                     return True
@@ -191,6 +192,7 @@ class CSignatureTool:
                 open_string="(",
                 close_string=")",
                 replacement="",
+                exceptions=("(anonymous namespace)", "operator"),
                 is_exception=cpp_argument_exceptions,
             )
 

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -177,7 +177,7 @@ class CSignatureTool:
 
         # Collapse arguments
         if self.collapse_arguments:
-            function = function.replace("(anonymous namespace)", "placeholder")
+            function = function.replace("(anonymous namespace)", "anonymous_namespace_placeholder")
             function = collapse(
                 function,
                 open_string="(",
@@ -185,7 +185,7 @@ class CSignatureTool:
                 replacement="",
                 exceptions=("operator",),
             )
-            function = function.replace("placeholder", "(anonymous namespace)")
+            function = function.replace("anonymous_namespace_placeholder", "(anonymous namespace)")
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if "clone .cold" in function:

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -175,16 +175,6 @@ class CSignatureTool:
             exceptions=("name omitted", "IPC::ParamTraits", " in "),
         )
 
-        def cpp_argument_exceptions(exceptions, before_token, after_token, token):
-            if not exceptions:
-                return False
-            for s in exceptions:
-                if before_token.endswith(s):
-                    return True
-                if s == token:
-                    return True
-            return False
-
         # Collapse arguments
         if self.collapse_arguments:
             function = collapse(
@@ -193,7 +183,6 @@ class CSignatureTool:
                 close_string=")",
                 replacement="",
                 exceptions=("(anonymous namespace)", "operator"),
-                is_exception=cpp_argument_exceptions,
             )
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -177,7 +177,9 @@ class CSignatureTool:
 
         # Collapse arguments
         if self.collapse_arguments:
-            function = function.replace("(anonymous namespace)", "anonymous_namespace_placeholder")
+            function = function.replace(
+                "(anonymous namespace)", "anonymous_namespace_placeholder"
+            )
             function = collapse(
                 function,
                 open_string="(",
@@ -185,7 +187,9 @@ class CSignatureTool:
                 replacement="",
                 exceptions=("operator",),
             )
-            function = function.replace("anonymous_namespace_placeholder", "(anonymous namespace)")
+            function = function.replace(
+                "anonymous_namespace_placeholder", "(anonymous namespace)"
+            )
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if "clone .cold" in function:

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -170,17 +170,14 @@ class CSignatureTool:
         # NOTE(willkg): The " in " is for handling "<unknown in foobar.dll>". bug
         # #1685178
         def get_type_replacement(before, inside, after):
-            exceptions = ["name omitted", "IPC::ParamTraits", " as "]
-            for s in exceptions:
-                if before.endswith(s):
-                    s_without_outer_tokens = inside[1:-1]
-
-                    inside_substring = replace_enclosed_slices(
-                        s_without_outer_tokens, "<", ">", get_type_replacement
-                    )
-                    return f"<{inside_substring}>"
-                if s in inside:
-                    return inside
+            if inside == "<name omitted>" or " as " in inside:
+                return inside
+            if before.endswith("IPC::ParamTraits"):
+                s_without_outer_tokens = inside[1:-1]
+                inside_substring = replace_enclosed_slices(
+                    s_without_outer_tokens, "<", ">", get_type_replacement
+                )
+                return f"<{inside_substring}>"
             return "<T>"
 
         function = replace_enclosed_slices(
@@ -189,14 +186,8 @@ class CSignatureTool:
 
         # Collapse arguments
         def get_argument_replacement(before, inside, after):
-            exceptions = ["(anonymous namespace)", "operator"]
-            for s in exceptions:
-                if before.endswith(s):
-                    return inside
-                if s in inside and not (s.startswith("(") and s.endswith(")")):
-                    return inside
-                if s == inside:
-                    return inside
+            if inside == "(anonymous namespace)" or before.endswith("operator"):
+                return inside
             return ""
 
         function = replace_enclosed_slices(

--- a/socorro/signature/rules.py
+++ b/socorro/signature/rules.py
@@ -13,6 +13,8 @@ from glom import glom
 from .siglists_utils import get_signature_list_content
 from .utils import (
     replace_enclosed_slices,
+    collapse_arguments,
+    collapse_types,
     drop_bad_characters,
     drop_prefix_and_return_type,
     get_crashing_thread,
@@ -169,33 +171,10 @@ class CSignatureTool:
         #
         # NOTE(willkg): The " in " is for handling "<unknown in foobar.dll>". bug
         # #1685178
-        def get_type_replacement(before, inside, after):
-            if inside == "<name omitted>" or " as " in inside:
-                return inside
-            if before.endswith("IPC::ParamTraits"):
-                s_without_outer_tokens = inside[1:-1]
-                inside_substring = replace_enclosed_slices(
-                    s_without_outer_tokens, "<", ">", get_type_replacement
-                )
-                return f"<{inside_substring}>"
-            return "<T>"
-
-        function = replace_enclosed_slices(
-            function, opening_token="<", closing_token=">", replace=get_type_replacement
-        )
+        function = collapse_types(function)
 
         # Collapse arguments
-        def get_argument_replacement(before, inside, after):
-            if inside == "(anonymous namespace)" or before.endswith("operator"):
-                return inside
-            return ""
-
-        function = replace_enclosed_slices(
-            function,
-            opening_token="(",
-            closing_token=")",
-            replace=get_argument_replacement,
-        )
+        function = collapse_arguments(function)
 
         # Remove PGO cold block labels like "[clone .cold.222]". bug #1397926
         if "clone .cold" in function:

--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -381,6 +381,11 @@ class TestCSignatureTool:
             # Normalize anonymous namespace
             ("`anonymous namespace'::foo", "23", "(anonymous namespace)::foo"),
             ("(anonymous namespace)::foo", "23", "(anonymous namespace)::foo"),
+            (
+                "mozilla::SpinEventLoopUntil(nsTSubstring<T> const&, (anonymous namespace)::ParentImpl::ShutdownBackgroundThread::<T>&&, nsIThread*)",
+                "23",
+                "mozilla::SpinEventLoopUntil",
+            ),
             # Normalize lambda numbers
             (
                 "ShutdownWorkThreads::$_52::__invoke",

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 
 from ..utils import (
-    collapse,
+    replace_enclosed_slices,
     drop_bad_characters,
     drop_prefix_and_return_type,
     get_crashing_thread,
@@ -114,6 +114,9 @@ def test_parse_source_file(source_file, expected):
     assert parse_source_file(source_file) == expected
 
 
+# TODO: add test cases for find_enclosed_slices
+
+
 @pytest.mark.parametrize(
     "function, expected",
     [
@@ -146,15 +149,28 @@ def test_parse_source_file(source_file, expected):
         ),
     ],
 )
-def test_collapse_types(function, expected):
+def test_replace_enclosed_slices_types(function, expected):
+    def get_type_replacement(before, inside, after):
+        exceptions = ["name omitted", "IPC::ParamTraits", " as "]
+        for s in exceptions:
+            if before.endswith(s):
+                s_without_outer_tokens = inside[1:-1]
+
+                inside_substring = replace_enclosed_slices(
+                    s_without_outer_tokens, "<", ">", get_type_replacement
+                )
+                return f"<{inside_substring}>"
+            if s in inside:
+                return inside
+        return "<T>"
+
     params = {
-        "function": function,
-        "open_string": "<",
-        "close_string": ">",
-        "replacement": "<T>",
-        "exceptions": ["name omitted", "IPC::ParamTraits", " as "],
+        "s": function,
+        "opening_token": "<",
+        "closing_token": ">",
+        "replace": get_type_replacement,
     }
-    assert collapse(**params) == expected
+    assert replace_enclosed_slices(**params) == expected
 
 
 @pytest.mark.parametrize(
@@ -178,15 +194,25 @@ def test_collapse_types(function, expected):
         ),
     ],
 )
-def test_collapse_arguments(function, expected):
+def test_replace_enclosed_slices_arguments(function, expected):
+    def get_argument_replacement(before, inside, after):
+        exceptions = ["(anonymous namespace)", "operator"]
+        for s in exceptions:
+            if before.endswith(s):
+                return inside
+            if s in inside and not (s.startswith("(") and s.endswith(")")):
+                return inside
+            if s == inside:
+                return inside
+        return ""
+
     params = {
-        "function": function,
-        "open_string": "(",
-        "close_string": ")",
-        "replacement": "",
-        "exceptions": ["(anonymous namespace)", "operator"],
+        "s": function,
+        "opening_token": "(",
+        "closing_token": ")",
+        "replace": get_argument_replacement,
     }
-    assert collapse(**params) == expected
+    assert replace_enclosed_slices(**params) == expected
 
 
 @pytest.mark.parametrize(

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -146,13 +146,45 @@ def test_parse_source_file(source_file, expected):
         ),
     ],
 )
-def test_collapse(function, expected):
+def test_collapse_types(function, expected):
     params = {
         "function": function,
         "open_string": "<",
         "close_string": ">",
         "replacement": "<T>",
         "exceptions": ["name omitted", "IPC::ParamTraits", " as "],
+    }
+    assert collapse(**params) == expected
+
+
+@pytest.mark.parametrize(
+    "function, expected",
+    [
+        ("", ""),
+        ("testVal", "testVal"),
+        ("f( *s)", "f"),
+        ("f( &s)", "f"),
+        ("f( *s , &n)", "f"),
+        ("f3(s,t,u)", "f3"),
+        ("(anonymous namespace)::foo", "(anonymous namespace)::foo"),
+        (
+            "CCGraphBuilder::BuildGraph(class js::SliceBudget& const)",
+            "CCGraphBuilder::BuildGraph",
+        ),
+        ("operator()(s,t,u)", "operator()"),
+        (
+            "mozilla::SpinEventLoopUntil(nsTSubstring<T> const&, (anonymous namespace)::ParentImpl::ShutdownBackgroundThread::<T>&&, nsIThread*)",
+            "mozilla::SpinEventLoopUntil",
+        ),
+    ],
+)
+def test_collapse_arguments(function, expected):
+    params = {
+        "function": function,
+        "open_string": "(",
+        "close_string": ")",
+        "replacement": "",
+        "exceptions": ["(anonymous namespace)", "operator"],
     }
     assert collapse(**params) == expected
 

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -7,6 +7,7 @@ import copy
 import pytest
 
 from ..utils import (
+    find_enclosed_slices,
     replace_enclosed_slices,
     drop_bad_characters,
     drop_prefix_and_return_type,
@@ -114,7 +115,39 @@ def test_parse_source_file(source_file, expected):
     assert parse_source_file(source_file) == expected
 
 
-# TODO: add test cases for find_enclosed_slices
+@pytest.mark.parametrize(
+    "s, opening_token, closing_token, expected",
+    [
+        ("", "(", ")", []),
+        ("(anonymous namespace)::foo", "(", ")", [(0, 21)]),
+        ("operator()(s,t,u)", "(", ")", [(8, 10), (10, 17)]),
+        ("testVal", "(", ")", []),
+        ("f( *s)", "(", ")", [(1, 6)]),
+        ("Foo<bar", "<", ">", [(3, 7)]),
+        ("Foo<bar <baz> >", "<", ">", [(3, 15)]),
+        ("Foo<bar<baz>", "<", ">", [(3, 12)]),
+        (
+            "mozilla::SpinEventLoopUntil(nsTSubstring<T> const&, (anonymous namespace)::ParentImpl::ShutdownBackgroundThread::<T>&&, nsIThread*)",
+            "(",
+            ")",
+            [(27, 131)],
+        ),
+        (
+            "<rayon_core::job::HeapJob<BODY> as rayon_core::job::Job>::execute",
+            "<",
+            ">",
+            [(0, 56)],
+        ),
+        (
+            "IPC::ParamTraits<nsTSubstring<char> >::Write(IPC::Message *,nsTSubstring<char> const &)",
+            "<",
+            ">",
+            [(16, 37), (72, 78)],
+        ),
+    ],
+)
+def test_find_enclosed_slices(s, opening_token, closing_token, expected):
+    assert list(find_enclosed_slices(s, opening_token, closing_token)) == expected
 
 
 @pytest.mark.parametrize(
@@ -151,17 +184,14 @@ def test_parse_source_file(source_file, expected):
 )
 def test_replace_enclosed_slices_types(function, expected):
     def get_type_replacement(before, inside, after):
-        exceptions = ["name omitted", "IPC::ParamTraits", " as "]
-        for s in exceptions:
-            if before.endswith(s):
-                s_without_outer_tokens = inside[1:-1]
-
-                inside_substring = replace_enclosed_slices(
-                    s_without_outer_tokens, "<", ">", get_type_replacement
-                )
-                return f"<{inside_substring}>"
-            if s in inside:
-                return inside
+        if inside == "<name omitted>" or " as " in inside:
+            return inside
+        if before.endswith("IPC::ParamTraits"):
+            s_without_outer_tokens = inside[1:-1]
+            inside_substring = replace_enclosed_slices(
+                s_without_outer_tokens, "<", ">", get_type_replacement
+            )
+            return f"<{inside_substring}>"
         return "<T>"
 
     params = {
@@ -196,14 +226,8 @@ def test_replace_enclosed_slices_types(function, expected):
 )
 def test_replace_enclosed_slices_arguments(function, expected):
     def get_argument_replacement(before, inside, after):
-        exceptions = ["(anonymous namespace)", "operator"]
-        for s in exceptions:
-            if before.endswith(s):
-                return inside
-            if s in inside and not (s.startswith("(") and s.endswith(")")):
-                return inside
-            if s == inside:
-                return inside
+        if inside == "(anonymous namespace)" or before.endswith("operator"):
+            return inside
         return ""
 
     params = {

--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -8,7 +8,8 @@ import pytest
 
 from ..utils import (
     find_enclosed_slices,
-    replace_enclosed_slices,
+    collapse_arguments,
+    collapse_types,
     drop_bad_characters,
     drop_prefix_and_return_type,
     get_crashing_thread,
@@ -182,25 +183,8 @@ def test_find_enclosed_slices(s, opening_token, closing_token, expected):
         ),
     ],
 )
-def test_replace_enclosed_slices_types(function, expected):
-    def get_type_replacement(before, inside, after):
-        if inside == "<name omitted>" or " as " in inside:
-            return inside
-        if before.endswith("IPC::ParamTraits"):
-            s_without_outer_tokens = inside[1:-1]
-            inside_substring = replace_enclosed_slices(
-                s_without_outer_tokens, "<", ">", get_type_replacement
-            )
-            return f"<{inside_substring}>"
-        return "<T>"
-
-    params = {
-        "s": function,
-        "opening_token": "<",
-        "closing_token": ">",
-        "replace": get_type_replacement,
-    }
-    assert replace_enclosed_slices(**params) == expected
+def test_collapse_types(function, expected):
+    assert collapse_types(function) == expected
 
 
 @pytest.mark.parametrize(
@@ -224,19 +208,8 @@ def test_replace_enclosed_slices_types(function, expected):
         ),
     ],
 )
-def test_replace_enclosed_slices_arguments(function, expected):
-    def get_argument_replacement(before, inside, after):
-        if inside == "(anonymous namespace)" or before.endswith("operator"):
-            return inside
-        return ""
-
-    params = {
-        "s": function,
-        "opening_token": "(",
-        "closing_token": ")",
-        "replace": get_argument_replacement,
-    }
-    assert replace_enclosed_slices(**params) == expected
+def test_collapse_arguments(function, expected):
+    assert collapse_arguments(function) == expected
 
 
 @pytest.mark.parametrize(

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -205,7 +205,14 @@ def _is_exception(exceptions, before_token, after_token, token):
     return False
 
 
-def collapse(function, open_string, close_string, replacement="", exceptions=None):
+def collapse(
+    function,
+    open_string,
+    close_string,
+    replacement="",
+    exceptions=None,
+    is_exception=None,
+):
     """Collapses the text between two delimiters in a frame function value
 
     This collapses the text between two delimiters and either removes the text
@@ -242,10 +249,14 @@ def collapse(function, open_string, close_string, replacement="", exceptions=Non
     open_count = 0
     open_token = []
 
+    if is_exception is None:
+        is_exception = _is_exception
+
     for i, char in enumerate(function):
         if not open_count:
-            if char == open_string and not _is_exception(
-                exceptions, function[:i], function[i + 1 :], ""
+            if char == open_string and not (
+                is_exception
+                and is_exception(exceptions, function[:i], function[i + 1 :], "")
             ):
                 open_count += 1
                 open_token = [char]
@@ -263,7 +274,7 @@ def collapse(function, open_string, close_string, replacement="", exceptions=Non
 
                 if open_count == 0:
                     token = "".join(open_token)
-                    if _is_exception(
+                    if is_exception and is_exception(
                         exceptions, function[:i], function[i + 1 :], token
                     ):
                         collapsed.append("".join(open_token))
@@ -275,7 +286,9 @@ def collapse(function, open_string, close_string, replacement="", exceptions=Non
 
     if open_count:
         token = "".join(open_token)
-        if _is_exception(exceptions, function[:i], function[i + 1 :], token):
+        if is_exception and is_exception(
+            exceptions, function[:i], function[i + 1 :], token
+        ):
             collapsed.append("".join(open_token))
         else:
             collapsed.append(replacement)

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -249,14 +249,10 @@ def collapse(
     open_count = 0
     open_token = []
 
-    if is_exception is None:
-        is_exception = _is_exception
-
     for i, char in enumerate(function):
         if not open_count:
-            if char == open_string and not (
-                is_exception
-                and is_exception(exceptions, function[:i], function[i + 1 :], "")
+            if char == open_string and not _is_exception(
+                exceptions, function[:i], function[i + 1 :], ""
             ):
                 open_count += 1
                 open_token = [char]
@@ -274,7 +270,7 @@ def collapse(
 
                 if open_count == 0:
                     token = "".join(open_token)
-                    if is_exception and is_exception(
+                    if _is_exception(
                         exceptions, function[:i], function[i + 1 :], token
                     ):
                         collapsed.append("".join(open_token))
@@ -286,9 +282,7 @@ def collapse(
 
     if open_count:
         token = "".join(open_token)
-        if is_exception and is_exception(
-            exceptions, function[:i], function[i + 1 :], token
-        ):
+        if _is_exception(exceptions, function[:i], function[i + 1 :], token):
             collapsed.append("".join(open_token))
         else:
             collapsed.append(replacement)

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -6,6 +6,7 @@
 import contextlib
 import copy
 import re
+from typing import Callable, Iterator
 from urllib.parse import urlsplit
 
 from glom import glom, assign
@@ -184,110 +185,60 @@ def parse_source_file(source_file):
     return None
 
 
-def _is_exception(exceptions, before_token, after_token, token):
-    """Predicate for whether the open token is in an exception context
+def find_enclosed_slices(
+    s: str, opening_token: str, closing_token: str
+) -> Iterator[tuple[int, int]]:
+    """Takes a string and returns a tuple of the start and end index for each substring enclosed
+    by opening_token and closing_token
 
-    :arg exceptions: list of strings or None
-    :arg before_token: the text of the function up to the token delimiter
-    :arg after_token: the text of the function after the token delimiter
-    :arg token: the token (only if we're looking at a close delimiter
+    :arg s: the string to search
+    :arg opening_token: the character that indicates the start of the substring
+    :arg closing_token: the character that indicates the end of the substring
 
-    :returns: bool
-
+    :returns: generator iterator where each value is a tuple (start_index, end_index)
     """
-    if not exceptions:
-        return False
-    for s in exceptions:
-        if before_token.endswith(s):
-            return True
-        if s in token:
-            return True
-    return False
+    nesting_level = 0
+    start_index = 0
+
+    for i, char in enumerate(s):
+        if char == opening_token:
+            if nesting_level == 0:
+                start_index = i
+            nesting_level += 1
+        elif char == closing_token and nesting_level > 0:
+            nesting_level -= 1
+            if nesting_level == 0:
+                yield start_index, i + 1
+    if nesting_level:
+        yield start_index, len(s)
 
 
-def collapse(
-    function,
-    open_string,
-    close_string,
-    replacement="",
-    exceptions=None,
-    is_exception=None,
-):
-    """Collapses the text between two delimiters in a frame function value
+def replace_enclosed_slices(
+    s: str,
+    opening_token: str,
+    closing_token: str,
+    replace: Callable[[str, str, str], str],
+) -> str:
+    """Takes a string and modifies the space inside the opening_token and closing_token based on replace function
 
-    This collapses the text between two delimiters and either removes the text
-    altogether or replaces it with a replacement string.
+    :arg s: The string to modify
+    :arg opening_token: the character that indicates the start of the substring
+    :arg closing_token: the character that indicates the end of the substring
+    :arg replace: A function that determines what the substring is replaced by
 
-    There are certain contexts in which we might not want to collapse the text
-    between two delimiters. These are denoted as "exceptions" and collapse will
-    check for those exception strings occuring before the token to be replaced
-    or inside the token to be replaced.
-
-    Before::
-
-        IPC::ParamTraits<nsTSubstring<char> >::Write(IPC::Message *,nsTSubstring<char> const &)
-               ^        ^ open token
-               exception string occurring before open token
-
-    Inside::
-
-        <rayon_core::job::HeapJob<BODY> as rayon_core::job::Job>::execute
-        ^                              ^^^^ exception string inside token
-        open token
-
-    :arg function: the function value from a frame to collapse tokens in
-    :arg open_string: the open delimiter; e.g. ``(``
-    :arg close_string: the close delimiter; e.g. ``)``
-    :arg replacement: what to replace the token with; e.g. ``<T>``
-    :arg exceptions: list of strings denoting exceptions where we don't want
-        to collapse the token
-
-    :returns: new function string with tokens collapsed
-
+    :returns: A new string with the slice replaced
     """
-    collapsed = []
-    open_count = 0
-    open_token = []
+    fragments = []
+    previous_end = 0
 
-    for i, char in enumerate(function):
-        if not open_count:
-            if char == open_string and not _is_exception(
-                exceptions, function[:i], function[i + 1 :], ""
-            ):
-                open_count += 1
-                open_token = [char]
-            else:
-                collapsed.append(char)
+    for start, end in find_enclosed_slices(s, opening_token, closing_token):
+        before, inside, after = s[previous_end:start], s[start:end], s[end:]
+        fragments.append(before)
+        fragments.append(replace(before, inside, after))
+        previous_end = end
 
-        else:
-            if char == open_string:
-                open_count += 1
-                open_token.append(char)
-
-            elif char == close_string:
-                open_count -= 1
-                open_token.append(char)
-
-                if open_count == 0:
-                    token = "".join(open_token)
-                    if _is_exception(
-                        exceptions, function[:i], function[i + 1 :], token
-                    ):
-                        collapsed.append("".join(open_token))
-                    else:
-                        collapsed.append(replacement)
-                    open_token = []
-            else:
-                open_token.append(char)
-
-    if open_count:
-        token = "".join(open_token)
-        if _is_exception(exceptions, function[:i], function[i + 1 :], token):
-            collapsed.append("".join(open_token))
-        else:
-            collapsed.append(replacement)
-
-    return "".join(collapsed)
+    fragments.append(s[previous_end:])
+    return "".join(fragments)
 
 
 def drop_prefix_and_return_type(function):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -241,6 +241,56 @@ def replace_enclosed_slices(
     return "".join(fragments)
 
 
+def collapse_types(func_signature: str) -> str:
+    """Takes a C++ function signature string and collapses the types
+    into <T> or an exception based on the replacement function
+
+    :arg func_signature: The function signature string
+
+    :returns: A new function signtaure string with types collapsed
+    """
+
+    def get_type_replacement(before, inside, after):
+        if inside == "<name omitted>" or " as " in inside:
+            return inside
+        if before.endswith("IPC::ParamTraits"):
+            s_without_outer_tokens = inside[1:-1]
+            inside_substring = replace_enclosed_slices(
+                s_without_outer_tokens, "<", ">", get_type_replacement
+            )
+            return f"<{inside_substring}>"
+        return "<T>"
+
+    return replace_enclosed_slices(
+        func_signature,
+        opening_token="<",
+        closing_token=">",
+        replace=get_type_replacement,
+    )
+
+
+def collapse_arguments(func_signature: str) -> str:
+    """Takes a C++ function signature string and collapses the arguments
+    into "" or an exception based on the replacement function
+
+    :arg func_signature: The function signature string
+
+    :returns: A new function signtaure string with types collapsed
+    """
+
+    def get_argument_replacement(before, inside, after):
+        if inside == "(anonymous namespace)" or before.endswith("operator"):
+            return inside
+        return ""
+
+    return replace_enclosed_slices(
+        func_signature,
+        opening_token="(",
+        closing_token=")",
+        replace=get_argument_replacement,
+    )
+
+
 def drop_prefix_and_return_type(function):
     """Takes the function value from a frame and drops prefix and return type
 

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -255,9 +255,7 @@ def collapse_types(func_signature: str) -> str:
             return inside
         if before.endswith("IPC::ParamTraits"):
             s_without_outer_tokens = inside[1:-1]
-            inside_substring = replace_enclosed_slices(
-                s_without_outer_tokens, "<", ">", get_type_replacement
-            )
+            inside_substring = collapse_types(s_without_outer_tokens)
             return f"<{inside_substring}>"
         return "<T>"
 


### PR DESCRIPTION
Because:
- [bug-2031036](https://bugzilla.mozilla.org/show_bug.cgi?id=2031036)

This PR:
- replaces the `(anonymous namespace)` with a placeholder value and removes it from the exceptions, thus allowing the argument with the `(anonymous namespace)` to be removed

Example:
-  Initial signature: `mozilla::SpinEventLoopUntil(nsTSubstring<T> const&, (anonymous namespace)::ParentImpl::ShutdownBackgroundThread::<T>&&, nsIThread*)`
- Post fix signature: `mozilla::SpinEventLoopUntil`