### PR TITLE
(no bug): point devcontainer python interpreter at the correct path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv",
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
         "python.terminal.activateEnvironment": true,
         "python.testing.unittestEnabled": false,
         "python.testing.pytestEnabled": true,


### PR DESCRIPTION
python.defaultInterpreterPath was set to ${containerWorkspaceFolder}/.venv, which is a directory. This worked fine for the previously installed Python extension, which looked for a python binary in the provided directory, but the newer ms-python.vscode-python-envs extension requires a more explicit path.

While I hit this because I use VS Code Insiders, this change doesn't break the path resolution for devs on regular VS Code. It's more explicit.