### PR TITLE
bug-2032278: escape user-provided field values for /signature graphs tab

### DIFF
--- a/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -103,11 +103,20 @@ SignatureReport.GraphsTab.prototype.formatData = function (data) {
     });
   });
 
+  // By reading back innerHTML, the browser serializes the text node
+  // into safe HTML thus escaping special characters.
+  function escapeHTML(str) {
+    let tmpDiv = document.createElement('div');
+    tmpDiv.textContent = str;
+    return tmpDiv.innerHTML;
+  }
+
   // Make the data object into an array of arrays for Metrics Graphics
   // and add the associated legend in the same order.
-  $.each(lineDataObject, function (key, lineData) {
+  // The keys of lineDataObject are crash report field values
+  $.each(lineDataObject, function (fieldValue, lineData) {
     lineDataArray.push(lineData);
-    legend.push(key);
+    legend.push(escapeHTML(fieldValue));
   });
 
   // Return the line data, the legend and also any remaining terms after the
@@ -150,7 +159,7 @@ SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElem
     legend_target: '.new-legend',
     show_secondary_x_label: false,
     mouseover: function (d) {
-      $('.mg-active-datapoint', contentElement).html(d.term + ': ' + d.count + (d.count === 1 ? ' crash' : ' crashes'));
+      $('.mg-active-datapoint', contentElement).text(d.term + ': ' + d.count + (d.count === 1 ? ' crash' : ' crashes'));
     },
   });
 


### PR DESCRIPTION
Because:
* We don't escape crash report field values in this tab (though I've confirmed that we do everywhere else).

This PR:
* Ensures we convert the value to text content before rendering it.
* I actually found a second place in this same tab where we weren't escaping (this one wasn't part of the bug report), and I fixed that as well.

How to test:
1. Load the crash from the bug report into a local running instance of Socorro
  a. This was a little annoying, since the crash report is only in stage, and our bin/process_crashes.sh script defaults to prod. You can pass a `--host` flag, but then those args also get passed to the `pubsub-cli` command which doesn't have that option and throws an error. This means the crash report was fetched and uploaded to the GCS emulator, but a message wasn't published to the local pubsub emulator. You can explicitly run the pubsub-cli command separately afterward as a workaround (`pubsub-cli publish test local-standard-topic {$crash_id}`).
2. Otherwise follow the STR in the bug report starting from step 4.

I have tested the fix locally.

Since we have no JS unit tests (see [CRINGE-3](https://mozilla-hub.atlassian.net/browse/CRINGE-3)), I didn't add any here.

Analogous Jira ticket: [CRINGE-249](https://mozilla-hub.atlassian.net/browse/CRINGE-249)