### PR TITLE
bug-2037932: Set crashing thread for shutdownhang to 0

### DIFF
--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -126,9 +126,10 @@ DEFAULT_RULESET = [
     MemoryReportExtraction(),
     SoftErrorsRule(),
     ThreadCountRule(),
-    ShutDownHangCrashingThreadRule(),
     # generate signature now that we've done all the processing it depends on
     SignatureGeneratorRule(),
+    # change the crashing thread if it's a shutdownhang
+    ShutDownHangCrashingThreadRule(),
 ]
 
 

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -59,6 +59,7 @@ from socorro.processor.rules.mozilla import (
     ThemePrettyNameRule,
     TopMostFilesRule,
     UtilityActorsNameRule,
+    ShutDownHangCrashingThreadRule,
 )
 
 
@@ -125,6 +126,7 @@ DEFAULT_RULESET = [
     MemoryReportExtraction(),
     SoftErrorsRule(),
     ThreadCountRule(),
+    ShutDownHangCrashingThreadRule(),
     # generate signature now that we've done all the processing it depends on
     SignatureGeneratorRule(),
 ]

--- a/socorro/mozilla_rulesets.py
+++ b/socorro/mozilla_rulesets.py
@@ -53,13 +53,13 @@ from socorro.processor.rules.mozilla import (
     PluginRule,
     ProcessTypeRule,
     ReportTypeRule,
+    ShutDownHangCrashingThreadRule,
     SignatureGeneratorRule,
     SoftErrorsRule,
     SubmittedFromRule,
     ThemePrettyNameRule,
     TopMostFilesRule,
     UtilityActorsNameRule,
-    ShutDownHangCrashingThreadRule,
 )
 
 

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1286,7 +1286,21 @@ class ShutDownHangCrashingThreadRule(Rule):
     """add docstring here"""
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
-        signature = processed_crash.get("signature")
-        threads = glom(processed_crash, "json_dump.threads", default=None)
-        if signature and signature.startswith("shutdownhang") and threads:
-            processed_crash["crashing_thread"] = 0
+        if "json_dump" in processed_crash:
+            crash_data = processed_crash["json_dump"]
+            try:
+                crash_info = crash_data.get("crash_info") or {}
+                crashing_thread = int(crash_info.get("crashing_thread", 0))
+            except (TypeError, ValueError):
+                crashing_thread = 0
+
+            stack = glom(crash_data, "threads.%d.frames" % crashing_thread, default=[])
+            
+            if crashing_thread == 0:
+                return
+            
+            for frame in stack:
+                if "RunWatchdog" in (frame.get("function") or ""):
+                    processed_crash["crashing_thread"] = 0
+                    return
+            

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1283,10 +1283,17 @@ class SoftErrorsRule(Rule):
 
 
 class ShutDownHangCrashingThreadRule(Rule):
-    """add docstring here"""
+    """Sets the crashing thread to 0 for shutdownhangs
+
+    Crashes with a `shutdownhang` signature always return the watchdog thread as
+    the crashing thread. But, we want the crashing thread to be 0 since its stack
+    frame reveals the actual reason for the crash.
+
+    Bug #2037932
+
+    """
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         signature = processed_crash.get("signature")
-        threads = glom(processed_crash, "json_dump.threads", default=None)
-        if signature and signature.startswith("shutdownhang") and threads:
+        if signature and signature.startswith("shutdownhang"):
             processed_crash["crashing_thread"] = 0

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1302,5 +1302,6 @@ class ShutDownHangCrashingThreadRule(Rule):
             for frame in stack:
                 if "RunWatchdog" in (frame.get("function") or ""):
                     processed_crash["crashing_thread"] = 0
-                    return
+                    if "crash_info" in processed_crash["json_dump"]:
+                        processed_crash["json_dump"]["crash_info"]["crashing_thread"] = 0
             

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1286,22 +1286,7 @@ class ShutDownHangCrashingThreadRule(Rule):
     """add docstring here"""
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
-        if "json_dump" in processed_crash:
-            crash_data = processed_crash["json_dump"]
-            try:
-                crash_info = crash_data.get("crash_info") or {}
-                crashing_thread = int(crash_info.get("crashing_thread", 0))
-            except (TypeError, ValueError):
-                crashing_thread = 0
-
-            stack = glom(crash_data, "threads.%d.frames" % crashing_thread, default=[])
-            
-            if crashing_thread == 0:
-                return
-            
-            for frame in stack:
-                if "RunWatchdog" in (frame.get("function") or ""):
-                    processed_crash["crashing_thread"] = 0
-                    if "crash_info" in processed_crash["json_dump"]:
-                        processed_crash["json_dump"]["crash_info"]["crashing_thread"] = 0
-            
+        signature = processed_crash.get("signature")
+        threads = glom(processed_crash, "json_dump.threads", default=None)
+        if signature and signature.startswith("shutdownhang") and threads:
+            processed_crash["crashing_thread"] = 0

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -1280,3 +1280,13 @@ class SoftErrorsRule(Rule):
         # Limit the size to 4KB to avoid any potential performance impacts.
         soft_errors_limited = soft_errors_str[:4096]
         processed_crash["soft_errors"] = soft_errors_limited
+
+
+class ShutDownHangCrashingThreadRule(Rule):
+    """add docstring here"""
+
+    def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
+        signature = processed_crash.get("signature")
+        threads = glom(processed_crash, "json_dump.threads", default=None)
+        if signature and signature.startswith("shutdownhang") and threads:
+            processed_crash["crashing_thread"] = 0

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -36,6 +36,7 @@ from socorro.processor.rules.mozilla import (
     PluginRule,
     ProcessTypeRule,
     ReportTypeRule,
+    ShutDownHangCrashingThreadRule,
     SignatureGeneratorRule,
     SoftErrorsRule,
     SubmittedFromRule,
@@ -2457,3 +2458,43 @@ class TestSoftErrorsRule:
         rule.act(raw_crash, dumps, processed, str(tmp_path), status)
 
         assert processed == expected
+
+
+class TestShutDownHangCrashingThreadRule:
+    def test_is_shutdownhang(self, tmp_path):
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {
+            "crashing_thread": 58,
+            "signature": "shutdownhang | mozilla::scache::StartupCache::GetBuffer",
+        }
+        status = Status()
+        rule = ShutDownHangCrashingThreadRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert processed_crash["crashing_thread"] == 0
+
+    def test_is_not_shutdownhang(self, tmp_path):
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {
+            "crashing_thread": 58,
+            "signature": "mozilla::scache::StartupCache::GetBuffer",
+        }
+        status = Status()
+        rule = ShutDownHangCrashingThreadRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert processed_crash["crashing_thread"] == 58
+
+    def test_no_crash_signature(self, tmp_path):
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {
+            "crashing_thread": 58,
+        }
+        status = Status()
+        rule = ShutDownHangCrashingThreadRule()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert processed_crash["crashing_thread"] == 58

--- a/webapp/crashstats/crashstats/tests/test_views.py
+++ b/webapp/crashstats/crashstats/tests/test_views.py
@@ -754,34 +754,6 @@ class Test_report_index:
         # Assert that the second unloaded module cert subject shows up
         assert "<td>Microsoft Windows</td>" in smart_str(response.content)
 
-    def test_shutdownhang_signature(self, client, db, storage_helper):
-        json_dump = {
-            "crash_info": {"crashing_thread": 2},
-            "status": "OK",
-            "threads": [
-                {"frame_count": 0, "frames": []},
-                {"frame_count": 0, "frames": []},
-                {"frame_count": 0, "frames": []},
-            ],
-            "modules": [],
-        }
-
-        crash_id, raw_crash, processed_crash = build_crash_data()
-        processed_crash["json_dump"] = json_dump
-        processed_crash["crashing_thread"] = json_dump["crash_info"]["crashing_thread"]
-        processed_crash["json_dump"] = json_dump
-        processed_crash["signature"] = "shutdownhang | foo::bar()"
-        upload_crash_data(
-            storage_helper, raw_crash=raw_crash, processed_crash=processed_crash
-        )
-
-        url = reverse("crashstats:report_index", args=(crash_id,))
-        response = client.get(url)
-        assert response.status_code == 200
-
-        assert "Crashing Thread (2)" not in smart_str(response.content)
-        assert "Crashing Thread (0)" in smart_str(response.content)
-
     def test_no_crashing_thread(self, client, db, storage_helper):
         # If the json_dump has no crashing thread available, do not display a
         # specific crashing thread, but instead display all threads.

--- a/webapp/crashstats/crashstats/views.py
+++ b/webapp/crashstats/crashstats/views.py
@@ -170,11 +170,6 @@ def report_index(request, crash_id, default_context=None):
         parsed_dump = {}
 
     context["crashing_thread"] = context["report"].get("crashing_thread")
-    if context["report"]["signature"].startswith("shutdownhang"):
-        # For shutdownhang signatures, we want to use thread 0 as the crashing thread,
-        # because that's the thread that actually contains the useful data about what
-        # happened.
-        context["crashing_thread"] = 0
 
     context["parsed_dump"] = parsed_dump
 


### PR DESCRIPTION
Purpose:
- A fix for bug-2037932
- Fixes an issue where the `"Bugzilla" > "Core"` tab bug form gets pre-filled with the watchdog thread, instead of the main thread (thread 0) for `shutdownhangs`.
- We want to ensure the bug form gets pre-filled with thread 0 (the main thread) by setting the `processed_crash.crashing_thread` to be 0. This will also populate the `details` page with the main thread stack frame, allowing us to remove the code that manually sets the crashing thread to 0.

This PR:
- Adds a post signature processing rule called `ShutDownHangCrashingThreadRule()` to `mozilla.py` which checks if a signature starts with `shutdownhang`. If it does, the processed crash crashing thread is set to 0.
- Adds test cases for the new `ShutDownHangCrashingThreadRule()` in `test_mozilla.py`
- Removes the redundant code in `crashstats/views.py` that sets the `details` page crashing thread to 0 and removes the test case that is associated with it.