### PR TITLE
CRINGE-38: Refactor jquery code

### DIFF
--- a/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -36,14 +36,14 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
   var fields = $('#mainbody').data('fields');
 
   // Append an option element for each field.
-  for (var field of fields) {
-    that.$selectElement.append(
+  that.$selectElement.append(
+    fields.map((f) =>
       $('<option>', {
-        value: field.id,
-        text: field.text,
+        value: f.id,
+        text: f.text,
       })
-    );
-  }
+    )
+  );
 
   // Append the control elements.
   this.$controlsElement.append(this.$selectElement, $('<hr>'));

--- a/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -66,56 +66,30 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
 SignatureReport.GraphsTab.prototype.formatData = function (data) {
   var option = data.aggregation;
 
-  // Object map to contain data for each element
-  var lineDataObject = {};
-  // Array list to hold the formatted dataset
-  var lineDataArray = [];
-  // Array of date values for the graph's x-axis
-  var dateValues = [];
+  // Get the top 4 elements of the crash data
+  var datasets = data.term_counts.splice(0, 4).map((element) => ({
+    label: element.term,
+  }));
 
-  // Array of objects containing the count for each term, in descending order
-  // of counts.
-  var termCounts = data.term_counts;
-
-  for (const element of termCounts.splice(0, 4)) {
-    lineDataObject[element.term] = {
-      label: element.term,
-      data: [],
-    };
-  }
-
-  // Each object in data.aggregates contains data for one date.
-  $.each(data.aggregates, function (i, dateData) {
-    var isoDate = new Date(dateData.term);
-    var formatDate = isoDate.toLocaleDateString('en-US', {
+  // Array of date values in month, day format
+  var dateValues = data.aggregates.map((dateData) =>
+    new Date(dateData.term).toLocaleDateString('en-US', {
       timeZone: 'UTC',
       month: 'long',
       day: 'numeric',
+    })
+  );
+
+  for (var dataset of datasets) {
+    dataset.data = data.aggregates.map((dateData) => {
+      var termData = dateData.facets[option].find((item) => item.term == dataset.label);
+      return termData ? termData.count : 0;
     });
-    dateValues.push(formatDate);
-
-    var currentDateCount = {};
-
-    // Maps the current date's crash count to the element
-    $.each(dateData.facets[option], function (j, termData) {
-      currentDateCount[termData.term] = termData.count;
-    });
-
-    // Check if each top 4 element contains crashes for the current date
-    $.each(lineDataObject, function (element, dataObject) {
-      let crashCount = currentDateCount[element] || 0;
-      dataObject.data.push(crashCount);
-    });
-  });
-
-  // Convert the data object into an array of data points for chart.js
-  $.each(lineDataObject, function (fieldValue, lineData) {
-    lineDataArray.push(lineData);
-  });
+  }
 
   // Return the line data, the date labels and also any remaining terms after the
   // top 4 were spliced out.
-  return { datasets: lineDataArray, labels: dateValues, missingTerms: termCounts };
+  return { datasets, labels: dateValues, missingTerms: data.term_counts };
 };
 
 SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElement) {

--- a/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -36,14 +36,14 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
   var fields = $('#mainbody').data('fields');
 
   // Append an option element for each field.
-  $.each(fields, function (i, field) {
+  for (var field of fields) {
     that.$selectElement.append(
       $('<option>', {
         value: field.id,
         text: field.text,
       })
     );
-  });
+  }
 
   // Append the control elements.
   this.$controlsElement.append(this.$selectElement, $('<hr>'));
@@ -116,9 +116,9 @@ SignatureReport.GraphsTab.prototype.drawGraph = function (graphData, contentElem
   // If there are extra terms missing, let the user know.
   if (graphData.missingTerms.length) {
     var message = 'Showing the top 4 results. Not showing:';
-    $.each(graphData.missingTerms, function (i, term) {
+    for (var term of graphData.missingTerms) {
       message += ' ' + term.term + ' (' + term.count + (term.count === 1 ? ' crash),' : ' crashes),');
-    });
+    }
     contentElement.append($('<p>', { text: message.slice(0, -1) }));
   }
 

--- a/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -80,11 +80,18 @@ SignatureReport.GraphsTab.prototype.formatData = function (data) {
     })
   );
 
+  // Build a dictionary for crash counts based on date and aggregation type
+  var crashData = {};
+  for (var dateData of data.aggregates) {
+    crashData[dateData.term] = {};
+    for (var item of dateData.facets[option]) {
+      crashData[dateData.term][item.term] = item.count;
+    }
+  }
+
+  // Add the crash counts to the dataset
   for (var dataset of datasets) {
-    dataset.data = data.aggregates.map((dateData) => {
-      var termData = dateData.facets[option].find((item) => item.term == dataset.label);
-      return termData ? termData.count : 0;
-    });
+    dataset.data = data.aggregates.map((dateData) => crashData[dateData.term][dataset.label] || 0);
   }
 
   // Return the line data, the date labels and also any remaining terms after the


### PR DESCRIPTION
Purpose:
- After changing the underlying graphing library, we wanted to improve readability in the `signature_tab_graph` file by modernizing some of the old Javascript code

This PR:
- Replaces the Jquery `.each()` loops with more modern javascript `.map()` and `for...of` loops, which makes the code easier to read.
- These changes were made on parts of the code that contribute to drawing the graph. Since we have no test cases for our front end, we would want to manually test the graphs to ensure that they are working as intended.

How to test:
- Load some crash data into your local Socorro
- Go to any crash signature report and click on the graphs tab
- Verify that the line graph renders properly, and loads within 2 seconds
- Select a different option in the dropdown menu and verify that a new line graph is drawn with the new option
- Hover your cursor near a line and confirm that data points can be hovered over and display the y-axis and x-axis details
- Resize your window to verify if the graph is scaled correctly