### PR TITLE
bug-2010995: added collapse exception for operator

### DIFF
--- a/socorro/signature/tests/test_rules.py
+++ b/socorro/signature/tests/test_rules.py
@@ -392,6 +392,16 @@ class TestCSignatureTool:
                 "23",
                 "ShutdownWorkThreads::$::__invoke",
             ),
+            (
+                "js::jit::CodePosition::operator<(js::jit::CodePosition) const",
+                "23",
+                "js::jit::CodePosition::operator<",
+            ),
+            (
+                "js::jit::CodePosition::operator<=>(js::jit::CodePosition const&) const",
+                "23",
+                "js::jit::CodePosition::operator<=>",
+            ),
         ],
     )
     def test_normalize_cpp_function(self, function, line, expected):

--- a/socorro/signature/utils.py
+++ b/socorro/signature/utils.py
@@ -253,6 +253,8 @@ def collapse_types(func_signature: str) -> str:
     def get_type_replacement(before, inside, after):
         if inside == "<name omitted>" or " as " in inside or " in " in inside:
             return inside
+        if before.endswith("operator"):
+            return inside
         if before.endswith("IPC::ParamTraits"):
             s_without_outer_tokens = inside[1:-1]
             inside_substring = collapse_types(s_without_outer_tokens)


### PR DESCRIPTION
Purpose:
- Socorro's signature parsing was failing to correctly normalize C++ stack frames that had comparison operators such as `operator<` and `operator<=>`
- The `collapse_types` function treated the `<` character as a type that needs to be collapsed, which caused the operator part to show up as `operator<T>`
- For example, signatures like `js::jit::CodePosition::operator<(js::jit::CodePosition) const` get collapsed to become `js::jit::CodePosition::operator<T>` when the correct output should be `js::jit::CodePosition::operator<`

This PR:
- Updates the `get_type_replacement` function in `utils.py` to check if the word `operator` comes before any `<` symbol
- This creates an exception for the `operator` word and stops the function from collapsing the signature into `operator<T>`
- Adds test cases to `test_rules.py` instead of `test_utils.py` because the new test cases need to have both their types and arguments collapsed which occurs in `normalize_cpp_function`

How to test:
- A good way to test would be to process signatures locally such as [example 1](https://crash-stats.mozilla.org/report/index/17330b4d-c9b6-4434-9c3b-742570260810) and [example 2](https://crash-stats.mozilla.org/report/index/31f9b65b-33ce-44e5-ba2d-0951b0260810) and confirm that the signature is processed correctly