### PR TITLE
bug-2038160: ensure authorized users can use _columns on protected fields in SuperSearch

### DIFF
--- a/webapp/crashstats/api/tests/test_views.py
+++ b/webapp/crashstats/api/tests/test_views.py
@@ -434,7 +434,6 @@ class TestSuperSearch(BaseTestViews):
                 "_aggs.signature",
                 "_histogram.date",
                 "_sort",
-                "_columns",
             )
             for key in restricted_params:
                 if key in params:
@@ -449,7 +448,7 @@ class TestSuperSearch(BaseTestViews):
                         "signature": "abcdef",
                         "product": "WaterWolf",
                         "version": "1.0",
-                        "url": "http://embarassing.website.com",
+                        "url": "http://embarrassing.website.com",
                         "user_comments": "hey I am thebig@lebowski.net",
                     }
                 ],
@@ -487,6 +486,38 @@ class TestSuperSearch(BaseTestViews):
         # Verify values can be lists.
         response = self.client.get(url, {"product": ["WaterWolf", "NightTrain"]})
         assert response.status_code == 200
+
+    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
+    def test_api_with_view_pii(self, mock_implementation):
+        def mocked_get(**params):
+            assert "url" in params["_columns"]
+            assert "signature" in params["_columns"]
+            return {
+                "hits": [
+                    {
+                        "signature": "abcdef",
+                        "url": "http://embarrassing.website.com",
+                    }
+                ],
+                "facets": {"signature": []},
+                "total": 1,
+            }
+
+        mock_implementation.return_value.get.side_effect = mocked_get
+
+        url = reverse("api:model_wrapper", args=("SuperSearch",))
+
+        user = self._login()
+        self._add_permission(user, "view_pii")
+
+        response = self.client.get(url, {"_columns": ["url", "signature"]})
+        assert response.status_code == 200
+        res = json.loads(response.content)
+
+        assert res["hits"]
+        for hit in res["hits"]:
+            assert hit["signature"] == "abcdef"
+            assert hit["url"] == "http://embarrassing.website.com"
 
 
 class TestSuperSearchUnredacted(BaseTestViews):

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -36,7 +36,6 @@ SUPERSEARCH_META_PARAMS = (
 PARAMETERS_LISTING_FIELDS = (
     "_aggs.product.version",
     "_aggs.android_cpu_abi.android_manufacturer.android_model",
-    "_columns",
     "_facets",
     "_sort",
 )


### PR DESCRIPTION
Because:
* My fix for bug-2038160 regressed some SuperSearch API behavior. Namely, users with `view_pii` permissions were previously able to get protected fields back in the API response with the `_columns` list-of-fields parameter, but now they are not.

This PR:
* Adds a test case for this scenario and restores the original API behavior. I've added a [more detailed explanation](https://bugzilla.mozilla.org/show_bug.cgi?id=2038160#c9) of the fix in the ticket.