### PR TITLE
bug-2046410: added exception to get_type_replacement()

### DIFF
--- a/socorro/signature/tests/test_utils.py
+++ b/socorro/signature/tests/test_utils.py
@@ -181,6 +181,7 @@ def test_find_enclosed_slices(s, opening_token, closing_token, expected):
             "IPC::ParamTraits<nsTSubstring<char> >::Write(IPC::Message *,nsTSubstring<char> const &)",
             "IPC::ParamTraits<nsTSubstring<T> >::Write(IPC::Message *,nsTSubstring<T> const &)",
         ),
+        ("<unknown in ntdll.pdb>", "<unknown in ntdll.pdb>"),
     ],
 )
 def test_collapse_types(function, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -251,7 +251,7 @@ def collapse_types(func_signature: str) -> str:
     """
 
     def get_type_replacement(before, inside, after):
-        if inside == "<name omitted>" or " as " in inside:
+        if inside == "<name omitted>" or " as " in inside or " in " in inside:
             return inside
         if before.endswith("IPC::ParamTraits"):
             s_without_outer_tokens = inside[1:-1]


### PR DESCRIPTION
Purpose:
- Fixes the regression caused by bug-2031036
- During the recent refactor of the `collapse()` function, the original exception function which caught all of the exceptions was replaced. The new exception function `get_type_replacement()` did not have the exception for the `" in "` edge case.
- This regression caused signatures such as `<unknown in ntdll.pdb>` to be incorrectly collapsed and returned as `<T>` which is not the intended function, we want the signature to be returned unchanged

This PR:
- Adds the `" in "` string as an exception in the `get_type_replacement()` function that is used by `collapse_types()`
- Adds a test for the `<unknown in ntdll.pdb>` edge case to confirm it remains unchanged due to the exception