### PR TITLE
bug-2068008: Fix control flow bug in the auditgroups cron job.

### DIFF
--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -69,6 +69,8 @@ def find_users(client_id, client_secret, domain, email, session):
 
 
 def is_blocked_in_auth0(email):
+    if settings.LOCAL_DEV_ENV:
+        return False
     session = session_with_retries(total_retries=5)
     users = find_users(
         settings.OIDC_RP_CLIENT_ID,
@@ -77,10 +79,7 @@ def is_blocked_in_auth0(email):
         email,
         session,
     )
-    for user in users:
-        if user.get("blocked"):
-            return True
-    return False
+    return any(user.get("blocked") for user in users)
 
 
 class Command(BaseCommand):
@@ -117,17 +116,17 @@ class Command(BaseCommand):
         # Go through the users and mark the ones for removal
         users_to_remove = []
         for user in hackers_group.user_set.all():
-            if not settings.LOCAL_DEV_ENV:
-                try:
-                    # User may be blocked as a security mitigation. Eg: too many login attempts
-                    if is_blocked_in_auth0(user.email):
-                        users_to_remove.append(
-                            (user, "user has most likely lost employment")
-                        )
-                except RuntimeError as e:
-                    self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
+            try:
+                # User may be blocked as a security mitigation. Eg: too many login attempts
+                if is_blocked_in_auth0(user.email):
+                    users_to_remove.append(
+                        (user, "user has most likely lost employment")
+                    )
+                    continue
+            except RuntimeError as e:
+                self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
-            elif not user.is_active:
+            if not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
             elif not self.is_employee_or_exception(user):

--- a/webapp/crashstats/authentication/management/commands/auditgroups.py
+++ b/webapp/crashstats/authentication/management/commands/auditgroups.py
@@ -70,6 +70,7 @@ def find_users(client_id, client_secret, domain, email, session):
 
 def is_blocked_in_auth0(email):
     if settings.LOCAL_DEV_ENV:
+        # This function calls an Auth0-specific API not available on the local OIDC provider.
         return False
     session = session_with_retries(total_retries=5)
     users = find_users(
@@ -116,17 +117,17 @@ class Command(BaseCommand):
         # Go through the users and mark the ones for removal
         users_to_remove = []
         for user in hackers_group.user_set.all():
+            is_blocked = False
             try:
                 # User may be blocked as a security mitigation. Eg: too many login attempts
-                if is_blocked_in_auth0(user.email):
-                    users_to_remove.append(
-                        (user, "user has most likely lost employment")
-                    )
-                    continue
-            except RuntimeError as e:
+                is_blocked = is_blocked_in_auth0(user.email)
+            except Exception as e:
                 self.stdout.write(f"Auth0 failed for: {user.email}: {e}")
 
-            if not user.is_active:
+            if is_blocked:
+                users_to_remove.append((user, "user is blocked in Auth0"))
+
+            elif not user.is_active:
                 users_to_remove.append((user, "!is_active"))
 
             elif not self.is_employee_or_exception(user):

--- a/webapp/crashstats/authentication/tests/test_auditgroups.py
+++ b/webapp/crashstats/authentication/tests/test_auditgroups.py
@@ -155,11 +155,6 @@ class TestAuditGroupsCommand:
         bob.save()
 
         monkeypatch.setattr(
-            "crashstats.authentication.management.commands.auditgroups.settings.LOCAL_DEV_ENV",
-            False,
-        )
-
-        monkeypatch.setattr(
             "crashstats.authentication.management.commands.auditgroups.is_blocked_in_auth0",
             lambda email: True,
         )
@@ -170,8 +165,7 @@ class TestAuditGroupsCommand:
         call_command("auditgroups", dry_run=False, stdout=buffer)
         assert hackers_group.user_set.count() == 0
         assert (
-            "Removing: bob@mozilla.com (user has most likely lost employment)"
-            in buffer.getvalue()
+            "Removing: bob@mozilla.com (user is blocked in Auth0)" in buffer.getvalue()
         )
 
     def test_user_not_blocked_in_auth0_is_not_removed(self, db, monkeypatch):


### PR DESCRIPTION
As described in the bug, the `if` sequence got broken in PR #7202, since in production only the `not settings.LOCAL_DEV_ENV` is alays true, so none of the `elif` branches will ever be executed.

I fixed this by moving the `LOCAL_DEV_ENV` check into `is_blocked_in_auth0()`, since that makes the control flow more similar between the dev env and production.

There is no good way to unit test this problem, unfortunately. We have tests for all the behaviours except the Auth0 check, and they all work in the tests because the tests run with `LOCAL_DEV_ENV = True`. 