### PR TITLE
CRINGE-16: Pull the collector image from GAR.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,14 +146,12 @@ services:
   # External services
   # -----------------------------
 
-  # https://hub.docker.com/r/mozilla/socorro_collector/
-  #
   # This pulls the latest Antenna and treats it as an external service.
   #
   # This uses the development ./bin/run_web.sh script from the Antenna
   # container since that creates a bucket before running Antenna.
   collector:
-    image: mozilla/socorro_collector:latest
+    image: us-docker.pkg.dev/moz-fx-socorro-prod/socorro-prod/antenna:latest
     env_file:
       - docker/config/local_dev.env
       - .env


### PR DESCRIPTION
The collector container in the Docker Compose configuration has been pulling a stale image from Docker Hub until now. I [made the new Docker repository in GAR public today](https://github.com/mozilla/webservices-infra/pull/10752) so we can now pull the collector image from there instead to get an up-to-date version.

https://mozilla-hub.atlassian.net/browse/CRINGE-16