### PR TITLE
bug-2033260: Only use symbols link if it start with http(s)://.

### DIFF
--- a/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -1010,7 +1010,7 @@
                         {% if module.missing_symbols %}
                           <span class="row-notice" title="missing symbol">&Oslash;</span>
                         {% endif %}
-                        {% if module.symbol_url %}
+                        {% if module.symbol_url and module.symbol_url.startswith(('http://', 'https://')) %}
                           <a href="{{ module.symbol_url }}">{{ module.filename }}</a>
                         {% else %}
                           {{ module.filename }}

--- a/webapp/crashstats/crashstats/tests/test_views.py
+++ b/webapp/crashstats/crashstats/tests/test_views.py
@@ -633,6 +633,20 @@ class Test_report_index:
                     "symbol_url": "https://s3.example.com/winmm.sym",
                     "version": "5.1.2600.2180",
                 },
+                {
+                    "base_addr": "0x00007ff6701d0000",
+                    "cert_subject": "Mozilla Corporation",
+                    "code_id": "69dff8aaaf000",
+                    "corrupt_symbols": False,
+                    "debug_file": "firefox.pdb",
+                    "debug_id": "5DE8036FC7DE826B4C4C44205044422E1",
+                    "end_addr": "0x00007ff67027f000",
+                    "filename": "firefox.exe",
+                    "loaded_symbols": True,
+                    "missing_symbols": False,
+                    "symbol_url": "javascript:alert(1)",
+                    "version": "150.0.0.3",
+                },
             ],
         }
 
@@ -647,10 +661,10 @@ class Test_report_index:
         response = client.get(url)
         assert response.status_code == 200
 
-        assert 'id="modules-list"' in smart_str(response.content)
-        assert '<a href="https://s3.example.com/winmm.sym">winmm.dll</a>' in smart_str(
-            response.content
-        )
+        content = smart_str(response.content)
+        assert 'id="modules-list"' in content
+        assert '<a href="https://s3.example.com/winmm.sym">winmm.dll</a>' in content
+        assert 'href="javascript:alert(1)"' not in content
 
     def test_cert_subject_in_modules(self, client, db, storage_helper):
         json_dump = {


### PR DESCRIPTION
This validates the scheme of links to symbols files shown in the modules tab for a crash report.

Generally, these links come from minidump-stackwalk and should be trustworthy. However, an security researcher found a way to fake a processed crash, allowing them to inject fake symbols URLs with a javascript: scheme. The JS code does not get executed because of our Content-Security-Policy, but we still don't want this to be possible.

This change validates the URLs and makes sure they start with "http://" or "https://"; other URLs will be ignored.

The tests don't use a proper HTML parser, so the verification of the generated HTML is a bit sloppy. The changes I made to `test_symbol_url_in_modules()` made it fail with the fix to the template, and now it passes, so I think it's the best we can do short of introducing a proper HTML parser for the unit tests.