### PR TITLE
bug-2052944: add Glean client ID as a protected field

### DIFF
--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -884,6 +884,7 @@ FIELDS = {
         "query_type": "bool",
         "storage_mapping": {"type": "boolean"},
     },
+    "glean_client_id": keyword_field(name="glean_client_id"),
     "gmp_library_path": {
         "data_validation_type": "str",
         "form_field_choices": [],

--- a/socorro/processor/rules/mozilla.py
+++ b/socorro/processor/rules/mozilla.py
@@ -904,13 +904,13 @@ class PlatformInfoRule(Rule):
 
     def action(self, raw_crash, dumps, processed_crash, tmpdir, status):
         for key, annotation, sentinel in self.FIELDS:
-            current = processed_crash.get(key) or ""
+            current = processed_crash.get(key, "")
             if current and current != sentinel:
                 # An earlier rule got a real value from the minidump or from an
                 # Android annotation, so leave it alone.
                 continue
 
-            value = (raw_crash.get(annotation) or "").strip()
+            value = raw_crash.get(annotation, "").strip()
             if value:
                 processed_crash[key] = value
 

--- a/socorro/schemas/processed_crash.schema.yaml
+++ b/socorro/schemas/processed_crash.schema.yaml
@@ -2564,6 +2564,27 @@ properties:
     type: boolean
     permissions: ["public"]
     source_annotation: EMCheckCompatibility
+  glean_client_id:
+    description: |
+      The Glean client id of the client that sent the crash ping. This client id
+      is unique to crash pings and is not used by any other Firefox telemetry.
+
+      This is only ever set for crash pings. Crash pings are ingested by
+      extracting the contents of the crash ping and submitting them to the
+      collector, where this value is included as though it were a crash
+      annotation. Because of this, it is not in
+      `toolkit/crashreporter/CrashAnnotations.yaml` in the Firefox source code.
+      Crash reports do not have a Glean client id.
+
+      Socorro needs this in order to process data deletion requests for crash
+      ping data.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1989439
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2052944
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2052950
+    type: string
+    permissions: ["protected"]
+    source_annotation: GleanClientId
   gmp_library_path:
     description: |
       Holds the path to the GMP plugin library.

--- a/socorro/schemas/raw_crash.schema.yaml
+++ b/socorro/schemas/raw_crash.schema.yaml
@@ -521,6 +521,29 @@ properties:
     type: string
     permissions: ["public"]
 
+  GleanClientId:
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2052944#c8
+    description: |
+      The Glean client id of the client that sent the crash ping. This client id
+      is unique to crash pings and is not used by any other Firefox telemetry.
+
+      This is only ever set for crash pings. Crash pings are ingested by
+      extracting the contents of the crash ping and submitting them to the
+      collector, where this value is included as though it were a crash
+      annotation. Because of this, it is not in
+      `toolkit/crashreporter/CrashAnnotations.yaml` in the Firefox source code.
+      Crash reports do not have a Glean client id.
+
+      Socorro needs this in order to process data deletion requests for crash
+      ping data.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1989439
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2052944
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2052950
+    type: string
+    permissions: ["protected"]
+
   GMPLibraryPath:
     data_reviews:
       - unknown

--- a/socorro/tests/external/es/test_supersearch.py
+++ b/socorro/tests/external/es/test_supersearch.py
@@ -154,6 +154,37 @@ class TestIntegrationSuperSearch:
         # processed_crash.json_dump.system_info.cpu_count -> cpu_count
         assert "cpu_count" in res["hits"][0]
 
+    def test_get_with_glean_client_id(self, es_helper):
+        now = utc_now()
+        crashstorage = self.build_crashstorage()
+        api = SuperSearchWithFields(crashstorage=crashstorage)
+
+        es_helper.index_crash(
+            processed_crash={
+                "uuid": create_new_ooid(timestamp=now),
+                "glean_client_id": "00000000-0000-0000-0000-000000000000",
+                "date_processed": now,
+            },
+        )
+        es_helper.index_crash(
+            processed_crash={
+                "uuid": create_new_ooid(timestamp=now),
+                "glean_client_id": "11111111-1111-1111-1111-111111111111",
+                "date_processed": now,
+            },
+        )
+        es_helper.refresh()
+
+        res = api.get(
+            glean_client_id="00000000-0000-0000-0000-000000000000",
+            _columns=["uuid", "glean_client_id"],
+        )
+
+        assert res["total"] == 1
+        assert (
+            res["hits"][0]["glean_client_id"] == "00000000-0000-0000-0000-000000000000"
+        )
+
     def test_get_with_bad_results_number(self, es_helper):
         """Run a very basic test, just to see if things work"""
         crashstorage = self.build_crashstorage()

--- a/socorro/tests/processor/rules/test_mozilla.py
+++ b/socorro/tests/processor/rules/test_mozilla.py
@@ -400,6 +400,35 @@ class TestCopyFromRawCrashRule:
         assert processed_crash == {copy_item.key: copy_item.default}
         assert status.notes == []
 
+    def test_glean_client_id(self, tmp_path):
+        # Verify the GleanClientId annotation is copied to glean_client_id in the
+        # processed crash using the real schema
+        rule = CopyFromRawCrashRule(schema=PROCESSED_CRASH_SCHEMA)
+        copy_item = self.get_copy_item(rule, "GleanClientId")
+        assert copy_item.key == "glean_client_id"
+
+        raw_crash = {"GleanClientId": "00000000-0000-0000-0000-000000000000"}
+        dumps = {}
+        processed_crash = {}
+        status = Status()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert (
+            processed_crash["glean_client_id"] == "00000000-0000-0000-0000-000000000000"
+        )
+        assert status.notes == []
+
+        # Crash reports don't have a GleanClientId annotation and there's no default,
+        # so the field isn't in the processed crash at all
+        raw_crash = {}
+        dumps = {}
+        processed_crash = {}
+        status = Status()
+        rule.act(raw_crash, dumps, processed_crash, str(tmp_path), status)
+
+        assert "glean_client_id" not in processed_crash
+        assert status.notes == []
+
 
 class TestConvertModuleSignatureInfoRule:
     def test_no_value(self, tmp_path):


### PR DESCRIPTION
Because:
* We need the Glean client ID from crash pings to process Firefox telemetry data deletion requests as required per [Bug 2052950](https://bugzilla.mozilla.org/show_bug.cgi?id=2052950#c4).

This commit:
* Adds the Glean client ID to the raw and processed crash schema, linking them via the `source_annotation` which ensures the field is copied into the processed crash via the `CopyFromRawCrashRule` in the processor.
* Indexes the new field as a keyword to ensure we can search for exact matches when processing data deletion requests.

Notes:
* As indicated in the raw crash schema changes, I obtained a `datareview+` [in the ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=2052944#c8).
* Since this field is only used for processing data deletion requests, I did not explicitly add it to any of the Crash Stats UIs.
* We have general tests that cover a lot of the mechanisms that I get "for free" in this patch: copying from the source annotation, asserting the field gets indexed, redacting the field in specific cases, ... I decided to add a couple of new tests specifically for this field to cover the critical processor and search behavior, though there is some overlap with existing tests. I couldn't find a good, recent reference patch for this class of new field (protected, based on a source annotation).