### PR TITLE
bug-2038160: improve SuperSearch params validation

### DIFF
--- a/webapp/crashstats/api/tests/test_views.py
+++ b/webapp/crashstats/api/tests/test_views.py
@@ -429,7 +429,13 @@ class TestSuperSearch(BaseTestViews):
     @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
     def test_api(self, mock_implementation):
         def mocked_get(**params):
-            restricted_params = ("_facets", "_aggs.signature", "_histogram.date")
+            restricted_params = (
+                "_facets",
+                "_aggs.signature",
+                "_histogram.date",
+                "_sort",
+                "_columns",
+            )
             for key in restricted_params:
                 if key in params:
                     assert "url" not in params[key]
@@ -472,6 +478,8 @@ class TestSuperSearch(BaseTestViews):
                 "_facets": ["url", "product"],
                 "_aggs.signature": ["url", "product"],
                 "_histogram.date": ["url", "product"],
+                "_sort": ["url", "-url"],
+                "_columns": ["url", "product"],
             },
         )
         assert response.status_code == 200

--- a/webapp/crashstats/supersearch/libsupersearch.py
+++ b/webapp/crashstats/supersearch/libsupersearch.py
@@ -114,3 +114,57 @@ class SuperSearchStatusModel:
             "latest_index": latest_index,
             "mapping": mapping_properties,
         }
+
+
+def get_allowed_fields(user=None):
+    """Return the names of SuperSearch fields the User may reference.
+
+    :arg user: A Django User or ``None``. If ``None``, only fields with no
+    permissions requirements are returned.
+
+    :returns: tuple of field name strings.
+
+    """
+
+    def permissions_condition(field):
+        if user is not None:
+            return user.has_perms(field["webapp_permissions_needed"])
+        return not field["webapp_permissions_needed"]
+
+    fields = get_supersearch_fields().values()
+
+    return tuple(
+        x["name"] for x in fields if x["is_exposed"] and permissions_condition(x)
+    )
+
+
+def sanitize_list_of_fields_params(
+    params, allowed_fields, list_of_fields_params=("_facets", "_columns", "_sort")
+):
+    """Strip disallowed field references from list-of-fields parameters.
+    Handles _sort fields that may be prefixed with `-`.
+
+    :arg params: dict of SuperSearch query parameters
+
+    :arg list_of_fields_params: tuple of parameter names whose values are
+    lists of field names
+
+    :returns: the mutated ``params`` dict, with disallowed entries
+    removed
+    """
+    allowed_fields_set = set(allowed_fields)
+
+    for key in list_of_fields_params:
+        # _sort: bare field name or with `-` prefix for reverse order.
+        if key == "_sort":
+            params[key] = [
+                v
+                for v in params.get(key, [])
+                if v in allowed_fields_set
+                or (v.startswith("-") and v[1:] in allowed_fields_set)
+            ]
+        # Other list-of-fields parameters (no `-` prefix)
+        else:
+            params[key] = [v for v in params.get(key, []) if v in allowed_fields_set]
+
+    return params

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -7,8 +7,10 @@ import copy
 from crashstats import libproduct
 from crashstats.crashstats import models
 from crashstats.supersearch.libsupersearch import (
+    get_allowed_fields,
     get_supersearch_fields,
     SuperSearchStatusModel,
+    sanitize_list_of_fields_params,
 )
 from socorro import settings as socorro_settings
 from socorro.lib import BadArgumentError
@@ -34,7 +36,9 @@ SUPERSEARCH_META_PARAMS = (
 PARAMETERS_LISTING_FIELDS = (
     "_aggs.product.version",
     "_aggs.android_cpu_abi.android_manufacturer.android_model",
+    "_columns",
     "_facets",
+    "_sort",
 )
 
 
@@ -151,12 +155,7 @@ class SuperSearch(ESSocorroMiddleware):
 
         # Initialize the list of allowed fields with all the fields we know
         # that are returned and do not require any permission.
-        allowed_fields = {
-            x
-            for x in self.all_fields
-            if self.all_fields[x]["is_returned"]
-            and not self.all_fields[x]["webapp_permissions_needed"]
-        }
+        allowed_fields = set(get_allowed_fields())
 
         # Extend that list with the special fields, like `_histogram.*`.
         # Those are accepted values for fields listing other fields.
@@ -178,10 +177,9 @@ class SuperSearch(ESSocorroMiddleware):
 
         # Now make sure all fields listing fields only have unrestricted
         # values.
-        for param in self.parameters_listing_fields:
-            values = kwargs.get(param, [])
-            filtered_values = [x for x in values if x in allowed_fields]
-            kwargs[param] = filtered_values
+        kwargs = sanitize_list_of_fields_params(
+            kwargs, allowed_fields, list_of_fields_params=self.parameters_listing_fields
+        )
 
         # SuperSearch requires that the list of fields be passed to it.
         kwargs["_fields"] = self.all_fields

--- a/webapp/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp/crashstats/supersearch/tests/test_libsupersearch.py
@@ -3,7 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-from crashstats.supersearch.libsupersearch import convert_permissions
+import pytest
+
+from crashstats.supersearch.libsupersearch import (
+    convert_permissions,
+    get_allowed_fields,
+    sanitize_list_of_fields_params,
+)
 
 
 def test_convert_permissions():
@@ -38,3 +44,128 @@ def test_convert_permissions():
     }
 
     assert convert_permissions(fields) == expected
+
+
+MINIMAL_SUPERSEARCH_FIELDS_FIXTURE = {
+    "signature": {
+        "name": "signature",
+        "is_exposed": True,
+        "webapp_permissions_needed": [],
+    },
+    "product": {
+        "name": "product",
+        "is_exposed": True,
+        "webapp_permissions_needed": [],
+    },
+    "user_comments": {
+        "name": "user_comments",
+        "is_exposed": True,
+        "webapp_permissions_needed": ["crashstats.view_pii"],
+    },
+    "url": {
+        "name": "url",
+        "is_exposed": True,
+        "webapp_permissions_needed": ["crashstats.view_pii"],
+    },
+    "_unexposed": {
+        "name": "_unexposed",
+        "is_exposed": False,
+        "webapp_permissions_needed": [],
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "user_type, included, excluded",
+    [
+        # No user passed -> public fields only
+        (
+            "none",
+            {"signature", "product"},
+            {"user_comments", "url", "_unexposed"},
+        ),
+        # Authorized user (view_pii via the Hackers group) -> public + protected fields
+        (
+            "authorized",
+            {"signature", "product", "user_comments", "url"},
+            {"_unexposed"},
+        ),
+        # Authenticated user without view_pii -> public fields only
+        (
+            "unauthorized",
+            {"signature", "product"},
+            {"user_comments", "url", "_unexposed"},
+        ),
+    ],
+)
+def test_get_allowed_fields(
+    db, user_helper, monkeypatch, user_type, included, excluded
+):
+    monkeypatch.setattr(
+        "crashstats.supersearch.libsupersearch.get_supersearch_fields",
+        lambda: MINIMAL_SUPERSEARCH_FIELDS_FIXTURE,
+    )
+
+    if user_type == "none":
+        user = None
+    elif user_type == "authorized":
+        user = user_helper.create_protected_user()
+    else:
+        user = user_helper.create_user()
+
+    result = set(get_allowed_fields(user=user))
+
+    assert included.issubset(result)
+    assert excluded.isdisjoint(result)
+
+
+@pytest.mark.parametrize(
+    "param_name, input_values, allowed, expected",
+    [
+        # --- _sort: with/without `-` prefix ---
+        # Without prefix on disallowed field is stripped
+        ("_sort", ["signature", "user_comments"], {"signature"}, ["signature"]),
+        # With prefix on disallowed field is stripped
+        ("_sort", ["-signature", "-user_comments"], {"signature"}, ["-signature"]),
+        # With prefix on allowed field remains
+        ("_sort", ["-signature"], {"signature"}, ["-signature"]),
+        # Both with and without prefix on allowed field remains
+        (
+            "_sort",
+            ["signature", "-signature"],
+            {"signature"},
+            ["signature", "-signature"],
+        ),
+        # All disallowed fields with and without prefix -> empty list
+        ("_sort", ["user_comments", "-user_comments"], {"signature"}, []),
+        # Empty input -> empty output
+        ("_sort", [], {"signature"}, []),
+        # --- Other list-of-fields params: no `-` prefix to handle as with _sort ---
+        # _facets / _columns / _aggs.* / _histogram.* all work identically.
+        ("_facets", ["signature", "user_comments"], {"signature"}, ["signature"]),
+        ("_columns", ["signature", "url"], {"signature"}, ["signature"]),
+        ("_aggs.product", ["version", "user_comments"], {"version"}, ["version"]),
+        ("_histogram.date", ["product", "url"], {"product"}, ["product"]),
+        # `-` prefix is NOT a sort directive on non-_sort params; rejected as literal.
+        ("_columns", ["-signature"], {"signature"}, []),
+    ],
+)
+def test_sanitize_list_of_fields_params(param_name, input_values, allowed, expected):
+    params = {param_name: input_values}
+    sanitize_list_of_fields_params(
+        params,
+        allowed_fields=allowed,
+        list_of_fields_params=(param_name,),
+    )
+    assert params[param_name] == expected
+
+
+def test_sanitize_list_of_fields_params_handles_missing_keys():
+    """Params dict without the listed keys gets them initialized to []."""
+    params = {}
+    sanitize_list_of_fields_params(
+        params,
+        allowed_fields={"signature"},
+        list_of_fields_params=("_sort", "_facets", "_columns"),
+    )
+    assert params == {"_sort": [], "_facets": [], "_columns": []}

--- a/webapp/crashstats/supersearch/tests/test_views.py
+++ b/webapp/crashstats/supersearch/tests/test_views.py
@@ -376,6 +376,51 @@ class TestViews:
             assert "$thanks" in params["reason"]
             assert "Exception" in params["java_stack_trace"]
 
+    def test_search_results_strips_disallowed_field_references(
+        self, client, db, es_helper
+    ):
+        """Anonymous users can't reference protected fields in list-of-fields params."""
+
+        calls = []
+
+        def mocked_supersearch_get(**params):
+            calls.append(params)
+            return {"hits": [], "facets": "", "total": 0}
+
+        with mock.patch(
+            "crashstats.supersearch.models.SuperSearchUnredacted.get_implementation"
+        ) as mocked_get_implementation:
+            mocked_get_implementation.return_value.get.side_effect = (
+                mocked_supersearch_get
+            )
+            url = reverse("supersearch:search_results")
+
+            response = client.get(
+                url,
+                {
+                    "_sort": ["user_comments", "-user_comments", "date"],
+                    "_columns": ["signature", "user_comments"],
+                    "_facets": ["signature", "user_comments"],
+                },
+            )
+            assert response.status_code == 200
+
+            # First call is get_versions_for_product(); the real query is calls[1]
+            params = calls[1]
+
+            # _sort: protected field is stripped (both forms), allowed field survives.
+            assert "user_comments" not in params["_sort"]
+            assert "-user_comments" not in params["_sort"]
+            assert "date" in params["_sort"]
+
+            # _columns: protected field is stripped.
+            assert "user_comments" not in params["_columns"]
+            assert "signature" in params["_columns"]
+
+            # _facets: protected field is stripped.
+            assert "user_comments" not in params["_facets"]
+            assert "signature" in params["_facets"]
+
     def test_search_results_pagination(self, client, db, es_helper):
         """Test that the pagination of results works as expected."""
 

--- a/webapp/crashstats/supersearch/views.py
+++ b/webapp/crashstats/supersearch/views.py
@@ -31,6 +31,10 @@ from crashstats.supersearch.models import (
 from socorro import settings as socorro_settings
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
+from webapp.crashstats.supersearch.libsupersearch import (
+    get_allowed_fields,
+    sanitize_list_of_fields_params,
+)
 
 
 DEFAULT_COLUMNS = ("date", "signature", "product", "version", "build_id", "platform")
@@ -48,14 +52,6 @@ DEFAULT_DATE_RANGE_DAYS = 7
 
 class ValidationError(Exception):
     pass
-
-
-def get_allowed_fields(user):
-    return tuple(
-        x["name"]
-        for x in SuperSearchFields().get().values()
-        if x["is_exposed"] and user.has_perms(x["webapp_permissions_needed"])
-    )
 
 
 def get_supersearch_form(request):
@@ -93,16 +89,9 @@ def get_params(request):
     params["_facets"] = request.GET.getlist("_facets", DEFAULT_FACETS)
     params["_columns"] = request.GET.getlist("_columns") or DEFAULT_COLUMNS
 
-    allowed_fields = get_allowed_fields(request.user)
-
     # Make sure only allowed fields are used.
-    params["_sort"] = [
-        x
-        for x in params["_sort"]
-        if x in allowed_fields or (x.startswith("-") and x[1:] in allowed_fields)
-    ]
-    params["_facets"] = [x for x in params["_facets"] if x in allowed_fields]
-    params["_columns"] = [x for x in params["_columns"] if x in allowed_fields]
+    allowed_fields = get_allowed_fields(request.user)
+    params = sanitize_list_of_fields_params(params, allowed_fields)
 
     # The uuid is always displayed in the UI so we need to make sure it is
     # always returned by the model.


### PR DESCRIPTION
Because:
* We want to use the same validation logic for our SuperSearch API as in the webapp.

This PR:
* Hoists the logic in the webapp to libsupersearch, so it can be used in both places.