### PR TITLE
bug-1685143: Changed Auth0 Audience URL

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -82,6 +82,7 @@ OIDC_RP_CLIENT_SECRET=bd01adf93cfb
 # Redirect for the browser which is running on the docker host
 OIDC_OP_AUTHORIZATION_ENDPOINT=http://localhost:8080/openid/authorize
 # Requests between the webapp container and the oidcprovider container
+AUTH0_MANAGEMENT_API_ENDPOINT=http://oidcprovider:8080/api/v2/
 OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider:8080/openid/token
 OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
 

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -42,12 +42,11 @@ def delta_days(since_datetime):
 
 def get_access_token(client_id, client_secret, domain, session):
     url = f"https://{domain}/oauth/token"
-    audience = f"https://{domain}/api/v2/"
     payload = {
         "client_id": client_id,
         "client_secret": client_secret,
         "grant_type": "client_credentials",
-        "audience": audience,
+        "audience": settings.AUTH0_MANAGEMENT_API_ENDPOINT,
     }
     response = session.post(url, json=payload)
     if response.status_code != 200:

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -117,15 +117,13 @@ class Command(BaseCommand):
         # Go through the users and mark the ones for removal
         users_to_remove = []
         for user in hackers_group.user_set.all():
-            is_blocked = False
-            try:
-                is_blocked = is_blocked_in_auth0(user.email)
-            except RuntimeError as e:
-                self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
-
-            # User may be blocked as a security mitigation. Eg: too many login attempts
-            if is_blocked:
-                users_to_remove.append((user, "user has most likely lost employment"))
+            if not settings.LOCAL_DEV_ENV:
+                try:
+                    # User may be blocked as a security mitigation. Eg: too many login attempts
+                    if is_blocked_in_auth0(user.email):
+                        users_to_remove.append((user, "user has most likely lost employment"))
+                except RuntimeError as e:
+                    self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
             elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -121,7 +121,9 @@ class Command(BaseCommand):
                 try:
                     # User may be blocked as a security mitigation. Eg: too many login attempts
                     if is_blocked_in_auth0(user.email):
-                        users_to_remove.append((user, "user has most likely lost employment"))
+                        users_to_remove.append(
+                            (user, "user has most likely lost employment")
+                        )
                 except RuntimeError as e:
                     self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 

--- a/webapp/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp/crashstats/authentication/tests/test_auditgroups.py
@@ -155,6 +155,11 @@ class TestAuditGroupsCommand:
         bob.save()
 
         monkeypatch.setattr(
+            "crashstats.authentication.management.commands.auditgroups.settings.LOCAL_DEV_ENV",
+            False,
+        )
+
+        monkeypatch.setattr(
             "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
             lambda email: True,
         )

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -510,6 +510,7 @@ OIDC_RP_CLIENT_SECRET = _config("OIDC_RP_CLIENT_SECRET", default="")
 OIDC_OP_AUTHORIZATION_ENDPOINT = _config("OIDC_OP_AUTHORIZATION_ENDPOINT", default="")
 OIDC_OP_TOKEN_ENDPOINT = _config("OIDC_OP_TOKEN_ENDPOINT", default="")
 OIDC_OP_USER_ENDPOINT = _config("OIDC_OP_USER_ENDPOINT", default="")
+AUTH0_MANAGEMENT_API_ENDPOINT = _config("AUTH0_MANAGEMENT_API_ENDPOINT", default="")
 # List of urls that are exempt from session refresh because they're used in XHR
 # contexts and that doesn't handle redirecting.
 OIDC_EXEMPT_URLS = [

--- a/webapp/crashstats/settings/base.py
+++ b/webapp/crashstats/settings/base.py
@@ -505,12 +505,12 @@ VALID_RULESETS = ["default", "regenerate_signature"]
 
 # OIDC credentials are needed to be able to connect with OpenID Connect.
 # Credentials for local development are set in /docker/config/oidcprovider-fixtures.json.
+AUTH0_MANAGEMENT_API_ENDPOINT = _config("AUTH0_MANAGEMENT_API_ENDPOINT", default="")
 OIDC_RP_CLIENT_ID = _config("OIDC_RP_CLIENT_ID", default="")
 OIDC_RP_CLIENT_SECRET = _config("OIDC_RP_CLIENT_SECRET", default="")
 OIDC_OP_AUTHORIZATION_ENDPOINT = _config("OIDC_OP_AUTHORIZATION_ENDPOINT", default="")
 OIDC_OP_TOKEN_ENDPOINT = _config("OIDC_OP_TOKEN_ENDPOINT", default="")
 OIDC_OP_USER_ENDPOINT = _config("OIDC_OP_USER_ENDPOINT", default="")
-AUTH0_MANAGEMENT_API_ENDPOINT = _config("AUTH0_MANAGEMENT_API_ENDPOINT", default="")
 # List of urls that are exempt from session refresh because they're used in XHR
 # contexts and that doesn't handle redirecting.
 OIDC_EXEMPT_URLS = [


### PR DESCRIPTION
Because:
- The `auditgroups` cronjob is raising a 403 error in the function `get_access_token`, meaning the Auth0 API is not able to query the users
- This error occurs because the `audience` parameter in the request payload points to the external domain behind a Fastly WAF (This ticket shows some context on the domain change in socorro: [CRINGE-135](https://mozilla-hub.atlassian.net/browse/CRINGE-135?atlOrigin=eyJpIjoiYTgwZWQ5OWE1ZGExNDU1M2E0OTJhMjA4NjAzOTk3OTIiLCJwIjoiaiJ9))
- The Auth0 management API only has a single identifier, thus we need to switch to using that single internal domain URL so that the Auth0 management API can generate a valid access token.

This PR:
- Adds a new config variable for the Auth0 management endpoint: `AUTH0_MANAGEMENT_API_ENDPOINT`.
- Updates the new variable to be used for the audience parameter in the `get_access_token` function.