### PR TITLE
bug-2050638: allow querying protected fields for authorized users in SuperSearch

### DIFF
--- a/webapp/crashstats/api/tests/test_views.py
+++ b/webapp/crashstats/api/tests/test_views.py
@@ -2,27 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from collections.abc import Iterable
 import contextlib
 import json
+from collections.abc import Iterable
 from unittest import mock
 
-from django.core.cache import cache
-from django.contrib.auth.models import User, Permission
-from django.forms import ValidationError
-from django.urls import reverse
-from django.utils.encoding import smart_str
-
-from markus.testing import MetricsMock
 import pyquery
 import pytest
-
 from crashstats import libproduct
 from crashstats.api.views import (
+    TYPE_MAP,
+    MultipleStringField,
     api_models_and_names,
     is_valid_model_class,
-    MultipleStringField,
-    TYPE_MAP,
 )
 from crashstats.crashstats.models import (
     BugAssociation,
@@ -31,13 +23,20 @@ from crashstats.crashstats.models import (
     SocorroMiddleware,
 )
 from crashstats.crashstats.tests.conftest import BaseTestViews
+from crashstats.crashstats.utils import DateTimeEncoder
 from crashstats.supersearch.models import (
+    ESSocorroMiddleware,
     SuperSearch,
     SuperSearchUnredacted,
-    ESSocorroMiddleware,
 )
 from crashstats.tokens.models import Token
-from crashstats.crashstats.utils import DateTimeEncoder
+from django.contrib.auth.models import Permission, User
+from django.core.cache import cache
+from django.forms import ValidationError
+from django.urls import reverse
+from django.utils.encoding import smart_str
+from markus.testing import MetricsMock
+
 from socorro.lib.libooid import create_new_ooid
 
 
@@ -426,79 +425,43 @@ class TestField(BaseTestViews):
 
 
 class TestSuperSearch(BaseTestViews):
-    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
-    def test_api(self, mock_implementation):
-        def mocked_get(**params):
-            restricted_params = (
-                "_facets",
-                "_aggs.signature",
-                "_histogram.date",
-                "_sort",
-            )
-            for key in restricted_params:
-                if key in params:
-                    assert "url" not in params[key]
+    """
+    SuperSearch must respect the caller's permissions.
 
-            if "product" in params:
-                assert params["product"] == ["WaterWolf", "NightTrain"]
-
-            return {
-                "hits": [
-                    {
-                        "signature": "abcdef",
-                        "product": "WaterWolf",
-                        "version": "1.0",
-                        "url": "http://embarrassing.website.com",
-                        "user_comments": "hey I am thebig@lebowski.net",
-                    }
-                ],
-                "facets": {"signature": []},
-                "total": 0,
-            }
-
-        mock_implementation.return_value.get.side_effect = mocked_get
-
-        url = reverse("api:model_wrapper", args=("SuperSearch",))
-        response = self.client.get(url)
-        assert response.status_code == 200
-        res = json.loads(response.content)
-
-        assert res["hits"]
-        assert res["facets"]
-
-        # Verify forbidden fields are not exposed.
-        assert "url" not in res["hits"]
-
-        # Verify it's not possible to use restricted parameters.
-        response = self.client.get(
-            url,
-            {
-                "url": "example.com",
-                "_facets": ["url", "product"],
-                "_aggs.signature": ["url", "product"],
-                "_histogram.date": ["url", "product"],
-                "_sort": ["url", "-url"],
-                "_columns": ["url", "product"],
-            },
-        )
-        assert response.status_code == 200
-
-        # Verify values can be lists.
-        response = self.client.get(url, {"product": ["WaterWolf", "NightTrain"]})
-        assert response.status_code == 200
+    Expected behavior:
+    * For unauthorized callers (anonymous/logged in user without ``crashstats.view_pii``):
+        - a request referencing only public fields (including the all-public
+          defaults) returns an HTTP 200 with public data;
+        - a request referencing a protected field in ANY form:
+            - as a param name (i.e. ``<field>=...``),
+            - as a list-of-fields value (e.g. ``_facets=[<field>]``), or
+            - as an ``_aggs.<field>`` param name)
+          returns an HTTP 200, redacting any protected fields before/after
+          running the query.
+    * For authorized callers (logged in user with ``crashstats.view_pii``):
+        - protected fields are honored in the query in every form, and are not
+          redacted from the returned hits.
+    """
 
     @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
-    def test_api_with_view_pii(self, mock_implementation):
+    def test_api_public_query_without_permission(self, mock_implementation):
+        """
+        Queries referencing only public fields (and the defaults which are all
+        public) succeed without auth, and the fields reach Elasticsearch.
+        """
+        # Store request parameters after the model-level permissions/sanitization
+        # logic is run, but before the ES query is run.
+        # This allows us to distinguish between the case the field was stripped
+        # from the ES query versus the case where the field was in the query but
+        # redacted from the ES response.
+        # See also https://bugzilla.mozilla.org/show_bug.cgi?id=2038160#c9.
+        params_before_query = {}
+
         def mocked_get(**params):
-            assert "url" in params["_columns"]
-            assert "signature" in params["_columns"]
+            params_before_query.clear()
+            params_before_query.update(params)
             return {
-                "hits": [
-                    {
-                        "signature": "abcdef",
-                        "url": "http://embarrassing.website.com",
-                    }
-                ],
+                "hits": [{"signature": "abcdef"}],
                 "facets": {"signature": []},
                 "total": 1,
             }
@@ -507,17 +470,168 @@ class TestSuperSearch(BaseTestViews):
 
         url = reverse("api:model_wrapper", args=("SuperSearch",))
 
-        user = self._login()
-        self._add_permission(user, "view_pii")
+        # The bare request relies on defaults that are all public fields
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert json.loads(response.content)["hits"]
 
-        response = self.client.get(url, {"_columns": ["url", "signature"]})
+        # Query with only public fields
+        response = self.client.get(
+            url,
+            {
+                "product": ["WaterWolf", "NightTrain"],
+                "_facets": ["product"],
+                "_sort": ["signature"],
+                "_columns": ["signature"],
+            },
+        )
         assert response.status_code == 200
         res = json.loads(response.content)
-
         assert res["hits"]
-        for hit in res["hits"]:
-            assert hit["signature"] == "abcdef"
-            assert hit["url"] == "http://embarrassing.website.com"
+        assert "signature" in res["hits"][0]
+        # Assert nothing is sanitized in this case.
+        # Also verify values can be lists.
+        assert params_before_query["product"] == ["WaterWolf", "NightTrain"]
+        assert params_before_query["_facets"] == ["product"]
+        assert params_before_query["_sort"] == ["signature"]
+        assert params_before_query["_columns"] == ["signature"]
+
+    def _assert_supersearch_field_permissions(
+        self, mock_implementation, *, authorized, auth_token=None
+    ):
+        """
+        Test helper for shared behavior and assertions between test cases.
+
+        `url` is used as an example of a protected field and `product` is used
+        as an example of a public field.
+
+        If `authorized` is `True`, `url` is not redacted from the ES query or its
+        response. Else, it is.
+        """
+        params_before_query = {}
+
+        def mocked_get(**params):
+            params_before_query.clear()
+            params_before_query.update(params)
+            # _columns is the only query parameter that requires sanitizing the ES
+            # response, so it is always returned regardless of permissions.
+            # A Cleaner runs on the response for unauthorized callers to redact it
+            # afterwards.
+            # Note: A realistic response for authorized callers would have more
+            # information (like`url` facets/aggregations), but the only part of
+            # the response being tested is how `hits` does or doesn't get sanitized.
+            return {
+                "hits": [
+                    {"signature": "abcdef", "url": "http://embarrassing.website.com"}
+                ],
+                "facets": {"signature": []},
+                "total": 1,
+            }
+
+        mock_implementation.return_value.get.side_effect = mocked_get
+
+        url = reverse("api:model_wrapper", args=("SuperSearch",))
+        headers = {"auth-token": auth_token} if auth_token else {}
+        response = self.client.get(
+            url,
+            {
+                # direct filter parameter
+                "url": "example.com",
+                # list-of-fields parameters
+                "_aggs.signature": ["url", "product"],
+                "_facets": ["url", "product"],
+                "_histogram.date": ["url", "product"],
+                "_sort": ["url", "-url"],
+                # parameter name
+                "_aggs.url": ["signature"],
+                # list-of-fields parameter sanitized AFTER the query (by the Cleaner)
+                "_columns": ["url", "signature"],
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        res = json.loads(response.content)
+        assert res["hits"]
+
+        # Public fields always reach the ES query and the response.
+        assert "product" in params_before_query.get("_aggs.signature", [])
+        assert "product" in params_before_query.get("_facets", [])
+        assert "product" in params_before_query.get("_histogram.date", [])
+        assert "signature" in res["hits"][0]
+
+        # `_columns` bypasses pre-query sanitization for everyone, so `url` always
+        # reaches ES as a column; only the response side differs by permission.
+        assert "url" in params_before_query.get("_columns", [])
+
+        if authorized:
+            # The protected field also reaches the ES query in every other form...
+            assert "url" in params_before_query
+            assert "url" in params_before_query.get("_facets", [])
+            assert "url" in params_before_query.get("_sort", [])
+            assert "-url" in params_before_query.get("_sort", [])
+            assert "_aggs.url" in params_before_query
+            assert "url" in params_before_query.get("_aggs.signature", [])
+            assert "url" in params_before_query.get("_histogram.date", [])
+            # ...and is returned unredacted in the hits.
+            assert "url" in res["hits"][0]
+        else:
+            # The protected field never reaches the ES query in any other form...
+            assert "url" not in params_before_query
+            assert "url" not in params_before_query.get("_facets", [])
+            assert "url" not in params_before_query.get("_sort", [])
+            assert "-url" not in params_before_query.get("_sort", [])
+            assert "_aggs.url" not in params_before_query
+            assert "url" not in params_before_query.get("_aggs.signature", [])
+            assert "url" not in params_before_query.get("_histogram.date", [])
+            # ...and is redacted from the hits by the Cleaner.
+            assert "url" not in res["hits"][0]
+
+    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
+    def test_api_protected_fields_redacted_for_anonymous_user(
+        self, mock_implementation
+    ):
+        """Anonymous caller: protected fields are stripped from the query and
+        redacted from the hits."""
+        self._assert_supersearch_field_permissions(
+            mock_implementation, authorized=False
+        )
+
+    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
+    def test_api_protected_fields_redacted_for_user_without_view_pii(
+        self, mock_implementation
+    ):
+        """A logged-in user lacking view_pii is treated exactly like an anonymous
+        caller: protected fields stripped from the query and redacted from hits."""
+        self._login()  # logged in, but without view_pii
+        self._assert_supersearch_field_permissions(
+            mock_implementation, authorized=False
+        )
+
+    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
+    def test_api_protected_fields_allowed_for_user_with_view_pii(
+        self, mock_implementation
+    ):
+        """With view_pii on the user, protected fields are not stripped from the ES
+        query and not redacted from the response."""
+        user = self._login()
+        self._add_permission(user, "view_pii")
+        self._assert_supersearch_field_permissions(mock_implementation, authorized=True)
+
+    @mock.patch("crashstats.supersearch.models.SuperSearch.get_implementation")
+    def test_api_protected_fields_allowed_with_view_pii_token(
+        self, mock_implementation
+    ):
+        """view_pii granted via an API token also honors protected fields in the
+        query and hits (token permissions resolve via a different code path than
+        session permissions)."""
+        user = User.objects.create(username="test")
+        self._add_permission(user, "view_pii")
+        token = Token.objects.create(user=user, notes="test token")
+        token.permissions.add(Permission.objects.get(codename="view_pii"))
+        self._assert_supersearch_field_permissions(
+            mock_implementation, authorized=True, auth_token=token.key
+        )
 
 
 class TestSuperSearchUnredacted(BaseTestViews):

--- a/webapp/crashstats/supersearch/libsupersearch.py
+++ b/webapp/crashstats/supersearch/libsupersearch.py
@@ -2,12 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from dataclasses import dataclass
 import datetime
+from dataclasses import dataclass
 
 from socorro import settings as socorro_settings
 from socorro.libclass import build_instance_from_settings
-
 
 # Map of processed crash schema permissions to webapp permissions
 PROCESSED_CRASH_TO_WEBAPP_PERMISSIONS = {
@@ -138,22 +137,51 @@ def get_allowed_fields(user=None):
     )
 
 
-def sanitize_list_of_fields_params(
-    params, allowed_fields, list_of_fields_params=("_facets", "_columns", "_sort")
+def sanitize_params(
+    params,
+    allowed_fields,
+    all_fields,
+    list_of_fields_params=("_facets", "_columns", "_sort"),
 ):
-    """Strip disallowed field references from list-of-fields parameters.
-    Handles _sort fields that may be prefixed with `-`.
+    """
+    Strip references to disallowed fields from SuperSearch query params
+    and their values.
+
+    Removes from ``params`` (mutated in place):
+    * disallowed field names inside list-of-fields params, e.g.
+      ``_facets=[<field>]`` (handles the ``-`` prefix used by ``_sort``);
+    * direct filters keyed by a disallowed field
+      name (e.g. ``<field>=...``), and
+    * aggregation/histogram params that encode a disallowed field in the param
+      name at any depth (e.g. ``_aggs.<field>`` or ``_histogram.<field>``).
 
     :arg params: dict of SuperSearch query parameters
+
+    :arg allowed_fields: iterable of field names (plus ``_histogram.*`` /
+    ``_cardinality.*`` pseudo-fields) the caller is permitted to reference
+
+    :arg all_fields: collection of all known field names, used to tell a field
+    filter apart from meta params like ``_results_number``.
 
     :arg list_of_fields_params: tuple of parameter names whose values are
     lists of field names
 
-    :returns: the mutated ``params`` dict, with disallowed entries
-    removed
+    :returns: the mutated ``params`` dict, with disallowed entries removed
     """
     allowed_fields_set = set(allowed_fields)
 
+    # Drop disallowed filters and aggregation/histogram params that name a field
+    # in the param key itself.
+    for key in list(params):
+        if key.startswith(("_aggs.", "_histogram.", "_histogram_interval.")):
+            # e.g. `_aggs.url`, `_aggs.product.version`, `_histogram.url`
+            referenced = key.split(".")[1:]
+            if any(name not in allowed_fields_set for name in referenced):
+                del params[key]
+        elif key in all_fields and key not in allowed_fields_set:
+            del params[key]
+
+    # Strip disallowed field names from the values of list-of-fields params.
     for key in list_of_fields_params:
         # _sort: bare field name or with `-` prefix for reverse order.
         if key == "_sort":

--- a/webapp/crashstats/supersearch/libsupersearch.py
+++ b/webapp/crashstats/supersearch/libsupersearch.py
@@ -6,7 +6,13 @@ import datetime
 from dataclasses import dataclass
 
 from socorro import settings as socorro_settings
+from socorro.external.es.search_common import SearchBase
 from socorro.libclass import build_instance_from_settings
+
+# To build an allowlist of fields to sanitize SuperSearch API calls against,
+# we need to combine SuperSearch fields (e.g. user_comments) with
+# meta fields (e.g. _results_number).
+META_FILTER_NAMES = frozenset(f.name for f in SearchBase.meta_filters)
 
 # Map of processed crash schema permissions to webapp permissions
 PROCESSED_CRASH_TO_WEBAPP_PERMISSIONS = {
@@ -140,7 +146,6 @@ def get_allowed_fields(user=None):
 def sanitize_params(
     params,
     allowed_fields,
-    all_fields,
     list_of_fields_params=("_facets", "_columns", "_sort"),
 ):
     """
@@ -160,9 +165,6 @@ def sanitize_params(
     :arg allowed_fields: iterable of field names (plus ``_histogram.*`` /
     ``_cardinality.*`` pseudo-fields) the caller is permitted to reference
 
-    :arg all_fields: collection of all known field names, used to tell a field
-    filter apart from meta params like ``_results_number``.
-
     :arg list_of_fields_params: tuple of parameter names whose values are
     lists of field names
 
@@ -172,13 +174,14 @@ def sanitize_params(
 
     # Drop disallowed filters and aggregation/histogram params that name a field
     # in the param key itself.
+    # Use a list here, since we're deleting keys from params while iterating over it.
     for key in list(params):
         if key.startswith(("_aggs.", "_histogram.", "_histogram_interval.")):
             # e.g. `_aggs.url`, `_aggs.product.version`, `_histogram.url`
             referenced = key.split(".")[1:]
             if any(name not in allowed_fields_set for name in referenced):
                 del params[key]
-        elif key in all_fields and key not in allowed_fields_set:
+        elif key not in allowed_fields_set and key not in META_FILTER_NAMES:
             del params[key]
 
     # Strip disallowed field names from the values of list-of-fields params.

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -7,15 +7,15 @@ import copy
 from crashstats import libproduct
 from crashstats.crashstats import models
 from crashstats.supersearch.libsupersearch import (
+    SuperSearchStatusModel,
     get_allowed_fields,
     get_supersearch_fields,
-    SuperSearchStatusModel,
-    sanitize_list_of_fields_params,
+    sanitize_params,
 )
+
 from socorro import settings as socorro_settings
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
-
 
 SUPERSEARCH_META_PARAMS = (
     ("_aggs.product.version", list),
@@ -174,10 +174,13 @@ class SuperSearch(ESSocorroMiddleware):
         for field in set(allowed_fields):
             allowed_fields.add("_cardinality.%s" % field)
 
-        # Now make sure all fields listing fields only have unrestricted
-        # values.
-        kwargs = sanitize_list_of_fields_params(
-            kwargs, allowed_fields, list_of_fields_params=self.parameters_listing_fields
+        # Strip every param referencing a field the caller isn't allowed to see:
+        # filters, aggregation/histogram param names, and list-of-fields values.
+        kwargs = sanitize_params(
+            kwargs,
+            allowed_fields,
+            all_fields=self.all_fields,
+            list_of_fields_params=self.parameters_listing_fields,
         )
 
         # SuperSearch requires that the list of fields be passed to it.

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -108,9 +108,7 @@ class SuperSearch(ESSocorroMiddleware):
 
         self.possible_params = (
             tuple(
-                (x["name"], list)
-                for x in self.all_fields.values()
-                if x["is_exposed"] and not x["webapp_permissions_needed"]
+                (x["name"], list) for x in self.all_fields.values() if x["is_exposed"]
             )
             + SUPERSEARCH_META_PARAMS
             + tuple(self.extended_fields)
@@ -121,10 +119,11 @@ class SuperSearch(ESSocorroMiddleware):
         return es_crash_dest.build_supersearch()
 
     def _get_extended_params(self):
-        # Add histogram fields for all 'date','integer', or 'float' fields.
+        # Add aggregation fields to all fields, and add histogram fields for all
+        # 'date','integer', or 'float' fields.
         extended_fields = []
         for field in self.all_fields.values():
-            if not field["is_exposed"] or field["webapp_permissions_needed"]:
+            if not field["is_exposed"]:
                 continue
 
             extended_fields.append(("_aggs.%s" % field["name"], list))
@@ -149,12 +148,9 @@ class SuperSearch(ESSocorroMiddleware):
         return tuple(extended_fields)
 
     def get(self, **kwargs):
-        # Sanitize all parameters listing fields and make sure no private data
-        # is requested.
+        # Sanitize all parameters based on the user's permissions.
 
-        # Initialize the list of allowed fields with all the fields we know
-        # that are returned and do not require any permission.
-        allowed_fields = set(get_allowed_fields())
+        allowed_fields = set(get_allowed_fields(self.api_user))
 
         # Extend that list with the special fields, like `_histogram.*`.
         # Those are accepted values for fields listing other fields.
@@ -167,7 +163,7 @@ class SuperSearch(ESSocorroMiddleware):
             if (
                 field_name in self.all_fields
                 and self.all_fields[field_name]["is_returned"]
-                and not self.all_fields[field_name]["webapp_permissions_needed"]
+                and field_name in allowed_fields
             ):
                 allowed_fields.add(histogram)
 

--- a/webapp/crashstats/supersearch/models.py
+++ b/webapp/crashstats/supersearch/models.py
@@ -147,8 +147,11 @@ class SuperSearch(ESSocorroMiddleware):
 
         return tuple(extended_fields)
 
-    def get(self, **kwargs):
+    def get(self, dont_cache=False, refresh_cache=False, **kwargs):
         # Sanitize all parameters based on the user's permissions.
+        # We sanitize kwargs via an allowlist of SuperSearch fields and
+        # meta fields. Without separating out dont_cache and refresh_cache,
+        # these would get removed from kwargs, which would regress crash_verify.
 
         allowed_fields = set(get_allowed_fields(self.api_user))
 
@@ -175,7 +178,6 @@ class SuperSearch(ESSocorroMiddleware):
         kwargs = sanitize_params(
             kwargs,
             allowed_fields,
-            all_fields=self.all_fields,
             list_of_fields_params=self.parameters_listing_fields,
         )
 
@@ -185,7 +187,7 @@ class SuperSearch(ESSocorroMiddleware):
         # Do some data validation here before we go further to reduce efforts
         validate_products(kwargs.get("product"))
 
-        return super().get(**kwargs)
+        return super().get(dont_cache=dont_cache, refresh_cache=refresh_cache, **kwargs)
 
 
 class SuperSearchUnredacted(SuperSearch):

--- a/webapp/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp/crashstats/supersearch/tests/test_libsupersearch.py
@@ -4,11 +4,10 @@
 
 
 import pytest
-
 from crashstats.supersearch.libsupersearch import (
     convert_permissions,
     get_allowed_fields,
-    sanitize_list_of_fields_params,
+    sanitize_params,
 )
 
 
@@ -122,10 +121,10 @@ def test_get_allowed_fields(
 @pytest.mark.parametrize(
     "param_name, input_values, allowed, expected",
     [
-        # --- _sort: with/without `-` prefix ---
-        # Without prefix on disallowed field is stripped
+        # _sort is the only param with a possible prefix
+        # Without - prefix on disallowed field is stripped
         ("_sort", ["signature", "user_comments"], {"signature"}, ["signature"]),
-        # With prefix on disallowed field is stripped
+        # With - prefix on disallowed field is stripped
         ("_sort", ["-signature", "-user_comments"], {"signature"}, ["-signature"]),
         # With prefix on allowed field remains
         ("_sort", ["-signature"], {"signature"}, ["-signature"]),
@@ -140,32 +139,86 @@ def test_get_allowed_fields(
         ("_sort", ["user_comments", "-user_comments"], {"signature"}, []),
         # Empty input -> empty output
         ("_sort", [], {"signature"}, []),
-        # --- Other list-of-fields params: no `-` prefix to handle as with _sort ---
         # _facets / _columns / _aggs.* / _histogram.* all work identically.
         ("_facets", ["signature", "user_comments"], {"signature"}, ["signature"]),
         ("_columns", ["signature", "url"], {"signature"}, ["signature"]),
-        ("_aggs.product", ["version", "user_comments"], {"version"}, ["version"]),
-        ("_histogram.date", ["product", "url"], {"product"}, ["product"]),
-        # `-` prefix is NOT a sort directive on non-_sort params; rejected as literal.
+        (
+            "_aggs.product",
+            ["version", "user_comments"],
+            {"product", "version"},
+            ["version"],
+        ),
+        ("_histogram.date", ["product", "url"], {"date", "product"}, ["product"]),
+        # `-` prefix is not a sort directive on non-_sort params, so the value is rejected.
         ("_columns", ["-signature"], {"signature"}, []),
     ],
 )
-def test_sanitize_list_of_fields_params(param_name, input_values, allowed, expected):
+def test_sanitize_params_list_of_fields_values(
+    param_name, input_values, allowed, expected
+):
+    """Params dict with list-of-fields have their values sanitized appropriately."""
     params = {param_name: input_values}
-    sanitize_list_of_fields_params(
+    sanitize_params(
         params,
         allowed_fields=allowed,
+        all_fields={},
         list_of_fields_params=(param_name,),
     )
     assert params[param_name] == expected
 
 
-def test_sanitize_list_of_fields_params_handles_missing_keys():
-    """Params dict without the listed keys gets them initialized to []."""
+def test_sanitize_params_handles_missing_keys_for_list_of_fields_values():
+    """Empty params dict results in empty default list-of-fields values."""
     params = {}
-    sanitize_list_of_fields_params(
+    sanitize_params(
         params,
         allowed_fields={"signature"},
+        all_fields={},
         list_of_fields_params=("_sort", "_facets", "_columns"),
     )
     assert params == {"_sort": [], "_facets": [], "_columns": []}
+
+
+def test_sanitize_params_drops_disallowed_filters_and_agg_names():
+    """
+    Params dict with direct filters, _aggs, _histograms parameter names containing
+    disallowed fields are sanitized.
+    """
+    params = {
+        "url": ["example.com"],  # filter on a disallowed field
+        "signature": ["abc"],  # filter on an allowed field
+        "_aggs.url": ["signature"],  # aggregation on a disallowed field
+        "_aggs.signature": ["signature"],  # aggregation on an allowed field
+        "_histogram.url": ["signature"],  # histogram on a disallowed field
+        "_histogram.signature": ["signature"],  # histogram on an allowed field
+        "_results_number": 10,  # meta param, not a field
+    }
+    sanitize_params(
+        params,
+        allowed_fields={"signature"},
+        all_fields={"url", "signature"},
+        list_of_fields_params=(),
+    )
+    assert "url" not in params
+    assert params["signature"] == ["abc"]
+    assert "_aggs.url" not in params
+    assert "_aggs.signature" in params
+    assert "_histogram.url" not in params
+    assert "_histogram.signature" in params
+    assert params["_results_number"] == 10
+
+
+def test_sanitize_params_agg_name_checks_all_dotted_segments():
+    """Params dict with subaggregations on disallowed fields are sanitized."""
+    params = {
+        "_aggs.product.version": ["signature"],  # all segments allowed
+        "_aggs.product.url": ["signature"],  # a later segment is disallowed
+    }
+    sanitize_params(
+        params,
+        allowed_fields={"product", "version", "signature"},
+        all_fields={"product", "version", "url", "signature"},
+        list_of_fields_params=(),
+    )
+    assert "_aggs.product.version" in params
+    assert "_aggs.product.url" not in params

--- a/webapp/crashstats/supersearch/tests/test_libsupersearch.py
+++ b/webapp/crashstats/supersearch/tests/test_libsupersearch.py
@@ -161,7 +161,6 @@ def test_sanitize_params_list_of_fields_values(
     sanitize_params(
         params,
         allowed_fields=allowed,
-        all_fields={},
         list_of_fields_params=(param_name,),
     )
     assert params[param_name] == expected
@@ -173,7 +172,6 @@ def test_sanitize_params_handles_missing_keys_for_list_of_fields_values():
     sanitize_params(
         params,
         allowed_fields={"signature"},
-        all_fields={},
         list_of_fields_params=("_sort", "_facets", "_columns"),
     )
     assert params == {"_sort": [], "_facets": [], "_columns": []}
@@ -196,7 +194,6 @@ def test_sanitize_params_drops_disallowed_filters_and_agg_names():
     sanitize_params(
         params,
         allowed_fields={"signature"},
-        all_fields={"url", "signature"},
         list_of_fields_params=(),
     )
     assert "url" not in params
@@ -217,8 +214,38 @@ def test_sanitize_params_agg_name_checks_all_dotted_segments():
     sanitize_params(
         params,
         allowed_fields={"product", "version", "signature"},
-        all_fields={"product", "version", "url", "signature"},
         list_of_fields_params=(),
     )
     assert "_aggs.product.version" in params
     assert "_aggs.product.url" not in params
+
+
+@pytest.mark.parametrize(
+    "field_filter",
+    [
+        # Case variants of a known field
+        "Signature",
+        "SIGNATURE",
+        # Leading/trailing whitespace variants of a known field
+        " signature",
+        "signature ",
+        # Percent-encoded variants of a known field.
+        # Note: Django should decode these upstream.
+        "%73ignature",
+        # Unknown field
+        "not_a_real_field",
+    ],
+)
+def test_sanitize_params_only_allows_exact_field_names(field_filter):
+    """Only exact matches of allowed field names are kept."""
+    params = {
+        "signature": ["abc"],  # allowed field is kept
+        field_filter: ["hmm"],  # variant/unknown field is dropped
+    }
+    sanitize_params(
+        params,
+        allowed_fields={"signature"},
+        list_of_fields_params=(),
+    )
+    assert params["signature"] == ["abc"]
+    assert field_filter not in params

--- a/webapp/crashstats/supersearch/views.py
+++ b/webapp/crashstats/supersearch/views.py
@@ -2,20 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from collections import defaultdict
 import datetime
 import json
 import math
-
-from django import http
-from django.conf import settings
-from django.contrib.auth.decorators import permission_required
-from django.shortcuts import render
-from django.urls import reverse
-from django.utils import timezone
-from django.views.decorators.http import require_POST
-
-from django_ratelimit.decorators import ratelimit
+from collections import defaultdict
 
 from crashstats import libproduct
 from crashstats.crashstats import models, utils
@@ -28,14 +18,23 @@ from crashstats.supersearch.models import (
     SuperSearchFields,
     SuperSearchUnredacted,
 )
+from django import http
+from django.conf import settings
+from django.contrib.auth.decorators import permission_required
+from django.shortcuts import render
+from django.urls import reverse
+from django.utils import timezone
+from django.views.decorators.http import require_POST
+from django_ratelimit.decorators import ratelimit
+
 from socorro import settings as socorro_settings
 from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
 from webapp.crashstats.supersearch.libsupersearch import (
     get_allowed_fields,
-    sanitize_list_of_fields_params,
+    get_supersearch_fields,
+    sanitize_params,
 )
-
 
 DEFAULT_COLUMNS = ("date", "signature", "product", "version", "build_id", "platform")
 
@@ -89,9 +88,13 @@ def get_params(request):
     params["_facets"] = request.GET.getlist("_facets", DEFAULT_FACETS)
     params["_columns"] = request.GET.getlist("_columns") or DEFAULT_COLUMNS
 
-    # Make sure only allowed fields are used.
     allowed_fields = get_allowed_fields(request.user)
-    params = sanitize_list_of_fields_params(params, allowed_fields)
+    # SearchForm already sanitizes all but list-of-field params
+    # (_facets/_sort/_columns) obtained from request.GET above, but we
+    # want to use the same logic in the webapp as in the API to guarantee
+    # consistent behavior.
+    all_fields = get_supersearch_fields()
+    params = sanitize_params(params, allowed_fields, all_fields)
 
     # The uuid is always displayed in the UI so we need to make sure it is
     # always returned by the model.

--- a/webapp/crashstats/supersearch/views.py
+++ b/webapp/crashstats/supersearch/views.py
@@ -32,7 +32,6 @@ from socorro.lib import BadArgumentError
 from socorro.libclass import build_instance_from_settings
 from webapp.crashstats.supersearch.libsupersearch import (
     get_allowed_fields,
-    get_supersearch_fields,
     sanitize_params,
 )
 
@@ -89,12 +88,7 @@ def get_params(request):
     params["_columns"] = request.GET.getlist("_columns") or DEFAULT_COLUMNS
 
     allowed_fields = get_allowed_fields(request.user)
-    # SearchForm already sanitizes all but list-of-field params
-    # (_facets/_sort/_columns) obtained from request.GET above, but we
-    # want to use the same logic in the webapp as in the API to guarantee
-    # consistent behavior.
-    all_fields = get_supersearch_fields()
-    params = sanitize_params(params, allowed_fields, all_fields)
+    params = sanitize_params(params, allowed_fields)
 
     # The uuid is always displayed in the UI so we need to make sure it is
     # always returned by the model.


### PR DESCRIPTION
Because:
* Users with `view_pii` permissions should be able to get protected data back from the `SuperSearch` API.

This PR:
* First commit:
  * Refactors and renames `sanitize_list_of_fields_params` to `sanitize_params`, and changes its scope to handle sanitizing all of the variants of query parameters and their values that could contain protected fields and values. Previously, it only sanitized list-of-fields query parameters like `_sort`, `_columns`, or `_facet`. Updates the tests accordingly.
    * I went back and forth on making `all_fields` an optional param, since the /search view sanitizes a subset of fields already, but I ultimately decided to keep the function simpler and err on always sanitizing everything, since the extra work of calling `get_all_fields` is cheap in this case.
* Second commit:
  * Removes the public fields only filter in `self.possible_params` and `self.extended_fields` from `SuperSearch.__init__`, which doesn't have a user to be permissions-aware.
  * Passes `self.api_user` (obtained from the API request) into `get_allowed_fields` in `SuperSearch.get`, so that it considers the user's permissions in getting the list of allowed fields rather than returning only public fields.
  * Removes the public fields only filter for `_histogram.*` fields added to `self.extended_fields` in `SuperSearch.get`.
  * Collectively, this means that the set of possible parameters going into the newly refactored `sanitize_params` in `SuperSearch.get` include both public and protected fields that are then pared down based on the now permissions-aware set of `allowed_fields` in `sanitize_params`.
  * Adds new test cases for the additive behavior and some tests to ensure we don't regress existing `SuperSearch` API behavior.