### PR TITLE
bug-2007193: dedupe json_dump.thread_count in processed crash schema

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+---
+extends: default
+rules:
+  key-duplicates: enable

--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -44,6 +44,9 @@ else
         license-check .
     fi
 
+    echo ">>> yamllint"
+    yamllint socorro/schemas/
+
     echo ">>> eslint (js)"
     cd /app/webapp
     /app/webapp/node_modules/.bin/eslint .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "urlwait",
     "werkzeug",
     "whitenoise",
+    "yamllint",
 ]
 
 [dependency-groups]

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -583,6 +583,7 @@ definitions:
         description: >
           Number of threads in the crashing process at the time of the crash.
         type: ["integer", "null"]
+        permissions: ["public"]
       unloaded_modules:
         description: |
           Modules no longer mapped into the process' address space when the
@@ -628,10 +629,6 @@ definitions:
           permissions: ["public"]
           type: object
         type: ["array", "null"]
-      thread_count:
-        description: How many threads there are.
-        type: ["integer", "null"]
-        permissions: ["public"]
       threads:
         items:
           description: Information on a thread.

--- a/socorro/schemas/raw_crash.schema.yaml
+++ b/socorro/schemas/raw_crash.schema.yaml
@@ -733,7 +733,7 @@ properties:
       Set to 1 when Marionette (WebDriver Classic) is enabled.
     type: string
     permissions: ["public"]
-  
+
   ModuleSignatureInfo:
     data_reviews:
       - unknown
@@ -923,7 +923,7 @@ properties:
       Set to 1 when the Remote Agent (WebDriver BiDi) is enabled.
     type: string
     permissions: ["public"]
-  
+
   RemoteType:
     data_reviews:
       - unknown

--- a/uv.lock
+++ b/uv.lock
@@ -976,6 +976,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1422,6 +1431,7 @@ dependencies = [
     { name = "urlwait", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "werkzeug", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "whitenoise", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "yamllint", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -1490,6 +1500,7 @@ requires-dist = [
     { name = "urlwait" },
     { name = "werkzeug" },
     { name = "whitenoise" },
+    { name = "yamllint" },
 ]
 
 [package.metadata.requires-dev]
@@ -1730,6 +1741,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/52/2da48b35193e39ac53cfb141467d9f259851522d0e8c87153f0ba4205fb1/wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1", size = 80746, upload-time = "2023-11-09T06:31:58.686Z" },
     { url = "https://files.pythonhosted.org/packages/25/62/cd284b2b747f175b5a96cbd8092b32e7369edab0644c45784871528eb852/wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d", size = 85712, upload-time = "2023-11-09T06:32:03.686Z" },
     { url = "https://files.pythonhosted.org/packages/ff/21/abdedb4cdf6ff41ebf01a74087740a709e2edb146490e4d9beea054b0b7a/wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1", size = 23362, upload-time = "2023-11-09T06:33:28.271Z" },
+]
+
+[[package]]
+name = "yamllint"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a0/8fc2d68e132cf918f18273fdc8a1b8432b60d75ac12fdae4b0ef5c9d2e8d/yamllint-1.38.0.tar.gz", hash = "sha256:09e5f29531daab93366bb061e76019d5e91691ef0a40328f04c927387d1d364d", size = 142446, upload-time = "2026-01-13T07:47:53.276Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl", hash = "sha256:fc394a5b3be980a4062607b8fdddc0843f4fa394152b6da21722f5d59013c220", size = 68940, upload-time = "2026-01-13T07:47:51.343Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Because:
* I accidentally added `thread_count` underneath `json_dump` when it was already present. This is a follow-up fix for #7087 .
* I also omitted the permissions on the duplicate entry. Since this entry was overwritten, the schema tests didn't catch it the first time around.

This PR:
* Removes the duplicate (lesser) entry. By lesser, I mean its description was less helpful.
* Adds a new yaml linting step in bin/lint.sh to check for duplicate fields among other things.

More in-depth explanation of what is happening:
* The YAML loader we're using, `pyyaml`, silently overwrites any duplicate keys during the loading process, so the one I'm removing is the one that was previously used in the schema.
  * Minimal example:
```py
import yaml
test_yaml = '''
foo: 1
bar: 2
foo: 3
'''
result = yaml.load(test_yaml, Loader = yaml.Loader)
print(result) # {'foo': 3, 'bar': 2}
```
* In this case, since everything was identical except the description, there's no real consequence other than less helpful documentation with the less helpful description.
* In the worst case scenario, if there's a later entry at the same nested level in the schema and it's not identical, this could cause more significant issues. E.g. if the later entry lists a field as public, and the earlier entry lists it as private, this would result in the field being made public.