### PR TITLE
bug-2038605 - set private: true and prefix name with @mozilla for webapp package.json

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "socorro-webapp",
+  "name": "@mozilla/socorro-webapp",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "socorro-webapp",
+      "name": "@mozilla/socorro-webapp",
       "version": "0.0.0",
       "license": "MPL-2.0",
       "dependencies": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "socorro-webapp",
+  "name": "@mozilla/socorro-webapp",
   "version": "0.0.0",
   "description": "webapp for crash-stats",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git://github.com/mozilla-services/socorro.git"


### PR DESCRIPTION
Because:
* We never intend to publish this package, so we should set `private: true`. If not specified, it defaults to `false`.
* To ensure that only a member of the `mozilla` npm org can publish the package if we ever were to publish it, we can rename the package to be namespaced under that org. A package name scoped to Mozilla can't be impersonated.

This PR:
* Sets `"private": true` and `"name": "@mozilla/socorro-webapp"` in `webapp/package.json`.
* Regenerates `package-lock.json` to match.