### PR TITLE
(no bug): start local Antenna service with 'web' command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,7 @@ services:
       - statsd
     expose:
       - 8000
+    command: web
     ports:
       - "8888:8000"
 


### PR DESCRIPTION
Since we're using the latest prod Antenna image thanks to [CRINGE-16](https://mozilla-hub.atlassian.net/browse/CRINGE-16), its entrypoint expects a subcommand to determine what to run.

I ran into this while working on [CRINGE-263](https://mozilla-hub.atlassian.net/browse/CRINGE-263).